### PR TITLE
Add state upgrade for provider_config

### DIFF
--- a/vault/resource_jwt_auth_backend.go
+++ b/vault/resource_jwt_auth_backend.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -22,6 +23,7 @@ func jwtAuthBackendResource() *schema.Resource {
 
 		CustomizeDiff: jwtCustomizeDiff,
 
+		SchemaVersion: 1,
 		Schema: map[string]*schema.Schema{
 
 			"path": {
@@ -131,7 +133,171 @@ func jwtAuthBackendResource() *schema.Resource {
 			},
 			"tune": authMountTuneSchema(),
 		},
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    resourceJwtAuthResourceV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: resourceJwtAuthStateUpgradeV0,
+				Version: 0,
+			},
+		},
 	}
+}
+
+func resourceJwtAuthResourceV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"path": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Description:  "path to mount the backend",
+				Default:      "jwt",
+				ValidateFunc: validateNoTrailingSlash,
+			},
+
+			"type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Description:  "Type of backend. Can be either 'jwt' or 'oidc'",
+				Default:      "jwt",
+				ValidateFunc: validation.StringInSlice([]string{"jwt", "oidc"}, false),
+			},
+
+			"description": {
+				Type:        schema.TypeString,
+				Required:    false,
+				ForceNew:    true,
+				Optional:    true,
+				Description: "The description of the auth backend",
+			},
+
+			"oidc_discovery_url": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"jwks_url", "jwt_validation_pubkeys"},
+				Description:   "The OIDC Discovery URL, without any .well-known component (base path). Cannot be used with 'jwks_url' or 'jwt_validation_pubkeys'.",
+			},
+
+			"oidc_discovery_ca_pem": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The CA certificate or chain of certificates, in PEM format, to use to validate connections to the OIDC Discovery URL. If not set, system certificates are used",
+			},
+
+			"oidc_client_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Client ID used for OIDC",
+			},
+
+			"oidc_client_secret": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				Description: "Client Secret used for OIDC",
+			},
+
+			"jwks_url": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"oidc_discovery_url", "jwt_validation_pubkeys"},
+				Description:   "JWKS URL to use to authenticate signatures. Cannot be used with 'oidc_discovery_url' or 'jwt_validation_pubkeys'.",
+			},
+
+			"jwks_ca_pem": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The CA certificate or chain of certificates, in PEM format, to use to validate connections to the JWKS URL. If not set, system certificates are used.",
+			},
+
+			"jwt_validation_pubkeys": {
+				Type:          schema.TypeList,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				Optional:      true,
+				ConflictsWith: []string{"jwks_url", "oidc_discovery_url"},
+				Description:   "A list of PEM-encoded public keys to use to authenticate signatures locally. Cannot be used with 'jwks_url' or 'oidc_discovery_url'. ",
+			},
+
+			"bound_issuer": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The value against which to match the iss claim in a JWT",
+			},
+
+			"jwt_supported_algs": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Optional:    true,
+				Description: "A list of supported signing algorithms. Defaults to [RS256]",
+			},
+
+			"default_role": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The default role to use if none is provided during login",
+			},
+
+			"accessor": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The accessor of the JWT auth backend",
+			},
+			"provider_config": {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Description: "Provider specific handling configuration",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"tune": authMountTuneSchema(),
+		},
+	}
+}
+
+func resourceJwtAuthStateUpgradeV0(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+
+	// The provider_config schema changed types from TypeMap to
+	// TypeSet, so we require a state upgrade. The values in this
+	// schema are already strings, so we just need to convert the
+	// non-string values.
+	if rawConfig, ok := rawState["provider_config"]; ok {
+		providerConfig := rawConfig.(map[string]interface{})
+		var newConfig []map[string]interface{}
+		newConfig = append(newConfig, providerConfig)
+
+		if len(newConfig) != 1 {
+			return rawState, fmt.Errorf("invalid length of provider_config during state upgrade")
+		}
+
+		if v, ok := providerConfig["fetch_groups"]; ok {
+			valBool, err := strconv.ParseBool(v.(string))
+			if err != nil {
+				return rawState, fmt.Errorf("could not convert fetch_groups to bool: %s", err)
+			}
+			newConfig[0]["fetch_groups"] = valBool
+		}
+
+		if v, ok := providerConfig["fetch_user_info"]; ok {
+			valBool, err := strconv.ParseBool(v.(string))
+			if err != nil {
+				return rawState, fmt.Errorf("could not convert fetch_user_info to bool: %s", err)
+			}
+			newConfig[0]["fetch_user_info"] = valBool
+		}
+
+		if v, ok := providerConfig["groups_recurse_max_depth"]; ok {
+			valInt, err := strconv.ParseInt(v.(string), 10, 64)
+			if err != nil {
+				return rawState, fmt.Errorf("could not convert groups_recurse_max_depth to int: %s", err)
+			}
+			newConfig[0]["groups_recurse_max_depth"] = valInt
+		}
+
+		rawState["provider_config"] = newConfig
+	}
+	return rawState, nil
 }
 
 func jwtCustomizeDiff(d *schema.ResourceDiff, meta interface{}) error {

--- a/vault/resource_jwt_auth_backend.go
+++ b/vault/resource_jwt_auth_backend.go
@@ -263,6 +263,11 @@ func resourceJwtAuthStateUpgradeV0(rawState map[string]interface{}, meta interfa
 	// schema are already strings, so we just need to convert the
 	// non-string values.
 	if rawConfig, ok := rawState["provider_config"]; ok {
+		if rawConfig == nil {
+			rawState["provider_config"] = make([]map[string]interface{}, 0)
+			return rawState, nil
+		}
+
 		providerConfig := rawConfig.(map[string]interface{})
 		var newConfig []map[string]interface{}
 		newConfig = append(newConfig, providerConfig)

--- a/vault/resource_jwt_auth_backend_test.go
+++ b/vault/resource_jwt_auth_backend_test.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"fmt"
+	"reflect"
 	"regexp"
 	"testing"
 
@@ -229,4 +230,38 @@ func TestAccJWTAuthBackend_missingMandatory(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testResourceJwtAuthStateV0() map[string]interface{} {
+	return map[string]interface{}{
+		"provider_config": map[string]interface{}{
+			"provider":                 "azure",
+			"fetch_groups":             "true",
+			"fetch_user_info":          "true",
+			"groups_recurse_max_depth": "1",
+		},
+	}
+}
+
+func testResourceJwtAuthStateV1() map[string]interface{} {
+	return map[string]interface{}{
+		"provider_config": []map[string]interface{}{{
+			"provider":                 "azure",
+			"fetch_groups":             true,
+			"fetch_user_info":          true,
+			"groups_recurse_max_depth": int64(1),
+		}},
+	}
+}
+
+func TestResourceJwtAuthStateUpgradeV0(t *testing.T) {
+	expected := testResourceJwtAuthStateV1()
+	actual, err := resourceJwtAuthStateUpgradeV0(testResourceJwtAuthStateV0(), nil)
+	if err != nil {
+		t.Fatalf("error migrating state: %s", err)
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("\n\nexpected:\n\n%+v\n\ngot:\n\n%+v\n\n", expected, actual)
+	}
 }


### PR DESCRIPTION
When changing types of a schema resource in #960 I introduced a small bug where Terraform would complain about unexpected state if this resource was being used. When changing the types of schema, a state upgrade is necessary to update the state file during the plan phase. This PR adds the StateUpgrader for the `provider_config` to automatically update the state file for the user.

Fixes #1112.