### PR TITLE
fix: support importing gcp_auth_backend

### DIFF
--- a/vault/resource_gcp_auth_backend_test.go
+++ b/vault/resource_gcp_auth_backend_test.go
@@ -25,59 +25,44 @@ const gcpJSONCredentials string = `
   }
 `
 
-func TestGCPAuthBackend(t *testing.T) {
-	tests := []struct {
-		name     string
-		preCheck func(t *testing.T)
-		steps    func(path string) []resource.TestStep
-		path     string
-	}{
-		{
-			name:     "basic",
-			path:     gcpAuthDefaultPath,
-			preCheck: util.TestAccPreCheck,
-			steps: func(path string) []resource.TestStep {
-				return []resource.TestStep{
-					{
-						Config: testGCPAuthBackendConfig_basic(path, gcpJSONCredentials),
-						Check:  testGCPAuthBackendCheck_attrs(),
-					},
-				}
-			},
-		},
-		{
-			name:     "import",
-			path:     resource.PrefixedUniqueId("gcp-import-"),
-			preCheck: util.TestAccPreCheck,
-			steps: func(path string) []resource.TestStep {
-				return []resource.TestStep{
-					{
-						Config: testGCPAuthBackendConfig_basic(path, gcpJSONCredentials),
-						Check:  testGCPAuthBackendCheck_attrs(),
-					},
-					{
-						ResourceName:      "vault_gcp_auth_backend.test",
-						ImportState:       true,
-						ImportStateVerify: true,
-						ImportStateVerifyIgnore: []string{
-							"credentials",
-						},
-					},
-				}
-			},
-		},
-	}
+func TestGCPAuthBackend_basic(t *testing.T) {
+	path := resource.PrefixedUniqueId("gcp-basic-")
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			resource.Test(t, resource.TestCase{
-				PreCheck:     func() { tt.preCheck(t) },
-				Providers:    testProviders,
-				CheckDestroy: testGCPAuthBackendDestroy,
-				Steps:        tt.steps(tt.path),
-			})
-		})
-	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { util.TestAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testGCPAuthBackendDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testGCPAuthBackendConfig_basic(path, gcpJSONCredentials),
+				Check:  testGCPAuthBackendCheck_attrs(),
+			},
+		},
+	})
+}
+
+func TestGCPAuthBackend_import(t *testing.T) {
+	path := resource.PrefixedUniqueId("gcp-import-")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { util.TestAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testGCPAuthBackendDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testGCPAuthBackendConfig_basic(path, gcpJSONCredentials),
+				Check:  testGCPAuthBackendCheck_attrs(),
+			},
+			{
+				ResourceName:      "vault_gcp_auth_backend.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"credentials",
+				},
+			},
+		},
+	})
 }
 
 func testGCPAuthBackendDestroy(s *terraform.State) error {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #795 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/gcp_auth_backend`: Support importing preexisting resource 
```

Output from acceptance testing:

```
$ make dev testacc TESTARGS='-run \^TestGCPAuthBackend$$'
==> Checking that code complies with gofmt requirements...
go build -o terraform-provider-vault
mv terraform-provider-vault ~/.terraform.d/plugins/
TF_ACC=1 go test $(go list ./...) -v -run \^TestGCPAuthBackend$ -timeout 120m

[...]

=== RUN   TestGCPAuthBackend
=== RUN   TestGCPAuthBackend/basic
=== RUN   TestGCPAuthBackend/import
--- PASS: TestGCPAuthBackend (0.31s)
    --- PASS: TestGCPAuthBackend/basic (0.15s)
    --- PASS: TestGCPAuthBackend/import (0.16s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     (cached)
```
