### PR TITLE
Add user_path and permissions_boundary_arn arguments to aws_secret_backend_role

### DIFF
--- a/vault/resource_aws_secret_backend_role_test.go
+++ b/vault/resource_aws_secret_backend_role_test.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -13,12 +14,16 @@ import (
 )
 
 const (
-	testAccAWSSecretBackendRolePolicyInline_basic   = `{"Version": "2012-10-17","Statement": [{"Effect": "Allow","Action": "iam:*","Resource": "*"}]}`
-	testAccAWSSecretBackendRolePolicyInline_updated = `{"Version": "2012-10-17","Statement": [{"Effect": "Allow","Action": "ec2:*","Resource": "*"}]}`
-	testAccAWSSecretBackendRolePolicyArn_basic      = "arn:aws:iam::123456789123:policy/foo"
-	testAccAWSSecretBackendRolePolicyArn_updated    = "arn:aws:iam::123456789123:policy/bar"
-	testAccAWSSecretBackendRoleRoleArn_basic        = "arn:aws:iam::123456789123:role/foo"
-	testAccAWSSecretBackendRoleRoleArn_updated      = "arn:aws:iam::123456789123:role/bar"
+	testAccAWSSecretBackendRolePolicyInline_basic             = `{"Version": "2012-10-17","Statement": [{"Effect": "Allow","Action": "iam:*","Resource": "*"}]}`
+	testAccAWSSecretBackendRolePolicyInline_updated           = `{"Version": "2012-10-17","Statement": [{"Effect": "Allow","Action": "ec2:*","Resource": "*"}]}`
+	testAccAWSSecretBackendRolePolicyArn_basic                = "arn:aws:iam::123456789123:policy/foo"
+	testAccAWSSecretBackendRolePolicyArn_updated              = "arn:aws:iam::123456789123:policy/bar"
+	testAccAWSSecretBackendRoleRoleArn_basic                  = "arn:aws:iam::123456789123:role/foo"
+	testAccAWSSecretBackendRoleRoleArn_updated                = "arn:aws:iam::123456789123:role/bar"
+	testAccAWSSecretBackendRolePermissionsBoundaryArn_basic   = "arn:aws:iam::123456789123:policy/boundary1"
+	testAccAWSSecretBackendRolePermissionsBoundaryArn_updated = "arn:aws:iam::123456789123:policy/boundary2"
+	testAccAWSSecretBackendRoleIamUserPath_basic              = "/path1/"
+	testAccAWSSecretBackendRoleIamUserPath_updated            = "/path2/"
 )
 
 func TestAccAWSSecretBackendRole_basic(t *testing.T) {
@@ -32,95 +37,15 @@ func TestAccAWSSecretBackendRole_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSecretBackendRoleConfig_basic(name, backend, accessKey, secretKey),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", fmt.Sprintf("%s-policy-inline", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
-					testutil.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy_document", testAccAWSSecretBackendRolePolicyInline_basic),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "iam_groups.#", "0"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "name", fmt.Sprintf("%s-policy-arn", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "policy_arns.#", "1"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "policy_arns.0", testAccAWSSecretBackendRolePolicyArn_basic),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "name", fmt.Sprintf("%s-policy-inline-and-arns", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "backend", backend),
-					testutil.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline_and_arns", "policy_document", testAccAWSSecretBackendRolePolicyInline_basic),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "policy_arns.#", "1"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "policy_arns.0", testAccAWSSecretBackendRolePolicyArn_basic),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "name", fmt.Sprintf("%s-role-arns", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "role_arns.#", "1"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "role_arns.0", testAccAWSSecretBackendRoleRoleArn_basic),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "policy_arns.#", "0"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_to_arn", "name", fmt.Sprintf("%s-policy-inline-to-arn", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_to_arn", "backend", backend),
-					testutil.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline_to_arn", "policy_document", testAccAWSSecretBackendRolePolicyInline_basic),
-				),
+				Check:  testAccAWSSecretBackendRoleCheckBasicAttributes(name, backend),
 			},
 			{
 				Config: testAccAWSSecretBackendRoleConfig_updated(name, backend, accessKey, secretKey),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", fmt.Sprintf("%s-policy-inline", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "default_sts_ttl", "3600"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "max_sts_ttl", "21600"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "policy_arns.#", "0"),
-					testutil.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy_document", testAccAWSSecretBackendRolePolicyInline_updated),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "iam_groups.#", "2"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "name", fmt.Sprintf("%s-policy-arn", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "policy_arns.#", "1"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "policy_arns.0", testAccAWSSecretBackendRolePolicyArn_updated),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "iam_groups.#", "2"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "name", fmt.Sprintf("%s-policy-inline-and-arns", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "backend", backend),
-					testutil.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline_and_arns", "policy_document", testAccAWSSecretBackendRolePolicyInline_updated),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "policy_arns.#", "1"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "policy_arns.0", testAccAWSSecretBackendRolePolicyArn_updated),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "iam_groups.#", "2"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "name", fmt.Sprintf("%s-role-arns", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "role_arns.#", "1"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "role_arns.0", testAccAWSSecretBackendRoleRoleArn_updated),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "iam_groups.#", "2"),
-					resource.TestCheckNoResourceAttr("vault_aws_secret_backend_role.test_role_arns", "policy_arns.#"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_groups", "name", fmt.Sprintf("%s-role-groups", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_groups", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_groups", "iam_groups.#", "2"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_to_arn", "name", fmt.Sprintf("%s-policy-inline-to-arn", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_to_arn", "backend", backend),
-					testutil.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline_to_arn", "policy_document", ""),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_to_arn", "policy_arns.#", "1"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_to_arn", "policy_arns.0", testAccAWSSecretBackendRolePolicyArn_updated),
-				),
+				Check:  testAccAWSSecretBackendRoleCheckUpdatedAttributes(name, backend),
 			},
 			{
 				Config: testAccAWSSecretBackendRoleConfig_basic(name, backend, accessKey, secretKey),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", fmt.Sprintf("%s-policy-inline", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
-					testutil.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy_document", testAccAWSSecretBackendRolePolicyInline_basic),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "iam_groups.#", "0"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "name", fmt.Sprintf("%s-policy-arn", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "policy_arns.#", "1"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "policy_arns.0", testAccAWSSecretBackendRolePolicyArn_basic),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "iam_groups.#", "0"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "name", fmt.Sprintf("%s-policy-inline-and-arns", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "backend", backend),
-					testutil.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline_and_arns", "policy_document", testAccAWSSecretBackendRolePolicyInline_basic),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "policy_arns.#", "1"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "policy_arns.0", testAccAWSSecretBackendRolePolicyArn_basic),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "iam_groups.#", "0"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "name", fmt.Sprintf("%s-role-arns", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "role_arns.0", testAccAWSSecretBackendRoleRoleArn_basic),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "policy_arns.#", "0"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "iam_groups.#", "0"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_to_arn", "name", fmt.Sprintf("%s-policy-inline-to-arn", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_to_arn", "backend", backend),
-					testutil.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline_to_arn", "policy_document", testAccAWSSecretBackendRolePolicyInline_basic),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_to_arn", "policy_arns.#", "0"),
-				),
+				Check:  testAccAWSSecretBackendRoleCheckBasicAttributes(name, backend),
 			},
 		},
 	})
