### PR TITLE
Add identity details to error messages

### DIFF
--- a/vault/data_identity_entity.go
+++ b/vault/data_identity_entity.go
@@ -197,16 +197,16 @@ func identityEntityLookup(client *api.Client, data map[string]interface{}) (*api
 	resp, err := client.Logical().Write("identity/lookup/entity", data)
 
 	if err != nil {
-		return nil, fmt.Errorf("Error reading Identity Entity: %s", err)
+		return nil, fmt.Errorf("Error reading Identity Entity '%v': %s", data, err)
 	}
 
 	if resp == nil {
-		return nil, fmt.Errorf("no Identity Entity found")
+		return nil, fmt.Errorf("no Identity Entity found '%v'", data)
 	}
 
 	_, ok := resp.Data["id"]
 	if !ok {
-		return nil, fmt.Errorf("no Identity Entity found")
+		return nil, fmt.Errorf("no Identity Entity found '%v'", data)
 	}
 
 	return resp, nil

--- a/vault/data_identity_group.go
+++ b/vault/data_identity_group.go
@@ -172,16 +172,16 @@ func identityGroupLookup(client *api.Client, data map[string]interface{}) (*api.
 	resp, err := client.Logical().Write("identity/lookup/group", data)
 
 	if err != nil {
-		return nil, fmt.Errorf("Error reading Identity Group: %s", err)
+		return nil, fmt.Errorf("Error reading Identity Group '%v': %s", data, err)
 	}
 
 	if resp == nil {
-		return nil, fmt.Errorf("no Identity Group found")
+		return nil, fmt.Errorf("no Identity Group found '%v'", data)
 	}
 
 	_, ok := resp.Data["id"]
 	if !ok {
-		return nil, fmt.Errorf("no Identity Group found")
+		return nil, fmt.Errorf("no Identity Group found '%v'", data)
 	}
 
 	return resp, nil


### PR DESCRIPTION
This adds more detail to the identity data resources error messages, making it possible to identify which entry is erroring when using `for_each` or `count` resources.

Before:
```
Error: no Identity Entity found

  on main.tf line 9, in data "vault_identity_entity" "user":
   9: data "vault_identity_entity" "user" {
```

After:
```
Error: no Identity Entity found 'map[name:john@doe.com]'

  on main.tf line 9, in data "vault_identity_entity" "user":
   9: data "vault_identity_entity" "user" {
```
