### PR TITLE
Add vault_azure_secret_backend_role support for azure_groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ In order to run the full suite of Acceptance tests, you will need the following:
 1. An instance of Vault running to run the tests against
 2. The following environment variables are set:
     - `VAULT_ADDR` - location of Vault
-    - `VAULT_TOKEN` - token to use to query Vault. These tests do not attempt to read `~/.vault-token`.
+    - `VAULT_TOKEN` - token used to query Vault. These tests do not attempt to read `~/.vault-token`.
 3. The following environment variables may need to be set depending on which acceptance tests you wish to run.
 There may be additional variables for specific tests. Consult the specific test(s) for more information.
     - `AWS_ACCESS_KEY_ID`
@@ -84,6 +84,11 @@ There may be additional variables for specific tests. Consult the specific test(
     - `RMQ_CONNECTION_URI`
     - `RMQ_USERNAME`
     - `RMQ_PASSWORD`
+    - `ARM_SUBSCRIPTION_ID`
+    - `ARM_TENANT_ID`
+    - `ARM_CLIENT_ID`
+    - `ARM_CLIENT_SECRET`
+    - `ARM_RESOURCE_GROUP`
 4. Run `make testacc`
 
 If you wish to run specific tests, use the `TESTARGS` environment variable:

--- a/vault/resource_azure_secret_backend_role_test.go
+++ b/vault/resource_azure_secret_backend_role_test.go
@@ -32,8 +32,17 @@ func TestAzureSecretBackendRole(t *testing.T) {
 			{
 				Config: testAzureSecretBackendRoleInitialConfig(subscriptionID, tenantID, clientID, clientSecret, path, role, resourceGroup),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_azure_secret_backend_role.test", "role", role),
-					resource.TestCheckResourceAttr("vault_azure_secret_backend_role.test", "description", "Test for Vault Provider"),
+					resource.TestCheckResourceAttr("vault_azure_secret_backend_role.test_azure_roles", "role", role+"-azure-roles"),
+					resource.TestCheckResourceAttr("vault_azure_secret_backend_role.test_azure_roles", "description", "Test for Vault Provider"),
+					resource.TestCheckResourceAttr("vault_azure_secret_backend_role.test_azure_roles", "azure_roles.#", "1"),
+					resource.TestCheckResourceAttr("vault_azure_secret_backend_role.test_azure_roles", "azure_roles.1111275791.role_name", "Reader"),
+					resource.TestCheckResourceAttrSet("vault_azure_secret_backend_role.test_azure_roles", "azure_roles.1111275791.scope"),
+					resource.TestCheckResourceAttrSet("vault_azure_secret_backend_role.test_azure_roles", "azure_roles.1111275791.role_id"),
+					resource.TestCheckResourceAttr("vault_azure_secret_backend_role.test_azure_groups", "role", role+"-azure-groups"),
+					resource.TestCheckResourceAttr("vault_azure_secret_backend_role.test_azure_groups", "description", "Test for Vault Provider"),
+					resource.TestCheckResourceAttr("vault_azure_secret_backend_role.test_azure_groups", "azure_groups.#", "1"),
+					resource.TestCheckResourceAttr("vault_azure_secret_backend_role.test_azure_groups", "azure_groups.2681484837.group_name", "foobar"),
+					resource.TestCheckResourceAttrSet("vault_azure_secret_backend_role.test_azure_groups", "azure_groups.2681484837.object_id"),
 				),
 			},
 		},
@@ -66,23 +75,35 @@ func testAccAzureSecretBackendRoleCheckDestroy(s *terraform.State) error {
 func testAzureSecretBackendRoleInitialConfig(subscriptionID string, tenantID string, clientID string, clientSecret string, path string, role string, resourceGroup string) string {
 	return fmt.Sprintf(`
 resource "vault_azure_secret_backend" "azure" {
-	subscription_id = "%s"
-	tenant_id = "%s"
-	client_id = "%s"
-	client_secret = "%s"
-	path = "%s"
+  subscription_id = "%s"
+  tenant_id       = "%s"
+  client_id       = "%s"
+  client_secret   = "%s"
+  path            = "%s"
 }
 
-resource "vault_azure_secret_backend_role" "test" {
-  backend                     = "${vault_azure_secret_backend.azure.path}"
-  role                        = "%s"
-  ttl                         = 300
-	max_ttl                     = 600
-	description									= "Test for Vault Provider"
+resource "vault_azure_secret_backend_role" "test_azure_roles" {
+  backend     = "${vault_azure_secret_backend.azure.path}"
+  role        = "%[6]s-azure-roles"
+  ttl         = 300
+  max_ttl     = 600
+  description = "Test for Vault Provider"
 
-	azure_roles {
+  azure_roles {
     role_name = "Reader"
-    scope =  "/subscriptions/%[1]s/resourceGroups/%s"
+    scope =  "/subscriptions/%[1]s/resourceGroups/%[7]s"
+  }
+}
+
+resource "vault_azure_secret_backend_role" "test_azure_groups" {
+  backend     = "${vault_azure_secret_backend.azure.path}"
+  role        = "%[6]s-azure-groups"
+  ttl         = 300
+  max_ttl     = 600
+  description = "Test for Vault Provider"
+
+  azure_groups {
+    group_name = "foobar"
   }
 }
 `, subscriptionID, tenantID, clientID, clientSecret, path, role, resourceGroup)

--- a/website/docs/r/azure_secret_backend_role.html.md
+++ b/website/docs/r/azure_secret_backend_role.html.md
@@ -44,7 +44,7 @@ resource "vault_azure_secret_backend_role" "generated_role" {
 resource "vault_azure_secret_backend_role" "existing_object_id" {
   backend                     = "${vault_azure_secret_backend.azure.path}"
   role                        = "existing_object_id"
-	application_object_id 			= "11111111-2222-3333-4444-44444444444"
+  application_object_id       = "11111111-2222-3333-4444-44444444444"
   ttl                         = 300
   max_ttl                     = 600
 }
@@ -56,6 +56,7 @@ The following arguments are supported:
 
 * `role` - (Required) Name of the Azure role
 * `backend` - Path to the mounted Azure auth backend
+* `azure_groups` - List of Azure groups to be assigned to the generated service principal.
 * `azure_roles` - List of Azure roles to be assigned to the generated service principal.
 * `application_object_id` - Application Object ID for an existing service principal that will
    be used instead of creating dynamic service principals. If present, `azure_roles` will be ignored.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #712

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`resource/vault_azure_secret_backend_role`: Added support for `azure_groups` (#891)
```

Output from acceptance testing:

```
$ TESTARGS="--run TestAzureSecretBackendRole" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v --run TestAzureSecretBackendRole -timeout 120m
?       github.com/terraform-providers/terraform-provider-vault [no test files]
?       github.com/terraform-providers/terraform-provider-vault/cmd/coverage    [no test files]
?       github.com/terraform-providers/terraform-provider-vault/cmd/generate    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/codegen (cached) [no tests to run]
?       github.com/terraform-providers/terraform-provider-vault/generated       [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/generated/datasources/transform/decode  (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/generated/datasources/transform/encode  (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/alphabet  (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/role      (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/template  (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/transformation       (cached) [no tests to run]
?       github.com/terraform-providers/terraform-provider-vault/schema  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/terraform-providers/terraform-provider-vault/util    (cached) [no tests to run]
=== RUN   TestAzureSecretBackendRole
--- PASS: TestAzureSecretBackendRole (0.62s)
PASS
ok      github.com/terraform-providers/terraform-provider-vault/vault   (cached)
```
