### PR TITLE
Optional child token config

### DIFF
--- a/vault/provider_test.go
+++ b/vault/provider_test.go
@@ -186,7 +186,7 @@ func TestTokenReadProviderConfigureWithHeaders(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testHeaderConfig("auth", "123"),
-				Check:  testTokenName_check("token-testtoken"),
+				Check:  checkTestSecretData("display_name", "token-testtoken"),
 			},
 		},
 	})
@@ -599,46 +599,123 @@ func TestAccTokenName(t *testing.T) {
 							}
 						}
 					},
-					Config: testTokenNameConfig(test.UseTokenNameSchema, test.TokenNameSchema),
-					Check:  testTokenName_check(test.WantTokenName),
+					Config: testProviderConfig(test.UseTokenNameSchema, `token_name = "`+test.TokenNameSchema+`"`),
+					Check:  checkTestSecretData("display_name", test.WantTokenName),
 				},
 			},
+			CheckDestroy: testEnvCleanup("VAULT_TOKEN_NAME"),
+		})
+	}
+}
+
+func TestAccChildToken(t *testing.T) {
+
+	tests := []struct {
+		ChildTokenEnv        string
+		TestChildTokenEnv    bool
+		ChildTokenSchema     string
+		TestChildTokenSchema bool
+		ExpectChildToken     bool
+	}{
+		{
+			TestChildTokenSchema: false,
+			TestChildTokenEnv:    false,
+			ExpectChildToken:     true,
+		},
+		{
+			ChildTokenEnv:     "",
+			TestChildTokenEnv: true,
+			ExpectChildToken:  true,
+		},
+		{
+			ChildTokenEnv:     "true",
+			TestChildTokenEnv: true,
+			ExpectChildToken:  true,
+		},
+		{
+			ChildTokenEnv:     "false",
+			TestChildTokenEnv: true,
+			ExpectChildToken:  false,
+		},
+		{
+			ChildTokenSchema:     "true",
+			TestChildTokenSchema: true,
+			ExpectChildToken:     true,
+		},
+		{
+			ChildTokenSchema:     "false",
+			TestChildTokenSchema: true,
+			ExpectChildToken:     false,
+		},
+		{
+			ChildTokenEnv:        "true",
+			TestChildTokenEnv:    true,
+			ChildTokenSchema:     "false",
+			TestChildTokenSchema: true,
+			ExpectChildToken:     false,
+		},
+		{
+			ChildTokenEnv:        "false",
+			TestChildTokenEnv:    true,
+			ChildTokenSchema:     "true",
+			TestChildTokenSchema: true,
+			ExpectChildToken:     true,
+		},
+	}
+
+	for _, test := range tests {
+		resource.Test(t, resource.TestCase{
+			Providers: testProviders,
+			PreCheck:  func() { testAccPreCheck(t) },
+			Steps: []resource.TestStep{
+				{
+					PreConfig: func() {
+						if test.TestChildTokenEnv {
+							err := os.Setenv("TERRAFORM_VAULT_CREATE_CHILD_TOKEN", test.ChildTokenEnv)
+							if err != nil {
+								t.Fatal(err)
+							}
+						} else {
+							err := os.Unsetenv("TERRAFORM_VAULT_CREATE_CHILD_TOKEN")
+							if err != nil {
+								t.Fatal(err)
+							}
+						}
+					},
+					Config: testProviderConfig(test.TestChildTokenSchema, `create_intermediate_child_token = `+test.ChildTokenSchema),
+					Check:  checkUsedToken(test.ExpectChildToken),
+				},
+			},
+			CheckDestroy: testEnvCleanup("TERRAFORM_VAULT_CREATE_CHILD_TOKEN"),
 		})
 	}
 }
 
 func testHeaderConfig(headerName, headerValue string) string {
 	providerConfig := fmt.Sprintf(`
-	provider "vault" {
 		headers {
 			name  = "%s" 
 			value = "%s"
 		}
 		token_name = "testtoken"
-	}
-
-	data "vault_generic_secret" "test" {
-		path = "/auth/token/lookup-self"
-	}
 	`, headerName, headerValue)
-	return providerConfig
+	return testProviderConfig(true, providerConfig)
 }
 
 // Using the data lookup generic_secret to inspect used token
 // by terraform (this enables check of token name)
