### PR TITLE
docs: Add Accessor Attribute for jwt_auth_backend

### DIFF
--- a/website/docs/r/jwt_auth_backend.html.md
+++ b/website/docs/r/jwt_auth_backend.html.md
@@ -103,4 +103,6 @@ The `tune` block is used to tune the auth backend:
 
 ## Attributes Reference
 
-No additional attributes are exposed by this resource.
+In addition to the fields above, the following attributes are exported:
+
+* `accessor` - The accessor for this auth method


### PR DESCRIPTION
- The `accessor` attribute missing from the jwt_auth_backend documentation, but
  is available on the jwt_auth_backend resource
- The `accessor` attribute is required when creating a vault_identity_group_alias

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Couldn't find any related issues for this PR.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`vault_jwt_auth_backend` - document `accessor` attribute
```

Very minor docs change; No acceptance tests.
