### PR TITLE
Add missing common fields to vault_database_secret_backend_connection

### DIFF
--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -171,7 +171,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				Type:          schema.TypeList,
 				Optional:      true,
 				Description:   "Connection parameters for the mongodb-database-plugin plugin.",
-				Elem:          connectionStringResource(),
+				Elem:          databaseResource(),
 				MaxItems:      1,
 				ConflictsWith: util.CalculateConflictsWith("mongodb", dbBackendTypes),
 			},
@@ -208,7 +208,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				Type:          schema.TypeList,
 				Optional:      true,
 				Description:   "Connection parameters for the hana-database-plugin plugin.",
-				Elem:          connectionStringResource(),
+				Elem:          databaseResource(),
 				MaxItems:      1,
 				ConflictsWith: util.CalculateConflictsWith("hana", dbBackendTypes),
 			},
@@ -217,7 +217,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				Type:          schema.TypeList,
 				Optional:      true,
 				Description:   "Connection parameters for the mssql-database-plugin plugin.",
-				Elem:          connectionStringResource(),
+				Elem:          databaseResource(),
 				MaxItems:      1,
 				ConflictsWith: util.CalculateConflictsWith("mssql", dbBackendTypes),
 			},
@@ -226,7 +226,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				Type:          schema.TypeList,
 				Optional:      true,
 				Description:   "Connection parameters for the mysql-database-plugin plugin.",
-				Elem:          connectionStringResource(),
+				Elem:          databaseResource(),
 				MaxItems:      1,
 				ConflictsWith: util.CalculateConflictsWith("mysql", dbBackendTypes),
 			},
@@ -234,7 +234,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				Type:          schema.TypeList,
 				Optional:      true,
 				Description:   "Connection parameters for the mysql-rds-database-plugin plugin.",
-				Elem:          connectionStringResource(),
+				Elem:          databaseResource(),
 				MaxItems:      1,
 				ConflictsWith: util.CalculateConflictsWith("mysql_rds", dbBackendTypes),
 			},
@@ -242,7 +242,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				Type:          schema.TypeList,
 				Optional:      true,
 				Description:   "Connection parameters for the mysql-aurora-database-plugin plugin.",
-				Elem:          connectionStringResource(),
+				Elem:          databaseResource(),
 				MaxItems:      1,
 				ConflictsWith: util.CalculateConflictsWith("mysql_aurora", dbBackendTypes),
 			},
@@ -250,7 +250,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				Type:          schema.TypeList,
 				Optional:      true,
 				Description:   "Connection parameters for the mysql-legacy-database-plugin plugin.",
-				Elem:          connectionStringResource(),
+				Elem:          databaseResource(),
 				MaxItems:      1,
 				ConflictsWith: util.CalculateConflictsWith("mysql_legacy", dbBackendTypes),
 			},
@@ -259,7 +259,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				Type:          schema.TypeList,
 				Optional:      true,
 				Description:   "Connection parameters for the postgresql-database-plugin plugin.",
-				Elem:          connectionStringResource(),
+				Elem:          databaseResource(),
 				MaxItems:      1,
 				ConflictsWith: util.CalculateConflictsWith("postgresql", dbBackendTypes),
 			},
@@ -268,7 +268,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				Type:          schema.TypeList,
 				Optional:      true,
 				Description:   "Connection parameters for the oracle-database-plugin plugin.",
-				Elem:          connectionStringResource(),
+				Elem:          databaseResource(),
 				MaxItems:      1,
 				ConflictsWith: util.CalculateConflictsWith("oracle", dbBackendTypes),
 			},
@@ -287,7 +287,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 	}
 }
 
-func connectionStringResource() *schema.Resource {
+func databaseResource() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"connection_url": {
@@ -310,6 +310,17 @@ func connectionStringResource() *schema.Resource {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Description: "Maximum number of seconds a connection may be reused.",
+			},
+			"username": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The root credential username used in the connection URL.",
+			},
+			"password": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The root credential password used in the connection URL.",
+				Sensitive:   true,
 			},
 		},
 	}
@@ -468,6 +479,16 @@ func getConnectionDetailsFromResponse(d *schema.ResourceData, prefix string, res
 			result["max_connection_lifetime"] = n.Seconds()
 		}
 	}
+	if v, ok := data["username"]; ok {
+		result["username"] = v.(string)
+	}
+	if v, ok := data["password"]; ok {
+		result["password"] = v.(string)
+	} else if v, ok := d.GetOk(prefix + "password"); ok {
+		// keep the password we have in state/config if the API doesn't return one
+		result["password"] = v.(string)
+	}
+
 	return []map[string]interface{}{result}
 }
 
