### PR TITLE
use github/issue-labeler@v2.4

### DIFF
--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: github/issue-labeler@v2
+    - uses: github/issue-labeler@v2.4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/labeler-issue-triage.yml


### PR DESCRIPTION
There doesn't appear to be a `v2` tag for https://github.com/github/issue-labeler