### PR TITLE
Support terraform import for vault_pki_secret_backend_config_urls resource

### DIFF
--- a/vault/import_pki_secret_backend_config_urls_test.go
+++ b/vault/import_pki_secret_backend_config_urls_test.go
@@ -1,0 +1,62 @@
+package vault
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccPkiSecretBackend_importBasic(t *testing.T) {
+	path := "test-" + acctest.RandString(10)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testPkiSecretBackendCertConfigUrlsConfig_basic(path, "http://the_issuer", "http://crl", "http://ocsp"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_config_urls.test", "issuing_certificates.0", "http://the_issuer"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_config_urls.test", "crl_distribution_points.0", "http://crl"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_config_urls.test", "ocsp_servers.0", "http://ocsp"),
+				),
+			},
+			{
+				ResourceName:      "vault_pki_secret_backend_config_urls.test",
+				ImportState:       true,
+				ImportStateIdFunc: testAccPkiSecretBackendImportStateIdFunc("vault_pki_secret_backend_config_urls.test"),
+				ImportStateVerify: true,
+				ImportStateCheck: func(s []*terraform.InstanceState) error {
+					if len(s) != 1 {
+						return fmt.Errorf("expected 1 state: %#v", s)
+					}
+					rs := s[0]
+
+					if !strings.HasSuffix(rs.Attributes["id"], "/config/urls") {
+						return fmt.Errorf("expected id attribute to be set and end with /config/urls, received: %s", rs.Attributes["id"])
+					}
+
+					if !strings.HasPrefix(rs.Attributes["id"], rs.Attributes["backend"]) {
+						return fmt.Errorf("expected id attribute to start with the backend name %s, received: %s", rs.Attributes["backend"], rs.Attributes["id"])
+					}
+
+					return nil
+				},
+			},
+		},
+	})
+}
+
+func testAccPkiSecretBackendImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		return rs.Primary.Attributes["backend"], nil
+	}
+}

--- a/vault/resource_identity_group.go
+++ b/vault/resource_identity_group.go
@@ -140,7 +140,6 @@ func identityGroupUpdateFields(d *schema.ResourceData, data map[string]interface
 			data["member_entity_ids"] = d.Get("member_entity_ids").(*schema.Set).List()
 			data["member_group_ids"] = d.Get("member_group_ids").(*schema.Set).List()
 
-
 			// Edge case where if external_policies is true, no policies
 			// should be configured on the entity.
 			data["external_policies"] = d.Get("external_policies").(bool)

--- a/website/docs/r/pki_secret_backend_config_urls.html.md
+++ b/website/docs/r/pki_secret_backend_config_urls.html.md
@@ -40,3 +40,11 @@ The following arguments are supported:
 ## Attributes Reference
 
 No additional attributes are exported by this resource.
+
+## Import
+
+PKI secret backend config urls can be imported using the pki secret backend name itself, e.g.
+
+```
+$ terraform import vault_pki_secret_backend_config_urls.pki pki
+```


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

## Summary
Support importing config urls in `vault_pki_secret_backend_config_urls`. I chose the backend as the terraform import identifier since the path is always deterministic to be `<the backend name>/config/urls`. As a result, some special handling needed to be done in the import implementation to support that. 

Closes #934

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):

```release-note
Adds support for importing config urls in "vault_pki_secret_backend_config_urls" (#934).
```

Output from acceptance testing:

```
$ TESTARGS="--run TestAccPkiSecretBackend_importBasic" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v --run TestAccPkiSecretBackend_importBasic -timeout 120m
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/codegen   (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
WARNING: Package "github.com/golang/protobuf/protoc-gen-go/generator" is deprecated.
        A future release of golang/protobuf will delete this package,
        which has long been excluded from the compatibility promise.

testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    (cached) [no tests to run]
WARNING: Package "github.com/golang/protobuf/protoc-gen-go/generator" is deprecated.
        A future release of golang/protobuf will delete this package,
        which has long been excluded from the compatibility promise.

testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    (cached) [no tests to run]
WARNING: Package "github.com/golang/protobuf/protoc-gen-go/generator" is deprecated.
        A future release of golang/protobuf will delete this package,
        which has long been excluded from the compatibility promise.

testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    (cached) [no tests to run]
WARNING: Package "github.com/golang/protobuf/protoc-gen-go/generator" is deprecated.
        A future release of golang/protobuf will delete this package,
        which has long been excluded from the compatibility promise.

testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        (cached) [no tests to run]
WARNING: Package "github.com/golang/protobuf/protoc-gen-go/generator" is deprecated.
        A future release of golang/protobuf will delete this package,
        which has long been excluded from the compatibility promise.

testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    (cached) [no tests to run]
WARNING: Package "github.com/golang/protobuf/protoc-gen-go/generator" is deprecated.
        A future release of golang/protobuf will delete this package,
        which has long been excluded from the compatibility promise.

testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
WARNING: Package "github.com/golang/protobuf/protoc-gen-go/generator" is deprecated.
        A future release of golang/protobuf will delete this package,
        which has long been excluded from the compatibility promise.

=== RUN   TestAccPkiSecretBackend_importBasic
--- PASS: TestAccPkiSecretBackend_importBasic (1.93s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     2.029s
...
```