@@ -511,6 +532,12 @@ func setDatabaseConnectionData(d *schema.ResourceData, prefix string, data map[s
 	}
 	if v, ok := d.GetOkExists(prefix + "max_connection_lifetime"); ok {
 		data["max_connection_lifetime"] = fmt.Sprintf("%ds", v)
+	}
+	if v, ok := d.GetOk(prefix + "username"); ok {
+		data["username"] = v.(string)
+	}
+	if v, ok := d.GetOk(prefix + "password"); ok {
+		data["password"] = v.(string)
 	}
 }
 

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -19,6 +19,8 @@ func TestAccDatabaseSecretBackendConnection_import(t *testing.T) {
 	if connURL == "" {
 		t.Skip("POSTGRES_URL not set")
 	}
+	username := "postgres"
+	password := "postgres"
 	backend := acctest.RandomWithPrefix("tf-test-db")
 	name := acctest.RandomWithPrefix("db")
 	resource.Test(t, resource.TestCase{
@@ -27,7 +29,7 @@ func TestAccDatabaseSecretBackendConnection_import(t *testing.T) {
 		CheckDestroy: testAccDatabaseSecretBackendConnectionCheckDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatabaseSecretBackendConnectionConfig_postgresql(name, backend, connURL),
+				Config: testAccDatabaseSecretBackendConnectionConfig_postgresql(name, backend, connURL, username, password),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
 					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
@@ -40,14 +42,15 @@ func TestAccDatabaseSecretBackendConnection_import(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "postgresql.0.connection_url", connURL),
 					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "postgresql.0.max_open_connections", "2"),
 					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "postgresql.0.max_idle_connections", "0"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "postgresql.0.max_connection_lifetime", "0"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "postgresql.0.username", username),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "postgresql.0.password", password),
 				),
 			},
 			{
 				ResourceName:            "vault_database_secret_backend_connection.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"verify_connection", "postgresql.0.connection_url"},
+				ImportStateVerifyIgnore: []string{"verify_connection", "postgresql.0.connection_url", "postgresql.0.password"},
 			},
 		},
 	})
@@ -465,6 +468,8 @@ func TestAccDatabaseSecretBackendConnection_postgresql(t *testing.T) {
 	if connURL == "" {
 		t.Skip("POSTGRES_URL not set")
 	}
+	username := "postgres"
+	password := "postgres"
 	backend := acctest.RandomWithPrefix("tf-test-db")
 	name := acctest.RandomWithPrefix("db")
 	resource.Test(t, resource.TestCase{
@@ -473,7 +478,7 @@ func TestAccDatabaseSecretBackendConnection_postgresql(t *testing.T) {
 		CheckDestroy: testAccDatabaseSecretBackendConnectionCheckDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatabaseSecretBackendConnectionConfig_postgresql(name, backend, connURL),
+				Config: testAccDatabaseSecretBackendConnectionConfig_postgresql(name, backend, connURL, username, password),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
 					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
@@ -487,6 +492,8 @@ func TestAccDatabaseSecretBackendConnection_postgresql(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "postgresql.0.max_open_connections", "2"),
 					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "postgresql.0.max_idle_connections", "0"),
 					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "postgresql.0.max_connection_lifetime", "0"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "postgresql.0.username", username),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "postgresql.0.password", password),
 				),
 			},
 		},
