### PR TITLE
feat: support tls_ca and tls_certificate_key for mongodb connections

### DIFF
--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -518,8 +518,11 @@ func setDatabaseConnectionData(d *schema.ResourceData, prefix string, data map[s
 	if v, ok := d.GetOkExists(prefix + "max_connection_lifetime"); ok {
 		data["max_connection_lifetime"] = fmt.Sprintf("%ds", v)
 	}
-	if v, ok := d.GetOkExists(prefix + "tls_ca"); ok {
+	if v, ok := d.GetOk(prefix + "tls_ca"); ok {
 		data["tls_ca"] = v.(string)
+	}
+	if v, ok := d.GetOk(prefix + "tls_certificate_key"); ok {
+		data["tls_certificate_key"] = v.(string)
 	}
 }
 

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -173,6 +173,17 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				Description: "Connection parameters for the mongodb-database-plugin plugin.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"username": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The username to use when authenticating with Cassandra.",
+						},
+						"password": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "The password to use when authenticating with Cassandra.",
+							Sensitive:   true,
+						},
 						"connection_url": {
 							Type:        schema.TypeString,
 							Optional:    true,
@@ -403,6 +414,12 @@ func getDatabaseAPIData(d *schema.ResourceData) (map[string]interface{}, error) 
 		setDatabaseConnectionData(d, "hana.0.", data)
 	case "mongodb-database-plugin":
 		setDatabaseConnectionData(d, "mongodb.0.", data)
+		if v, ok := d.GetOk("mongodb.0.username"); ok {
+			data["username"] = v.(string)
+		}
+		if v, ok := d.GetOk("mongodb.0.password"); ok {
+			data["password"] = v.(string)
+		}
 		if v, ok := d.GetOk("mongodb.0.tls_ca"); ok {
 			data["tls_ca"] = v.(string)
 		}
@@ -473,6 +490,13 @@ func getConnectionDetailsFromResponse(d *schema.ResourceData, prefix string, res
 	}
 	if v, ok := data["tls_certificate_key"]; ok {
 		result["tls_certificate_key"] = v.(string)
+	}
+
+	if v, ok := data["username"]; ok {
+		result["username"] = v.(string)
+	}
+	if v, ok := data["password"]; ok {
+		result["password"] = v.(string)
 	}
 	return []map[string]interface{}{result}
 }

--- a/website/docs/r/database_secret_backend_connection.md
+++ b/website/docs/r/database_secret_backend_connection.md
@@ -112,6 +112,10 @@ Exactly one of the nested blocks of configuration options must be supplied.
   docs](https://www.vaultproject.io/api-docs/secret/databases/mongodb.html#sample-payload)
   for an example.
 
+* `tls_ca` - (Optional) A x509 CA file for validating the certificate presented by the MongoDB server. Must be PEM encoded.
+
+* `tls_certificate_key` - (Optional) A x509 certificate for conneting to the database. This must be a PEM encoded version of the private key and certificate combined.
+
 ### SAP HanaDB Configuration Options
 
 * `connection_url` - (Required) A URL containing connection information. See


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Add TLS options to MongoDB database connection to allow verification of certificate as well as client auth. This is in line with the CLI options .

```release-note

Add `tls_ca` and `tls_certificate_key` fields to `vault_database_secret_backend_connection` for `mongodb` connections. 

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

- WIP
...
```
