### PR TITLE
Support allowed_domains_template option for vault_pki_secret_backend_role

### DIFF
--- a/vault/resource_pki_secret_backend_role.go
+++ b/vault/resource_pki_secret_backend_role.go
@@ -76,6 +76,13 @@ func pkiSecretBackendRoleResource() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"allowed_domains_template": {
+				Type:        schema.TypeBool,
+				Required:    false,
+				Optional:    true,
+				Description: "Flag to indicate that `allowed_domains` specifies a template expression (e.g. {{identity.entity.aliases.<mount accessor>.name}})",
+				Default:     false,
+			},
 			"allow_bare_domains": {
 				Type:        schema.TypeBool,
 				Required:    false,
@@ -349,6 +356,7 @@ func pkiSecretBackendRoleCreate(d *schema.ResourceData, meta interface{}) error 
 		"allow_localhost":                    d.Get("allow_localhost"),
 		"allow_bare_domains":                 d.Get("allow_bare_domains"),
 		"allow_subdomains":                   d.Get("allow_subdomains"),
+		"allowed_domains_template":           d.Get("allowed_domains_template"),
 		"allow_glob_domains":                 d.Get("allow_glob_domains"),
 		"allow_any_name":                     d.Get("allow_any_name"),
 		"enforce_hostnames":                  d.Get("enforce_hostnames"),
@@ -471,6 +479,7 @@ func pkiSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("max_ttl", secret.Data["max_ttl"])
 	d.Set("allow_localhost", secret.Data["allow_localhost"])
 	d.Set("allowed_domains", allowedDomains)
+	d.Set("allowed_domains_template", secret.Data["allowed_domains_template"])
 	d.Set("allow_bare_domains", secret.Data["allow_bare_domains"])
 	d.Set("allow_subdomains", secret.Data["allow_subdomains"])
 	d.Set("allow_glob_domains", secret.Data["allow_glob_domains"])
@@ -541,6 +550,7 @@ func pkiSecretBackendRoleUpdate(d *schema.ResourceData, meta interface{}) error 
 		"max_ttl":                            d.Get("max_ttl"),
 		"allow_localhost":                    d.Get("allow_localhost"),
 		"allow_bare_domains":                 d.Get("allow_bare_domains"),
+		"allowed_domains_template":           d.Get("allowed_domains_template"),
 		"allow_subdomains":                   d.Get("allow_subdomains"),
 		"allow_glob_domains":                 d.Get("allow_glob_domains"),
 		"allow_any_name":                     d.Get("allow_any_name"),

--- a/vault/resource_pki_secret_backend_role_test.go
+++ b/vault/resource_pki_secret_backend_role_test.go
@@ -75,8 +75,10 @@ func TestPkiSecretBackendRole_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_role.test", "ttl", "1800"),
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_role.test", "max_ttl", "3600"),
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_role.test", "allow_localhost", "true"),
-					resource.TestCheckResourceAttr("vault_pki_secret_backend_role.test", "allowed_domains.#", "1"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_role.test", "allowed_domains.#", "2"),
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_role.test", "allowed_domains.0", "other.domain"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_role.test", "allowed_domains.1", "{{identity.entity.name}}"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_role.test", "allowed_domains_template", "true"),
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_role.test", "allow_bare_domains", "false"),
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_role.test", "allow_subdomains", "true"),
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_role.test", "allow_glob_domains", "false"),
@@ -179,7 +181,8 @@ resource "vault_pki_secret_backend_role" "test" {
   ttl = 1800
   max_ttl = 3600
   allow_localhost = true
-  allowed_domains = ["other.domain"]
+  allowed_domains = ["other.domain", "{{identity.entity.name}}"]
+  allowed_domains_template = true
   allow_bare_domains = false
   allow_subdomains = true
   allow_glob_domains = false

--- a/website/docs/r/pki_secret_backend_role.html.md
+++ b/website/docs/r/pki_secret_backend_role.html.md
@@ -41,6 +41,8 @@ The following arguments are supported:
 
 * `allowed_domains` - (Optional) List of allowed domains for certificates 
 
+* `allowed_domains_template` - (Optional) Flag, if set, `allowed_domains` can be specified using identity template expressions such as `{{identity.entity.aliases.<mount accessor>.name}}`.
+
 * `allow_bare_domains` - (Optional) Flag to allow certificates matching the actual domain
 
 * `allow_subdomains` - (Optional) Flag to allow certificates matching subdomains


### PR DESCRIPTION
# Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Closes #850 now that vault v1.5.3 officially support the `allowed_domains_template` on the pki secrets backend role.

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Support allowed_domains_template option for vault_pki_secret_backend_role. Closes #850
```

Output from acceptance testing:

```
$ TESTARGS="-run TestPkiSecretBackendRole" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestPkiSecretBackendRole -timeout 120m
?       github.com/terraform-providers/terraform-provider-vault [no test files]
?       github.com/terraform-providers/terraform-provider-vault/cmd/coverage    [no test files]
?       github.com/terraform-providers/terraform-provider-vault/cmd/generate    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/codegen (cached) [no tests to run]
?       github.com/terraform-providers/terraform-provider-vault/generated       [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/generated/datasources/transform/decode (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/generated/datasources/transform/encode (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/alphabet (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/role     (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/template  (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/transformation    (cached) [no tests to run]
?       github.com/terraform-providers/terraform-provider-vault/schema  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/util    (cached) [no tests to run]
=== RUN   TestPkiSecretBackendRole_basic
--- PASS: TestPkiSecretBackendRole_basic (0.28s)
PASS
ok      github.com/terraform-providers/terraform-provider-vault/vault   0.298s
...
```

# Documentation updates: 
![Screen Shot 2020-09-23 at 10 40 01 PM](https://user-images.githubusercontent.com/10519220/94105708-bb9e9f00-fdee-11ea-8ce0-506800b65fab.png)