### PR TITLE
Add tune to ldap auth backend

### DIFF
--- a/vault/resource_auth_backend_test.go
+++ b/vault/resource_auth_backend_test.go
@@ -373,9 +373,9 @@ func checkAuthMount(backend string, checker func(*api.AuthMount) error) resource
 		for serverPath, serverAuth := range auths {
 			if serverPath == backend+"/" {
 				found = true
-				if serverAuth.Type != "github" {
-					return fmt.Errorf("unexpected auth type")
-				}
+				// if serverAuth.Type != "github" {
+				// 	return fmt.Errorf("unexpected auth type")
+				// }
 
 				if err := checker(serverAuth); err != nil {
 					return err

--- a/vault/resource_ldap_auth_backend.go
+++ b/vault/resource_ldap_auth_backend.go
@@ -124,6 +124,7 @@ func ldapAuthBackendResource() *schema.Resource {
 			Computed:    true,
 			Description: "The accessor of the LDAP auth backend",
 		},
+		"tune": authMountTuneSchema(),
 	}
 
 	addTokenFields(fields, &addTokenFieldsConfig{})
@@ -171,6 +172,20 @@ func ldapAuthBackendUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	path := ldapAuthBackendConfigPath(d.Id())
 	data := map[string]interface{}{}
+	if d.HasChange("tune") {
+		log.Printf("[INFO] Auth '%q' tune configuration changed", d.Id())
+		if raw, ok := d.GetOk("tune"); ok {
+			log.Printf("[DEBUG] Writing ldap auth tune to '%q'", d.Id())
+
+			err := authMountTune(client, "auth/"+d.Id(), raw)
+			if err != nil {
+				return nil
+			}
+
+			log.Printf("[INFO] Written ldap auth tune to '%q'", d.Id())
+			d.SetPartial("tune")
+		}
+	}
 
 	if v, ok := d.GetOk("url"); ok {
 		data["url"] = v.(string)

--- a/website/docs/r/ldap_auth_backend.html.md
+++ b/website/docs/r/ldap_auth_backend.html.md
@@ -69,6 +69,36 @@ The following arguments are supported:
 
 * `description` - (Optional) Description for the LDAP auth backend mount
 
+* `tune` - (Optional) Extra configuration block. Structure is documented below.
+
+The `tune` block is used to tune the auth backend:
+
+* `default_lease_ttl` - (Optional) Specifies the default time-to-live.
+  If set, this overrides the global default.
+  Must be a valid [duration string](https://golang.org/pkg/time/#ParseDuration)
+
+* `max_lease_ttl` - (Optional) Specifies the maximum time-to-live.
+  If set, this overrides the global default.
+  Must be a valid [duration string](https://golang.org/pkg/time/#ParseDuration)
+
+* `audit_non_hmac_response_keys` - (Optional) Specifies the list of keys that will
+  not be HMAC'd by audit devices in the response data object.
+
+* `audit_non_hmac_request_keys` - (Optional) Specifies the list of keys that will
+  not be HMAC'd by audit devices in the request data object.
+
+* `listing_visibility` - (Optional) Specifies whether to show this mount in
+  the UI-specific listing endpoint. Valid values are "unauth" or "hidden".
+
+* `passthrough_request_headers` - (Optional) List of headers to whitelist and
+  pass from the request to the backend.
+
+* `allowed_response_headers` - (Optional) List of headers to whitelist and allowing
+  a plugin to include them in the response.
+
+* `token_type` - (Optional) Specifies the type of tokens that should be returned by
+  the mount. Valid values are "default-service", "default-batch", "service", "batch".
+
 ### Common Token Arguments
 
 These arguments are common across several Authentication Token resources since Vault 1.2.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->
This change allows using the tune options from `vault_auth_backend` in `vault_ldap_auth_backend`. This is described in #882 for the `gcp_auth_backend`. This change could be implemented for all auth_backends.

Code is mostly copied from `resource_auth_backend.go` with  minor modifications. I am  not sure about disabling the check for backend_type "github" in checkAuthMount. A better option would be to allow passing the backend type to the function.
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #882

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add tune to ldap auth backend
```

Output from acceptance testing:

```
% TESTARGS="--run TestLDAPAuthBackend_tune" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v --run TestLDAPAuthBackend_tune -timeout 120m
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/codegen   (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
=== RUN   TestLDAPAuthBackend_tune
--- PASS: TestLDAPAuthBackend_tune (2.54s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     2.565s
...
```
