### PR TITLE
Fix sample code in documentation for `vault_terraform_cloud_secret_backend`

### DIFF
--- a/website/docs/r/terraform_cloud_secret_backend.md
+++ b/website/docs/r/terraform_cloud_secret_backend.md
@@ -23,7 +23,7 @@ for more details.
 
 ```hcl
 resource "vault_terraform_cloud_secret_backend" "test" {
-  path        = "terraform"
+  backend     = "terraform"
   description = "Manages the Terraform Cloud backend"
   token       = "V0idfhi2iksSDU234ucdbi2nidsi..."
 }


### PR DESCRIPTION
This was reported in #1129.
The sample code uses `path` argument which does not exist for the resource `vault_terraform_cloud_secret_backend`. It should be instead be using the `backend` argument