### PR TITLE
database_secret_backend_connection: use data in example

### DIFF
--- a/website/docs/r/database_secret_backend_connection.md
+++ b/website/docs/r/database_secret_backend_connection.md
@@ -32,7 +32,13 @@ resource "vault_database_secret_backend_connection" "postgres" {
   allowed_roles = ["dev", "prod"]
 
   postgresql {
-    connection_url = "postgres://username:password@host:port/database"
+    connection_url = "postgres://{{username}}:{{password}}@host:port/database"
+  }
+
+  # persisted in state but hidden in plan/apply output
+  data = {
+    username = "user"
+    password = "secret"
   }
 }
 ```


### PR DESCRIPTION
This PR emphasizes the use of the `data` attribute to substitute sensitive values. Since the example has a password in the `connection_url`, a reader might reasonably assume that it is a sensitive attribute and would be hidden in `terraform plan` and `terraform apply` output. This revises the example to make it clearer to users that they probably want to use `data`.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates to #281

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`vault_database_secret_backend_connection`: Revise example configuration in docs to avoid leaking a password in plan/apply output
```