### PR TITLE
Fix bug where group values not removed

### DIFF
--- a/vault/resource_identity_group.go
+++ b/vault/resource_identity_group.go
@@ -110,26 +110,41 @@ func identityGroupResource() *schema.Resource {
 	}
 }
 
-func identityGroupUpdateFields(d *schema.ResourceData, data map[string]interface{}) error {
-	if name, ok := d.GetOk("name"); ok {
-		data["name"] = name
-	}
-
-	if externalPolicies, ok := d.GetOk("external_policies"); !(ok && externalPolicies.(bool)) {
-		data["policies"] = d.Get("policies").(*schema.Set).List()
-	}
-
-	// Member groups and entities can't be set for external groups
-	if d.Get("type").(string) == "internal" {
-		data["member_group_ids"] = d.Get("member_group_ids").(*schema.Set).List()
-
-		if externalMemberEntityIds, ok := d.GetOk("external_member_entity_ids"); !(ok && externalMemberEntityIds.(bool)) {
-			data["member_entity_ids"] = d.Get("member_entity_ids").(*schema.Set).List()
+func identityGroupUpdateFields(d *schema.ResourceData, data map[string]interface{}, create bool) error {
+	if create {
+		if name, ok := d.GetOk("name"); ok {
+			data["name"] = name
 		}
-	}
 
-	if metadata, ok := d.GetOk("metadata"); ok {
-		data["metadata"] = metadata
+		if externalPolicies, ok := d.GetOk("external_policies"); !(ok && externalPolicies.(bool)) {
+			data["policies"] = d.Get("policies").(*schema.Set).List()
+		}
+
+		// Member groups and entities can't be set for external groups
+		if d.Get("type").(string) == "internal" {
+			data["member_group_ids"] = d.Get("member_group_ids").(*schema.Set).List()
+
+			if externalMemberEntityIds, ok := d.GetOk("external_member_entity_ids"); !(ok && externalMemberEntityIds.(bool)) {
+				data["member_entity_ids"] = d.Get("member_entity_ids").(*schema.Set).List()
+			}
+		}
+
+		if metadata, ok := d.GetOk("metadata"); ok {
+			data["metadata"] = metadata
+		}
+	} else {
+		if d.HasChanges("name", "external_policies", "policies", "metadata") {
+			data["name"] = d.Get("name")
+			data["metadata"] = d.Get("metadata")
+			data["policies"] = d.Get("policies").(*schema.Set).List()
+
+			// Edge case where if external_policies is true, no policies
+			// should be configured on the entity.
+			data["external_policies"] = d.Get("external_policies").(bool)
+			if data["external_policies"].(bool) {
+				data["policies"] = nil
+			}
+		}
 	}
 
 	return nil
@@ -147,7 +162,7 @@ func identityGroupCreate(d *schema.ResourceData, meta interface{}) error {
 		"type": typeValue,
 	}
 
-	if err := identityGroupUpdateFields(d, data); err != nil {
+	if err := identityGroupUpdateFields(d, data, true); err != nil {
 		return fmt.Errorf("error writing IdentityGroup to %q: %s", name, err)
 	}
 
@@ -175,7 +190,7 @@ func identityGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	data := map[string]interface{}{}
 
-	if err := identityGroupUpdateFields(d, data); err != nil {
+	if err := identityGroupUpdateFields(d, data, false); err != nil {
 		return fmt.Errorf("error updating IdentityGroup %q: %s", id, err)
 	}
 

--- a/vault/resource_identity_group.go
+++ b/vault/resource_identity_group.go
@@ -133,16 +133,24 @@ func identityGroupUpdateFields(d *schema.ResourceData, data map[string]interface
 			data["metadata"] = metadata
 		}
 	} else {
-		if d.HasChanges("name", "external_policies", "policies", "metadata") {
+		if d.HasChanges("name", "external_policies", "policies", "metadata", "member_entity_ids", "member_group_ids") {
 			data["name"] = d.Get("name")
 			data["metadata"] = d.Get("metadata")
 			data["policies"] = d.Get("policies").(*schema.Set).List()
+			data["member_entity_ids"] = d.Get("member_entity_ids").(*schema.Set).List()
+			data["member_group_ids"] = d.Get("member_group_ids").(*schema.Set).List()
+
 
 			// Edge case where if external_policies is true, no policies
 			// should be configured on the entity.
 			data["external_policies"] = d.Get("external_policies").(bool)
 			if data["external_policies"].(bool) {
 				data["policies"] = nil
+			}
+			// if external_member_entity_ids is true, member_entity_ids will be nil
+			data["external_member_entity_ids"] = d.Get("external_member_entity_ids").(bool)
+			if data["external_member_entity_ids"].(bool) {
+				data["member_entity_ids"] = nil
 			}
 		}
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates
This change is similar to PR (https://github.com/hashicorp/terraform-provider-vault/pull/1054) but just for `vault_identity_group`. 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--

-->

```release-note
resource/vault_identity_group: Fix bug where metadata values are not removed if removed from file
```
If values are removed from the terraform file, update sees the change but sends no values to Vault. This results in no value changes on the Vault side but Terraform says it succeeded. Updated the code slightly to use HasChange.
