### PR TITLE
Mark expiration and serial_number fields as computed during certificate auto_renew

### DIFF
--- a/vault/resource_pki_secret_backend_cert.go
+++ b/vault/resource_pki_secret_backend_cert.go
@@ -243,6 +243,12 @@ func pkiSecretBackendCertDiff(d *schema.ResourceDiff, meta interface{}) error {
 		if err := d.SetNewComputed("private_key"); err != nil {
 			return err
 		}
+		if err := d.SetNewComputed("expiration"); err != nil {
+			return err
+		}
+		if err := d.SetNewComputed("serial_number"); err != nil {
+			return err
+		}
 		return nil
 	}
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #0353
Closes #0835

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Mark expiration and serial number fields as computed change when auto_renew is triggered.
```
