### PR TITLE
Revert "Fix bug where provider_config only used strings (#960)"

### DIFF
--- a/vault/provider_test.go
+++ b/vault/provider_test.go
@@ -67,14 +67,6 @@ func testAccPreCheck(t *testing.T) {
 	}
 }
 
-func testJWTLocal(t *testing.T) {
-	testAccPreCheck(t)
-	if v := os.Getenv("TEST_JWT"); v == "" {
-		t.Log("TEST_JWT must be set for jwt provider_config acceptance tests")
-		t.Skip()
-	}
-}
-
 func getTestAWSCreds(t *testing.T) (string, string) {
 	accessKey := os.Getenv("AWS_ACCESS_KEY_ID")
 	secretKey := os.Getenv("AWS_SECRET_ACCESS_KEY")


### PR DESCRIPTION
This reverts commit 56fa28df401683317463b92b3a1d85bb299966bb. This is being done due to issues uncovered with type migrations in #1112.