@@ -137,24 +62,7 @@ func TestAccAWSSecretBackendRole_import(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSecretBackendRoleConfig_basic(name, backend, accessKey, secretKey),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", fmt.Sprintf("%s-policy-inline", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
-					testutil.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy_document", testAccAWSSecretBackendRolePolicyInline_basic),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "name", fmt.Sprintf("%s-policy-arn", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "policy_arns.#", "1"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "policy_arns.0", testAccAWSSecretBackendRolePolicyArn_basic),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "name", fmt.Sprintf("%s-policy-inline-and-arns", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "backend", backend),
-					testutil.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline_and_arns", "policy_document", testAccAWSSecretBackendRolePolicyInline_basic),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "policy_arns.#", "1"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "policy_arns.0", testAccAWSSecretBackendRolePolicyArn_basic),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "name", fmt.Sprintf("%s-role-arns", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "role_arns.0", testAccAWSSecretBackendRoleRoleArn_basic),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "policy_arns.#", "0"),
-				),
+				Check:  testAccAWSSecretBackendRoleCheckBasicAttributes(name, backend),
 			},
 			{
 				ResourceName:      "vault_aws_secret_backend_role.test_policy_inline",
@@ -176,6 +84,11 @@ func TestAccAWSSecretBackendRole_import(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				ResourceName:      "vault_aws_secret_backend_role.test_iam_user_type_optional_attributes",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -191,51 +104,11 @@ func TestAccAWSSecretBackendRole_nested(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSecretBackendRoleConfig_basic(name, backend, accessKey, secretKey),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", fmt.Sprintf("%s-policy-inline", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
-					testutil.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy_document", testAccAWSSecretBackendRolePolicyInline_basic),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "name", fmt.Sprintf("%s-policy-arn", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "policy_arns.#", "1"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "policy_arns.0", testAccAWSSecretBackendRolePolicyArn_basic),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "name", fmt.Sprintf("%s-policy-inline-and-arns", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "backend", backend),
-					testutil.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline_and_arns", "policy_document", testAccAWSSecretBackendRolePolicyInline_basic),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "policy_arns.#", "1"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "policy_arns.0", testAccAWSSecretBackendRolePolicyArn_basic),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "name", fmt.Sprintf("%s-role-arns", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "role_arns.0", testAccAWSSecretBackendRoleRoleArn_basic),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "policy_arns.#", "0"),
-				),
+				Check:  testAccAWSSecretBackendRoleCheckBasicAttributes(name, backend),
 			},
 			{
 				Config: testAccAWSSecretBackendRoleConfig_updated(name, backend, accessKey, secretKey),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", fmt.Sprintf("%s-policy-inline", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "default_sts_ttl", "3600"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "max_sts_ttl", "21600"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "iam_groups.#", "2"),
-					testutil.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy_document", testAccAWSSecretBackendRolePolicyInline_updated),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "name", fmt.Sprintf("%s-policy-arn", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "policy_arns.#", "1"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "policy_arns.0", testAccAWSSecretBackendRolePolicyArn_updated),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "iam_groups.#", "2"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "name", fmt.Sprintf("%s-policy-inline-and-arns", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "backend", backend),
-					testutil.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline_and_arns", "policy_document", testAccAWSSecretBackendRolePolicyInline_updated),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "policy_arns.#", "1"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "policy_arns.0", testAccAWSSecretBackendRolePolicyArn_updated),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "iam_groups.#", "2"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "name", fmt.Sprintf("%s-role-arns", name)),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "backend", backend),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "role_arns.0", testAccAWSSecretBackendRoleRoleArn_updated),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "iam_groups.#", "2"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "policy_arns.#", "0"),
-				),
+				Check:  testAccAWSSecretBackendRoleCheckUpdatedAttributes(name, backend),
 			},
 		},
 	})
