### PR TITLE
[WIP] Creating data source for vault_policy

### DIFF
--- a/vault/data_source_policy.go
+++ b/vault/data_source_policy.go
@@ -1,0 +1,54 @@
+package vault
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/vault/api"
+)
+
+func policyDataSource() *schema.Resource {
+	return &schema.Resource{
+		Read: policyDataSourceRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the policy",
+			},
+
+			"policy": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The policy document",
+			},
+		},
+	}
+}
+
+func policyDataSourceRead (d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	targetPolicy := d.Get("name").(string)
+
+	policies, err := client.Sys().ListPolicies()
+	if err != nil {
+		return fmt.Errorf("error listing policies from Vault: %s", err)
+	}
+
+	for _, policyName := range policies {
+		if policyName == targetPolicy {
+			policy, err := client.Sys().GetPolicy(policyName)
+			if err != nil {
+				return fmt.Errorf("error reading policy %s from Vault: %s", policyName, err)
+			}
+
+			d.Set("name", policyName)
+			d.Set("policy", policy)
+			return nil
+		}
+	}
+
+	// If we fell out here then we didn't find our policy in the list.
+	return nil
+}

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -240,6 +240,10 @@ var (
 			Resource:      genericSecretDataSource(),
 			PathInventory: []string{"/secret/data/{path}"},
 		},
+		"vault_policy": {
+			Resource:      policyDataSource(),
+			PathInventory: []string{"/sys/policy/{name}"},
+		},
 		"vault_policy_document": {
 			Resource:      policyDocumentDataSource(),
 			PathInventory: []string{"/sys/policy/{name}"},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->
This PR creates a data source for the `vault_policy` resource. An use case is when you need to validate if a given policy exists (for example, if this policy is not defined in the current workspace or were mannually created).

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
<!--- Relates OR Closes #0000 --->

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`vault_policy`: Created data source to get Vault policies
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
