### PR TITLE
Tune mount when description is changed

### DIFF
--- a/vault/resource_mount.go
+++ b/vault/resource_mount.go
@@ -38,7 +38,7 @@ func MountResource() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Required:    false,
-				ForceNew:    true,
+				ForceNew:    false,
 				Description: "Human-friendly description of the mount",
 			},
 
@@ -140,6 +140,11 @@ func mountUpdate(d *schema.ResourceData, meta interface{}) error {
 		DefaultLeaseTTL: fmt.Sprintf("%ds", d.Get("default_lease_ttl_seconds")),
 		MaxLeaseTTL:     fmt.Sprintf("%ds", d.Get("max_lease_ttl_seconds")),
 		Options:         opts(d),
+	}
+
+	if d.HasChange("description") {
+		description := fmt.Sprintf("%s", d.Get("description"))
+		config.Description = &description
 	}
 
 	path := d.Id()

--- a/vault/resource_mount_test.go
+++ b/vault/resource_mount_test.go
@@ -241,7 +241,7 @@ var testResourceMount_updateConfig = `
 resource "vault_mount" "test" {
 	path = "remountingExample"
 	type = "kv"
-	description = "Example mount for testing"
+	description = "Updated example mount for testing"
 	default_lease_ttl_seconds = 7200
 	max_lease_ttl_seconds = 72000
 	options = {
@@ -270,7 +270,7 @@ func testResourceMount_updateCheck(s *terraform.State) error {
 		return fmt.Errorf("error reading back mount: %s", err)
 	}
 
-	if wanted := "Example mount for testing"; mount.Description != wanted {
+	if wanted := "Updated example mount for testing"; mount.Description != wanted {
 		return fmt.Errorf("description is %v; wanted %v", mount.Description, wanted)
 	}
 

--- a/vault/resource_ssh_secret_backend_ca_test.go
+++ b/vault/resource_ssh_secret_backend_ca_test.go
@@ -26,27 +26,6 @@ func TestAccSSHSecretBackendCA_basic(t *testing.T) {
 	})
 }
 
-func TestAccSSHSecretBackendCA_mount_updated_basic(t *testing.T) {
-	backend := "ssh-" + acctest.RandString(10)
-
-	resource.Test(t, resource.TestCase{
-		Providers:    testProviders,
-		PreCheck:     func() { testAccPreCheck(t) },
-		CheckDestroy: testAccCheckSSHSecretBackendCADestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccSSHSecretBackendCAConfigGenerated(backend),
-				Check:  testAccSSHSecretBackendCACheck(backend),
-			},
-			{
-				Config:             testAccSSHSecretBackendCAConfigGenerated_mount_edit(backend),
-				Check:              testAccSSHSecretBackendCACheck(backend),
-				ExpectNonEmptyPlan: true,
-			},
-		},
-	})
-}
-
 func TestAccSSHSecretBackendCA_provided(t *testing.T) {
 	backend := "ssh-" + acctest.RandString(10)
 
@@ -107,21 +86,7 @@ func testAccSSHSecretBackendCAConfigGenerated(backend string) string {
 resource "vault_mount" "test" {
   type = "ssh"
   path = "%s"
-	description = "something"
-}
-
-resource "vault_ssh_secret_backend_ca" "test" {
-  backend              = "${vault_mount.test.path}"
-  generate_signing_key = true
-}`, backend)
-}
-
-func testAccSSHSecretBackendCAConfigGenerated_mount_edit(backend string) string {
-	return fmt.Sprintf(`
-resource "vault_mount" "test" {
-  type = "ssh"
-  path = "%s"
-	description = "something else"
+  description = "SSH Secret backend"
 }
 
 resource "vault_ssh_secret_backend_ca" "test" {
@@ -135,6 +100,7 @@ func testAccSSHSecretBackendCAConfigProvided(backend string) string {
 resource "vault_mount" "test" {
   type = "ssh"
   path = "%s"
+  description = "SSH Secret backend"
 }
 
 resource "vault_ssh_secret_backend_ca" "test" {
@@ -174,6 +140,7 @@ EOF
 
 func testAccSSHSecretBackendCACheck(backend string) resource.TestCheckFunc {
 	return resource.ComposeTestCheckFunc(
+		resource.TestCheckResourceAttrSet("vault_mount.test", "description"),
 		resource.TestCheckResourceAttrSet("vault_ssh_secret_backend_ca.test", "public_key"),
 		resource.TestCheckResourceAttr("vault_ssh_secret_backend_ca.test", "backend", backend),
 	)


### PR DESCRIPTION
The `vault_mount` resource has a bug where if you change the description of the mount, it deletes the mount and recreates. This is due to the parameter having `ForceNew: true` enabled in the schema.

Instead this should be tuning the description instead of deleting the resource when updating the mount description.

Fixes #909.
Fixes #782.