@@ -259,27 +132,105 @@ func testAccAWSSecretBackendRoleCheckDestroy(s *terraform.State) error {
 	return nil
 }
 
+func testAccAWSSecretBackendRoleCheckBasicAttributes(name, backend string) resource.TestCheckFunc {
+	return resource.ComposeTestCheckFunc(
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", fmt.Sprintf("%s-policy-inline", name)),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
+		testutil.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy_document", testAccAWSSecretBackendRolePolicyInline_basic),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "iam_groups.#", "0"),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "name", fmt.Sprintf("%s-policy-arn", name)),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "backend", backend),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "policy_arns.#", "1"),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "policy_arns.0", testAccAWSSecretBackendRolePolicyArn_basic),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "name", fmt.Sprintf("%s-policy-inline-and-arns", name)),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "backend", backend),
+		testutil.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline_and_arns", "policy_document", testAccAWSSecretBackendRolePolicyInline_basic),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "policy_arns.#", "1"),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "policy_arns.0", testAccAWSSecretBackendRolePolicyArn_basic),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "name", fmt.Sprintf("%s-role-arns", name)),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "backend", backend),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "role_arns.0", testAccAWSSecretBackendRoleRoleArn_basic),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "role_arns.#", "1"),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_to_arn", "name", fmt.Sprintf("%s-policy-inline-to-arn", name)),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_to_arn", "backend", backend),
+		testutil.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline_to_arn", "policy_document", testAccAWSSecretBackendRolePolicyInline_basic),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_iam_user_type_optional_attributes", "name", fmt.Sprintf("%s-iam-user-type-optional-attributes", name)),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_iam_user_type_optional_attributes", "backend", backend),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_iam_user_type_optional_attributes", "policy_arns.#", "1"),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_iam_user_type_optional_attributes", "policy_arns.0", testAccAWSSecretBackendRolePolicyArn_basic),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_iam_user_type_optional_attributes", "permissions_boundary_arn", testAccAWSSecretBackendRolePermissionsBoundaryArn_basic),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_iam_user_type_optional_attributes", "user_path", testAccAWSSecretBackendRoleIamUserPath_basic),
+	)
+}
+
+func testAccAWSSecretBackendRoleCheckUpdatedAttributes(name, backend string) resource.TestCheckFunc {
+	return resource.ComposeTestCheckFunc(
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", fmt.Sprintf("%s-policy-inline", name)),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "default_sts_ttl", "3600"),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "max_sts_ttl", "21600"),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "iam_groups.#", "2"),
+		testutil.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy_document", testAccAWSSecretBackendRolePolicyInline_updated),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "name", fmt.Sprintf("%s-policy-arn", name)),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "backend", backend),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "policy_arns.#", "1"),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "policy_arns.0", testAccAWSSecretBackendRolePolicyArn_updated),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "iam_groups.#", "2"),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "name", fmt.Sprintf("%s-policy-inline-and-arns", name)),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "backend", backend),
+		testutil.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline_and_arns", "policy_document", testAccAWSSecretBackendRolePolicyInline_updated),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "policy_arns.#", "1"),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "policy_arns.0", testAccAWSSecretBackendRolePolicyArn_updated),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "iam_groups.#", "2"),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "name", fmt.Sprintf("%s-role-arns", name)),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "backend", backend),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "role_arns.#", "1"),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "role_arns.0", testAccAWSSecretBackendRoleRoleArn_updated),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "iam_groups.#", "2"),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_to_arn", "name", fmt.Sprintf("%s-policy-inline-to-arn", name)),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_to_arn", "backend", backend),
+		testutil.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline_to_arn", "policy_document", ""),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_to_arn", "policy_arns.#", "1"),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_to_arn", "policy_arns.0", testAccAWSSecretBackendRolePolicyArn_updated),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_iam_user_type_optional_attributes", "name", fmt.Sprintf("%s-iam-user-type-optional-attributes", name)),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_iam_user_type_optional_attributes", "backend", backend),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_iam_user_type_optional_attributes", "policy_arns.#", "1"),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_iam_user_type_optional_attributes", "policy_arns.0", testAccAWSSecretBackendRolePolicyArn_updated),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_iam_user_type_optional_attributes", "permissions_boundary_arn", testAccAWSSecretBackendRolePermissionsBoundaryArn_updated),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_iam_user_type_optional_attributes", "user_path", testAccAWSSecretBackendRoleIamUserPath_updated),
+	)
+}
+
 func testAccAWSSecretBackendRoleConfig_basic(name, path, accessKey, secretKey string) string {
-	return fmt.Sprintf(`
+	resources := []string{
+
+		fmt.Sprintf(`
 resource "vault_aws_secret_backend" "test" {
   path = "%s"
   access_key = "%s"
   secret_key = "%s"
 }
+`, path, accessKey, secretKey),
 
+		fmt.Sprintf(`
 resource "vault_aws_secret_backend_role" "test_policy_inline" {
   name = "%s-policy-inline"
   policy_document = %q
   credential_type = "assumed_role"
   backend = vault_aws_secret_backend.test.path
 }
+`, name, testAccAWSSecretBackendRolePolicyInline_basic),
 
+		fmt.Sprintf(`
 resource "vault_aws_secret_backend_role" "test_policy_arns" {
   name = "%s-policy-arn"
   policy_arns = ["%s"]
   credential_type = "iam_user"
   backend = vault_aws_secret_backend.test.path
 }
+`, name, testAccAWSSecretBackendRolePolicyArn_basic),
+
+		fmt.Sprintf(`
 
 resource "vault_aws_secret_backend_role" "test_policy_inline_and_arns" {
   name = "%s-policy-inline-and-arns"
@@ -288,31 +239,53 @@ resource "vault_aws_secret_backend_role" "test_policy_inline_and_arns" {
   credential_type = "iam_user"
   backend = vault_aws_secret_backend.test.path
 }
+`, name, testAccAWSSecretBackendRolePolicyInline_basic, testAccAWSSecretBackendRolePolicyArn_basic),
+
+		fmt.Sprintf(`
 
 resource "vault_aws_secret_backend_role" "test_role_arns" {
-	name = "%s-role-arns"
-	role_arns = ["%s"]
-	credential_type = "assumed_role"
-	backend = vault_aws_secret_backend.test.path
+  name = "%s-role-arns"
+  role_arns = ["%s"]
+  credential_type = "assumed_role"
+  backend = vault_aws_secret_backend.test.path
 }
+`, name, testAccAWSSecretBackendRoleRoleArn_basic),
 
+		fmt.Sprintf(`
 resource "vault_aws_secret_backend_role" "test_policy_inline_to_arn" {
   name = "%s-policy-inline-to-arn"
   policy_document = %q
   credential_type = "assumed_role"
   backend = vault_aws_secret_backend.test.path
 }
-`, path, accessKey, secretKey, name, testAccAWSSecretBackendRolePolicyInline_basic, name, testAccAWSSecretBackendRolePolicyArn_basic, name, testAccAWSSecretBackendRolePolicyInline_basic, testAccAWSSecretBackendRolePolicyArn_basic, name, testAccAWSSecretBackendRoleRoleArn_basic, name, testAccAWSSecretBackendRolePolicyInline_basic)
+`, name, testAccAWSSecretBackendRolePolicyInline_basic),
+
+		fmt.Sprintf(`
+resource "vault_aws_secret_backend_role" "test_iam_user_type_optional_attributes" {
+  name = "%s-iam-user-type-optional-attributes"
+  policy_arns = ["%s"]
+  credential_type = "iam_user"
+  backend = vault_aws_secret_backend.test.path
+  permissions_boundary_arn = "%s"
+  user_path = "%s"
+}
+`, name, testAccAWSSecretBackendRolePolicyArn_basic, testAccAWSSecretBackendRolePermissionsBoundaryArn_basic, testAccAWSSecretBackendRoleIamUserPath_basic),
+	}
+
+	return strings.Join(resources, "\n")
 }
 
 func testAccAWSSecretBackendRoleConfig_updated(name, path, accessKey, secretKey string) string {
-	return fmt.Sprintf(`
+	resources := []string{
+		fmt.Sprintf(`
 resource "vault_aws_secret_backend" "test" {
   path = "%s"
   access_key = "%s"
   secret_key = "%s"
 }
+`, path, accessKey, secretKey),
 
+		fmt.Sprintf(`
 resource "vault_aws_secret_backend_role" "test_policy_inline" {
   name = "%s-policy-inline"
   policy_document = %q
@@ -322,7 +295,9 @@ resource "vault_aws_secret_backend_role" "test_policy_inline" {
   max_sts_ttl = 21600
   iam_groups = ["group1", "group2"]
 }
+`, name, testAccAWSSecretBackendRolePolicyInline_updated),
 
+		fmt.Sprintf(`
 resource "vault_aws_secret_backend_role" "test_policy_arns" {
   name = "%s-policy-arn"
   policy_arns = ["%s"]
@@ -330,7 +305,9 @@ resource "vault_aws_secret_backend_role" "test_policy_arns" {
   iam_groups = ["group1", "group2"]
   backend = vault_aws_secret_backend.test.path
 }
+`, name, testAccAWSSecretBackendRolePolicyArn_updated),
 
+		fmt.Sprintf(`
 resource "vault_aws_secret_backend_role" "test_policy_inline_and_arns" {
   name = "%s-policy-inline-and-arns"
   policy_document = %q
@@ -339,27 +316,46 @@ resource "vault_aws_secret_backend_role" "test_policy_inline_and_arns" {
   iam_groups = ["group1", "group2"]
   backend = vault_aws_secret_backend.test.path
 }
+`, name, testAccAWSSecretBackendRolePolicyInline_updated, testAccAWSSecretBackendRolePolicyArn_updated),
 
+		fmt.Sprintf(`
 resource "vault_aws_secret_backend_role" "test_role_arns" {
-	name = "%s-role-arns"
-	role_arns = ["%s"]
-	credential_type = "assumed_role"
-	iam_groups = ["group1", "group2"]
-	backend = vault_aws_secret_backend.test.path
+    name = "%s-role-arns"
+    role_arns = ["%s"]
+    credential_type = "assumed_role"
+    iam_groups = ["group1", "group2"]
+    backend = vault_aws_secret_backend.test.path
 }
+`, name, testAccAWSSecretBackendRoleRoleArn_updated),
 
+		fmt.Sprintf(`
 resource "vault_aws_secret_backend_role" "test_role_groups" {
-	name = "%s-role-groups"
-	credential_type = "assumed_role"
-	iam_groups = ["group1", "group2"]
-	backend = vault_aws_secret_backend.test.path
+    name = "%s-role-groups"
+    credential_type = "assumed_role"
+    iam_groups = ["group1", "group2"]
+    backend = vault_aws_secret_backend.test.path
 }
+`, name),
 
+		fmt.Sprintf(`
 resource "vault_aws_secret_backend_role" "test_policy_inline_to_arn" {
   name = "%s-policy-inline-to-arn"
   policy_arns = ["%s"]
   credential_type = "assumed_role"
   backend = vault_aws_secret_backend.test.path
 }
-`, path, accessKey, secretKey, name, testAccAWSSecretBackendRolePolicyInline_updated, name, testAccAWSSecretBackendRolePolicyArn_updated, name, testAccAWSSecretBackendRolePolicyInline_updated, testAccAWSSecretBackendRolePolicyArn_updated, name, testAccAWSSecretBackendRoleRoleArn_updated, name, name, testAccAWSSecretBackendRolePolicyArn_updated)
+`, name, testAccAWSSecretBackendRolePolicyArn_updated),
+
+		fmt.Sprintf(`
+resource "vault_aws_secret_backend_role" "test_iam_user_type_optional_attributes" {
+  name = "%s-iam-user-type-optional-attributes"
+  policy_arns = ["%s"]
+  credential_type = "iam_user"
+  backend = vault_aws_secret_backend.test.path
+  permissions_boundary_arn = "%s"
+  user_path = "%s"
+}
+`, name, testAccAWSSecretBackendRolePolicyArn_updated, testAccAWSSecretBackendRolePermissionsBoundaryArn_updated, testAccAWSSecretBackendRoleIamUserPath_updated),
+	}
+	return strings.Join(resources, "\n")
 }

--- a/website/docs/r/aws_secret_backend_role.html.md
+++ b/website/docs/r/aws_secret_backend_role.html.md
@@ -95,6 +95,14 @@ The following arguments are supported:
   (credentials TTL are capped to `max_sts_ttl`). Valid only when `credential_type` is
   one of `assumed_role` or `federation_token`.
 
+* `user_path` - (Optional) The path for the user name. Valid only when 
+`credential_type` is `iam_user`. Default is `/`.
+
+* `permissions_boundary_arn` - (Optional) The ARN of the AWS Permissions 
+Boundary to attach to IAM users created in the role. Valid only when 
+`credential_type` is `iam_user`. If not specified, then no permissions boundary 
+policy will be attached.
+
 ## Attributes Reference
 
 No additional attributes are exported by this resource.


### PR DESCRIPTION
 I modified the aws_secret_backend_role resource to accept the user_path and permissions_boundary_arn arguments.  I updated the resource's tests to account for the new arguments and consolidated some duplicate code in the tests into functions.  I also removed the tests' dependency on AWS credentials because Vault doesn't interact with AWS during CRUD operations on the backend role.  It will now be easier to run the tests on the aws_secret_backend_role resource.

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #716, #769 

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add `user_path` and `permissions_boundary_arn` fields to `aws_secret_backend_role`.
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSSecretBackendRole'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccAWSSecretBackendRole -timeout 120m
?       github.com/terraform-providers/terraform-provider-vault [no test files]
?       github.com/terraform-providers/terraform-provider-vault/cmd/coverage    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/util    0.023s [no tests to run]
=== RUN   TestAccAWSSecretBackendRole_basic
--- PASS: TestAccAWSSecretBackendRole_basic (0.27s)
=== RUN   TestAccAWSSecretBackendRole_import
--- PASS: TestAccAWSSecretBackendRole_import (0.23s)
=== RUN   TestAccAWSSecretBackendRole_nested
--- PASS: TestAccAWSSecretBackendRole_nested (0.25s)
PASS
ok      github.com/terraform-providers/terraform-provider-vault/vault   0.772s
...
```
