### PR TITLE
WIP: Trim leading / from Vault auth backend path

### DIFF
--- a/vault/resource_auth_backend.go
+++ b/vault/resource_auth_backend.go
@@ -40,6 +40,9 @@ func AuthBackendResource() *schema.Resource {
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					return old+"/" == new || new+"/" == old
 				},
+				StateFunc: func(v interface{}) string {
+					return strings.Trim(v.(string), "/")
+				},
 			},
 
 			"description": {

--- a/website/docs/r/auth_backend.html.md
+++ b/website/docs/r/auth_backend.html.md
@@ -28,7 +28,7 @@ The following arguments are supported:
 
 * `type` - (Required) The name of the auth method type
 
-* `path` - (Optional) The path to mount the auth method — this defaults to the name of the type
+* `path` - (Optional) The path to mount the auth method — this defaults to the name of the type. Note that leading slashes will be auto-removed if used.
 
 * `description` - (Optional) A description of the auth method
 


### PR DESCRIPTION
@catsby, I was trying to work on this and a bit confused since I don't see any files where validateFunc, DiffSuppressFunc, and StateFunc are used at the same time. Hopefully this is okay. The other approach I was wondering would be to update ValidateFunc's `validateNoTrailingSlash` method to be a `validateNoTrailingAndLeadingSlash` method. Let me know either way. 

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-vault/issues/865

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Trim leading / from Vault auth backend path
```