### PR TITLE
Expand PR899 to also cover Entity Groups

### DIFF
--- a/vault/resource_identity_entity.go
+++ b/vault/resource_identity_entity.go
@@ -115,9 +115,9 @@ func identityEntityCreate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		return fmt.Errorf("Identity Entity %q already exists. %s", name, entityMsg)
+	} else {
+		log.Printf("[DEBUG] Wrote IdentityEntity %q", name)
 	}
-
-	log.Printf("[DEBUG] Wrote IdentityEntity %q", name)
 
 	d.SetId(resp.Data["id"].(string))
 

--- a/vault/resource_identity_group.go
+++ b/vault/resource_identity_group.go
@@ -156,7 +156,19 @@ func identityGroupCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("error writing IdentityGroup to %q: %s", name, err)
 	}
-	log.Printf("[DEBUG] Wrote IdentityGroup %q", resp.Data["name"])
+
+	if resp == nil {
+		path := identityGroupNamePath(name)
+		groupMsg := "Unable to determine group id."
+
+		if group, err := client.Logical().Read(path); err == nil {
+			groupMsg = fmt.Sprintf("Group resource ID %q may be imported.", group.Data["id"])
+		}
+
+		return fmt.Errorf("Identity Group %q already exists. %s", name, groupMsg)
+	} else {
+		log.Printf("[DEBUG] Wrote IdentityGroup %q", resp.Data["name"])
+	}
 
 	d.SetId(resp.Data["id"].(string))
 
@@ -255,6 +267,10 @@ func identityGroupExists(d *schema.ResourceData, meta interface{}) (bool, error)
 	}
 	log.Printf("[DEBUG] Checked if IdentityGroup %q exists", key)
 	return resp != nil, nil
+}
+
+func identityGroupNamePath(name string) string {
+	return fmt.Sprintf("%s/name/%s", identityGroupPath, name)
 }
 
 func identityGroupIDPath(id string) string {

--- a/website/docs/r/identity_group.html.md
+++ b/website/docs/r/identity_group.html.md
@@ -67,3 +67,11 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The `id` of the created group.
+
+## Import
+
+Identity group can be imported using the `id`, e.g.
+
+```
+$ terraform import vault_identity_group.test 'fcbf1efb-2b69-4209-bed8-811e3475dad3'
+```


### PR DESCRIPTION
* [`resource_identity_entity.go`] Log `Wrote IdentityEntity` only when `resp != nil`
* [`resource_identity_group.go`] Catch empty response in `identityGroupCreate()` and prompt to import existing resource
* [`resource_identity_group.go`] Add `identityGrpupNamePath()` function to align with `resource_identity_entity.go`
* [`identity_group.html.md`] Add import details

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request


Relates: https://github.com/hashicorp/terraform-provider-vault/issues/734, https://github.com/hashicorp/terraform-provider-vault/pull/899


Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
```release-note
BUG FIXES:
* `resource/vault_identity_group`: Fix nil pointer exception when attempting to create Identity Group which already exists ([#1010](https://github.com/hashicorp/terraform-provider-vault/pull/1010))
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccIdentityGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccIdentityGroup -timeout 120m
?   	github.com/hashicorp/terraform-provider-vault	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/generate	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/codegen	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/generated	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/schema	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/util	(cached) [no tests to run]
=== RUN   TestAccIdentityGroupAlias
--- PASS: TestAccIdentityGroupAlias (11.17s)
=== RUN   TestAccIdentityGroupAliasUpdate
--- PASS: TestAccIdentityGroupAliasUpdate (19.20s)
=== RUN   TestAccIdentityGroupMemberEntityIdsExclusiveEmpty
--- PASS: TestAccIdentityGroupMemberEntityIdsExclusiveEmpty (29.25s)
=== RUN   TestAccIdentityGroupMemberEntityIdsExclusive
    resource_identity_group_member_entity_ids_test.go:51: &{{{{0 0} 0 0 0 0} [] {0xc0022ffe00} false false false false map[] map[] []  [] 0xc00048d5c0 false false 0 0 testing.tRunner 0xc000103200 1 [17984120 17963375 17970430 17965803 31229432 17024246 17250081] TestAccIdentityGroupMemberEntityIdsExclusive {13839184608674777960 59620865687 0x29b4520} 0 0xc000279b00 0xc0003c8a80 [] {0 0}  <nil> 0} false 0xc000148ff0}
--- SKIP: TestAccIdentityGroupMemberEntityIdsExclusive (0.00s)
=== RUN   TestAccIdentityGroupMemberEntityIdsNonExclusiveEmpty
--- PASS: TestAccIdentityGroupMemberEntityIdsNonExclusiveEmpty (30.76s)
=== RUN   TestAccIdentityGroupMemberEntityIdsNonExclusive
    resource_identity_group_member_entity_ids_test.go:121: &{{{{0 0} 0 0 0 0} [] {0xc004708900} false false false false map[] map[] []  [] 0xc00048d5c0 false false 0 0 testing.tRunner 0xc000103200 1 [17984120 17963375 17970430 17965803 31229432 17024246 17250081] TestAccIdentityGroupMemberEntityIdsNonExclusive {13839184641725862504 90385257859 0x29b4520} 0 0xc004172ba0 0xc004172c00 [] {0 0}  <nil> 0} false 0xc000148ff0}
--- SKIP: TestAccIdentityGroupMemberEntityIdsNonExclusive (0.00s)
=== RUN   TestAccIdentityGroupPoliciesExclusive
--- PASS: TestAccIdentityGroupPoliciesExclusive (18.38s)
=== RUN   TestAccIdentityGroupPoliciesNonExclusive
--- PASS: TestAccIdentityGroupPoliciesNonExclusive (19.97s)
=== RUN   TestAccIdentityGroup
--- PASS: TestAccIdentityGroup (9.79s)
=== RUN   TestAccIdentityGroupUpdate
--- PASS: TestAccIdentityGroupUpdate (41.19s)
=== RUN   TestAccIdentityGroupExternal
--- PASS: TestAccIdentityGroupExternal (9.10s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/vault	190.247s
```
