### PR TITLE
Add support for all provider_config types

### DIFF
--- a/vault/resource_jwt_auth_backend.go
+++ b/vault/resource_jwt_auth_backend.go
@@ -312,17 +312,15 @@ func jwtAuthBackendUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	configuration := map[string]interface{}{}
 	for _, configOption := range matchingJwtMountConfigOptions {
-		if configOption != "provider_config" {
-			// Set the configuration if the user has specified it, or the attribute is in the Diff
-			if _, ok := d.GetOkExists(configOption); ok || d.HasChange(configOption) {
-				configuration[configOption] = d.Get(configOption)
-			}
-		} else {
-			if _, ok := d.GetOkExists(configOption); ok || d.HasChange(configOption) {
+		if _, ok := d.GetOkExists(configOption); ok || d.HasChange(configOption) {
+			configuration[configOption] = d.Get(configOption)
+
+			if configOption == "provider_config" {
 				newConfig, err := convertProviderConfigValues(d.Get(configOption).(map[string]interface{}))
 				if err != nil {
 					return err
 				}
+
 				configuration[configOption] = newConfig
 			}
 		}

--- a/vault/resource_jwt_auth_backend.go
+++ b/vault/resource_jwt_auth_backend.go
@@ -284,21 +284,22 @@ func jwtAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 func convertProviderConfigValues(input map[string]interface{}) (map[string]interface{}, error) {
 	newConfig := make(map[string]interface{})
 	for k, v := range input {
+		val := v.(string)
 		switch k {
 		case "fetch_groups", "fetch_user_info":
-			valBool, err := strconv.ParseBool(v.(string))
+			valBool, err := strconv.ParseBool(val)
 			if err != nil {
 				return nil, fmt.Errorf("could not convert %s to bool: %s", k, err)
 			}
 			newConfig[k] = valBool
 		case "groups_recurse_max_depth":
-			valInt, err := strconv.ParseInt(v.(string), 10, 64)
+			valInt, err := strconv.ParseInt(val, 10, 64)
 			if err != nil {
 				return nil, fmt.Errorf("could not convert %s to int: %s", k, err)
 			}
 			newConfig[k] = valInt
 		default:
-			newConfig[k] = v.(string)
+			newConfig[k] = val
 		}
 	}
 	return newConfig, nil

--- a/vault/resource_jwt_auth_backend_test.go
+++ b/vault/resource_jwt_auth_backend_test.go
@@ -50,6 +50,27 @@ func TestAccJWTAuthBackend(t *testing.T) {
 		},
 	})
 }
+
+func TestAccJWTAuthBackendProviderConfig(t *testing.T) {
+	path := acctest.RandomWithPrefix("oidc")
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testJWTAuthBackend_Destroyed(path),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJWTAuthBackendProviderConfig(path),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend.oidc", "oidc_discovery_url", "https://myco.auth0.com/"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend.oidc", "type", "oidc"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend.oidc", "provider_config.provider", "azure"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend.oidc", "provider_config.groups_recurse_max_depth", "1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccJWTAuthBackend_OIDC(t *testing.T) {
 	path := acctest.RandomWithPrefix("oidc")
 	resource.Test(t, resource.TestCase{
@@ -160,6 +181,21 @@ resource "vault_jwt_auth_backend" "oidc" {
 `, path)
 }
 
+func testAccJWTAuthBackendProviderConfig(path string) string {
+	return fmt.Sprintf(`
+resource "vault_jwt_auth_backend" "oidc" {
+  description = "OIDC backend"
+  oidc_discovery_url = "https://myco.auth0.com/"
+  path = "%s"
+  type = "oidc"
+  provider_config = {
+	provider = "azure"
+	groups_recurse_max_depth = "1"
+  }
+}
+`, path)
+}
+
 func testJWTAuthBackend_Destroyed(path string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
@@ -226,6 +262,137 @@ func TestAccJWTAuthBackend_missingMandatory(t *testing.T) {
 					// force value to be unknown until apply phase
 					oidc_discovery_url = "https://myco.auth0.${vault_identity_oidc_key.key.id}/"
 				}`, path),
+			},
+		},
+	})
+}
+
+func TestAccJWTAuthBackendProviderConfigConversionBool(t *testing.T) {
+	type test struct {
+		name  string
+		value string
+		err   bool
+		want  interface{}
+	}
+
+	tests := []test{
+		{name: "fetch_groups", value: "true", err: false, want: true},
+		{name: "fetch_groups", value: "TRUE", err: false, want: true},
+		{name: "fetch_groups", value: "false", err: false, want: false},
+		{name: "fetch_groups", value: "FALSE", err: false, want: false},
+		{name: "fetch_groups", value: "foo", err: true, want: ""},
+
+		{name: "fetch_user_info", value: "true", err: false, want: true},
+		{name: "fetch_user_info", value: "TRUE", err: false, want: true},
+		{name: "fetch_user_info", value: "false", err: false, want: false},
+		{name: "fetch_user_info", value: "FALSE", err: false, want: false},
+		{name: "fetch_user_info", value: "foo", err: true, want: ""},
+	}
+
+	for _, tc := range tests {
+		config := map[string]interface{}{
+			tc.name: tc.value,
+		}
+		actual, err := convertProviderConfigValues(config)
+		if tc.err && err == nil {
+			t.Fatalf("exepcted error, got none for key: %s, value: %s", tc.name, tc.value)
+		} else if !tc.err && err != nil {
+			t.Fatalf("expected no error, got one: %s", err)
+		} else if !tc.err {
+			if actual[tc.name] != tc.want {
+				t.Fatalf("exepcted %s, got %s", tc.want, actual[tc.name])
+			}
+		}
+	}
+}
+
+func TestAccJWTAuthBackendProviderConfigConversionInt(t *testing.T) {
+	type test struct {
+		name  string
+		value string
+		err   bool
+		want  interface{}
+	}
+
+	tests := []test{
+		{name: "groups_recurse_max_depth", value: "1", err: false, want: int64(1)},
+		{name: "groups_recurse_max_depth", value: "0", err: false, want: int64(0)},
+		{name: "groups_recurse_max_depth", value: "-1", err: false, want: int64(-1)},
+		{name: "groups_recurse_max_depth", value: "foo", err: true, want: int64(0)},
+	}
+
+	for _, tc := range tests {
+		config := map[string]interface{}{
+			tc.name: tc.value,
+		}
+		actual, err := convertProviderConfigValues(config)
+		if tc.err && err == nil {
+			t.Fatalf("exepcted error, got none for key: %s, value: %s", tc.name, tc.value)
+		} else if !tc.err && err != nil {
+			t.Fatalf("expected no error, got one: %s", err)
+		} else if !tc.err {
+			if actual[tc.name] != tc.want {
+				t.Fatalf("exepcted %s, got %s", tc.want, actual[tc.name])
+			}
+		}
+	}
+}
+
+// Testing bad values here for various parameters. This test leaks backends that don't get
+// cleaned up because a race condition exists that make it hard to get the error
+// before Terraform destroys the resource. Since we are creating both a Vault mount
+// and configuring it in a single resource, the mount creation succeeds but the config fails.
+// There seems to be a race condition if you destroy the resource, so auth backends never
+// get deleted because only the config failed.
+// Leaving this test here for now until we can update to newer versions of SDK, which might
+// have resolved this race condition.
+func TestAccJWTAuthBackendProviderConfig_negative(t *testing.T) {
+	t.Skip(true)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`resource "vault_jwt_auth_backend" "oidc" {
+					description = "OIDC Backend"
+					oidc_discovery_url = "https://myco.auth0.com/"
+					path = "%s"
+					type = "oidc"
+					provider_config = {
+						provider = "azure"
+						fetch_groups = "foo"
+					}
+				  }`, acctest.RandomWithPrefix("oidc")),
+				Destroy:     false,
+				ExpectError: regexp.MustCompile("could not convert fetch_groups to bool: strconv.ParseBool: parsing \"foo\": invalid syntax"),
+			},
+			{
+				Config: fmt.Sprintf(`resource "vault_jwt_auth_backend" "oidc" {
+					description = "OIDC Backend"
+					oidc_discovery_url = "https://myco.auth0.com/"
+					path = "%s"
+					type = "oidc"
+					provider_config = {
+						provider = "azure"
+						fetch_user_info = "foo"
+					}
+				  }`, acctest.RandomWithPrefix("oidc")),
+				Destroy:     false,
+				ExpectError: regexp.MustCompile("could not convert fetch_user_info to bool: strconv.ParseBool: parsing \"foo\": invalid syntax"),
+			},
+			{
+				Config: fmt.Sprintf(`resource "vault_jwt_auth_backend" "oidc" {
+					description = "OIDC Backend"
+					oidc_discovery_url = "https://myco.auth0.com/"
+					path = "%s"
+					type = "oidc"
+					provider_config = {
+						provider = "azure"
+						groups_recurse_max_depth = "foo"
+					}
+				  }`, acctest.RandomWithPrefix("oidc")),
+				Destroy:     false,
+				ExpectError: regexp.MustCompile("could not convert groups_recurse_max_depth to int: strconv.ParseInt: parsing \"foo\": invalid syntax"),
 			},
 		},
 	})

