### PR TITLE
Add tune support for resource_okta_auth_backend

### DIFF
--- a/vault/okta.go
+++ b/vault/okta.go
@@ -146,6 +146,10 @@ func deleteOktaGroup(client *api.Client, path, name string) error {
 	return err
 }
 
+func oktaTuneEndpoint(path string) string {
+	return fmt.Sprintf("/auth/%s", path)
+}
+
 func oktaConfigEndpoint(path string) string {
 	return fmt.Sprintf("/auth/%s/config", path)
 }

--- a/vault/resource_okta_auth_backend.go
+++ b/vault/resource_okta_auth_backend.go
@@ -214,6 +214,7 @@ func oktaAuthBackendResource() *schema.Resource {
 				Computed:    true,
 				Description: "The mount accessor related to the auth mount.",
 			},
+			"tune": authMountTuneSchema(),
 		},
 	})
 }
@@ -317,6 +318,19 @@ func oktaAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("error reading okta oth mount from '%q': %s", path, err)
 	}
+
+	log.Printf("[INFO] Reading okta auth tune from '%q/tune'", path)
+	rawTune, err := authMountTuneGet(client, oktaTuneEndpoint(path))
+	if err != nil {
+		return fmt.Errorf("error reading tune information from Vault: %s", err)
+	}
+
+	if err := d.Set("tune", []map[string]interface{}{rawTune}); err != nil {
+		log.Printf("[ERROR] Error when setting tune config from path '%q/tune' to state: %s", path, err)
+		return err
+	}
+
+	log.Printf("[INFO] Read okta auth tune from '%q/tune'", path)
 
 	if err := d.Set("accessor", mount.Accessor); err != nil {
 		return err
@@ -441,6 +455,19 @@ func oktaAuthBackendUpdate(d *schema.ResourceData, meta interface{}) error {
 		err = oktaAuthUpdateUsers(d, client, path, oldValue, newValue)
 		if err != nil {
 			return err
+		}
+	}
+
+	if d.HasChange("tune") {
+		if raw, ok := d.GetOk("tune"); ok {
+			log.Printf("[INFO] Writing okta auth tune to '%q'", oktaTuneEndpoint(path))
+
+			err := authMountTune(client, oktaTuneEndpoint(path), raw)
+			if err != nil {
+				return nil
+			}
+
+			d.SetPartial("tune")
 		}
 	}
 

--- a/vault/resource_okta_auth_backend_test.go
+++ b/vault/resource_okta_auth_backend_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestAccOktaAuthBackend_basic(t *testing.T) {
+	resName := "vault_okta_auth_backend.test"
 	organization := "example"
 	path := resource.PrefixedUniqueId("okta-basic-")
 
@@ -34,6 +35,10 @@ func TestAccOktaAuthBackend_basic(t *testing.T) {
 					testAccOktaAuthBackend_InitialCheck,
 					testAccOktaAuthBackend_GroupsCheck(path, "dummy", []string{"one", "two", "default"}),
 					testAccOktaAuthBackend_UsersCheck(path, "foo", []string{"dummy"}, []string{}),
+					resource.TestCheckResourceAttr(resName, "tune.1140311728.default_lease_ttl", "10m"),
+					resource.TestCheckResourceAttr(resName, "tune.1140311728.max_lease_ttl", "20m"),
+					resource.TestCheckResourceAttr(resName, "tune.1140311728.listing_visibility", "hidden"),
+					resource.TestCheckResourceAttr(resName, "tune.1140311728.token_type", "batch"),
 				),
 			},
 			{
@@ -41,6 +46,10 @@ func TestAccOktaAuthBackend_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccOktaAuthBackend_GroupsCheck(path, "example", []string{"three", "four", "default"}),
 					testAccOktaAuthBackend_UsersCheck(path, "bar", []string{"example"}, []string{}),
+					resource.TestCheckResourceAttr(resName, "tune.1364225787.default_lease_ttl", "30m"),
+					resource.TestCheckResourceAttr(resName, "tune.1364225787.max_lease_ttl", "1h"),
+					resource.TestCheckResourceAttr(resName, "tune.1364225787.listing_visibility", "unauth"),
+					resource.TestCheckResourceAttr(resName, "tune.1364225787.token_type", "default-batch"),
 				),
 			},
 		},
@@ -173,6 +182,12 @@ resource "vault_okta_auth_backend" "test" {
         username = "foo"
         groups = ["dummy"]
     }
+	tune {
+		default_lease_ttl = "10m"
+		max_lease_ttl = "20m"
+		listing_visibility = "hidden"
+		token_type = "batch"
+	}
 }
 `, path, organization)
 }
@@ -192,6 +207,12 @@ resource "vault_okta_auth_backend" "test" {
         username = "bar"
         groups = ["example"]
     }
+	tune {
+		default_lease_ttl = "30m"
+		max_lease_ttl = "1h"
+		listing_visibility = "unauth"
+		token_type = "default-batch"
+	}
 }
 `, path, organization)
 }

--- a/website/docs/r/okta_auth_backend.html.md
+++ b/website/docs/r/okta_auth_backend.html.md
@@ -68,6 +68,36 @@ If this is not supplied only locally configured groups will be enabled.
 * `user` - (Optional) Associate Okta users with groups or policies within Vault.
 [See below for more details](#okta-user). 
 
+* tune - (Optional) Extra configuration block. Structure is documented below.
+
+The `tune` block is used to tune the auth backend:
+
+* `default_lease_ttl` - (Optional) Specifies the default time-to-live.
+  If set, this overrides the global default.
+  Must be a valid [duration string](https://golang.org/pkg/time/#ParseDuration)
+
+* `max_lease_ttl` - (Optional) Specifies the maximum time-to-live.
+  If set, this overrides the global default.
+  Must be a valid [duration string](https://golang.org/pkg/time/#ParseDuration)
+
+* `audit_non_hmac_response_keys` - (Optional) Specifies the list of keys that will
+  not be HMAC'd by audit devices in the response data object.
+
+* `audit_non_hmac_request_keys` - (Optional) Specifies the list of keys that will
+  not be HMAC'd by audit devices in the request data object.
+
+* `listing_visibility` - (Optional) Specifies whether to show this mount in
+  the UI-specific listing endpoint. Valid values are "unauth" or "hidden".
+
+* `passthrough_request_headers` - (Optional) List of headers to whitelist and
+  pass from the request to the backend.
+
+* `allowed_response_headers` - (Optional) List of headers to whitelist and allowing
+  a plugin to include them in the response.
+
+* `token_type` - (Optional) Specifies the type of tokens that should be returned by
+  the mount. Valid values are "default-service", "default-batch", "service", "batch".
+
 ### Okta Group
 
 * `group_name` - (Required) Name of the group within the Okta


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

### Changes
This change adds support for tune in Okta auth. It's based on the way this was implemented with`resource_github_auth_backend`.

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
 - Adds support to `resource_okta_auth_backend` for common backend tune params
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=OktaAuthBackend'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./vault -v --run OktaAuthBackend -timeout 120m
=== RUN   TestAccOktaAuthBackendGroup_basic
--- PASS: TestAccOktaAuthBackendGroup_basic (0.32s)
=== RUN   TestAccOktaAuthBackendGroup_specialChar
--- PASS: TestAccOktaAuthBackendGroup_specialChar (0.30s)
=== RUN   TestAccOktaAuthBackend
--- PASS: TestAccOktaAuthBackend (0.52s)
=== RUN   TestAccOktaAuthBackendUser
--- PASS: TestAccOktaAuthBackendUser (0.26s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/vault	2.669s
```
