### PR TITLE
Fix exists check when create and read policy

### DIFF
--- a/vault/data_source_aws_access_credentials_test.go
+++ b/vault/data_source_aws_access_credentials_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/sts"
-	cleanhttp "github.com/hashicorp/go-cleanhttp"
+	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"

--- a/vault/resource_gcp_secret_roleset.go
+++ b/vault/resource_gcp_secret_roleset.go
@@ -235,7 +235,7 @@ func gcpSecretRolesetFlattenBinding(v interface{}) interface{} {
 		return v
 	}
 
-	rawBindings := v.((map[string]interface{}))
+	rawBindings := v.(map[string]interface{})
 	transformed := schema.NewSet(gcpSecretRolesetBindingHash, []interface{}{})
 	for resource, roles := range rawBindings {
 		transformed.Add(map[string]interface{}{

--- a/vault/resource_pki_secret_backend_cert_test.go
+++ b/vault/resource_pki_secret_backend_cert_test.go
@@ -257,7 +257,7 @@ func testPkiSecretBackendCertWaitUntilRenewal(n string) resource.TestCheckFunc {
 			return fmt.Errorf("Invalid min_seconds_remaining value: %s", err)
 		}
 
-		secondsUntilRenewal := (expiration - (int(time.Now().Unix()) + minSecondsRemain))
+		secondsUntilRenewal := expiration - (int(time.Now().Unix()) + minSecondsRemain)
 		time.Sleep(time.Duration(secondsUntilRenewal+1) * time.Second)
 
 		return nil

--- a/vault/resource_pki_secret_backend_sign_test.go
+++ b/vault/resource_pki_secret_backend_sign_test.go
@@ -311,7 +311,7 @@ func testPkiSecretBackendSignWaitUntilRenewal(n string) resource.TestCheckFunc {
 			return fmt.Errorf("Invalid min_seconds_remaining value: %s", err)
 		}
 
-		secondsUntilRenewal := (expiration - (int(time.Now().Unix()) + minSecondsRemain))
+		secondsUntilRenewal := expiration - (int(time.Now().Unix()) + minSecondsRemain)
 		time.Sleep(time.Duration(secondsUntilRenewal+1) * time.Second)
 
 		return nil


### PR DESCRIPTION
Fixs:
- Exists check when create: If policy is already exists, then return error
- Exists check when read: If policy is not exists, then return error
- Add exists function to resource scheme

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:

resource/vault_policy: Fix exists check when create and read policy
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestResourcePolicy'
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/codegen   (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
=== RUN   TestResourcePolicy
--- PASS: TestResourcePolicy (0.23s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     0.258s
```
