### PR TITLE
Update pki_secret_backend_role to allow key_type "any"

### DIFF
--- a/vault/resource_pki_secret_backend_role.go
+++ b/vault/resource_pki_secret_backend_role.go
@@ -175,7 +175,7 @@ func pkiSecretBackendRoleResource() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     false,
 				Optional:     true,
-				Description:  "The type of generated keys.",
+				Description:  "The generated key type.",
 				ValidateFunc: validation.StringInSlice([]string{"rsa", "ec", "ed25519", "any"}, false),
 				Default:      "rsa",
 			},

--- a/vault/resource_pki_secret_backend_role.go
+++ b/vault/resource_pki_secret_backend_role.go
@@ -176,7 +176,7 @@ func pkiSecretBackendRoleResource() *schema.Resource {
 				Required:     false,
 				Optional:     true,
 				Description:  "The type of generated keys.",
-				ValidateFunc: validation.StringInSlice([]string{"rsa", "ec", "ed25519"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"rsa", "ec", "ed25519", "any"}, false),
 				Default:      "rsa",
 			},
 			"key_bits": {

--- a/website/docs/r/pki_secret_backend_role.html.md
+++ b/website/docs/r/pki_secret_backend_role.html.md
@@ -74,7 +74,8 @@ The following arguments are supported:
 
 * `email_protection_flag` - (Optional) Flag to specify certificates for email protection use
 
-* `key_type` - (Optional) The type of generated keys, one of ["rsa" (default), "ec", "ed25519", "any"]
+* `key_type` - (Optional) The generated key type, choices: `rsa`, `ec`, `ed25519`, `any`  
+  Defaults to `rsa`
 
 * `key_bits` - (Optional) The number of bits of generated keys
 

--- a/website/docs/r/pki_secret_backend_role.html.md
+++ b/website/docs/r/pki_secret_backend_role.html.md
@@ -74,7 +74,7 @@ The following arguments are supported:
 
 * `email_protection_flag` - (Optional) Flag to specify certificates for email protection use
 
-* `key_type` - (Optional) The type of generated keys
+* `key_type` - (Optional) The type of generated keys, one of ["rsa" (default), "ec", "ed25519", "any"]
 
 * `key_bits` - (Optional) The number of bits of generated keys
 


### PR DESCRIPTION
This PR updates the `vault_pki_secret_backend_role` to allow `any` as `key_type`. It permits issuing certificates with private keys other than `ec` or `rsa` from CSRs.

Relevant vault docs specifying this feature: https://www.vaultproject.io/api-docs/secret/pki#key_type-1
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
vault_pki_secret_backend_role: Allow key_type "any" for pki roles.
```
