### PR TITLE
Fix bug where entity values not removed

### DIFF
--- a/vault/resource_identity_entity.go
+++ b/vault/resource_identity_entity.go
@@ -87,20 +87,18 @@ func identityEntityUpdateFields(d *schema.ResourceData, data map[string]interfac
 			data["disabled"] = disabled
 		}
 	} else {
-		if d.HasChange("name") {
+		if d.HasChanges("name", "external_policies", "policies", "metadata", "disabled") {
 			data["name"] = d.Get("name")
-		}
-
-		if d.HasChange("policies") {
-			data["policies"] = d.Get("policies").(*schema.Set).List()
-		}
-
-		if d.HasChange("metadata") {
 			data["metadata"] = d.Get("metadata")
-		}
-
-		if d.HasChange("disabled") {
 			data["disabled"] = d.Get("disabled")
+			data["policies"] = d.Get("policies").(*schema.Set).List()
+
+			// Edge case where if external_policies is true, no policies
+			// should be configured on the entity.
+			data["external_policies"] = d.Get("external_policies").(bool)
+			if data["external_policies"].(bool) {
+				data["policies"] = nil
+			}
 		}
 	}
 }

--- a/vault/resource_identity_entity_test.go
+++ b/vault/resource_identity_entity_test.go
@@ -56,6 +56,29 @@ func TestAccIdentityEntityUpdate(t *testing.T) {
 	})
 }
 
+func TestAccIdentityEntityUpdateRemoveMetadata(t *testing.T) {
+	entity := acctest.RandomWithPrefix("test-entity")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckIdentityEntityDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityEntityConfig(entity),
+				Check:  testAccIdentityEntityCheckAttrs(),
+			},
+			{
+				Config: testAccIdentityEntityConfigUpdateRemoveMetadata(entity),
+				Check: resource.ComposeTestCheckFunc(
+					testAccIdentityEntityCheckAttrs(),
+					resource.TestCheckResourceAttr("vault_identity_entity.entity", "name", fmt.Sprintf("%s-2", entity)),
+					resource.TestCheckNoResourceAttr("vault_identity_entity.entity", "metadata")),
+			},
+		},
+	})
+}
+
 func testAccCheckIdentityEntityDestroy(s *terraform.State) error {
 	client := testProvider.Meta().(*api.Client)
 
@@ -188,5 +211,13 @@ resource "vault_identity_entity" "entity" {
   metadata = {
     version = "2"
   }
+}`, entityName)
+}
+
+func testAccIdentityEntityConfigUpdateRemoveMetadata(entityName string) string {
+	return fmt.Sprintf(`
+resource "vault_identity_entity" "entity" {
+  name = "%s-2"
+  policies = ["dev", "test"]
 }`, entityName)
 }

--- a/vault/resource_identity_entity_test.go
+++ b/vault/resource_identity_entity_test.go
@@ -56,7 +56,7 @@ func TestAccIdentityEntityUpdate(t *testing.T) {
 	})
 }
 
-func TestAccIdentityEntityUpdateRemoveMetadata(t *testing.T) {
+func TestAccIdentityEntityUpdateRemoveValues(t *testing.T) {
 	entity := acctest.RandomWithPrefix("test-entity")
 
 	resource.Test(t, resource.TestCase{
@@ -69,11 +69,14 @@ func TestAccIdentityEntityUpdateRemoveMetadata(t *testing.T) {
 				Check:  testAccIdentityEntityCheckAttrs(),
 			},
 			{
-				Config: testAccIdentityEntityConfigUpdateRemoveMetadata(entity),
+				Config: testAccIdentityEntityConfigUpdateRemove(entity),
 				Check: resource.ComposeTestCheckFunc(
 					testAccIdentityEntityCheckAttrs(),
 					resource.TestCheckResourceAttr("vault_identity_entity.entity", "name", fmt.Sprintf("%s-2", entity)),
-					resource.TestCheckNoResourceAttr("vault_identity_entity.entity", "metadata")),
+					resource.TestCheckResourceAttr("vault_identity_entity.entity", "external_policies", "false"),
+					resource.TestCheckResourceAttr("vault_identity_entity.entity", "disabled", "false"),
+					resource.TestCheckNoResourceAttr("vault_identity_entity.entity", "metadata"),
+					resource.TestCheckNoResourceAttr("vault_identity_entity.entity", "policies")),
 			},
 		},
 	})
@@ -211,13 +214,14 @@ resource "vault_identity_entity" "entity" {
   metadata = {
     version = "2"
   }
+  disabled = true
+  external_policies = true
 }`, entityName)
 }
 
