### PR TITLE
Add support for the bound_claims_type attribute in the JWT auth

### DIFF
--- a/vault/resource_jwt_auth_backend_role.go
+++ b/vault/resource_jwt_auth_backend_role.go
@@ -86,7 +86,6 @@ func jwtAuthBackendRoleResource() *schema.Resource {
 		"bound_claims_type": {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Default:     "string",
 			Description: "How to interpret values in the claims/values map: can be either \"string\" (exact match) or \"glob\" (wildcard match).",
 		},
 		"bound_claims": {

--- a/vault/resource_jwt_auth_backend_role.go
+++ b/vault/resource_jwt_auth_backend_role.go
@@ -83,6 +83,12 @@ func jwtAuthBackendRoleResource() *schema.Resource {
 				Type: schema.TypeString,
 			},
 		},
+		"bound_claims_type": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "string",
+			Description: "How to interpret values in the claims/values map: can be either \"string\" (exact match) or \"glob\" (wildcard match).",
+		},
 		"bound_claims": {
 			Type:        schema.TypeMap,
 			Optional:    true,
@@ -362,6 +368,10 @@ func jwtAuthBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("oidc_scopes", make([]string, 0))
 	}
 
+	if v, ok := resp.Data["bound_claims_type"]; ok {
+		d.Set("bound_claims_type", v)
+	}
+
 	if resp.Data["bound_claims"] != nil {
 		boundClaims := make(map[string]interface{})
 		respBoundClaims := resp.Data["bound_claims"].(map[string]interface{})
@@ -517,6 +527,10 @@ func jwtAuthBackendRoleDataToWrite(d *schema.ResourceData, create bool) map[stri
 
 	if dataList := util.TerraformSetToStringArray(d.Get("oidc_scopes")); len(dataList) > 0 {
 		data["oidc_scopes"] = dataList
+	}
+
+	if v, ok := d.GetOkExists("bound_claims_type"); ok {
+		data["bound_claims_type"] = v.(string)
 	}
 
 	if v, ok := d.GetOk("bound_claims"); ok {

--- a/vault/resource_jwt_auth_backend_role_test.go
+++ b/vault/resource_jwt_auth_backend_role_test.go
@@ -300,6 +300,8 @@ func TestAccJWTAuthBackendRoleOIDC_full(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
 						"allowed_redirect_uris.4240710842", "http://localhost:8080"),
 					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_claims_type", "string"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
 						"bound_claims.%", "2"),
 					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
 						"bound_claims.department", "engineering,admin"),
@@ -414,6 +416,14 @@ func TestAccJWTAuthBackendRole_fullUpdate(t *testing.T) {
 						"user_claim", "https://vault/updateuser"),
 					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
 						"groups_claim", "https://vault/updategroups"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_claims_type", "glob"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_claims.%", "2"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_claims.department", "engineering-*-admin"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_claims.sector", "7g"),
 					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
 						"clock_skew_leeway", "0"),
 					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
@@ -665,6 +675,11 @@ resource "vault_jwt_auth_backend_role" "role" {
   token_ttl = 7200
   token_num_uses = 24
   token_max_ttl = 10800
+  bound_claims_type = "glob"
+  bound_claims = {
+    department = "engineering-*-admin"
+    sector = "7g"
+  }
 }`, backend, role)
 }
 

--- a/website/docs/r/jwt_auth_backend_role.html.md
+++ b/website/docs/r/jwt_auth_backend_role.html.md
@@ -73,6 +73,10 @@ The following arguments are supported:
 * `bound_claims` - (Optional) If set, a map of claims/values to match against.
   The expected value may be a single string or a list of strings.
 
+* `bonud_claims_type` - (Optional) How to interpret values in the claims/values
+  map (`bound_claims`): can be either `string` (exact match) or `glob` (wildcard
+  match). Requires Vault 1.4.0 or above. Defaults to `string`.
+
 * `claim_mappings` - (Optional) If set, a map of claims (keys) to be copied
   to specified metadata fields (values).
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Closes #700

Reopen of https://github.com/terraform-providers/terraform-provider-vault/pull/701

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):

```release-note
Added support for using globs in matching bound_claims for the jwt_auth_backend_role
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccXXX -timeout 120m
?   	github.com/terraform-providers/terraform-provider-vault	[no test files]
?   	github.com/terraform-providers/terraform-provider-vault/cmd/coverage	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/util	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/vault	(cached) [no tests to run]
```
