### PR TITLE
update go mod to point to hashicorp/terraform-provider-vault

### DIFF
--- a/cmd/coverage/main.go
+++ b/cmd/coverage/main.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"sort"
 
+	"github.com/hashicorp/terraform-provider-vault/vault"
 	"github.com/hashicorp/vault/sdk/framework"
-	"github.com/terraform-providers/terraform-provider-vault/vault"
 )
 
 var pathToOpenAPIDoc = flag.String("openapi-doc", "", "path/to/openapi.json")

--- a/cmd/generate/main.go
+++ b/cmd/generate/main.go
@@ -8,8 +8,8 @@ import (
 	"os"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/terraform-provider-vault/codegen"
 	"github.com/hashicorp/vault/sdk/framework"
-	"github.com/terraform-providers/terraform-provider-vault/codegen"
 )
 
 var pathToOpenAPIDoc = flag.String("openapi-doc", "", "path/to/openapi.json")

--- a/codegen/generate.go
+++ b/codegen/generate.go
@@ -250,7 +250,7 @@ func stripCurlyBraces(path string) string {
 
 // pathToHomeDir yields the path to the terraform-vault-provider
 // home directory on the machine on which it's running.
-// ex. /home/your-name/go/src/github.com/terraform-providers/terraform-provider-vault
+// ex. /home/your-name/go/src/github.com/hashicorp/terraform-provider-vault
 func pathToHomeDir() (string, error) {
 	repoName := "terraform-provider-vault"
 	wd, err := os.Getwd()

--- a/codegen/templates/datasource.go.tpl
+++ b/codegen/templates/datasource.go.tpl
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
+	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
 const {{ .LowerCaseDifferentiator }}Endpoint = "{{ .Endpoint }}"

--- a/codegen/templates/resource.go.tpl
+++ b/codegen/templates/resource.go.tpl
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
+	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
 {{- if or .SupportsRead .SupportsWrite }}

--- a/generated/datasources/transform/decode/role_name.go
+++ b/generated/datasources/transform/decode/role_name.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 const roleNameEndpoint = "/transform/decode/{role_name}"

--- a/generated/datasources/transform/decode/role_name_test.go
+++ b/generated/datasources/transform/decode/role_name_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/role"
-	"github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/transformation"
-	"github.com/terraform-providers/terraform-provider-vault/schema"
-	"github.com/terraform-providers/terraform-provider-vault/util"
-	"github.com/terraform-providers/terraform-provider-vault/vault"
+	"github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role"
+	"github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation"
+	"github.com/hashicorp/terraform-provider-vault/schema"
+	"github.com/hashicorp/terraform-provider-vault/util"
+	"github.com/hashicorp/terraform-provider-vault/vault"
 )
 
 var roleNameTestProvider = func() *schema.Provider {

--- a/generated/datasources/transform/encode/role_name.go
+++ b/generated/datasources/transform/encode/role_name.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 const roleNameEndpoint = "/transform/encode/{role_name}"

--- a/generated/datasources/transform/encode/role_name_test.go
+++ b/generated/datasources/transform/encode/role_name_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
-	"github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/role"
-	"github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/transformation"
-	"github.com/terraform-providers/terraform-provider-vault/schema"
-	"github.com/terraform-providers/terraform-provider-vault/util"
-	"github.com/terraform-providers/terraform-provider-vault/vault"
+	"github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role"
+	"github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation"
+	"github.com/hashicorp/terraform-provider-vault/schema"
+	"github.com/hashicorp/terraform-provider-vault/util"
+	"github.com/hashicorp/terraform-provider-vault/vault"
 )
 
 var roleNameTestProvider = func() *schema.Provider {

--- a/generated/resources/transform/alphabet/name.go
+++ b/generated/resources/transform/alphabet/name.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 const nameEndpoint = "/transform/alphabet/{name}"

--- a/generated/resources/transform/alphabet/name_test.go
+++ b/generated/resources/transform/alphabet/name_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/terraform-provider-vault/schema"
+	"github.com/hashicorp/terraform-provider-vault/util"
+	"github.com/hashicorp/terraform-provider-vault/vault"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/schema"
-	"github.com/terraform-providers/terraform-provider-vault/util"
-	"github.com/terraform-providers/terraform-provider-vault/vault"
 )
 
 var nameTestProvider = func() *schema.Provider {

--- a/generated/resources/transform/role/name.go
+++ b/generated/resources/transform/role/name.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 const nameEndpoint = "/transform/role/{name}"

--- a/generated/resources/transform/role/name_test.go
+++ b/generated/resources/transform/role/name_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/terraform-provider-vault/schema"
+	"github.com/hashicorp/terraform-provider-vault/util"
+	"github.com/hashicorp/terraform-provider-vault/vault"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/schema"
-	"github.com/terraform-providers/terraform-provider-vault/util"
-	"github.com/terraform-providers/terraform-provider-vault/vault"
 )
 
 var nameTestProvider = func() *schema.Provider {

--- a/generated/resources/transform/template/name.go
+++ b/generated/resources/transform/template/name.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 const nameEndpoint = "/transform/template/{name}"

--- a/generated/resources/transform/template/name_test.go
+++ b/generated/resources/transform/template/name_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet"
+	"github.com/hashicorp/terraform-provider-vault/schema"
+	"github.com/hashicorp/terraform-provider-vault/util"
+	"github.com/hashicorp/terraform-provider-vault/vault"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/alphabet"
-	"github.com/terraform-providers/terraform-provider-vault/schema"
-	"github.com/terraform-providers/terraform-provider-vault/util"
-	"github.com/terraform-providers/terraform-provider-vault/vault"
 )
 
 var nameTestProvider = func() *schema.Provider {

--- a/generated/resources/transform/transformation/name.go
+++ b/generated/resources/transform/transformation/name.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 const nameEndpoint = "/transform/transformation/{name}"

--- a/generated/resources/transform/transformation/name_test.go
+++ b/generated/resources/transform/transformation/name_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/terraform-provider-vault/schema"
+	"github.com/hashicorp/terraform-provider-vault/util"
+	"github.com/hashicorp/terraform-provider-vault/vault"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/schema"
-	"github.com/terraform-providers/terraform-provider-vault/util"
-	"github.com/terraform-providers/terraform-provider-vault/vault"
 )
 
 var nameTestProvider = func() *schema.Provider {

--- a/generated/terraform_registry.go
+++ b/generated/terraform_registry.go
@@ -2,12 +2,12 @@ package generated
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/terraform-providers/terraform-provider-vault/generated/datasources/transform/decode"
-	"github.com/terraform-providers/terraform-provider-vault/generated/datasources/transform/encode"
-	"github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/alphabet"
-	"github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/role"
-	"github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/template"
-	"github.com/terraform-providers/terraform-provider-vault/generated/resources/transform/transformation"
+	"github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode"
+	"github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode"
+	"github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet"
+	"github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role"
+	"github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template"
+	"github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation"
 )
 
 // Please alphabetize.

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,6 @@
 module github.com/hashicorp/terraform-provider-vault
 
+// This should ensure existing PRs are still valid
 replace github.com/terraform-providers/terraform-provider-vault => ./
 
 go 1.13
@@ -20,5 +21,4 @@ require (
 	github.com/hashicorp/vault/sdk v0.1.14-0.20191017173300-47a54ac8bc6c
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/rainycape/unidecode v0.0.0-20150907023854-cb7f23ec59be // indirect
-	github.com/terraform-providers/terraform-provider-vault v0.0.0-00010101000000-000000000000
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,6 @@
-module github.com/terraform-providers/terraform-provider-vault
+module github.com/hashicorp/terraform-provider-vault
+
+replace github.com/terraform-providers/terraform-provider-vault => ./
 
 go 1.13
 
@@ -18,4 +20,5 @@ require (
 	github.com/hashicorp/vault/sdk v0.1.14-0.20191017173300-47a54ac8bc6c
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/rainycape/unidecode v0.0.0-20150907023854-cb7f23ec59be // indirect
+	github.com/terraform-providers/terraform-provider-vault v0.0.0-00010101000000-000000000000
 )

--- a/main.go
+++ b/main.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
-	"github.com/terraform-providers/terraform-provider-vault/generated"
-	"github.com/terraform-providers/terraform-provider-vault/schema"
-	"github.com/terraform-providers/terraform-provider-vault/vault"
+	"github.com/hashicorp/terraform-provider-vault/generated"
+	"github.com/hashicorp/terraform-provider-vault/schema"
+	"github.com/hashicorp/terraform-provider-vault/vault"
 )
 
 func main() {

--- a/vault/data_source_ad_credentials_test.go
+++ b/vault/data_source_ad_credentials_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/terraform-providers/terraform-provider-vault/util"
+	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
 func TestAccDataSourceADAccessCredentials_basic(t *testing.T) {

--- a/vault/okta.go
+++ b/vault/okta.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 type oktaUser struct {

--- a/vault/provider_test.go
+++ b/vault/provider_test.go
@@ -702,7 +702,7 @@ func TestAccProviderVaultAddrEnv(t *testing.T) {
 
 	// clear BASH_ENV for this test so any cmd.Exec invocations do not source the BASH_ENV
 	// file which is configured with a VAULT_ADDR here:
-	// https://github.com/terraform-providers/terraform-provider-vault/blob/f42716aae3aebc8daf9702dfa20ce3f8d09d9f4d/.circleci/config.yml#L27
+	// https://github.com/hashicorp/terraform-provider-vault/blob/f42716aae3aebc8daf9702dfa20ce3f8d09d9f4d/.circleci/config.yml#L27
 	// All values set in that BASH_ENV file will still be in the process environment of this
 	// test, they just won't clobber any values this test modifies in the process environment
 	// when the ExternalTokenHelper's command is formatted into a shell invocation to exec here:

--- a/vault/resource_ad_secret_backend.go
+++ b/vault/resource_ad_secret_backend.go
@@ -2,7 +2,7 @@ package vault
 
 import (
 	"fmt"
-	"github.com/terraform-providers/terraform-provider-vault/util"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"log"
 	"strings"
 

--- a/vault/resource_ad_secret_backend_test.go
+++ b/vault/resource_ad_secret_backend_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 func TestADSecretBackend(t *testing.T) {

--- a/vault/resource_ad_secret_library.go
+++ b/vault/resource_ad_secret_library.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 var (

--- a/vault/resource_ad_secret_library_test.go
+++ b/vault/resource_ad_secret_library_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 func TestAccADSecretBackendLibrary_basic(t *testing.T) {

--- a/vault/resource_ad_secret_roles.go
+++ b/vault/resource_ad_secret_roles.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 var (

--- a/vault/resource_ad_secret_roles_test.go
+++ b/vault/resource_ad_secret_roles_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 func TestAccADSecretBackendRole_basic(t *testing.T) {

--- a/vault/resource_approle_auth_backend_login.go
+++ b/vault/resource_approle_auth_backend_login.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 func approleAuthBackendLoginResource() *schema.Resource {

--- a/vault/resource_approle_auth_backend_role.go
+++ b/vault/resource_approle_auth_backend_role.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 var (

--- a/vault/resource_approle_auth_backend_role_secret_id.go
+++ b/vault/resource_approle_auth_backend_role_secret_id.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 var (

--- a/vault/resource_approle_auth_backend_role_test.go
+++ b/vault/resource_approle_auth_backend_role_test.go
@@ -522,7 +522,7 @@ resource "vault_approle_auth_backend_role" "role" {
 }
 
 // TestAccAppRoleAuthBackendRole_token_policy_update is a regression test for
-// https://github.com/terraform-providers/terraform-provider-vault/issues/533
+// https://github.com/hashicorp/terraform-provider-vault/issues/533
 func TestAccAppRoleAuthBackendRole_token_policy_update(t *testing.T) {
 	backend := acctest.RandomWithPrefix("approle")
 	role := acctest.RandomWithPrefix("test-role")

--- a/vault/resource_aws_secret_backend_role.go
+++ b/vault/resource_aws_secret_backend_role.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 func awsSecretBackendRoleResource() *schema.Resource {

--- a/vault/resource_aws_secret_backend_role_test.go
+++ b/vault/resource_aws_secret_backend_role_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 const testAccAWSSecretBackendRolePolicyInline_basic = `{"Version": "2012-10-17","Statement": [{"Effect": "Allow","Action": "iam:*","Resource": "*"}]}`

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 var (

--- a/vault/resource_identity_entity.go
+++ b/vault/resource_identity_entity.go
@@ -5,8 +5,8 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 const identityEntityPath = "/identity/entity"

--- a/vault/resource_identity_entity_policies.go
+++ b/vault/resource_identity_entity_policies.go
@@ -5,8 +5,8 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 func identityEntityPoliciesResource() *schema.Resource {

--- a/vault/resource_identity_entity_policies_test.go
+++ b/vault/resource_identity_entity_policies_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 func TestAccIdentityEntityPoliciesExclusive(t *testing.T) {

--- a/vault/resource_identity_group.go
+++ b/vault/resource_identity_group.go
@@ -5,8 +5,8 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 const identityGroupPath = "/identity/group"

--- a/vault/resource_identity_group_member_entity_ids.go
+++ b/vault/resource_identity_group_member_entity_ids.go
@@ -5,8 +5,8 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 func identityGroupMemberEntityIdsResource() *schema.Resource {

--- a/vault/resource_identity_group_member_entity_ids_test.go
+++ b/vault/resource_identity_group_member_entity_ids_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 func TestAccIdentityGroupMemberEntityIdsExclusiveEmpty(t *testing.T) {

--- a/vault/resource_identity_group_policies.go
+++ b/vault/resource_identity_group_policies.go
@@ -5,8 +5,8 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 func identityGroupPoliciesResource() *schema.Resource {

--- a/vault/resource_identity_group_policies_test.go
+++ b/vault/resource_identity_group_policies_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 func TestAccIdentityGroupPoliciesExclusive(t *testing.T) {

--- a/vault/resource_identity_oidc_key_allowed_client_id.go
+++ b/vault/resource_identity_oidc_key_allowed_client_id.go
@@ -5,8 +5,8 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 func identityOidcKeyAllowedClientId() *schema.Resource {

--- a/vault/resource_identity_oidc_key_allowed_client_id_test.go
+++ b/vault/resource_identity_oidc_key_allowed_client_id_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 func TestAccIdentityOidcKeyAllowedClientId(t *testing.T) {

--- a/vault/resource_jwt_auth_backend_role.go
+++ b/vault/resource_jwt_auth_backend_role.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 var (

--- a/vault/resource_kubernetes_auth_backend_role.go
+++ b/vault/resource_kubernetes_auth_backend_role.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 var (

--- a/vault/resource_ldap_auth_backend_group_test.go
+++ b/vault/resource_ldap_auth_backend_group_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 func TestLDAPAuthBackendGroup_import(t *testing.T) {

--- a/vault/resource_ldap_auth_backend_user.go
+++ b/vault/resource_ldap_auth_backend_user.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 var (

--- a/vault/resource_ldap_auth_backend_user_test.go
+++ b/vault/resource_ldap_auth_backend_user_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 func TestLDAPAuthBackendUser_import(t *testing.T) {

--- a/vault/resource_okta_auth_backend.go
+++ b/vault/resource_okta_auth_backend.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/hashcode"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 var oktaAuthType = "okta"

--- a/vault/resource_okta_auth_backend_group.go
+++ b/vault/resource_okta_auth_backend_group.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 func oktaAuthBackendGroupResource() *schema.Resource {

--- a/vault/resource_okta_auth_backend_test.go
+++ b/vault/resource_okta_auth_backend_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 func TestAccOktaAuthBackend(t *testing.T) {

--- a/vault/resource_okta_auth_backend_user.go
+++ b/vault/resource_okta_auth_backend_user.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 func oktaAuthBackendUserResource() *schema.Resource {

--- a/vault/structures.go
+++ b/vault/structures.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
-	"github.com/terraform-providers/terraform-provider-vault/util"
 )
 
 func expandAuthMethodTune(rawL []interface{}) api.MountConfigInput {

--- a/website/docs/guides/version_2_upgrade.html.markdown
+++ b/website/docs/guides/version_2_upgrade.html.markdown
@@ -17,7 +17,7 @@ to upgrade from version `1.9.0` to `2.0.0`.
 Most of the changes outlined in this guide have been previously marked as
 deprecated in the Terraform `plan`/`apply` output throughout previous provider
 releases, up to and including 1.9.0. These changes, such as deprecation notices,
-can always be found in the [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md).
+can always be found in the [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md).
 
 Version 2.0.0 of the Vault provider is the first version to offer compatibility with
 Terraform 0.12.


### PR DESCRIPTION
This PR updates `go.mod` to reference `hashicorp/terraform-provider-vault`, from the old `terraform-providers/` org. Note the oddity in `go.mod` where we depend on ourselves; I believe that is due to the handful of sub-package in `generated/` (?)