### PR TITLE
fix: handle nil value for member_entity_ids

### DIFF
--- a/vault/resource_identity_group_member_entity_ids.go
+++ b/vault/resource_identity_group_member_entity_ids.go
@@ -146,8 +146,8 @@ func identityGroupMemberEntityIdsRead(d *schema.ResourceData, meta interface{}) 
 		}
 	} else {
 		set := map[interface{}]bool{}
-		if curIDS != nil {
-			for _, v := range curIDS.([]interface{}) {
+		if ids, ok := curIDS.([]interface{}); ok {
+			for _, v := range ids {
 				set[v] = true
 			}
 		}


### PR DESCRIPTION
Addresses this issue: https://github.com/hashicorp/terraform-provider-vault/issues/1136

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Closes #1136 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):

```release-note
Fixes panic in `vault_identity_group_member_entity_ids` when `member_entity_ids` is not present in response.
```

Output from acceptance testing:

```
❯ make testacc TESTARGS='-run=TestAccIdentityGroupMemberEntity'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -run=TestAccIdentityGroupMemberEntity -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/codegen   (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
?       github.com/hashicorp/terraform-provider-vault/testutil  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
=== RUN   TestAccIdentityGroupMemberEntityIdsExclusiveEmpty
--- PASS: TestAccIdentityGroupMemberEntityIdsExclusiveEmpty (2.46s)
=== RUN   TestAccIdentityGroupMemberEntityIdsExclusive
--- PASS: TestAccIdentityGroupMemberEntityIdsExclusive (1.63s)
=== RUN   TestAccIdentityGroupMemberEntityIdsNonExclusiveEmpty
--- PASS: TestAccIdentityGroupMemberEntityIdsNonExclusiveEmpty (2.33s)
=== RUN   TestAccIdentityGroupMemberEntityIdsNonExclusive
--- PASS: TestAccIdentityGroupMemberEntityIdsNonExclusive (2.35s)
=== RUN   TestAccIdentityGroupMemberEntityIdsDynamic
--- PASS: TestAccIdentityGroupMemberEntityIdsDynamic (4.45s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     13.606s
```
