### PR TITLE
Add allowed_serial_numbers support

### DIFF
--- a/vault/resource_pki_secret_backend_role.go
+++ b/vault/resource_pki_secret_backend_role.go
@@ -398,7 +398,6 @@ func pkiSecretBackendRoleCreate(d *schema.ResourceData, meta interface{}) error 
 		"require_cn":                         d.Get("require_cn"),
 		"basic_constraints_valid_for_non_ca": d.Get("basic_constraints_valid_for_non_ca"),
 		"not_before_duration":                d.Get("not_before_duration"),
-		"allowed_serial_numbers":             d.Get("allowed_serial_numbers"),
 	}
 
 	if len(allowedDomains) > 0 {
@@ -611,7 +610,6 @@ func pkiSecretBackendRoleUpdate(d *schema.ResourceData, meta interface{}) error 
 		"require_cn":                         d.Get("require_cn"),
 		"basic_constraints_valid_for_non_ca": d.Get("basic_constraints_valid_for_non_ca"),
 		"not_before_duration":                d.Get("not_before_duration"),
-		"allowed_serial_numbers":             d.Get("allowed_serial_numbers"),
 	}
 
 	if len(allowedDomains) > 0 {

--- a/vault/resource_pki_secret_backend_role_test.go
+++ b/vault/resource_pki_secret_backend_role_test.go
@@ -65,6 +65,7 @@ func TestPkiSecretBackendRole_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_role.test", "policy_identifiers.0", "1.2.3.4"),
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_role.test", "basic_constraints_valid_for_non_ca", "false"),
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_role.test", "not_before_duration", "45m"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_role.test", "allowed_serial_numbers.0", "*"),
 				),
 			},
 			{
@@ -114,6 +115,7 @@ func TestPkiSecretBackendRole_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_role.test", "policy_identifiers.0", "1.2.3.4"),
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_role.test", "basic_constraints_valid_for_non_ca", "false"),
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_role.test", "not_before_duration", "45m"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_role.test", "allowed_serial_numbers.0", "*"),
 				),
 			},
 		},
@@ -165,6 +167,7 @@ resource "vault_pki_secret_backend_role" "test" {
   policy_identifiers = ["1.2.3.4"]
   basic_constraints_valid_for_non_ca = false
   not_before_duration = "45m"
+  allowed_serial_numbers = ["*"]
 }`, path, name)
 }
 
@@ -214,6 +217,7 @@ resource "vault_pki_secret_backend_role" "test" {
   policy_identifiers = ["1.2.3.4"]
   basic_constraints_valid_for_non_ca = false
   not_before_duration = "45m"
+  allowed_serial_numbers = ["*"]
 }`, path, name)
 }
 

--- a/website/docs/r/pki_secret_backend_role.html.md
+++ b/website/docs/r/pki_secret_backend_role.html.md
@@ -111,6 +111,8 @@ The following arguments are supported:
 
 * `not_before_duration` - (Optional) Specifies the duration by which to backdate the NotBefore property.
 
+* `allowed_serial_numbers` - (Optional) An array of allowed serial numbers to put in Subject
+
 ## Attributes Reference
 
 No additional attributes are exported by this resource.


### PR DESCRIPTION
This adds support for the `allowed_serial_numbers` setting in the `vault_pki_secret_backend_role` resource.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`resource/vault_pki_secret_backend_role`: Add `allowed_serial_numbers` option
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestPkiSecretBackendRole'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./...) -v -run=TestPkiSecretBackendRole -timeout 120m
?   	github.com/hashicorp/terraform-provider-vault	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/generate	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/codegen	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/generated	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/schema	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/util	(cached) [no tests to run]
=== RUN   TestPkiSecretBackendRole_basic
--- PASS: TestPkiSecretBackendRole_basic (0.47s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/vault	0.483s
```
