### PR TITLE
fix: Check-and-Set parameter

### DIFF
--- a/vault/resource_generic_secret.go
+++ b/vault/resource_generic_secret.go
@@ -119,10 +119,36 @@ func genericSecretResourceWrite(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	if v2 {
+		options := map[string]interface{}{}
 		path = addPrefixToVKVPath(path, mountPath, "data")
+
+		log.Printf("[DEBUG] Reading KV Engine configuration from Vault")
+		config, err := client.Logical().Read(mountPath + "config")
+
+		if err != nil {
+			return fmt.Errorf("error reading from Vault: %s", err)
+		}
+
+		casRequired := config.Data["cas_required"].(bool)
+		if casRequired {
+			log.Printf("[DEBUG] Reading %s from Vault", path)
+			secret, err := kvReadRequest(client, path, nil)
+
+			if err != nil {
+				return fmt.Errorf("error reading from Vault: %s", err)
+			}
+
+			if secret == nil {
+				options["cas"] = 0
+			} else {
+				metadata := secret.Data["metadata"].(map[string]interface{})
+				options["cas"] = metadata["version"]
+			}
+		}
+
 		data = map[string]interface{}{
 			"data":    data,
-			"options": map[string]interface{}{},
+			"options": options,
 		}
 
 	}


### PR DESCRIPTION
I'm newbie in Go. I encountered an error when setting `cas_required: true`
```
Error: error writing to Vault: Error making API request.

URL: PUT http://10.0.0.106:8200/v1/secret/data/roman/foo
Code: 400. Errors:

* check-and-set parameter required for this call
```
After reviewing the documentation [Check-and-Set](https://learn.hashicorp.com/tutorials/vault/versioned-kv#step-8-check-and-set-operations) and [KV Secrets Engine - Version 2](https://www.vaultproject.io/api-docs/secret/kv/kv-v2) , I tried to fix it 

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fixed resource vault_generic_secret fail when cas_required is true 
```

Output from acceptance testing:

```
$ TESTARGS="--run TestResourceGenericSecret" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./...) -v --run TestResourceGenericSecret -timeout 120m
?   	github.com/hashicorp/terraform-provider-vault	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/generate	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/codegen	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/generated	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/schema	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/util	(cached) [no tests to run]
=== RUN   TestResourceGenericSecret
--- PASS: TestResourceGenericSecret (0.36s)
=== RUN   TestResourceGenericSecret_deleted
--- PASS: TestResourceGenericSecret_deleted (0.36s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/vault	(cached)
...
```
