### PR TITLE
jwt_auth_backend: fix perpetual diff in oidc_client_secret

### DIFF
--- a/vault/resource_jwt_auth_backend.go
+++ b/vault/resource_jwt_auth_backend.go
@@ -143,7 +143,6 @@ var (
 		"oidc_discovery_url",
 		"oidc_discovery_ca_pem",
 		"oidc_client_id",
-		"oidc_client_secret",
 		"jwks_url",
 		"jwks_ca_pem",
 		"jwt_validation_pubkeys",
@@ -235,7 +234,7 @@ func jwtAuthBackendUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Updating auth %s in Vault", path)
 
 	configuration := map[string]interface{}{}
-	for _, configOption := range matchingJwtMountConfigOptions {
+	for _, configOption := range append(matchingJwtMountConfigOptions, "oidc_client_secret") {
 		// Set the configuration if the user has specified it, or the attribute is in the Diff
 		if _, ok := d.GetOkExists(configOption); ok || d.HasChange(configOption) {
 			configuration[configOption] = d.Get(configOption)

--- a/vault/resource_jwt_auth_backend_test.go
+++ b/vault/resource_jwt_auth_backend_test.go
@@ -155,12 +155,6 @@ resource "vault_jwt_auth_backend" "oidc" {
   path = "%s"
   type = "oidc"
   default_role = "api"
-  lifecycle {
-	ignore_changes = [
-     # Ignore changes to odic_clie_secret inside the tests
-     "oidc_client_secret"
-    ]
-  }
 }
 `, path)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

This PR fixes an issue where `oidc_client_secret` will present a perpetual diff when set for `jwt_auth_backend`. 

This occurs because Vault will never send `oidc_client_secret` in a response, but the provider is trying to set a value in `Read`, resulting in Terraform observing a diff between the refreshed state (nil) and the user provided value.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
jwt_auth_backend: fix perpetual diff in oidc_client_secret
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run TestAccJWTAuthBackend'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccJWTAuthBackend -timeout 120m
?   	github.com/terraform-providers/terraform-provider-vault	[no test files]
?   	github.com/terraform-providers/terraform-provider-vault/cmd/coverage	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/util	(cached) [no tests to run]
=== RUN   TestAccJWTAuthBackendRole_import
--- PASS: TestAccJWTAuthBackendRole_import (0.17s)
=== RUN   TestAccJWTAuthBackendRole_basic
--- PASS: TestAccJWTAuthBackendRole_basic (0.14s)
=== RUN   TestAccJWTAuthBackendRole_update
--- PASS: TestAccJWTAuthBackendRole_update (0.24s)
=== RUN   TestAccJWTAuthBackendRole_full
--- PASS: TestAccJWTAuthBackendRole_full (0.14s)
=== RUN   TestAccJWTAuthBackendRoleOIDC_full
--- PASS: TestAccJWTAuthBackendRoleOIDC_full (0.54s)
=== RUN   TestAccJWTAuthBackendRole_fullUpdate
--- PASS: TestAccJWTAuthBackendRole_fullUpdate (0.23s)
=== RUN   TestAccJWTAuthBackendRole_fullDeprecated
--- PASS: TestAccJWTAuthBackendRole_fullDeprecated (0.23s)
=== RUN   TestAccJWTAuthBackend
--- PASS: TestAccJWTAuthBackend (0.38s)
=== RUN   TestAccJWTAuthBackend_OIDC
--- PASS: TestAccJWTAuthBackend_OIDC (0.15s)
=== RUN   TestAccJWTAuthBackend_negative
--- PASS: TestAccJWTAuthBackend_negative (0.04s)
=== RUN   TestAccJWTAuthBackend_missingMandatory
--- PASS: TestAccJWTAuthBackend_missingMandatory (0.12s)
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/vault	2.720s
```

Previously, this bug was obscured in the relevant tests by the use of `ignore_changes` in the configuration.

When this is removed without fixing the source code, the test fails:

```
=== RUN   TestAccJWTAuthBackend_OIDC
    TestAccJWTAuthBackend_OIDC: testing.go:640: Step 0 error: After applying this step, the plan was not empty:

        DIFF:

        UPDATE: vault_jwt_auth_backend.oidc
          accessor:              "auth_oidc_4aaa22fc" => "auth_oidc_4aaa22fc"
          bound_issuer:          "api://default" => "api://default"
          default_role:          "api" => "api"
          description:           "OIDC backend" => "OIDC backend"
          id:                    "oidc-4730728380665000419" => "oidc-4730728380665000419"
          jwks_ca_pem:           "" => ""
          jwks_url:              "" => ""
          oidc_client_id:        "client" => "client"
          oidc_client_secret:    "" => "secret"
          oidc_discovery_ca_pem: "" => ""
          oidc_discovery_url:    "https://myco.auth0.com/" => "https://myco.auth0.com/"
          path:                  "oidc-4730728380665000419" => "oidc-4730728380665000419"
          tune.#:                "0" => "0"
          type:                  "oidc" => "oidc"



        STATE:

        vault_jwt_auth_backend.oidc:
          ID = oidc-4730728380665000419
          provider = provider.vault
          accessor = auth_oidc_4aaa22fc
          bound_issuer = api://default
          default_role = api
          description = OIDC backend
          jwks_ca_pem =
          jwks_url =
          oidc_client_id = client
          oidc_client_secret =
          oidc_discovery_ca_pem =
          oidc_discovery_url = https://myco.auth0.com/
          path = oidc-4730728380665000419
          type = oidc
--- FAIL: TestAccJWTAuthBackend_OIDC (0.12s)
```

Similarly, `TF_LOG=trace` both shows the root cause (client_secret is not returned) and identifies a similar error:

```
2020-05-20T16:04:55.729-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4: -----------------------------------------------------
2020-05-20T16:04:55.729-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4: 2020/05/20 16:04:55 [DEBUG] Vault API Request Details:
2020-05-20T16:04:55.729-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4: ---[ REQUEST ]---------------------------------------
2020-05-20T16:04:55.729-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4: GET /v1/auth/oidc/config HTTP/1.1
2020-05-20T16:04:55.729-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4: Host: 127.0.0.1:8200
2020-05-20T16:04:55.729-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4: User-Agent: Go-http-client/1.1
2020-05-20T16:04:55.729-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4: X-Vault-Token: s.QkSw57EfCrB0YgnW5mBeerPs
2020-05-20T16:04:55.729-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4: Accept-Encoding: gzip
2020-05-20T16:04:55.729-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4: 
2020-05-20T16:04:55.729-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4: 
2020-05-20T16:04:55.729-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4: -----------------------------------------------------
2020-05-20T16:04:55.731-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4: 2020/05/20 16:04:55 [DEBUG] Vault API Response Details:
2020-05-20T16:04:55.731-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4: ---[ RESPONSE ]--------------------------------------
2020-05-20T16:04:55.731-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4: HTTP/1.1 200 OK
2020-05-20T16:04:55.731-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4: Content-Length: 433
2020-05-20T16:04:55.731-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4: Cache-Control: no-store
2020-05-20T16:04:55.731-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4: Content-Type: application/json
2020-05-20T16:04:55.731-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4: Date: Wed, 20 May 2020 23:04:55 GMT
2020-05-20T16:04:55.731-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4: 
2020-05-20T16:04:55.731-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4: {
2020-05-20T16:04:55.731-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4:  "request_id": "3e624f44-5d2a-0d09-b266-4611684c5c01",
2020-05-20T16:04:55.731-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4:  "lease_id": "",
2020-05-20T16:04:55.731-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4:  "renewable": false,
2020-05-20T16:04:55.731-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4:  "lease_duration": 0,
2020-05-20T16:04:55.731-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4:  "data": {
2020-05-20T16:04:55.731-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4:   "bound_issuer": "",
2020-05-20T16:04:55.731-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4:   "default_role": "test-role",
2020-05-20T16:04:55.731-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4:   "jwks_ca_pem": "",
2020-05-20T16:04:55.731-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4:   "jwks_url": "",
2020-05-20T16:04:55.731-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4:   "jwt_supported_algs": [],
2020-05-20T16:04:55.731-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4:   "jwt_validation_pubkeys": [],
2020-05-20T16:04:55.731-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4:   "oidc_client_id": "0oacng9win0duWSpd4x6",
2020-05-20T16:04:55.731-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4:   "oidc_discovery_ca_pem": "",
2020-05-20T16:04:55.731-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4:   "oidc_discovery_url": "https://dev-469256.okta.com/oauth2/auscnhfdu5e2CRcR34x6"
2020-05-20T16:04:55.731-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4:  },
2020-05-20T16:04:55.731-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4:  "wrap_info": null,
2020-05-20T16:04:55.731-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4:  "warnings": null,
2020-05-20T16:04:55.731-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4:  "auth": null
2020-05-20T16:04:55.731-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4: }
2020-05-20T16:04:55.731-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4: 
2020-05-20T16:04:55.731-0700 [DEBUG] plugin.terraform-provider-vault_v2.10.0_x4: -----------------------------------------------------
2020/05/20 16:04:55 [WARN] Provider "registry.terraform.io/-/vault" produced an unexpected new value for vault_jwt_auth_backend.example, but we are tolerating it because it is using the legacy plugin SDK.
    The following problems may be the cause of any confusing errors from downstream operations:
      - .oidc_client_secret: inconsistent values for sensitive attribute
``` 