### PR TITLE
Fix time format bug for generic secret data source

### DIFF
--- a/vault/data_source_generic_secret.go
+++ b/vault/data_source_generic_secret.go
@@ -111,7 +111,7 @@ func genericSecretDataSourceRead(d *schema.ResourceData, meta interface{}) error
 
 	d.Set("lease_id", secret.LeaseID)
 	d.Set("lease_duration", secret.LeaseDuration)
-	d.Set("lease_start_time", time.Now().Format("RFC3339"))
+	d.Set("lease_start_time", time.Now().Format(time.RFC3339))
 	d.Set("lease_renewable", secret.Renewable)
 
 	return nil


### PR DESCRIPTION
A typo in the generic secret data source resulted in invalid timestamp outputs for `lease_start_time`, like this:

```
 <= data "vault_generic_secret" "test"  {
        data             = {
            "foo"   = "bar"
        }
        data_json        = jsonencode(
            {
                foo   = "bar"
            }
        )
      ~ id               = "ab2c2e32-2245-b304-9435-634755285858" -> "f1f5ffa7-32bd-cfc8-3ec8-d7932697a59e"
        lease_duration   = 0
        lease_renewable  = false
        lease_start_time = "RFC3339"
        path             = "secret/thingy"
        version          = -1
    }
```

After this commit:

```
 <= data "vault_generic_secret" "boop"  {
        data             = {
            "foo"   = "bar"
        }
        data_json        = jsonencode(
            {
                foo   = "bar"
            }
        )
      ~ id               = "1100e888-c1b9-6b7c-c506-f3fa66fef046" -> "e9c3a8d5-59d7-8289-4d50-3a09cac5dc52"
        lease_duration   = 0
        lease_renewable  = false
        lease_start_time = "2020-05-21T15:29:40-04:00"
        path             = "secret/thingy"
        version          = -1
    }
```

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`vault_generic_secret`: fix timestamp format for `lease_start_time`
```

Output from acceptance testing:

```shellsession
$ make testacc TESTARGS='-run TestV2Secret'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestV2Secret -timeout 120m
?   	github.com/terraform-providers/terraform-provider-vault	[no test files]
?   	github.com/terraform-providers/terraform-provider-vault/cmd/coverage	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/util	1.474s [no tests to run]
=== RUN   TestV2Secret
--- PASS: TestV2Secret (0.39s)
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/vault	0.998s...
```
