### PR TITLE
docs: Added "Import" section for identity_entity_alias

### DIFF
--- a/website/docs/r/identity_entity_alias.html.md
+++ b/website/docs/r/identity_entity_alias.html.md
@@ -41,3 +41,11 @@ The following arguments are supported:
 ## Attributes Reference
 
 * `id` - ID of the entity alias.
+
+## Import
+
+Identity entity alias can be imported using the `id`, e.g.
+
+```
+$ terraform import vault_identity_entity_alias.test "3856fb4d-3c91-dcaf-2401-68f446796bfb"
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* Adds "Import" section for "identity_entity_alias" resource documentation page.
```