-func testAccIdentityEntityConfigUpdateRemoveMetadata(entityName string) string {
+func testAccIdentityEntityConfigUpdateRemove(entityName string) string {
 	return fmt.Sprintf(`
 resource "vault_identity_entity" "entity" {
   name = "%s-2"
-  policies = ["dev", "test"]
 }`, entityName)
 }

--- a/vault/resource_identity_entity_test.go
+++ b/vault/resource_identity_entity_test.go
@@ -50,6 +50,7 @@ func TestAccIdentityEntityUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_identity_entity.entity", "policies.#", "2"),
 					resource.TestCheckResourceAttr("vault_identity_entity.entity", "policies.326271447", "dev"),
 					resource.TestCheckResourceAttr("vault_identity_entity.entity", "policies.1785148924", "test"),
+					resource.TestCheckResourceAttr("vault_identity_entity.entity", "disabled", "true"),
 				),
 			},
 		},
@@ -244,7 +245,6 @@ resource "vault_identity_entity" "entity" {
 }
 
 func testAccIdentityEntityConfigUpdateRemove(entityName string) string {
-	fmt.Println("remove")
 	return fmt.Sprintf(`
 resource "vault_identity_entity" "entity" {
   name = "%s-2"
@@ -252,7 +252,6 @@ resource "vault_identity_entity" "entity" {
 }
 
 func testAccIdentityEntityConfigUpdateRemovePolicies(entityName string) string {
-	fmt.Println("remove")
 	return fmt.Sprintf(`
 resource "vault_identity_entity" "entity" {
   name = "%s-2"


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/vault_identity_entity: Fix bug where values are not removed if removed from file
```

If values are removed from the terraform file, update sees the change but sends no values to Vault. This results in no value changes on the Vault side but Terraform says it succeeded. I've updated the code slightly to use `HasChange`.

Output from acceptance testing:

```
$ VAULT_TOKEN=root TF_ACC=true go test -v -run TestAccIdentityEntityUpdate
=== RUN   TestAccIdentityEntityUpdate
vault_identity_entity.entity:
  ID = 880aae6c-8253-d7ed-ca74-1a51cc875126
  provider = provider.vault
  disabled = false
  external_policies = false
  metadata.% = 1
  metadata.version = 2
  name = test-entity-495886142902770503-2
  policies.# = 2
  policies.1785148924 = test
  policies.326271447 = dev
vault_identity_entity.entity:
  ID = 880aae6c-8253-d7ed-ca74-1a51cc875126
  provider = provider.vault
  disabled = false
  external_policies = false
  metadata.% = 1
  metadata.version = 2
  name = test-entity-495886142902770503-2
  policies.# = 2
  policies.1785148924 = test
  policies.326271447 = dev
vault_identity_entity.entity:
  ID = 880aae6c-8253-d7ed-ca74-1a51cc875126
  provider = provider.vault
  disabled = false
  external_policies = false
  metadata.% = 1
  metadata.version = 2
  name = test-entity-495886142902770503-2
  policies.# = 2
  policies.1785148924 = test
  policies.326271447 = dev
vault_identity_entity.entity:
  ID = 880aae6c-8253-d7ed-ca74-1a51cc875126
  provider = provider.vault
  disabled = false
  external_policies = false
  metadata.% = 1
  metadata.version = 2
  name = test-entity-495886142902770503-2
  policies.# = 2
  policies.1785148924 = test
  policies.326271447 = dev
vault_identity_entity.entity:
  ID = 880aae6c-8253-d7ed-ca74-1a51cc875126
  provider = provider.vault
  disabled = false
  external_policies = false
  metadata.% = 1
  metadata.version = 2
  name = test-entity-495886142902770503-2
  policies.# = 2
  policies.1785148924 = test
  policies.326271447 = dev
--- PASS: TestAccIdentityEntityUpdate (0.17s)
=== RUN   TestAccIdentityEntityUpdateRemoveMetadata
vault_identity_entity.entity:
  ID = 7be2bf99-76df-6e7e-eeb8-e11753448044
  provider = provider.vault
  disabled = false
  external_policies = false
  metadata.% = 0
  name = test-entity-6777686168158487119-2
  policies.# = 2
  policies.1785148924 = test
  policies.326271447 = dev
vault_identity_entity.entity:
  ID = 7be2bf99-76df-6e7e-eeb8-e11753448044
  provider = provider.vault
  disabled = false
  external_policies = false
  metadata.% = 0
  name = test-entity-6777686168158487119-2
  policies.# = 2
  policies.1785148924 = test
  policies.326271447 = dev
--- PASS: TestAccIdentityEntityUpdateRemoveMetadata (0.16s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/vault	0.712s
```