--- a/vault/resource_jwt_auth_backend_test.go
+++ b/vault/resource_jwt_auth_backend_test.go
@@ -295,7 +295,7 @@ func TestAccJWTAuthBackendProviderConfigConversionBool(t *testing.T) {
 		}
 		actual, err := convertProviderConfigValues(config)
 		if tc.err && err == nil {
-			t.Fatalf("exepcted error, got none for key: %s, value: %s", tc.name, tc.value)
+			t.Fatalf("expected error, got none for key: %s, value: %s", tc.name, tc.value)
 		} else if !tc.err && err != nil {
 			t.Fatalf("expected no error, got one: %s", err)
 		} else if !tc.err {

--- a/vault/resource_jwt_auth_backend_test.go
+++ b/vault/resource_jwt_auth_backend_test.go
@@ -300,7 +300,7 @@ func TestAccJWTAuthBackendProviderConfigConversionBool(t *testing.T) {
 			t.Fatalf("expected no error, got one: %s", err)
 		} else if !tc.err {
 			if actual[tc.name] != tc.want {
-				t.Fatalf("exepcted %s, got %s", tc.want, actual[tc.name])
+				t.Fatalf("expected %s, got %s", tc.want, actual[tc.name])
 			}
 		}
 	}

--- a/website/docs/r/jwt_auth_backend.html.md
+++ b/website/docs/r/jwt_auth_backend.html.md
@@ -51,9 +51,9 @@ resource "vault_jwt_auth_backend" "gsuite" {
     type = "oidc"
     provider_config = {
         provider = "gsuite"
-        fetch_groups = "true"
-        fetch_user_info = "true"
-        groups_recurse_max_depth = "1"
+        fetch_groups = true
+        fetch_user_info = true
+        groups_recurse_max_depth = 1
     }
 }
 ```

--- a/website/docs/r/jwt_auth_backend.html.md
+++ b/website/docs/r/jwt_auth_backend.html.md
@@ -89,7 +89,7 @@ The following arguments are supported:
 
 * `default_role` - (Optional) The default role to use if none is provided during login
 
-* `provider_config` - (Optional) Provider specific handling configuration. All values should be a string, but the provider will convert to the appropriate type when configuring Vault.
+* `provider_config` - (Optional) Provider specific handling configuration. All values may be strings, and the provider will convert to the appropriate type when configuring Vault.
 
 * tune - (Optional) Extra configuration block. Structure is documented below.
 

--- a/website/docs/r/jwt_auth_backend.html.md
+++ b/website/docs/r/jwt_auth_backend.html.md
@@ -41,6 +41,24 @@ resource "vault_jwt_auth_backend" "example" {
 }
 ```
 
