### PR TITLE
Add endpoints configuration options to AWS Secrets Backend Resource

### DIFF
--- a/vault/resource_aws_secret_backend_test.go
+++ b/vault/resource_aws_secret_backend_test.go
@@ -29,6 +29,8 @@ func TestAccAWSSecretBackend_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "access_key", accessKey),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "secret_key", secretKey),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "region", "us-east-1"),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "iam_endpoint", ""),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "sts_endpoint", ""),
 				),
 			},
 			{
@@ -41,6 +43,8 @@ func TestAccAWSSecretBackend_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "access_key", accessKey),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "secret_key", secretKey),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "region", "us-west-1"),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "iam_endpoint", "https://iam.amazonaws.com"),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "sts_endpoint", "https://sts.us-west-1.amazonaws.com"),
 				),
 			},
 			{
@@ -53,6 +57,8 @@ func TestAccAWSSecretBackend_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "access_key", ""),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "secret_key", ""),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "region", "us-west-1"),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "iam_endpoint", ""),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "sts_endpoint", ""),
 				),
 			},
 		},
@@ -135,6 +141,9 @@ resource "vault_aws_secret_backend" "test" {
   access_key = "%s"
   secret_key = "%s"
   region = "us-west-1"
+
+  iam_endpoint = "https://iam.amazonaws.com"
+  sts_endpoint = "https://sts.us-west-1.amazonaws.com"
 }`, path, accessKey, secretKey)
 }
 

--- a/website/docs/r/aws_secret_backend.html.md
+++ b/website/docs/r/aws_secret_backend.html.md
@@ -63,6 +63,10 @@ issued by this backend.
 * `max_lease_ttl_seconds` - (Optional) The maximum TTL that can be requested
 for credentials issued by this backend.
 
+* `iam_endpoint` - (Optional) Specifies a custom HTTP IAM endpoint to use.
+
+* `sts_endpoint` - (Optional) Specifies a custom HTTP STS endpoint to use.
+
 ## Attributes Reference
 
 No additional attributes are exported by this resource.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add `iam_endpoint` and `sts_endpoint` options to `vault_aws_secret_backend`
```

Output from acceptance testing:

```
$ $ VAULT_ADDR='http://127.0.0.1:8200' VAULT_TOKEN=12345 TESTARGS="--run TestAccAWSSecretBackend_basic" AWS_ACCESS_KEY_ID=12344 AWS_SECRET_ACCESS_KEY=123454 make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v --run TestAccAWSSecretBackend_basic -timeout 120m
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/codegen   (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
=== RUN   TestAccAWSSecretBackend_basic
--- PASS: TestAccAWSSecretBackend_basic (0.28s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     (cached)
```
