### PR TITLE
[doc] Add optional argument `version` for KV v2 backend

### DIFF
--- a/website/docs/d/generic_secret.html.md
+++ b/website/docs/d/generic_secret.html.md
@@ -50,6 +50,10 @@ default, this should be prefixed with `secret/`. Reading from other backends
 with this data source is possible; consult each backend's documentation
 to see which endpoints support the `GET` method.
 
+* `version` - The version of the secret to read. This is used by the
+Vault KV secrets engine - version 2 to indicate which version of the secret
+to read.
+
 ## Required Vault Capabilities
 
 Use of this resource requires the `read` capability on the given path.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Documentation change to indicate available "version" option to vault_generic_secret.
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
