### PR TITLE
Create optional provider config setting for using or disabling the child token

### DIFF
--- a/vault/provider.go
+++ b/vault/provider.go
@@ -138,6 +138,15 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("VAULT_SKIP_VERIFY", false),
 				Description: "Set this to true only if the target Vault server is an insecure development instance.",
 			},
+			"create_intermediate_child_token": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("TERRAFORM_VAULT_CREATE_CHILD_TOKEN", true),
+
+				// Setting to false will cause max_lease_ttl_seconds and token_name to be ignored (not used).
+				// Note that this is strongly discouraged due to the potential of exposing sensitive secret data.
+				Description: "Set this to false to prevent the creation and use of ephemeral child token used by this provider.",
+			},
 			"max_lease_ttl_seconds": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -148,7 +157,7 @@ func Provider() *schema.Provider {
 				// after Terraform has finished running.
 				DefaultFunc: schema.EnvDefaultFunc("TERRAFORM_VAULT_MAX_TTL", 1200),
 
-				Description: "Maximum TTL for secret leases requested by this provider",
+				Description: "Maximum TTL for secret leases requested by this provider.",
 			},
 			"max_retries": {
 				Type:     schema.TypeInt,
@@ -161,7 +170,7 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("VAULT_NAMESPACE", ""),
-				Description: "The namespace to use. Available only for Vault Enterprise",
+				Description: "The namespace to use. Available only for Vault Enterprise.",
 			},
 			"headers": {
 				Type:        schema.TypeList,
@@ -706,6 +715,62 @@ func providerToken(d *schema.ResourceData) (string, error) {
 	return strings.TrimSpace(token), nil
 }
 
+func providerChildToken(d *schema.ResourceData, c interface{}) error {
+	client := c.(*api.Client)
+
+	tokenName := d.Get("token_name").(string)
+	if tokenName == "" {
+		tokenName = "terraform"
+	}
+
+	// In order to enforce our relatively-short lease TTL, we derive a
+	// temporary child token that inherits all of the policies of the
+	// token we were given but expires after max_lease_ttl_seconds.
+	//
+	// The intent here is that Terraform will need to re-fetch any
+	// secrets on each run and so we limit the exposure risk of secrets
+	// that end up stored in the Terraform state, assuming that they are
+	// credentials that Vault is able to revoke.
+	//
+	// Caution is still required with state files since not all secrets
+	// can explicitly be revoked, and this limited scope won't apply to
+	// any secrets that are *written* by Terraform to Vault.
+
+	// Set the namespace to the token's namespace only for the
+	// child token creation
+	tokenInfo, err := client.Auth().Token().LookupSelf()
+	if err != nil {
+		return err
+	}
+	if tokenNamespaceRaw, ok := tokenInfo.Data["namespace_path"]; ok {
+		tokenNamespace := tokenNamespaceRaw.(string)
+		if tokenNamespace != "" {
+			client.SetNamespace(tokenNamespace)
+		}
+	}
+
+	renewable := false
+	childTokenLease, err := client.Auth().Token().Create(&api.TokenCreateRequest{
+		DisplayName:    tokenName,
+		TTL:            fmt.Sprintf("%ds", d.Get("max_lease_ttl_seconds").(int)),
+		ExplicitMaxTTL: fmt.Sprintf("%ds", d.Get("max_lease_ttl_seconds").(int)),
+		Renewable:      &renewable,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create limited child token: %s", err)
+	}
+
+	childToken := childTokenLease.Auth.ClientToken
+	policies := childTokenLease.Auth.Policies
+
+	log.Printf("[INFO] Using Vault token with the following policies: %s", strings.Join(policies, ", "))
+
+	// Set the token to the generated child token
+	client.SetToken(childToken)
+
+	return nil
+}
+
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	clientConfig := api.DefaultConfig()
 	addr := d.Get("address").(string)
@@ -810,55 +875,13 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		return nil, errors.New("no vault token found")
 	}
 
-	tokenName := d.Get("token_name").(string)
-	if tokenName == "" {
-		tokenName = "terraform"
-	}
-
-	// In order to enforce our relatively-short lease TTL, we derive a
-	// temporary child token that inherits all of the policies of the
-	// token we were given but expires after max_lease_ttl_seconds.
-	//
-	// The intent here is that Terraform will need to re-fetch any
-	// secrets on each run and so we limit the exposure risk of secrets
-	// that end up stored in the Terraform state, assuming that they are
-	// credentials that Vault is able to revoke.
-	//
-	// Caution is still required with state files since not all secrets
-	// can explicitly be revoked, and this limited scope won't apply to
-	// any secrets that are *written* by Terraform to Vault.
-
-	// Set the namespace to the token's namespace only for the
-	// child token creation
-	tokenInfo, err := client.Auth().Token().LookupSelf()
-	if err != nil {
-		return nil, err
-	}
-	if tokenNamespaceRaw, ok := tokenInfo.Data["namespace_path"]; ok {
-		tokenNamespace := tokenNamespaceRaw.(string)
-		if tokenNamespace != "" {
-			client.SetNamespace(tokenNamespace)
+	createChild := d.Get("create_intermediate_child_token").(bool)
+	if createChild {
+		err := providerChildToken(d, client)
+		if err != nil {
+			return nil, err
 		}
 	}
-
-	renewable := false
-	childTokenLease, err := client.Auth().Token().Create(&api.TokenCreateRequest{
-		DisplayName:    tokenName,
-		TTL:            fmt.Sprintf("%ds", d.Get("max_lease_ttl_seconds").(int)),
-		ExplicitMaxTTL: fmt.Sprintf("%ds", d.Get("max_lease_ttl_seconds").(int)),
-		Renewable:      &renewable,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create limited child token: %s", err)
-	}
-
-	childToken := childTokenLease.Auth.ClientToken
-	policies := childTokenLease.Auth.Policies
-
-	log.Printf("[INFO] Using Vault token with the following policies: %s", strings.Join(policies, ", "))
-
-	// Set the token to the generated child token
-	client.SetToken(childToken)
 
 	// Set the namespace to the requested namespace, if provided
 	namespace := d.Get("namespace").(string)

--- a/vault/provider_test.go
+++ b/vault/provider_test.go
@@ -630,55 +630,55 @@ func TestAccTokenName(t *testing.T) {
 func TestAccChildToken(t *testing.T) {
 
 	tests := []struct {
-		ChildTokenEnv        string
-		TestChildTokenEnv    bool
-		ChildTokenSchema     string
-		TestChildTokenSchema bool
-		ExpectChildToken     bool
+		skipChildTokenEnv    string
+		useChildTokenEnv     bool
+		skipChildTokenSchema string
+		useChildTokenSchema  bool
+		expectChildToken     bool
 	}{
 		{
-			TestChildTokenSchema: false,
-			TestChildTokenEnv:    false,
-			ExpectChildToken:     true,
+			useChildTokenSchema: false,
+			useChildTokenEnv:    false,
+			expectChildToken:    true,
 		},
 		{
-			ChildTokenEnv:     "",
-			TestChildTokenEnv: true,
-			ExpectChildToken:  true,
+			skipChildTokenEnv: "",
+			useChildTokenEnv:  true,
+			expectChildToken:  true,
 		},
 		{
-			ChildTokenEnv:     "true",
-			TestChildTokenEnv: true,
-			ExpectChildToken:  true,
+			skipChildTokenEnv: "true",
+			useChildTokenEnv:  true,
+			expectChildToken:  false,
 		},
 		{
-			ChildTokenEnv:     "false",
-			TestChildTokenEnv: true,
-			ExpectChildToken:  false,
+			skipChildTokenEnv: "false",
+			useChildTokenEnv:  true,
+			expectChildToken:  true,
 		},
 		{
-			ChildTokenSchema:     "true",
-			TestChildTokenSchema: true,
-			ExpectChildToken:     true,
+			skipChildTokenSchema: "true",
+			useChildTokenSchema:  true,
+			expectChildToken:     false,
 		},
 		{
-			ChildTokenSchema:     "false",
-			TestChildTokenSchema: true,
-			ExpectChildToken:     false,
+			skipChildTokenSchema: "false",
+			useChildTokenSchema:  true,
+			expectChildToken:     true,
 		},
 		{
-			ChildTokenEnv:        "true",
-			TestChildTokenEnv:    true,
-			ChildTokenSchema:     "false",
-			TestChildTokenSchema: true,
-			ExpectChildToken:     false,
+			skipChildTokenEnv:    "true",
+			useChildTokenEnv:     true,
+			skipChildTokenSchema: "false",
+			useChildTokenSchema:  true,
+			expectChildToken:     true,
 		},
 		{
-			ChildTokenEnv:        "false",
-			TestChildTokenEnv:    true,
-			ChildTokenSchema:     "true",
-			TestChildTokenSchema: true,
-			ExpectChildToken:     true,
+			skipChildTokenEnv:    "false",
+			useChildTokenEnv:     true,
+			skipChildTokenSchema: "true",
+			useChildTokenSchema:  true,
+			expectChildToken:     false,
 		},
 	}
 
@@ -689,23 +689,23 @@ func TestAccChildToken(t *testing.T) {
 			Steps: []resource.TestStep{
 				{
 					PreConfig: func() {
-						if test.TestChildTokenEnv {
-							err := os.Setenv("TERRAFORM_VAULT_CREATE_CHILD_TOKEN", test.ChildTokenEnv)
+						if test.useChildTokenEnv {
+							err := os.Setenv("VAULT_SKIP_CHILD_TOKEN", test.skipChildTokenEnv)
 							if err != nil {
 								t.Fatal(err)
 							}
 						} else {
-							err := os.Unsetenv("TERRAFORM_VAULT_CREATE_CHILD_TOKEN")
+							err := os.Unsetenv("VAULT_SKIP_CHILD_TOKEN")
 							if err != nil {
 								t.Fatal(err)
 							}
 						}
 					},
-					Config: testProviderConfig(test.TestChildTokenSchema, `create_intermediate_child_token = `+test.ChildTokenSchema),
-					Check:  checkUsedToken(test.ExpectChildToken),
+					Config: testProviderConfig(test.useChildTokenSchema, `skip_child_token = `+test.skipChildTokenSchema),
+					Check:  checkUsedToken(test.expectChildToken),
 				},
 			},
-			CheckDestroy: testEnvCleanup("TERRAFORM_VAULT_CREATE_CHILD_TOKEN"),
+			CheckDestroy: testEnvCleanup("VAULT_SKIP_CHILD_TOKEN"),
 		})
 	}
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -150,9 +150,8 @@ variables in order to keep credential information out of the configuration.
   Terraform. May be set via the `TERRAFORM_VAULT_SKIP_CHILD_TOKEN` environment
   variable. **Note**: Setting to `true` will cause `token_name`
   and `max_lease_ttl_seconds` to be ignored.
-
-  See the section above on *Using Vault credentials in Terraform configuration*
-  for more details on why it is not recommended to disable this setting.
+  Please see [Using Vault credentials in Terraform configuration](#using-vault-credentials-in-terraform-configuration)
+  before enabling this setting.
 
 * `max_lease_ttl_seconds` - (Optional) Used as the duration for the
   intermediate Vault token Terraform issues itself, which in turn limits

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -103,7 +103,8 @@ variables in order to keep credential information out of the configuration.
   If none is otherwise supplied, Terraform will attempt to read it from
   `~/.vault-token` (where the vault command stores its current token).
   Terraform will issue itself a new token that is a child of the one given,
-  with a short TTL to limit the exposure of any requested secrets. Note that
+  with a short TTL to limit the exposure of any requested secrets, unless
+  `skip_child_token` is set to `true` (see below). Note that
   the given token must have the update capability on the auth/token/create
   path in Vault in order to create child tokens.
 
@@ -139,14 +140,15 @@ variables in order to keep credential information out of the configuration.
   that Terraform can be tricked into writing secrets to a server controlled
   by an intruder. May be set via the `VAULT_SKIP_VERIFY` environment variable.
 
-* `create_intermediate_child_token` - (Optional) Set this to `false` to disable
+* `skip_child_token` - (Optional) Set this to `true` to disable
   creation of an intermediate ephemeral Vault token for Terraform to
   use. This is strongly discouraged in most cases and environments because it
-  can result in the provided Vault token being exposed by Terraform's output.
+  can result in the provided Vault token being exposed by Terraform's output
+  when `TF_LOG` is set to `debug`.
   Only change this setting when the provided token cannot be permitted to
   create child tokens and there is no risk of exposure from the output of
-  Terraform. May be set via the `TERRAFORM_VAULT_CREATE_CHILD_TOKEN`
-  environment variable. **Note**: Setting to `false` will cause `token_name`
+  Terraform. May be set via the `VAULT_SKIP_CHILD_TOKEN` environment variable.
+  **Note**: Setting to `true` will cause `token_name`
   and `max_lease_ttl_seconds` to be ignored.
 
   See the section above on *Using Vault credentials in Terraform configuration*

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -147,8 +147,8 @@ variables in order to keep credential information out of the configuration.
   when `TF_LOG` is set to `debug`.
   Only change this setting when the provided token cannot be permitted to
   create child tokens and there is no risk of exposure from the output of
-  Terraform. May be set via the `VAULT_SKIP_CHILD_TOKEN` environment variable.
-  **Note**: Setting to `true` will cause `token_name`
+  Terraform. May be set via the `TERRAFORM_VAULT_SKIP_CHILD_TOKEN` environment
+  variable. **Note**: Setting to `true` will cause `token_name`
   and `max_lease_ttl_seconds` to be ignored.
 
   See the section above on *Using Vault credentials in Terraform configuration*

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -139,6 +139,19 @@ variables in order to keep credential information out of the configuration.
   that Terraform can be tricked into writing secrets to a server controlled
   by an intruder. May be set via the `VAULT_SKIP_VERIFY` environment variable.
 
+* `create_intermediate_child_token` - (Optional) Set this to `false` to disable
+  creation of an intermediate ephemeral Vault token for Terraform to
+  use. This is strongly discouraged in most cases and environments because it
+  can result in the provided Vault token being exposed by Terraform's output.
+  Only change this setting when the provided token cannot be permitted to
+  create child tokens and there is no risk of exposure from the output of
+  Terraform. May be set via the `TERRAFORM_VAULT_CREATE_CHILD_TOKEN`
+  environment variable. **Note**: Setting to `false` will cause `token_name`
+  and `max_lease_ttl_seconds` to be ignored.
+
+  See the section above on *Using Vault credentials in Terraform configuration*
+  for more details on why it is not recommended to disable this setting.
+
 * `max_lease_ttl_seconds` - (Optional) Used as the duration for the
   intermediate Vault token Terraform issues itself, which in turn limits
   the duration of secret leases issued by Vault. Defaults to 20 minutes


### PR DESCRIPTION
This adds a new (often requested) vault provider configuration setting which can allow users to disable the creation of the intermediate child token (strongly discouraged, but made available for the cases that need it).

```
provider "vault" {
    address = "https://vault.testdomain"
    create_intermediate_child_token = false
}
```

(Open to changing the name of this config item, or related env var, but I like to be verbose with settings that typically shouldn't be adjusted without reading the documentation).

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request


Closes #29 
Closes #722 
Relates #550 
Relates #368 
Relates #192 

Relates to the following as well:
https://github.com/hashicorp/terraform/issues/16457
https://github.com/hashicorp/terraform/pull/14839
https://groups.google.com/forum/#!topic/terraform-tool/wtlLrKVQlAo

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):

```release-note
Add `create_intermediate_child_token` optional provider configuration setting to control the use of ephemeral child tokens for use by terraform.
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run TestAccChildToken'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccChildToken -timeout 120m
?   	github.com/terraform-providers/terraform-provider-vault	[no test files]
?   	github.com/terraform-providers/terraform-provider-vault/cmd/coverage	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/util	0.012s [no tests to run]
=== RUN   TestAccChildToken
--- PASS: TestAccChildToken (1.15s)
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/vault	1.168s

```
