### PR TITLE
Check is kv2 secret deleted

### DIFF
--- a/vault/kv_helpers.go
+++ b/vault/kv_helpers.go
@@ -37,6 +37,12 @@ func versionedSecret(requestedVersion int, path string, client *api.Client) (*ap
 	}
 
 	if v2 && secret != nil {
+		// v2 secret can be deleted
+		if metadata, ok := secret.Data["metadata"].(map[string]interface{}); ok && metadata != nil {
+			if _, deleted := metadata["deletion_time"]; deleted {
+				return nil, nil
+			}
+		}
 		// This is a v2, grab the data field
 		if data, ok := secret.Data["data"]; ok && data != nil {
 			if dataMap, ok := data.(map[string]interface{}); ok {


### PR DESCRIPTION
Currentry on deleted kv2 secret version `versionedSecret` returns data with two fields like:
```json
{
  "data": null,
  "metadata": {
    "created_time": "2021-08-03T15:41:55.520255191Z",
    "deletion_time": "2021-08-03T15:43:43.175152029Z",
    "destroyed": false,
    "version": 2
  }
}
```
In this case terraform don't try recreate manually deleted resource and put this `data` to resource output.