### PR TITLE
database_secret_backend_connection: add redshift support

### DIFF
--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -16,7 +16,7 @@ import (
 var (
 	databaseSecretBackendConnectionBackendFromPathRegex = regexp.MustCompile("^(.+)/config/.+$")
 	databaseSecretBackendConnectionNameFromPathRegex    = regexp.MustCompile("^.+/config/(.+$)")
-	dbBackendTypes                                      = []string{"cassandra", "hana", "mongodb", "mssql", "mysql", "mysql_rds", "mysql_aurora", "mysql_legacy", "postgresql", "oracle", "elasticsearch"}
+	dbBackendTypes                                      = []string{"cassandra", "hana", "mongodb", "mssql", "mysql", "mysql_rds", "mysql_aurora", "mysql_legacy", "postgresql", "redshift", "oracle", "elasticsearch"}
 )
 
 func databaseSecretBackendConnectionResource() *schema.Resource {
@@ -236,6 +236,15 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				ConflictsWith: util.CalculateConflictsWith("postgresql", dbBackendTypes),
 			},
 
+			"redshift": {
+				Type:          schema.TypeList,
+				Optional:      true,
+				Description:   "Connection parameters for the redshift-database-plugin plugin.",
+				Elem:          connectionStringResource(),
+				MaxItems:      1,
+				ConflictsWith: util.CalculateConflictsWith("redshift", dbBackendTypes),
+			},
+
 			"oracle": {
 				Type:          schema.TypeList,
 				Optional:      true,
@@ -309,6 +318,8 @@ func getDatabasePluginName(d *schema.ResourceData) (string, error) {
 		return "oracle-database-plugin", nil
 	case len(d.Get("postgresql").([]interface{})) > 0:
 		return "postgresql-database-plugin", nil
+	case len(d.Get("redshift").([]interface{})) > 0:
+		return "redshift-database-plugin", nil
 	case len(d.Get("elasticsearch").([]interface{})) > 0:
 		return "elasticsearch-database-plugin", nil
 	default:
@@ -383,6 +394,8 @@ func getDatabaseAPIData(d *schema.ResourceData) (map[string]interface{}, error) 
 		setDatabaseConnectionData(d, "oracle.0.", data)
 	case "postgresql-database-plugin":
 		setDatabaseConnectionData(d, "postgresql.0.", data)
+	case "redshift-database-plugin":
+		setDatabaseConnectionData(d, "redshift.0.", data)
 	case "elasticsearch-database-plugin":
 		setElasticsearchDatabaseConnectionData(d, "elasticsearch.0.", data)
 	}
@@ -638,6 +651,8 @@ func databaseSecretBackendConnectionRead(d *schema.ResourceData, meta interface{
 		d.Set("oracle", getConnectionDetailsFromResponse(d, "oracle.0.", resp))
 	case "postgresql-database-plugin":
 		d.Set("postgresql", getConnectionDetailsFromResponse(d, "postgresql.0.", resp))
+	case "redshift-database-plugin":
+		d.Set("redshift", getConnectionDetailsFromResponse(d, "redshift.0.", resp))
 	case "elasticsearch-database-plugin":
 		d.Set("elasticsearch", getElasticsearchConnectionDetailsFromResponse(d, "elasticsearch.0.", resp))
 	}

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -458,6 +458,39 @@ func TestAccDatabaseSecretBackendConnection_postgresql(t *testing.T) {
 	})
 }
 
+func TestAccDatabaseSecretBackendConnection_redshift(t *testing.T) {
+	connURL := os.Getenv("REDSHIFT_URL")
+	if connURL == "" {
+		t.Skip("REDSHIFT_URL not set")
+	}
+	backend := acctest.RandomWithPrefix("tf-test-db")
+	name := acctest.RandomWithPrefix("db")
+	resource.Test(t, resource.TestCase{
+		Providers:    testProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccDatabaseSecretBackendConnectionCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseSecretBackendConnectionConfig_redshift(name, backend, connURL),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "redshift.0.connection_url", connURL),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "redshift.0.max_open_connections", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "redshift.0.max_idle_connections", "0"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "redshift.0.max_connection_lifetime", "0"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDatabaseSecretBackendConnection_elasticsearch(t *testing.T) {
 	connURL := os.Getenv("ELASTIC_URL")
 	if connURL == "" {
@@ -765,6 +798,26 @@ resource "vault_database_secret_backend_connection" "test" {
   root_rotation_statements = ["FOOBAR"]
 
   postgresql {
+	  connection_url = "%s"
+  }
+}
+`, path, name, connURL)
+}
+
+func testAccDatabaseSecretBackendConnectionConfig_redshift(name, path, connURL string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "db" {
+  path = "%s"
+  type = "database"
+}
+
+resource "vault_database_secret_backend_connection" "test" {
+  backend = "${vault_mount.db.path}"
+  name = "%s"
+  allowed_roles = ["dev", "prod"]
+  root_rotation_statements = ["FOOBAR"]
+
+  redshift {
 	  connection_url = "%s"
   }
 }

--- a/website/docs/r/database_secret_backend_connection.md
+++ b/website/docs/r/database_secret_backend_connection.md
@@ -73,6 +73,8 @@ The following arguments are supported:
 
 * `postgresql` - (Optional) A nested block containing configuration options for PostgreSQL connections.
 
+* `redshift` - (Optional) A nested block containing configuration options for Redshift connections.
+
 * `oracle` - (Optional) A nested block containing configuration options for Oracle connections.
 
 * `elasticsearch` - (Optional) A nested block containing configuration options for Elasticsearch connections.
@@ -165,6 +167,22 @@ Exactly one of the nested blocks of configuration options must be supplied.
 * `connection_url` - (Required) A URL containing connection information. See
   the [Vault
   docs](https://www.vaultproject.io/api-docs/secret/databases/postgresql.html#sample-payload)
+  for an example.
+
+* `max_open_connections` - (Optional) The maximum number of open connections to
+  use.
+
+* `max_idle_connections` - (Optional) The maximum number of idle connections to
+  maintain.
+
+* `max_connection_lifetime` - (Optional) The maximum number of seconds to keep
+  a connection alive for.
+
+### Redshift Configuration Options
+
+* `connection_url` - (Required) A URL containing connection information. See
+  the [Vault
+  docs](https://www.vaultproject.io/api-docs/secret/databases/redshift.html#sample-payload)
   for an example.
 
 * `max_open_connections` - (Optional) The maximum number of open connections to


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

This PR adds support for the [Redshift database plugin](https://www.vaultproject.io/api-docs/secret/databases/redshift.html) to `vault_database_secret_backend_connection`. I've added corresponding acceptance tests and have included the passing output from running them against a local Vault server and an internet-accessible test cluster running in AWS. 

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #808

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`vault_database_secret_backend_connection`: add support for redshift-database-plugin
```

Output from acceptance testing:

```
$ export REDSHIFT_URL="postgres://test:$REDSHIFT_PASSWORD@$REDSHIFT_HOSTNAME:5439/dev"
$ make testacc TESTARGS='-run TestAccDatabaseSecretBackendConnection_redshift'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccDatabaseSecretBackendConnection_redshift -timeout 120m
?   	github.com/terraform-providers/terraform-provider-vault	[no test files]
?   	github.com/terraform-providers/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/terraform-providers/terraform-provider-vault/cmd/generate	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/codegen	(cached) [no tests to run]
?   	github.com/terraform-providers/terraform-provider-vault/generated	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/generated/datasources/transform/decode	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/generated/datasources/transform/encode	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/alphabet	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/role	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/template	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/transformation	(cached) [no tests to run]
?   	github.com/terraform-providers/terraform-provider-vault/schema	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/util	(cached) [no tests to run]
=== RUN   TestAccDatabaseSecretBackendConnection_redshift
--- PASS: TestAccDatabaseSecretBackendConnection_redshift (0.40s)
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/vault	0.731s
...
```
