### PR TITLE
Create azure secrets backend Update Functionality

### DIFF
--- a/vault/resource_azure_secret_backend.go
+++ b/vault/resource_azure_secret_backend.go
@@ -13,7 +13,7 @@ func azureSecretBackendResource() *schema.Resource {
 	return &schema.Resource{
 		Create: azureSecretBackendCreate,
 		Read:   azureSecretBackendRead,
-		Update: azureSecretBackendCreate,
+		Update: azureSecretBackendUpdate,
 		Delete: azureSecretBackendDelete,
 		Exists: azureSecretBackendExists,
 		Importer: &schema.ResourceImporter{
@@ -145,10 +145,66 @@ func azureSecretBackendRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
+	log.Printf("[DEBUG] Read Azure secret Backend config %s", path)
+	resp, err := client.Logical().Read(path + "/config")
+	if err != nil {
+		if v, ok := resp.Data["client_id"].(string); ok {
+			d.Set("client_id", v)
+		}
+		if v, ok := resp.Data["subscription_id"].(string); ok {
+			d.Set("subscription_id", v)
+		}
+		if v, ok := resp.Data["tenant_id"].(string); ok {
+			d.Set("tenant_id", v)
+		}
+		if v, ok := resp.Data["environment"].(string); ok && v != "" {
+			d.Set("environment", v)
+		} else {
+			d.Set("environment", "AzurePublicCloud")
+		}
+	}
+
 	d.Set("path", path)
 	d.Set("description", mount.Description)
 
 	return nil
+}
+
+func azureSecretBackendUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	path := d.Id()
+	d.Partial(true)
+	if d.HasChange("client_id") || d.HasChange("environment") || d.HasChange("tenant_id") || d.HasChange("client_secret") {
+		log.Printf("[DEBUG] Updating Azure Backend Config at %q", path+"/config")
+		data := map[string]interface{}{
+			"tenant_id":       d.Get("tenant_id").(string),
+			"client_id":       d.Get("client_id").(string),
+			"client_secret":   d.Get("client_secret").(string),
+			"subscription_id": d.Get("subscription_id").(string),
+		}
+
+		environment := d.Get("environment").(string)
+		if environment != "" {
+			data["environment"] = environment
+		}
+
+		_, err := client.Logical().Write(path+"/config", data)
+		if err != nil {
+			return fmt.Errorf("error writing config for %q: %s", path, err)
+		}
+		log.Printf("[DEBUG] Updated Azure Backend Config at %q", path+"/config")
+		d.SetPartial("tenant_id")
+		d.SetPartial("client_id")
+		d.SetPartial("cleint_secret")
+		d.SetPartial("subscription_id")
+		if environment == "" {
+			d.Set("environment", "AzurePublicCloud")
+		}
+		d.SetPartial("environment")
+	}
+	d.Partial(false)
+	return azureSecretBackendRead(d, meta)
 }
 
 func azureSecretBackendDelete(d *schema.ResourceData, meta interface{}) error {

--- a/vault/resource_azure_secret_backend_test.go
+++ b/vault/resource_azure_secret_backend_test.go
@@ -69,24 +69,24 @@ func testAccAzureSecretBackendCheckDestroy(s *terraform.State) error {
 
 func testAzureSecretBackend_initialConfig(path string) string {
 	return fmt.Sprintf(`
-resource "vault_azure_secret_backend" "test" {
-  path = "%s"
-	subscription_id = "11111111-2222-3333-4444-111111111111"
-	tenant_id = "11111111-2222-3333-4444-222222222222"
-  client_id = "11111111-2222-3333-4444-333333333333"
-	client_secret = "12345678901234567890"
-	environment = "AzurePublicCloud"
-}`, path)
+	resource "vault_azure_secret_backend" "test" {
+	 path = "%s"
+	 subscription_id = "11111111-2222-3333-4444-111111111111"
+	 tenant_id = "11111111-2222-3333-4444-222222222222"
+	 client_id = "11111111-2222-3333-4444-333333333333"
+	 client_secret = "12345678901234567890"
+	 environment = "AzurePublicCloud"
+	}`, path)
 }
 
 func testAzureSecretBackend_updated(path string) string {
 	return fmt.Sprintf(`
 	resource "vault_azure_secret_backend" "test" {
-	  path = "%s"
-		subscription_id = "11111111-2222-3333-4444-111111111111"
-		tenant_id = "22222222-3333-4444-5555-333333333333"
-		client_id = "22222222-3333-4444-5555-444444444444"
-		client_secret = "098765432109876543214"
-		environment = "AzurePublicCloud"
+	 path = "%s"
+	 subscription_id = "11111111-2222-3333-4444-111111111111"
+	 tenant_id = "22222222-3333-4444-5555-333333333333"
+	 client_id = "22222222-3333-4444-5555-444444444444"
+	 client_secret = "098765432109876543214"
+	 environment = "AzurePublicCloud"
 	}`, path)
 }

--- a/vault/resource_azure_secret_backend_test.go
+++ b/vault/resource_azure_secret_backend_test.go
@@ -29,6 +29,17 @@ func TestAzureSecretBackend(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_azure_secret_backend.test", "environment", "AzurePublicCloud"),
 				),
 			},
+			{
+				Config: testAzureSecretBackend_updated(path),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_azure_secret_backend.test", "path", path),
+					resource.TestCheckResourceAttr("vault_azure_secret_backend.test", "subscription_id", "11111111-2222-3333-4444-111111111111"),
+					resource.TestCheckResourceAttr("vault_azure_secret_backend.test", "tenant_id", "22222222-3333-4444-5555-333333333333"),
+					resource.TestCheckResourceAttr("vault_azure_secret_backend.test", "client_id", "22222222-3333-4444-5555-444444444444"),
+					resource.TestCheckResourceAttr("vault_azure_secret_backend.test", "client_secret", "098765432109876543214"),
+					resource.TestCheckResourceAttr("vault_azure_secret_backend.test", "environment", "AzurePublicCloud"),
+				),
+			},
 		},
 	})
 }
@@ -66,4 +77,16 @@ resource "vault_azure_secret_backend" "test" {
 	client_secret = "12345678901234567890"
 	environment = "AzurePublicCloud"
 }`, path)
+}
+
+func testAzureSecretBackend_updated(path string) string {
+	return fmt.Sprintf(`
+	resource "vault_azure_secret_backend" "test" {
+	  path = "%s"
+		subscription_id = "11111111-2222-3333-4444-111111111111"
+		tenant_id = "22222222-3333-4444-5555-333333333333"
+		client_id = "22222222-3333-4444-5555-444444444444"
+		client_secret = "098765432109876543214"
+		environment = "AzurePublicCloud"
+	}`, path)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Creating `azureSecretBackendUpdate` to handle updating of backend configuration avoiding bug where TF Apply will fail due to mount already existing in Vault.
```

Output from acceptance testing:

```
❯ make testacc TESTARGS='-run=TestAzureSecretBackend'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAzureSecretBackend -timeout 120m
?   	github.com/hashicorp/terraform-provider-vault	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/generate	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/codegen	0.067s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/generated	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode	0.417s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode	0.810s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet	0.679s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role	0.290s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template	0.554s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation     	0.172s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/schema	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/util	0.128s [no tests to run]
=== RUN   TestAzureSecretBackendRole
    resource_azure_secret_backend_role_test.go:18: ARM_SUBSCRIPTION_ID not set
--- SKIP: TestAzureSecretBackendRole (0.00s)
=== RUN   TestAzureSecretBackend
--- PASS: TestAzureSecretBackend (0.18s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/vault	1.136s
...
```
