### PR TITLE
Error handling for identity_oidc_key vault calls

### DIFF
--- a/vault/resource_identity_oidc_key.go
+++ b/vault/resource_identity_oidc_key.go
@@ -93,7 +93,9 @@ func identityOidcKeyCreate(d *schema.ResourceData, meta interface{}) error {
 	data := make(map[string]interface{})
 
 	identityOidcKeyUpdateFields(d, data)
-	identityOidcKeyApiWrite(name, data, client)
+	if err := identityOidcKeyApiWrite(name, data, client); err != nil {
+		return err
+	}
 
 	d.SetId(name)
 
@@ -113,7 +115,9 @@ func identityOidcKeyUpdate(d *schema.ResourceData, meta interface{}) error {
 	data := map[string]interface{}{}
 
 	identityOidcKeyUpdateFields(d, data)
-	identityOidcKeyApiWrite(name, data, client)
+	if err := identityOidcKeyApiWrite(name, data, client); err != nil {
+		return err
+	}
 
 	return identityOidcKeyRead(d, meta)
 }

--- a/vault/resource_identity_oidc_key_allowed_client_id_test.go
+++ b/vault/resource_identity_oidc_key_allowed_client_id_test.go
@@ -22,6 +22,9 @@ func TestAccIdentityOidcKeyAllowedClientId(t *testing.T) {
 			{
 				Config: testAccIdentityOidcKeyAllowedClientIdConfig(name),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_identity_oidc_key.key", "rotation_period", "86400"),
+					resource.TestCheckResourceAttr("vault_identity_oidc_key.key", "verification_ttl", "86400"),
+					resource.TestCheckResourceAttr("vault_identity_oidc_key.key", "algorithm", "RS256"),
 					testAccIdentityOidcKeyAllowedClientIdCheckAttrs("vault_identity_oidc_key_allowed_client_id.role_one", 3),
 					testAccIdentityOidcKeyAllowedClientIdCheckAttrs("vault_identity_oidc_key_allowed_client_id.role_two", 3),
 					testAccIdentityOidcKeyAllowedClientIdCheckAttrs("vault_identity_oidc_key_allowed_client_id.role_three", 3),
@@ -30,12 +33,18 @@ func TestAccIdentityOidcKeyAllowedClientId(t *testing.T) {
 			{
 				Config: testAccIdentityOidcKeyAllowedClientIdRemove(name),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_identity_oidc_key.key", "rotation_period", "86401"),
+					resource.TestCheckResourceAttr("vault_identity_oidc_key.key", "verification_ttl", "86401"),
+					resource.TestCheckResourceAttr("vault_identity_oidc_key.key", "algorithm", "RS256"),
 					testAccIdentityOidcKeyAllowedClientIdCheckAttrs("vault_identity_oidc_key_allowed_client_id.role_one", 1),
 				),
 			},
 			{
 				Config: testAccIdentityOidcKeyAllowedClientIdRecreate(name),
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_identity_oidc_key.key", "rotation_period", "86400"),
+					resource.TestCheckResourceAttr("vault_identity_oidc_key.key", "verification_ttl", "86400"),
+					resource.TestCheckResourceAttr("vault_identity_oidc_key.key", "algorithm", "RS256"),
 					testAccIdentityOidcKeyAllowedClientIdCheckAttrs("vault_identity_oidc_key_allowed_client_id.role", 1),
 				),
 			},
@@ -152,8 +161,8 @@ resource "vault_identity_oidc_key" "key" {
   name = "%s"
 	algorithm = "RS256"
 
-	rotation_period  = 3600
-	verification_ttl = 3600
+	rotation_period  = 86401
+	verification_ttl = 86401
 }
 
 resource "vault_identity_oidc_role" "role_one" {


### PR DESCRIPTION
Checks the err from `identityOidcKeyApiWrite()` and adds tests to
exercise the error handling. Updates allowed client id test to satisfy
rotation_period and verification_ttl restrictions that are now
enforced in Vault 1.8.1 per https://github.com/hashicorp/vault/pull/12151.

Since CI is using the latest vault image, `TestAccIdentityOidcKeyAllowedClientId()` [started failing](https://app.circleci.com/pipelines/github/hashicorp/terraform-provider-vault/1696/workflows/fc016d5a-4c09-455b-a13a-a1bf6d359eac/jobs/1644) because the config change in ttl's wasn't being successfully applied to Vault, because `3600` was lower than the associated role's token ttl. The error being ignored from Vault was of the form:

```
unable to update key "test-role-8337740116836207150" because it is currently referenced by one or more roles with a token ttl greater than 3600 seconds
```

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates to https://github.com/hashicorp/vault/pull/12151

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/identity_oidc_key: Error handling for identity oidc key vault calls
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccIdentityOidc -count=1'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./...) -v -run=TestAccIdentityOidc -count=1 -timeout 120m
[...]
=== RUN   TestAccIdentityOidcKeyAllowedClientId
--- PASS: TestAccIdentityOidcKeyAllowedClientId (0.53s)
=== RUN   TestAccIdentityOidcKey
--- PASS: TestAccIdentityOidcKey (0.30s)
=== RUN   TestAccIdentityOidcKeyUpdate
--- PASS: TestAccIdentityOidcKeyUpdate (0.55s)
=== RUN   TestAccIdentityOidcRole
--- PASS: TestAccIdentityOidcRole (0.23s)
=== RUN   TestAccIdentityOidcRoleWithClientId
--- PASS: TestAccIdentityOidcRoleWithClientId (0.31s)
=== RUN   TestAccIdentityOidcRoleUpdate
--- PASS: TestAccIdentityOidcRoleUpdate (0.45s)
=== RUN   TestAccIdentityOidc
--- PASS: TestAccIdentityOidc (0.20s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/vault	4.632s
```
