### PR TITLE
feat: support for VAULT_TLS_SERVER_NAME

### DIFF
--- a/vault/provider.go
+++ b/vault/provider.go
@@ -157,6 +157,12 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("VAULT_SKIP_VERIFY", false),
 				Description: "Set this to true only if the target Vault server is an insecure development instance.",
 			},
+			"tls_server_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("VAULT_TLS_SERVER_NAME", false),
+				Description: "Name to use as the SNI host when connecting via TLS.",
+			},
 			"max_lease_ttl_seconds": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -789,9 +795,10 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	}
 
 	err := clientConfig.ConfigureTLS(&api.TLSConfig{
-		CACert:   d.Get("ca_cert_file").(string),
-		CAPath:   d.Get("ca_cert_dir").(string),
-		Insecure: d.Get("skip_tls_verify").(bool),
+		CACert:        d.Get("ca_cert_file").(string),
+		CAPath:        d.Get("ca_cert_dir").(string),
+		Insecure:      d.Get("skip_tls_verify").(bool),
+		TLSServerName: d.Get("tls_server_name").(string),
 
 		ClientCert: clientAuthCert,
 		ClientKey:  clientAuthKey,

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -160,7 +160,7 @@ func Provider() *schema.Provider {
 			"tls_server_name": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("VAULT_TLS_SERVER_NAME", false),
+				DefaultFunc: schema.EnvDefaultFunc(api.EnvVaultTLSServerName, ""),
 				Description: "Name to use as the SNI host when connecting via TLS.",
 			},
 			"max_lease_ttl_seconds": {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -142,6 +142,9 @@ variables in order to keep credential information out of the configuration.
   that Terraform can be tricked into writing secrets to a server controlled
   by an intruder. May be set via the `VAULT_SKIP_VERIFY` environment variable.
 
+* `tls_server_name` - (Optional) Name to use as the SNI host when connecting
+  via TLS. May be set via the `VAULT_TLS_SERVER_NAME` environment variable.
+
 * `skip_child_token` - (Optional) Set this to `true` to disable
   creation of an intermediate ephemeral Vault token for Terraform to
   use. Enabling this is strongly discouraged since it increases


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #300

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
FEATURES:
* `provider`: Add support for `tls_server_name` to use as the SNI host when connecting via TLS.
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
