### PR TITLE
Fix bound_lables not being set in gcp auth

### DIFF
--- a/vault/resource_gcp_auth_backend_role.go
+++ b/vault/resource_gcp_auth_backend_role.go
@@ -220,8 +220,8 @@ func gcpRoleUpdateFields(d *schema.ResourceData, data map[string]interface{}, cr
 		data["bound_instance_groups"] = v.(*schema.Set).List()
 	}
 
-	if v, ok := d.GetOk("bound_instance_labels"); ok {
-		data["bound_instance_labels"] = v.(*schema.Set).List()
+	if v, ok := d.GetOk("bound_labels"); ok {
+		data["bound_labels"] = v.(*schema.Set).List()
 	}
 }
 

--- a/vault/resource_gcp_auth_backend_role_test.go
+++ b/vault/resource_gcp_auth_backend_role_test.go
@@ -316,7 +316,7 @@ resource "vault_gcp_auth_backend_role" "test" {
     token_policies         = ["policy_a", "policy_b"]
     bound_regions          = ["eu-west2"]
     bound_zones            = ["europe-west2-c"]
-    bound_labels           = ["foo"]
+    bound_labels           = ["foo:bar"]
 }
 `, backend, name, projectId)
 

--- a/vault/resource_gcp_auth_backend_role_test.go
+++ b/vault/resource_gcp_auth_backend_role_test.go
@@ -91,7 +91,11 @@ func TestGCPAuthBackendRole_gce(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testGCPAuthBackendRoleConfig_gce(backend, name, projectId),
-				Check:  testGCPAuthBackendRoleCheck_attrs(expectedAttrs, backend, name),
+				Check: resource.ComposeTestCheckFunc(
+					testGCPAuthBackendRoleCheck_attrs(expectedAttrs, backend, name),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend_role.test",
+						"bound_labels.#", "1"),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
A typo in the `vault_gcp_auth_backend_role` resulted in roles not applying `bound_labels`, even if one was specified. Unfortunately the test suite didn't explicitly test for this value and the GCP auth method doesn't return empty values for roles: https://github.com/hashicorp/vault-plugin-auth-gcp/blob/master/plugin/path_role.go#L307-L310.

I've changed the test code slightly to check Vault for the appropriate resources.

Fixes #996.