### PR TITLE
add flag for all version deletion

### DIFF
--- a/vault/import_generic_secret_test.go
+++ b/vault/import_generic_secret_test.go
@@ -18,9 +18,10 @@ func TestAccGenericSecret_importBasic(t *testing.T) {
 				Check:  testResourceGenericSecret_initialCheck(path),
 			},
 			{
-				ResourceName:      "vault_generic_secret.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "vault_generic_secret.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"delete_all_versions"},
 			},
 		},
 	})

--- a/vault/resource_generic_secret.go
+++ b/vault/resource_generic_secret.go
@@ -65,7 +65,7 @@ func genericSecretResource() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
-				Description: "Only applicable for kv-v2 stores.  if set to true, permanently delete all versions of the secret.  If set to false, only the most recent secret version is deleted.",
+				Description: "Only applicable for kv-v2 stores.  If set to true, permanently delete all versions of the secret.  If set to false, only the most recent secret version is deleted.",
 			},
 			"data": {
 				Type:        schema.TypeMap,

--- a/vault/resource_generic_secret.go
+++ b/vault/resource_generic_secret.go
@@ -61,6 +61,12 @@ func genericSecretResource() *schema.Resource {
 				Description: "Don't attempt to read the token from Vault if true; drift won't be detected.",
 			},
 
+			"delete_all_versions": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Only applicable for kv-v2 stores.  if set to true, permanently delete all versions of the secret.  If set to false, only the most recent secret version is deleted.",
+			},
 			"data": {
 				Type:        schema.TypeMap,
 				Computed:    true,
@@ -149,7 +155,12 @@ func genericSecretResourceDelete(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if v2 {
-		path = addPrefixToVKVPath(path, mountPath, "data")
+		deleteAllVersions := d.Get("delete_all_versions").(bool)
+		if deleteAllVersions {
+			path = addPrefixToVKVPath(path, mountPath, "metadata")
+		} else {
+			path = addPrefixToVKVPath(path, mountPath, "data")
+		}
 	}
 
 	log.Printf("[DEBUG] Deleting vault_generic_secret from %q", path)

--- a/vault/resource_generic_secret_test.go
+++ b/vault/resource_generic_secret_test.go
@@ -194,7 +194,7 @@ func testResourceGenericSecret_kvV2_initialCheck(expectedPath string) resource.T
 		keys := secretList.Data["keys"].([]interface{})
 		secret, err := client.Logical().Read(fmt.Sprintf("secretsv2/data/%s", keys[0]))
 		if secret == nil {
-			return fmt.Errorf("The secret is NIL!: %v", secret)
+			return fmt.Errorf("no kv-v2 secret, expected one.")
 		}
 		// Test the JSON.  Kv-v2 data is nested one level deeper than kv-v1.
 		nestedData := secret.Data["data"].(map[string]interface{})

--- a/website/docs/r/generic_secret.html.md
+++ b/website/docs/r/generic_secret.html.md
@@ -62,6 +62,10 @@ The following arguments are supported:
   authentication is not able to read the data. Setting this to `true` will
   break drift detection. Defaults to false.
 
+* `delete_all_versions` - (Optional) True/false.  Only applicable for kv-v2 stores.
+  Set this to `true` if you want vault to permanently delete all versions of secret.  By
+  default, only the last secret version will be removed.  Defaults to false. 
+
 ## Required Vault Capabilities
 
 Use of this resource requires the `create` or `update` capability


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes https://github.com/terraform-providers/terraform-provider-vault/issues/760

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add `delete_all_versions` flag to `vault_generic_secret` resource to allow Terraform to delete all versions of a kv-v2 secret so that the entire secret is removed from Vault.
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
