### PR TITLE
Add sts_region for AWS auth backend

### DIFF
--- a/vault/resource_aws_auth_backend_client.go
+++ b/vault/resource_aws_auth_backend_client.go
@@ -93,6 +93,7 @@ func awsAuthBackendWrite(d *schema.ResourceData, meta interface{}) error {
 		"endpoint":                   ec2Endpoint,
 		"iam_endpoint":               iamEndpoint,
 		"sts_endpoint":               stsEndpoint,
+		"sts_region":                 stsRegion,
 		"iam_server_id_header_value": iamServerIDHeaderValue,
 	}
 
@@ -100,10 +101,6 @@ func awsAuthBackendWrite(d *schema.ResourceData, meta interface{}) error {
 		log.Printf("[DEBUG] Updating AWS credentials at %q", path)
 		data["access_key"] = d.Get("access_key").(string)
 		data["secret_key"] = d.Get("secret_key").(string)
-	}
-
-	if stsRegion != "" {
-		data["sts_region"] = stsRegion
 	}
 
 	// sts_endpoint and sts_region are required to be set together

--- a/vault/resource_aws_auth_backend_client.go
+++ b/vault/resource_aws_auth_backend_client.go
@@ -106,9 +106,9 @@ func awsAuthBackendWrite(d *schema.ResourceData, meta interface{}) error {
 		data["sts_region"] = stsRegion
 	}
 
-	// sts_endpoint is required when sts_region is set
-	if stsEndpoint == "" && stsRegion != "" {
-		return fmt.Errorf("sts_endpoint must be set if sts_region is configured")
+	// sts_endpoint and sts_region are required to be set together
+	if (stsEndpoint == "") != (stsRegion == "") {
+		return fmt.Errorf("both sts_endpoint and sts_region need to be set")
 	}
 
 	log.Printf("[DEBUG] Writing AWS auth backend client config to %q", path)

--- a/vault/resource_aws_auth_backend_client.go
+++ b/vault/resource_aws_auth_backend_client.go
@@ -150,6 +150,7 @@ func awsAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("ec2_endpoint", secret.Data["endpoint"])
 	d.Set("iam_endpoint", secret.Data["iam_endpoint"])
 	d.Set("sts_endpoint", secret.Data["sts_endpoint"])
+	d.Set("sts_region", secret.Data["sts_region"])
 	d.Set("iam_server_id_header_value", secret.Data["iam_server_id_header_value"])
 	return nil
 }

--- a/vault/resource_aws_auth_backend_client_test.go
+++ b/vault/resource_aws_auth_backend_client_test.go
@@ -106,7 +106,7 @@ func TestAccAWSAuthBackendClientStsRegionNoEndpoint(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAWSAuthBackendClientConfigSTSRegionNoEndpoint(backend),
-				ExpectError: regexp.MustCompile("sts_endpoint must be set if sts_region is configured"),
+				ExpectError: regexp.MustCompile("both sts_endpoint and sts_region need to be set"),
 			},
 		},
 	})

--- a/vault/resource_aws_auth_backend_client_test.go
+++ b/vault/resource_aws_auth_backend_client_test.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -96,6 +97,21 @@ func TestAccAWSAuthBackendClient_withoutSecretKey(t *testing.T) {
 	})
 }
 
