### PR TITLE
Fix username_template usage for snowflake

### DIFF
--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -357,7 +357,7 @@ func mysqlConnectionStringResource() *schema.Resource {
 }
 
 func snowflakeConnectionStringResource() *schema.Resource {
-	r := connectionStringResource()
+	r := connectionStringResource(&connectionStringConfig{})
 	r.Schema["username"] = &schema.Schema{
 		Type:        schema.TypeString,
 		Optional:    true,
@@ -368,12 +368,6 @@ func snowflakeConnectionStringResource() *schema.Resource {
 		Optional:    true,
 		Description: "The password with the provided user",
 		Sensitive:   true,
-	}
-	r.Schema["username_template"] = &schema.Schema{
-		Type:        schema.TypeString,
-		Optional:    true,
-		Description: "Template describing how dynamic usernames are generated.",
-		Sensitive:   false,
 	}
 	return r
 }

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -584,8 +584,9 @@ func TestAccDatabaseSecretBackendConnection_snowflake(t *testing.T) {
 	password := os.Getenv("SNOWFLAKE_PASSWORD")
 	backend := acctest.RandomWithPrefix("tf-test-db")
 	name := acctest.RandomWithPrefix("db")
+	userTempl := "{{.DisplayName}}"
 
-	config := testAccDatabaseSecretBackendConnectionConfig_snowflake(name, backend, url, username, password)
+	config := testAccDatabaseSecretBackendConnectionConfig_snowflake(name, backend, url, username, password, userTempl)
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -603,6 +604,7 @@ func TestAccDatabaseSecretBackendConnection_snowflake(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "snowflake.0.connection_url", url),
 					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "snowflake.0.username", username),
 					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "snowflake.0.password", password),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "snowflake.0.username_template", userTempl),
 				),
 			},
 		},
@@ -943,7 +945,7 @@ resource "vault_database_secret_backend_connection" "test" {
 `, path, name, connURL, userTempl)
 }
 
-func testAccDatabaseSecretBackendConnectionConfig_snowflake(name, path, url, username, password string) string {
+func testAccDatabaseSecretBackendConnectionConfig_snowflake(name, path, url, username, password, userTempl string) string {
 	return fmt.Sprintf(`
 resource "vault_mount" "db" {
   path = "%s"
@@ -958,11 +960,12 @@ resource "vault_database_secret_backend_connection" "test" {
 
   snowflake { 
     connection_url = "%s"
-	username = "%s"
-	password = "%s"
+    username = "%s"
+    password = "%s"
+    username_template = "%s"
   }
 }
-`, path, name, url, username, password)
+`, path, name, url, username, password, userTempl)
 }
 
 func newMySQLConnection(t *testing.T, connURL string, username string, password string) *sql.DB {


### PR DESCRIPTION
Use the `username_template` in `connectionStringResource()` for snowflake
instead of defining it separately. Adds `username_template` to the
snowflake test as well.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccDatabaseSecretBackendConnection_snowflake -count=1' SNOWFLAKE_URL="***:*****@***.azure.snowflakecomputing.com/***"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./...) -v -run=TestAccDatabaseSecretBackendConnection_snowflake -count=1 -timeout 120m
[...]
=== RUN   TestAccDatabaseSecretBackendConnection_snowflake
--- PASS: TestAccDatabaseSecretBackendConnection_snowflake (1.29s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/vault	3.294s
```
