### PR TITLE
Fixing JWT issuer docs

### DIFF
--- a/vault/data_source_kubernetes_auth_backend_config.go
+++ b/vault/data_source_kubernetes_auth_backend_config.go
@@ -4,9 +4,10 @@ import (
 	"strings"
 
 	"fmt"
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/vault/api"
-	"log"
 )
 
 func kubernetesAuthBackendConfigDataSource() *schema.Resource {
@@ -47,7 +48,7 @@ func kubernetesAuthBackendConfigDataSource() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Optional:    true,
-				Description: "Optional JWT issuer. If no issuer is specified, kubernetes.io/serviceaccount will be used as the default issuer.",
+				Description: "Optional JWT issuer. If no issuer is specified, kubernetes/serviceaccount will be used as the default issuer.",
 			},
 			"disable_iss_validation": {
 				Type:        schema.TypeBool,

--- a/vault/resource_kubernetes_auth_backend_config.go
+++ b/vault/resource_kubernetes_auth_backend_config.go
@@ -64,7 +64,7 @@ func kubernetesAuthBackendConfigResource() *schema.Resource {
 			"issuer": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Optional JWT issuer. If no issuer is specified, kubernetes.io/serviceaccount will be used as the default issuer.",
+				Description: "Optional JWT issuer. If no issuer is specified, kubernetes/serviceaccount will be used as the default issuer.",
 			},
 			"disable_iss_validation": {
 				Type:        schema.TypeBool,

--- a/website/docs/d/kubernetes_auth_backend_config.md
+++ b/website/docs/d/kubernetes_auth_backend_config.md
@@ -41,4 +41,4 @@ In addition to the above arguments, the following attributes are exported:
 
 * `pem_keys` - Optional list of PEM-formatted public keys or certificates used to verify the signatures of Kubernetes service account JWTs. If a certificate is given, its public key will be extracted. Not every installation of Kubernetes exposes these keys.
 
-* `issuer` - Optional JWT issuer. If no issuer is specified, `kubernetes.io/serviceaccount` will be used as the default issuer.
+* `issuer` - Optional JWT issuer. If no issuer is specified, `kubernetes/serviceaccount` will be used as the default issuer.

--- a/website/docs/r/kubernetes_auth_backend_config.md
+++ b/website/docs/r/kubernetes_auth_backend_config.md
@@ -41,7 +41,7 @@ The following arguments are supported:
 
 * `pem_keys` - (Optional) List of PEM-formatted public keys or certificates used to verify the signatures of Kubernetes service account JWTs. If a certificate is given, its public key will be extracted. Not every installation of Kubernetes exposes these keys.
 
-* `issuer` - Optional JWT issuer. If no issuer is specified, `kubernetes.io/serviceaccount` will be used as the default issuer.
+* `issuer` - Optional JWT issuer. If no issuer is specified, `kubernetes/serviceaccount` will be used as the default issuer.
 
 * `disable_iss_validation` - (Optional) Disable JWT issuer validation. Allows to skip ISS validation. Requires Vault `v1.5.4+` or Vault auth kubernetes plugin `v0.7.1+`
 


### PR DESCRIPTION
I've noticed a small typo in the documentation around JWT issuer default being `kubernetes.io/serviceaccount` whereas the default value is `kubernetes/serviceaccount`. I've created this PR but I'm not used to contribute to opensource projects (this is my first opensource PR contribution), please let me know if something can be improved!

Thanks!