### PR TITLE
RabbitMQ doc fix - path defaults to `rabbitmq`, not `aws`.

### DIFF
--- a/website/docs/r/rabbitmq_secret_backend.html.md
+++ b/website/docs/r/rabbitmq_secret_backend.html.md
@@ -48,7 +48,7 @@ on `connection_uri`, `username`, `password` or `verify_connection`. Changing the
 overwrite the previously stored values.
 
 * `path` - (Optional) The unique path this backend should be mounted at. Must
-not begin or end with a `/`. Defaults to `aws`.
+not begin or end with a `/`. Defaults to `rabbitmq`.
 
 * `description` - (Optional) A human-friendly description for this backend.
 


### PR DESCRIPTION
This fixes a typo in the `rabbitmq_secret_backend` doc. [The path defaults to rabbitmq](https://github.com/hashicorp/terraform-provider-vault/blob/a75e80a5f635e03091a5336b5064a463b5a6e9a9/vault/resource_rabbitmq_secret_backend.go#L26), not `aws`. 

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

N/A
```
