### PR TITLE
Secrets from the AD, AWS, Azure & Nomad Secrets Engines are sensitive

### DIFF
--- a/vault/data_source_ad_credentials.go
+++ b/vault/data_source_ad_credentials.go
@@ -5,7 +5,6 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
@@ -28,11 +27,13 @@ func adAccessCredentialsDataSource() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Password for the service account.",
+				Sensitive:   true,
 			},
 			"last_password": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Last known password for the service account.",
+				Sensitive:   true,
 			},
 			"username": {
 				Type:        schema.TypeString,

--- a/vault/data_source_aws_access_credentials.go
+++ b/vault/data_source_aws_access_credentials.go
@@ -94,6 +94,7 @@ func awsAccessCredentialsDataSource() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "AWS security token read from Vault. (Only returned if type is 'sts').",
+				Sensitive:   true,
 			},
 
 			consts.FieldLeaseID: {

--- a/vault/data_source_azure_access_credentials.go
+++ b/vault/data_source_azure_access_credentials.go
@@ -67,6 +67,7 @@ func azureAccessCredentialsDataSource() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "The client secret for credentials to query the Azure APIs.",
+				Sensitive:   true,
 			},
 			consts.FieldLeaseID: {
 				Type:        schema.TypeString,

--- a/vault/data_source_nomad_credentials.go
+++ b/vault/data_source_nomad_credentials.go
@@ -33,6 +33,7 @@ func nomadAccessCredentialsDataSource() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Used to make requests to Nomad and should be kept private.",
+				Sensitive:   true,
 			},
 		},
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Secrets from the Active Directory, AWS, Azure & Nomad Secrets Engines are marked as sensitive.
```