+Configuring the auth backend with a `provider_config:
+
+```hcl
+resource "vault_jwt_auth_backend" "gsuite" {
+    description = "OIDC backend"
+    oidc_discovery_url = "https://accounts.google.com"
+    path = "oidc"
+    type = "oidc"
+    provider_config = {
+        provider = "gsuite"
+        fetch_groups = "true"
+        fetch_user_info = "true"
+        groups_recurse_max_depth = "1"
+    }
+}
+```
+
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -71,7 +89,7 @@ The following arguments are supported:
 
 * `default_role` - (Optional) The default role to use if none is provided during login
 
-* `provider_config` - (Optional) Provider specific handling configuration
+* `provider_config` - (Optional) Provider specific handling configuration. All values should be a string, but the provider will convert to the appropriate type when configuring Vault.
 
 * tune - (Optional) Extra configuration block. Structure is documented below.
 


### PR DESCRIPTION
Originally we decided to change `provider_config` to a TypeSet, to support different types of values for this config. This unfortunately leaves users to migrate their TF to use the new type and requires the provider to do state upgrades. Additionally issues were uncovered using TypeSet where the provider was sending default type values to Vault, which resulted in configuring the auth method incorrectly.

This PR proposes a different way of configuring `provider_config` by keeping the `TypeMap` but adding conversion code when certain parameters are found in the configuration. The UX is a little weird but a lot of issues are solved by using this method and users won't need to migrate to the new type.

I found some weird issues when testing this with Terraform itself and in Vault. It's difficult to test this auth method with the full range of `provider_config` values due to credential files being required when configuring it. Vault will try to open the credentials file and will result in an error if it's not there. It's possible to send the escaped JSON credentials file to Vault but after trying for a while, I could to get it to work correctly.

There's also an issue with a race condition when deleting test cases in the testing framework. Please see the comment on the skipped test describing what I found.

Fixes #1112.