+func TestAccAWSAuthBackendClientStsRegionNoEndpoint(t *testing.T) {
+	backend := acctest.RandomWithPrefix("aws")
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckAWSAuthBackendClientDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSAuthBackendClientConfigSTSRegionNoEndpoint(backend),
+				ExpectError: regexp.MustCompile("sts_endpoint must be set if sts_region is configured"),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSAuthBackendClientDestroy(s *terraform.State) error {
 	client := testProvider.Meta().(*api.Client)
 
@@ -146,6 +162,7 @@ func testAccAWSAuthBackendClientCheck_attrs(backend string) resource.TestCheckFu
 			"ec2_endpoint":               "endpoint",
 			"iam_endpoint":               "iam_endpoint",
 			"sts_endpoint":               "sts_endpoint",
+			"sts_region":                 "sts_region",
 			"iam_server_id_header_value": "iam_server_id_header_value",
 		}
 		for stateAttr, apiAttr := range attrs {
@@ -175,6 +192,7 @@ resource "vault_aws_auth_backend_client" "client" {
   ec2_endpoint = "http://vault.test/ec2"
   iam_endpoint = "http://vault.test/iam"
   sts_endpoint = "http://vault.test/sts"
+  sts_region = "vault-test"
   iam_server_id_header_value = "vault.test"
 }
 `, backend)
@@ -195,6 +213,7 @@ resource "vault_aws_auth_backend_client" "client" {
   ec2_endpoint = "http://updated.vault.test/ec2"
   iam_endpoint = "http://updated.vault.test/iam"
   sts_endpoint = "http://updated.vault.test/sts"
+  sts_region = "updated-vault-test"
   iam_server_id_header_value = "updated.vault.test"
 }`, backend)
 }
@@ -213,6 +232,7 @@ resource "vault_aws_auth_backend_client" "client" {
   ec2_endpoint = "http://vault.test/ec2"
   iam_endpoint = "http://vault.test/iam"
   sts_endpoint = "http://vault.test/sts"
+  sts_region = "vault-test"
   iam_server_id_header_value = "vault.test"
 }`, backend)
 }
@@ -231,6 +251,25 @@ resource "vault_aws_auth_backend_client" "client" {
   ec2_endpoint = "http://updated2.vault.test/ec2"
   iam_endpoint = "http://updated2.vault.test/iam"
   sts_endpoint = "http://updated2.vault.test/sts"
+  sts_region = "updated-vault-test"
   iam_server_id_header_value = "updated2.vault.test"
+}`, backend)
+}
+
+func testAccAWSAuthBackendClientConfigSTSRegionNoEndpoint(backend string) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "aws" {
+  path = "%s"
+  type = "aws"
+  description = "Test auth backend for AWS backend client config"
+}
+
+resource "vault_aws_auth_backend_client" "client" {
+  backend = "${vault_auth_backend.aws.path}"
+  access_key = "AWSACCESSKEY"
+  ec2_endpoint = "http://vault.test/ec2"
+  iam_endpoint = "http://vault.test/iam"
+  sts_region = "vault-test"
+  iam_server_id_header_value = "vault.test"
 }`, backend)
 }

--- a/website/docs/r/aws_auth_backend_client.html.md
+++ b/website/docs/r/aws_auth_backend_client.html.md
@@ -60,6 +60,9 @@ The following arguments are supported:
 * `sts_endpoint` - (Optional) Override the URL Vault uses when making STS API
 	calls.
 
+* `sts_region` - (Optional) Override the default region when making STS API 
+    calls. The `sts_endpoint` argument must be set when using `sts_region`.
+
 * `iam_server_id_header_value` - (Optional) The value to require in the
 	`X-Vault-AWS-IAM-Server-ID` header as part of `GetCallerIdentity` requests
 	that are used in the IAM auth method.


### PR DESCRIPTION
This adds `sts_region` to the AWS auth backend client to allows users to configure the default STS region when `sts_endpoint` is used.

Closes #689.

```release-note
* `vault_aws_auth_backend_client`: Added `sts_region` parameter
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run TestAccAWSAuthBackendClientStsRegionNoEndpoint'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccAWSAuthBackendClientStsRegionNoEndpoint -timeout 120m
?   	github.com/hashicorp/terraform-provider-vault	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/generate	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/codegen	0.377s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/generated	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode	2.039s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode	1.508s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet	1.234s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role	1.772s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template	0.659s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation	0.968s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/schema	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/util	0.605s [no tests to run]
=== RUN   TestAccAWSAuthBackendClientStsRegionNoEndpoint
--- PASS: TestAccAWSAuthBackendClientStsRegionNoEndpoint (0.15s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/vault	1.948s
```
