### PR TITLE
Added possibility to define groups for Azure Service Principals

### DIFF
--- a/vault/resource_azure_secret_backend_role.go
+++ b/vault/resource_azure_secret_backend_role.go
@@ -66,6 +66,23 @@ func azureSecretBackendRoleResource() *schema.Resource {
 					},
 				},
 			},
+			"azure_groups": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"group_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"group_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
 			"application_object_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -90,13 +107,25 @@ func azureSecretBackendRoleUpdateFields(d *schema.ResourceData, data map[string]
 	if v, ok := d.GetOk("azure_roles"); ok {
 		rawAzureList := v.(*schema.Set).List()
 
-		// Vaults API requires we send trhe policy as an escaped string
-		// So we marshall and then change into a string
+		// Vaults API requires we send the policy as an escaped string
+		// So we marshal it and then change into a string
 		jsonAzureList, _ := json.Marshal(rawAzureList)
 		jsonAzureListString := string(jsonAzureList)
 
 		log.Printf("[DEBUG] Azure RoleSet turned to escaped JSON: %s", jsonAzureListString)
 		data["azure_roles"] = string(jsonAzureListString)
+	}
+
+	if v, ok := d.GetOk("azure_groups"); ok {
+		rawAzureList := v.(*schema.Set).List()
+
+		// Vaults API requires we send the policy as an escaped string
+		// So we marshal it and then change into a string
+		jsonAzureList, _ := json.Marshal(rawAzureList)
+		jsonAzureListString := string(jsonAzureList)
+
+		log.Printf("[DEBUG] Azure GroupSet turned to escaped JSON: %s", jsonAzureListString)
+		data["azure_groups"] = string(jsonAzureListString)
 	}
 
 	if v, ok := d.GetOk("application_object_id"); ok {

--- a/website/docs/r/azure_secret_backend_role.html.md
+++ b/website/docs/r/azure_secret_backend_role.html.md
@@ -39,6 +39,10 @@ resource "vault_azure_secret_backend_role" "generated_role" {
     role_name = "Reader"
     scope =  "/subscriptions/${var.subscription_id}/resourceGroups/azure-vault-group"
   }
+
+  azure_groups {
+    group_name = "Developers"
+  }
 }
 
 resource "vault_azure_secret_backend_role" "existing_object_id" {
@@ -57,6 +61,7 @@ The following arguments are supported:
 * `role` - (Required) Name of the Azure role
 * `backend` - Path to the mounted Azure auth backend
 * `azure_roles` - List of Azure roles to be assigned to the generated service principal.
+* `azure_groups` - List of Azure groups to be assigned to the generated service principal.
 * `application_object_id` - Application Object ID for an existing service principal that will
    be used instead of creating dynamic service principals. If present, `azure_roles` will be ignored.
 * `ttl` – (Optional) Specifies the default TTL for service principals generated using this role.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
It is now possible to add a Dynamic Azure Service Principal to an AAD group.
```


