### PR TITLE
don't send empty "name" to identity/group

### DIFF
--- a/vault/resource_identity_group.go
+++ b/vault/resource_identity_group.go
@@ -144,7 +144,6 @@ func identityGroupCreate(d *schema.ResourceData, meta interface{}) error {
 	path := identityGroupPath
 
 	data := map[string]interface{}{
-		"name": name,
 		"type": typeValue,
 	}
 
@@ -157,7 +156,7 @@ func identityGroupCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("error writing IdentityGroup to %q: %s", name, err)
 	}
-	log.Printf("[DEBUG] Wrote IdentityGroup %q", name)
+	log.Printf("[DEBUG] Wrote IdentityGroup %q", resp.Data["name"])
 
 	d.SetId(resp.Data["id"].(string))
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

Vault used to ignore an empty "name" parameter for identity/group, but as of 1.6.3 it throws an error.

vault 1.6.2:
```
❯ vault write identity/group name=""                                                                                                                 
Key     Value
---     -----
id      fb5d8983-dbf3-410d-6642-2691baf10579
name    group_a8d03a5d
```

vault 1.6.3:
```
❯ vault write identity/group name=""
Error writing data to identity/group: Error making API request.

URL: PUT http://127.0.0.1:8200/v1/identity/group
Code: 400. Errors:

* empty group name

```

This resulted in a few of the TestAccIdentityGroup tests failing, so this PR doesn't set "name" on the data payload unless it's specified. 

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->


Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/vault_identity_group: Don't send name parameter unless specified.
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=^TestAccIdentityGroup'                                                     
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=^TestAccIdentityGroup -timeout 120m
?   	github.com/hashicorp/terraform-provider-vault	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/generate	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/codegen	1.347s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/generated	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode	0.833s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode	2.138s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet	1.900s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role	1.644s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template	1.413s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation	1.135s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/schema	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/util	0.508s [no tests to run]
=== RUN   TestAccIdentityGroupAlias
--- PASS: TestAccIdentityGroupAlias (0.14s)
=== RUN   TestAccIdentityGroupAliasUpdate
--- PASS: TestAccIdentityGroupAliasUpdate (0.22s)
=== RUN   TestAccIdentityGroupMemberEntityIdsExclusiveEmpty
--- PASS: TestAccIdentityGroupMemberEntityIdsExclusiveEmpty (0.28s)
=== RUN   TestAccIdentityGroupMemberEntityIdsExclusive
--- SKIP: TestAccIdentityGroupMemberEntityIdsExclusive (0.00s)
    resource_identity_group_member_entity_ids_test.go:51: &{{{{0 0} 0 0 0 0} [] {0xc0005aae00} false false false false map[] true false 0 0 testing.tRunner 0xc0005aa100 1 [17906504 17890857 17897223 17892966 33687925 16985990 17175873] TestAccIdentityGroupMemberEntityIdsExclusive {13838484055737031576 652386480 0x32ba280} 0 0xc0004bc5a0 0xc0004bc600 []} false 0xc00046afc0}
=== RUN   TestAccIdentityGroupMemberEntityIdsNonExclusiveEmpty
--- PASS: TestAccIdentityGroupMemberEntityIdsNonExclusiveEmpty (0.30s)
=== RUN   TestAccIdentityGroupMemberEntityIdsNonExclusive
--- SKIP: TestAccIdentityGroupMemberEntityIdsNonExclusive (0.00s)
    resource_identity_group_member_entity_ids_test.go:121: &{{{{0 0} 0 0 0 0} [] {0xc001148e00} false false false false map[] true false 0 0 testing.tRunner 0xc0005aa100 1 [17906504 17890857 17897223 17892966 33687925 16985990 17175873] TestAccIdentityGroupMemberEntityIdsNonExclusive {13838484056032804576 948149750 0x32ba280} 0 0xc0004bc8a0 0xc0004bc900 []} false 0xc00046afc0}
=== RUN   TestAccIdentityGroupPoliciesExclusive
--- PASS: TestAccIdentityGroupPoliciesExclusive (0.19s)
=== RUN   TestAccIdentityGroupPoliciesNonExclusive
--- PASS: TestAccIdentityGroupPoliciesNonExclusive (0.20s)
=== RUN   TestAccIdentityGroup
--- PASS: TestAccIdentityGroup (0.10s)
=== RUN   TestAccIdentityGroupUpdate
--- PASS: TestAccIdentityGroupUpdate (0.41s)
=== RUN   TestAccIdentityGroupExternal
--- PASS: TestAccIdentityGroupExternal (0.10s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/vault	4.111s

```
