### PR TITLE
[FIX] resource/vault_identity_group external member_entity_ids & member_group_ids 

### DIFF
--- a/vault/resource_identity_group.go
+++ b/vault/resource_identity_group.go
@@ -137,9 +137,11 @@ func identityGroupUpdateFields(d *schema.ResourceData, data map[string]interface
 			data["name"] = d.Get("name")
 			data["metadata"] = d.Get("metadata")
 			data["policies"] = d.Get("policies").(*schema.Set).List()
-			data["member_entity_ids"] = d.Get("member_entity_ids").(*schema.Set).List()
-			data["member_group_ids"] = d.Get("member_group_ids").(*schema.Set).List()
-
+			// Member groups and entities can't be set for external groups
+			if d.Get("type").(string) == "internal" {
+				data["member_entity_ids"] = d.Get("member_entity_ids").(*schema.Set).List()
+				data["member_group_ids"] = d.Get("member_group_ids").(*schema.Set).List()
+			}
 			// Edge case where if external_policies is true, no policies
 			// should be configured on the entity.
 			data["external_policies"] = d.Get("external_policies").(bool)


### PR DESCRIPTION
# Summary

Follow up from Linked PRS #1061 & #1054 to ensure  `member_entity_ids` & `member_group_ids` are only managed on internal groups 

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1133

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/vault_identity_group: Fix bug where member_entity_ids &  member_group_ids  were attempted to be managed on external identity groups.
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
