### PR TITLE
Add allowed_email_sans field to write and update functions of vault_cert_auth_backend_role

### DIFF
--- a/vault/resource_cert_auth_backend_role.go
+++ b/vault/resource_cert_auth_backend_role.go
@@ -186,6 +186,10 @@ func certAuthResourceWrite(d *schema.ResourceData, meta interface{}) error {
 		data["allowed_dns_sans"] = v.(*schema.Set).List()
 	}
 
+	if v, ok := d.GetOk("allowed_email_sans"); ok {
+		data["allowed_email_sans"] = v.(*schema.Set).List()
+	}        
+        
 	if v, ok := d.GetOk("allowed_uri_sans"); ok {
 		data["allowed_uri_sans"] = v.(*schema.Set).List()
 	}
@@ -255,6 +259,10 @@ func certAuthResourceUpdate(d *schema.ResourceData, meta interface{}) error {
 	if v, ok := d.GetOk("allowed_dns_sans"); ok {
 		data["allowed_dns_sans"] = v.(*schema.Set).List()
 	}
+        
+	if v, ok := d.GetOk("allowed_email_sans"); ok {
+		data["allowed_email_sans"] = v.(*schema.Set).List()
+	}        
 
 	if v, ok := d.GetOk("allowed_uri_sans"); ok {
 		data["allowed_uri_sans"] = v.(*schema.Set).List()


### PR DESCRIPTION
https://github.com/hashicorp/terraform-provider-vault/pull/282 introduced many missing optional parameters in vault_cert_auth_backend_role, but missed validating and reading the `allowed_email_sans` field in the `certAuthResourceUpdate` and `certAuthResourceWrite` functions. Terraform currently correctly reads and plans for updating `allowed_email_sans`, but never actually does it.

For example, locally I have defined a set of emails that are added to the `allowed_common_names` parameter and `allowed_email_sans`. Only `allowed_common_names` is created/updated. `allowed_email_sans` is not.

```
locals {
  allowed_emails = ['a@b.example', 'b@b.example']
}
resource "vault_cert_auth_backend_role" "employee-cert-auth" { 
  # other stuff defined here
  allowed_common_names = locals.allowed_emails
  allowed_email_sans   = locals.allowed_emails
}
```

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add allowed_email_sans field to write and update functions of vault_cert_auth_backend_role so that allowed_email_sans is actually created and updated.
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
I did not run this.
```
