### PR TITLE
WIP: JWT/OIDC provider_config for gsuite

### DIFF
--- a/vault/resource_jwt_auth_backend.go
+++ b/vault/resource_jwt_auth_backend.go
@@ -121,12 +121,42 @@ func jwtAuthBackendResource() *schema.Resource {
 				Computed:    true,
 				Description: "The accessor of the JWT auth backend",
 			},
+
 			"provider_config": {
-				Type:        schema.TypeMap,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "Provider specific handling configuration",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"provider": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"gsuit_service_account": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"gsuite_admin_impersonate": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"fetch_groups": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"fetch_user_info": {
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"groups_recurse_max_depth": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"user_custom_schemas": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
 				},
 			},
 			"tune": authMountTuneSchema(),


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #828 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Enable all variables in provider_config block of OIDC auth as per documentation concerning gsuite. 
This should add on top of @Gaardsholt implementation at https://github.com/hashicorp/terraform-provider-vault/pull/943
```

Output from acceptance testing:

```
   ╰╼ ϟ make test                                                                                                                                                   
==> Checking that code complies with gofmt requirements...
go test -i $(go list ./... |grep -v 'vendor') || exit 1
echo $(go list ./... |grep -v 'vendor') | \
        xargs -t -n4 go test  -timeout=30s -parallel=4
go test '-timeout=30s' '-parallel=4' github.com/hashicorp/terraform-provider-vault github.com/hashicorp/terraform-provider-vault/cmd/coverage github.com/hashicorp/terraform-provider-vault/cmd/generate github.com/hashicorp/terraform-provider-vault/codegen 
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/codegen   (cached)
go test '-timeout=30s' '-parallel=4' github.com/hashicorp/terraform-provider-vault/generated github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet 
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    (cached)
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    (cached)
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    (cached)
go test '-timeout=30s' '-parallel=4' github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation github.com/hashicorp/terraform-provider-vault/schema 
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        (cached)
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    (cached)
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      (cached)
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
go test '-timeout=30s' '-parallel=4' github.com/hashicorp/terraform-provider-vault/util github.com/hashicorp/terraform-provider-vault/vault 
ok      github.com/hashicorp/terraform-provider-vault/util      (cached)
ok      github.com/hashicorp/terraform-provider-vault/vault     (cached)
```

...
```
