### PR TITLE
Add Basic Constraints attribute to vault_pki_secret_backend_intermediate_cert_request

### DIFF
--- a/vault/resource_pki_secret_backend_intermediate_cert_request.go
+++ b/vault/resource_pki_secret_backend_intermediate_cert_request.go
@@ -2,11 +2,12 @@ package vault
 
 import (
 	"fmt"
+	"log"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/hashicorp/vault/api"
-	"log"
-	"strings"
 )
 
 func pkiSecretBackendIntermediateCertRequestResource() *schema.Resource {
@@ -166,6 +167,13 @@ func pkiSecretBackendIntermediateCertRequestResource() *schema.Resource {
 				Computed:    true,
 				Description: "The private key type.",
 			},
+			"add_basic_constraints": {
+				Type:        schema.TypeBool,
+				Description: "Whether to add a Basic Constraints extension with CA: true",
+				ForceNew:    true,
+				Default:     false,
+				Optional:    true,
+			},
 		},
 	}
 }
@@ -203,19 +211,20 @@ func pkiSecretBackendIntermediateCertRequestCreate(d *schema.ResourceData, meta 
 	}
 
 	data := map[string]interface{}{
-		"common_name":          d.Get("common_name").(string),
-		"format":               d.Get("format").(string),
-		"private_key_format":   d.Get("private_key_format").(string),
-		"key_type":             d.Get("key_type").(string),
-		"key_bits":             d.Get("key_bits").(int),
-		"exclude_cn_from_sans": d.Get("exclude_cn_from_sans").(bool),
-		"ou":                   d.Get("ou").(string),
-		"organization":         d.Get("organization").(string),
-		"country":              d.Get("country").(string),
-		"locality":             d.Get("locality").(string),
-		"province":             d.Get("province").(string),
-		"street_address":       d.Get("street_address").(string),
-		"postal_code":          d.Get("postal_code").(string),
+		"common_name":           d.Get("common_name").(string),
+		"format":                d.Get("format").(string),
+		"private_key_format":    d.Get("private_key_format").(string),
+		"key_type":              d.Get("key_type").(string),
+		"key_bits":              d.Get("key_bits").(int),
+		"exclude_cn_from_sans":  d.Get("exclude_cn_from_sans").(bool),
+		"ou":                    d.Get("ou").(string),
+		"organization":          d.Get("organization").(string),
+		"country":               d.Get("country").(string),
+		"locality":              d.Get("locality").(string),
+		"province":              d.Get("province").(string),
+		"street_address":        d.Get("street_address").(string),
+		"postal_code":           d.Get("postal_code").(string),
+		"add_basic_constraints": d.Get("add_basic_constraints").(bool),
 	}
 
 	if len(altNames) > 0 {

--- a/website/docs/r/pki_secret_backend_intermediate_cert_request.html.md
+++ b/website/docs/r/pki_secret_backend_intermediate_cert_request.html.md
@@ -72,6 +72,8 @@ The following arguments are supported:
 
 * `postal_code` - (Optional) The postal code
 
+* `add_basic_constraints` - (Optional) Add CA basic constraints to the CSR to allow signing with ADCS
+
 ## Attributes Reference
 
 In addition to the fields above, the following attributes are exported:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Updates `vault_pki_secret_backend_intermediate_cert_request` resource to include the `add_basic_constraints` argument. This adds extensions required when signing intermediate CSRs by Microsoft AD CS Root Authorities.
```