### PR TITLE
Allow client_id to be configured on vault_identity_oidc_role resources

### DIFF
--- a/vault/resource_identity_oidc_role.go
+++ b/vault/resource_identity_oidc_role.go
@@ -53,6 +53,7 @@ func identityOidcRole() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "The value that will be included in the `aud` field of all the OIDC identity tokens issued by this role",
 				Computed:    true,
+				Optional:    true,
 			},
 		},
 	}
@@ -60,6 +61,7 @@ func identityOidcRole() *schema.Resource {
 
 func identityOidcRoleUpdateFields(d *schema.ResourceData, data map[string]interface{}) {
 	data["key"] = d.Get("key").(string)
+	data["client_id"] = d.Get("client_id").(string)
 	data["template"] = d.Get("template").(string)
 	data["ttl"] = d.Get("ttl").(int)
 }

--- a/website/docs/r/identity_oidc_role.html.md
+++ b/website/docs/r/identity_oidc_role.html.md
@@ -90,14 +90,14 @@ The following arguments are supported:
 
 * `ttl` - (Optional) TTL of the tokens generated against the role in number of seconds.
 
+* `client_id` - (Optional) The value that will be included in the `aud` field of all the OIDC identity
+  tokens issued by this role
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The name of the created role.
-
-* `client_id` - The value that will be included in the `aud` field of all the OIDC identity
-  tokens issued by this role
 
 ## Import
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

### Allow client_id to be configured on vault_identity_oidc_role resources

[Vault v1.4.0](https://github.com/hashicorp/vault/blob/master/CHANGELOG.md#140-april-7th-2020) added support for configuring the `client_id` of OIDC Identity Roles (via https://github.com/hashicorp/vault/pull/8165)

This pull request adds support to the `vault_identity_oidc_role` resource for configuring the `client_id` parameter now supported by Vault v1.4.0+

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md): 

```release-note
* resource/vault_identity_oidc_role: `client_id` parameter can optionally be configured ([#815](https://github.com/terraform-providers/terraform-provider-vault/pull/815)).
```

#### Output from acceptance testing:

- existing integration test with no client_id set to help ensure backwards compatibility was maintained
- integration test with a configured client_id was added
- added client_id update to the existing integration test of updating the resource

```
> make testacc TESTARGS='-run TestAccIdentityOidcRole.*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccIdentityOidcRole.* -timeout 120m
?       github.com/terraform-providers/terraform-provider-vault [no test files]
?       github.com/terraform-providers/terraform-provider-vault/cmd/coverage    [no test files]
?       github.com/terraform-providers/terraform-provider-vault/cmd/generate    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/codegen 0.025s [no tests to run]
?       github.com/terraform-providers/terraform-provider-vault/generated       [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/generated/datasources/transform/decode  0.037s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/generated/datasources/transform/encode  0.037s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/alphabet  0.037s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/role      0.106s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/template  0.036s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/transformation    0.031s [no tests to run]
?       github.com/terraform-providers/terraform-provider-vault/schema  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/util    0.037s [no tests to run]
=== RUN   TestAccIdentityOidcRole
--- PASS: TestAccIdentityOidcRole (0.60s)
=== RUN   TestAccIdentityOidcRoleWithClientId
--- PASS: TestAccIdentityOidcRoleWithClientId (0.40s)
=== RUN   TestAccIdentityOidcRoleUpdate
--- PASS: TestAccIdentityOidcRoleUpdate (0.46s)
PASS
ok      github.com/terraform-providers/terraform-provider-vault/vault   1.490s
```
