### PR TITLE
doc: fix typo in PKI

### DIFF
--- a/website/docs/r/pki_secret_backend_root_sign_intermediate.html.md
+++ b/website/docs/r/pki_secret_backend_root_sign_intermediate.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # vault\_pki\_secret\_backend\_root\_sign\_intermediate
 
-Creates an PKI certificate.
+Creates PKI certificate.
 
 ## Example Usage
 


### PR DESCRIPTION
Incorrect grammar in the PKI documentation.

Fixes #940.