-func testTokenNameConfig(tokenNameSchema bool, tokenName string) string {
+func testProviderConfig(includeProviderConfig bool, config string) string {
 	testConfig := ""
-	providerConfig := `
-provider "vault" {
-    token_name = "` + tokenName + `"
-}`
+	providerConfig := fmt.Sprintf(`
+	provider "vault" {
+		%s
+	}`, config)
 
 	dataConfig := `
-data "vault_generic_secret" "test" {
-    path = "/auth/token/lookup-self"
-}
-`
-	if tokenNameSchema {
+	data "vault_generic_secret" "test" {
+		path = "/auth/token/lookup-self"
+	}`
+	if includeProviderConfig {
 		testConfig = providerConfig + dataConfig
 	} else {
 		testConfig = dataConfig
@@ -646,7 +723,7 @@ data "vault_generic_secret" "test" {
 	return testConfig
 }
 
-func testTokenName_check(expectedTokenName string) resource.TestCheckFunc {
+func checkTestSecretData(attrName string, expectedValue string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		resourceState := s.Modules[0].Resources["data.vault_generic_secret.test"]
 		if resourceState == nil {
@@ -658,16 +735,35 @@ func testTokenName_check(expectedTokenName string) resource.TestCheckFunc {
 			return fmt.Errorf("resource has no primary instance")
 		}
 
-		tokenName, ok := resourceState.Primary.Attributes["data.display_name"]
+		actualValue, ok := resourceState.Primary.Attributes["data."+attrName]
 		if !ok {
-			return fmt.Errorf("cannot access token [%s] for check", "display_name")
+			return fmt.Errorf("cannot access attribute [%s] for check", attrName)
 		}
 
-		if tokenName != expectedTokenName {
-			return fmt.Errorf("token name [%s] expected, but got [%s]", expectedTokenName, tokenName)
+		if actualValue != expectedValue {
+			return fmt.Errorf("%s [%s] expected, but got [%s]", attrName, expectedValue, actualValue)
 		}
 
 		return nil
+	}
+}
+
+func checkUsedToken(expectChildToken bool) resource.TestCheckFunc {
+	if expectChildToken {
+		// If the default child token was created, we expect the token
+		// used by the provider was named the default "token-terraform"
+		return checkTestSecretData("display_name", "token-terraform")
+	} else {
+		// If the child token setting was disabled, the used token
+		// should match the user-provided VAULT_TOKEN
+		return checkTestSecretData("id", os.Getenv("VAULT_TOKEN"))
+	}
+}
+
+func testEnvCleanup(envVar string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		err := os.Unsetenv(envVar)
+		return err
 	}
 }
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -135,6 +135,19 @@ variables in order to keep credential information out of the configuration.
   that Terraform can be tricked into writing secrets to a server controlled
   by an intruder. May be set via the `VAULT_SKIP_VERIFY` environment variable.
 
+* `create_intermediate_child_token` - (Optional) Set this to `false` to disable
+  creation and use of an intermediate ephemeral Vault token for Terraform to
+  use. This is strongly discouraged in most cases and environments because it
+  can result in the provided Vault token being exposed by Terraform's output.
+  Only change this setting when the provided token cannot be permitted to
+  create child tokens and there is no risk of exposure from the output of
+  Terraform. May be set via the `TERRAFORM_VAULT_CREATE_CHILD_TOKEN`
+  environment variable. **Note**: Setting to `false` will cause `token_name`
+  and `max_lease_ttl_seconds` to be ignored.
+
+  See the section above on *Using Vault credentials in Terraform configuration*
+  for more details on why it is not recommended to disable this setting.
+
 * `max_lease_ttl_seconds` - (Optional) Used as the duration for the
   intermediate Vault token Terraform issues itself, which in turn limits
   the duration of secret leases issued by Vault. Defaults to 20 minutes


### PR DESCRIPTION
> This adds a new (often requested) vault provider configuration setting which can allow users to disable the creation of the intermediate child token (strongly discouraged, but made available for the cases that need it).
> 
> ```
> provider "vault" {
>     address = "https://vault.testdomain"
>     create_intermediate_child_token = false
> }
> ```
> 
> (Open to changing the name of this config item, or related env var, but I like to be verbose with settings that typically shouldn't be adjusted without reading the documentation).
> ### Community Note
> 
>     * Please vote on this pull request by adding a +1 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
> 
>     * Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request
> 
> 
> Closes #29
> Closes #722
> Relates #550
> Relates #368
> Relates #192
> 
> Relates to the following as well:
> [hashicorp/terraform#16457](https://github.com/hashicorp/terraform/issues/16457)
> [hashicorp/terraform#14839](https://github.com/hashicorp/terraform/pull/14839)
> https://groups.google.com/forum/#!topic/terraform-tool/wtlLrKVQlAo
> 
> Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-vault/blob/master/CHANGELOG.md):
> 
> ```
> Add `create_intermediate_child_token` optional provider configuration setting to control the use of ephemeral child tokens for use by terraform.
> ```
> 
> Output from acceptance testing:
> 
> ```
> $ make testacc TESTARGS='-run TestAccChildToken'
> ==> Checking that code complies with gofmt requirements...
> TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run TestAccChildToken -timeout 120m
> ?   	github.com/terraform-providers/terraform-provider-vault	[no test files]
> ?   	github.com/terraform-providers/terraform-provider-vault/cmd/coverage	[no test files]
> testing: warning: no tests to run
> PASS
> ok  	github.com/terraform-providers/terraform-provider-vault/util	0.012s [no tests to run]
> === RUN   TestAccChildToken
> --- PASS: TestAccChildToken (1.15s)
> PASS
> ok  	github.com/terraform-providers/terraform-provider-vault/vault	1.168s
> ```