@@ -808,7 +815,7 @@ resource "vault_database_secret_backend_connection" "test" {
 `, path, name, connURL)
 }
 
-func testAccDatabaseSecretBackendConnectionConfig_postgresql(name, path, connURL string) string {
+func testAccDatabaseSecretBackendConnectionConfig_postgresql(name, path, connURL, username, password string) string {
 	return fmt.Sprintf(`
 resource "vault_mount" "db" {
   path = "%s"
@@ -823,9 +830,11 @@ resource "vault_database_secret_backend_connection" "test" {
 
   postgresql {
 	  connection_url = "%s"
+	  username = "%s"
+	  password = "%s"
   }
 }
-`, path, name, connURL)
+`, path, name, connURL, username, password)
 }
 
 func newMySQLConnection(t *testing.T, connURL string, username string, password string) *sql.DB {


### PR DESCRIPTION
Added fields 'username' and 'password' for database backends.

To be able to automatically rotate root user credentials, these fields
need to be configurable.

https://www.vaultproject.io/api-docs/secret/databases#common-fields

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #281

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add 'username' and 'password' fields for database backends.
```

Output from acceptance testing:

```
$ make test TESTARGS="-v -run TestAccDatabaseSecretBackendConnection"
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
	xargs -t -n4 go test -v -run TestAccDatabaseSecretBackendConnection -timeout=30s -parallel=4
go test -v -run TestAccDatabaseSecretBackendConnection '-timeout=30s' '-parallel=4' github.com/terraform-providers/terraform-provider-vault github.com/terraform-providers/terraform-provider-vault/cmd/coverage github.com/terraform-providers/terraform-provider-vault/cmd/generate github.com/terraform-providers/terraform-provider-vault/codegen
?   	github.com/terraform-providers/terraform-provider-vault	[no test files]
?   	github.com/terraform-providers/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/terraform-providers/terraform-provider-vault/cmd/generate	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/codegen	0.288s [no tests to run]
go test -v -run TestAccDatabaseSecretBackendConnection '-timeout=30s' '-parallel=4' github.com/terraform-providers/terraform-provider-vault/generated github.com/terraform-providers/terraform-provider-vault/generated/datasources/transform/decode github.com/terraform-providers/terraform-provider-vault/generated/datasources/transform/encode github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/alphabet
?   	github.com/terraform-providers/terraform-provider-vault/generated	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/generated/datasources/transform/decode	2.609s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/generated/datasources/transform/encode	1.473s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/alphabet	0.920s [no tests to run]
go test -v -run TestAccDatabaseSecretBackendConnection '-timeout=30s' '-parallel=4' github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/role github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/template github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/transformation github.com/terraform-providers/terraform-provider-vault/schema
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/role	0.923s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/template	0.636s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/transformation	1.201s [no tests to run]
?   	github.com/terraform-providers/terraform-provider-vault/schema	[no test files]
go test -v -run TestAccDatabaseSecretBackendConnection '-timeout=30s' '-parallel=4' github.com/terraform-providers/terraform-provider-vault/util github.com/terraform-providers/terraform-provider-vault/vault
testing: warning: no tests to run
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/util	0.421s [no tests to run]
=== RUN   TestAccDatabaseSecretBackendConnection_import
--- PASS: TestAccDatabaseSecretBackendConnection_import (0.61s)
=== RUN   TestAccDatabaseSecretBackendConnection_cassandra
--- SKIP: TestAccDatabaseSecretBackendConnection_cassandra (0.00s)
    resource_database_secret_backend_connection_test.go:62: CASSANDRA_HOST not set
=== RUN   TestAccDatabaseSecretBackendConnection_cassandraProtocol
--- SKIP: TestAccDatabaseSecretBackendConnection_cassandraProtocol (0.00s)
    resource_database_secret_backend_connection_test.go:105: CASSANDRA_HOST not set
=== RUN   TestAccDatabaseSecretBackendConnection_mongodbatlas
--- SKIP: TestAccDatabaseSecretBackendConnection_mongodbatlas (0.00s)
    resource_database_secret_backend_connection_test.go:148: MONGODB_ATLAS_PUBLIC_KEY not set
=== RUN   TestAccDatabaseSecretBackendConnection_mongodb
--- SKIP: TestAccDatabaseSecretBackendConnection_mongodb (0.00s)
    resource_database_secret_backend_connection_test.go:183: MONGODB_URL not set
=== RUN   TestAccDatabaseSecretBackendConnection_mssql
--- SKIP: TestAccDatabaseSecretBackendConnection_mssql (0.00s)
    resource_database_secret_backend_connection_test.go:213: MSSQL_URL not set
=== RUN   TestAccDatabaseSecretBackendConnection_mysql
--- SKIP: TestAccDatabaseSecretBackendConnection_mysql (0.00s)
    resource_database_secret_backend_connection_test.go:246: MYSQL_URL not set
=== RUN   TestAccDatabaseSecretBackendConnectionUpdate_mysql
--- SKIP: TestAccDatabaseSecretBackendConnectionUpdate_mysql (0.00s)
    resource_database_secret_backend_connection_test.go:333: MYSQL_URL not set
=== RUN   TestAccDatabaseSecretBackendConnectionTemplatedUpdateExcludePassword_mysql
--- SKIP: TestAccDatabaseSecretBackendConnectionTemplatedUpdateExcludePassword_mysql (0.00s)
    resource_database_secret_backend_connection_test.go:386: MYSQL_CONNECTION_URL not set
=== RUN   TestAccDatabaseSecretBackendConnection_postgresql
--- PASS: TestAccDatabaseSecretBackendConnection_postgresql (0.54s)
=== RUN   TestAccDatabaseSecretBackendConnection_elasticsearch
--- SKIP: TestAccDatabaseSecretBackendConnection_elasticsearch (0.00s)
    resource_database_secret_backend_connection_test.go:506: ELASTIC_URL not set
PASS
ok  	github.com/terraform-providers/terraform-provider-vault/vault	1.625s
...
```
