### PR TITLE
Add intermediate (child) token policies

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -1,7 +1,7 @@
 ---
-layout: "vault"
-page_title: "Provider: Vault"
-sidebar_current: "docs-vault-index"
+layout: 'vault'
+page_title: 'Provider: Vault'
+sidebar_current: 'docs-vault-index'
 description: |-
   The Vault provider allows Terraform to read from, write to, and configure HashiCorp Vault
 ---
@@ -13,7 +13,7 @@ The Vault provider allows Terraform to read from, write to, and configure
 
 ~> **Important** Interacting with Vault from Terraform causes any secrets
 that you read and write to be persisted in both Terraform's state file
-*and* in any generated plan files. For any Terraform module that reads or
+_and_ in any generated plan files. For any Terraform module that reads or
 writes Vault secrets, these files should be treated as sensitive and
 protected accordingly.
 
@@ -49,7 +49,7 @@ to the state and consider carefully whether such usage is compatible with
 their security policies.
 
 Except as otherwise noted, the resources that write secrets into Vault are
-designed such that they require only the *create* and *update* capabilities
+designed such that they require only the _create_ and _update_ capabilities
 on the relevant resources, so that distinct tokens can be used for reading
 vs. writing and thus limit the exposure of a compromised token.
 
@@ -81,7 +81,7 @@ intermediate token has expired, due to the revocation of the secrets that
 are stored in the plan.
 
 Except as otherwise noted, the resources that read secrets from Vault
-are designed such that they require only the *read* capability on the relevant
+are designed such that they require only the _read_ capability on the relevant
 resources.
 
 ## Provider Arguments
@@ -90,15 +90,15 @@ The provider configuration block accepts the following arguments.
 In most cases it is recommended to set them via the indicated environment
 variables in order to keep credential information out of the configuration.
 
-* `address` - (Required) Origin URL of the Vault server. This is a URL
+- `address` - (Required) Origin URL of the Vault server. This is a URL
   with a scheme, a hostname and a port but with no path. May be set
   via the `VAULT_ADDR` environment variable.
 
-* `add_address_to_env` - (Optional) If `true` the environment variable
+- `add_address_to_env` - (Optional) If `true` the environment variable
   `VAULT_ADDR` in the Terraform process environment will be set to the
   value of the `address` argument from this provider. By default, this is false.
 
-* `token` - (Required) Vault token that will be used by Terraform to
+- `token` - (Required) Vault token that will be used by Terraform to
   authenticate. May be set via the `VAULT_TOKEN` environment variable.
   If none is otherwise supplied, Terraform will attempt to read it from
   `~/.vault-token` (where the vault command stores its current token).
@@ -107,90 +107,94 @@ variables in order to keep credential information out of the configuration.
   the given token must have the update capability on the auth/token/create
   path in Vault in order to create child tokens.
 
-* `token_name` - (Optional) Token name, that will be used by Terraform when
+- `token_name` - (Optional) Token name, that will be used by Terraform when
   creating the child token (`display_name`). This is useful to provide a reference of the
   Terraform run traceable in vault audit log, e.g. commit hash or id of the CI/CD
   execution job. May be set via the `VAULT_TOKEN_NAME` environment variable.
   Default value will be `terraform` if not set or empty.
 
-* `ca_cert_file` - (Optional) Path to a file on local disk that will be
+- `ca_cert_file` - (Optional) Path to a file on local disk that will be
   used to validate the certificate presented by the Vault server.
   May be set via the `VAULT_CACERT` environment variable.
 
-* `ca_cert_dir` - (Optional) Path to a directory on local disk that
+- `ca_cert_dir` - (Optional) Path to a directory on local disk that
   contains one or more certificate files that will be used to validate
   the certificate presented by the Vault server. May be set via the
   `VAULT_CAPATH` environment variable.
 
-* `auth_login` - (Optional) A configuration block, described below, that
+- `auth_login` - (Optional) A configuration block, described below, that
   attempts to authenticate using the `auth/<method>/login` path to
   aquire a token which Terraform will use. Terraform still issues itself
   a limited child token using auth/token/create in order to enforce a short
   TTL and limit exposure.
 
-* `client_auth` - (Optional) A configuration block, described below, that
+- `client_auth` - (Optional) A configuration block, described below, that
   provides credentials used by Terraform to authenticate with the Vault
   server. At present there is little reason to set this, because Terraform
   does not support the TLS certificate authentication mechanism.
 
-* `skip_tls_verify` - (Optional) Set this to `true` to disable verification
+- `skip_tls_verify` - (Optional) Set this to `true` to disable verification
   of the Vault server's TLS certificate. This is strongly discouraged except
   in prototype or development environments, since it exposes the possibility
   that Terraform can be tricked into writing secrets to a server controlled
   by an intruder. May be set via the `VAULT_SKIP_VERIFY` environment variable.
 
-* `max_lease_ttl_seconds` - (Optional) Used as the duration for the
+- `max_lease_ttl_seconds` - (Optional) Used as the duration for the
   intermediate Vault token Terraform issues itself, which in turn limits
   the duration of secret leases issued by Vault. Defaults to 20 minutes
   and may be set via the `TERRAFORM_VAULT_MAX_TTL` environment variable.
-  See the section above on *Using Vault credentials in Terraform configuration*
+  See the section above on _Using Vault credentials in Terraform configuration_
   for the implications of this setting.
 
-* `max_retries` - (Optional) Used as the maximum number of retries when a 5xx
+- `max_retries` - (Optional) Used as the maximum number of retries when a 5xx
   error code is encountered. Defaults to 2 retries and may be set via the
   `VAULT_MAX_RETRIES` environment variable.
 
-* `namespace` - (Optional) Set the namespace to use. May be set via the
-  `VAULT_NAMESPACE` environment variable. *Available only for Vault Enterprise*.
+- `namespace` - (Optional) Set the namespace to use. May be set via the
+  `VAULT_NAMESPACE` environment variable. _Available only for Vault Enterprise_.
 
-* `policies` - (Optional) A list a policies to attach to the child token.
-  Needs sudo capability on `auth/token/create`.
+- `policies` - (Optional) A list of policies for the intermediate Vault token Terraform issues itself.
+  This must be a subset of the policies belonging to the token making the request, unless the calling
+  token is root or contains sudo capabilities to `auth/token/create`.
+  If an empty list is specified, Vault will default to all the policies of the calling token.
+  See the section above on _Using Vault credentials in Terraform configuration_
+  for the implications of this setting.
 
-* `headers` - (Optional) A configuration block, described below, that provides headers
-to be sent along with all requests to the Vault server.  This block can be specified
-multiple times.
+- `headers` - (Optional) A configuration block, described below, that provides headers
+  to be sent along with all requests to the Vault server. This block can be specified
+  multiple times.
 
 The `auth_login` configuration block accepts the following arguments:
 
-* `path` - (Required) The login path of the auth backend. For example, login with
+- `path` - (Required) The login path of the auth backend. For example, login with
   approle by setting this path to `auth/approle/login`. Additionally, some mounts use parameters
   in the URL, like with `userpass`: `auth/userpass/login/:username`.
 
-* `namespace` - (Optional) The path to the namespace that has the mounted auth method.
+- `namespace` - (Optional) The path to the namespace that has the mounted auth method.
   This defaults to the root namespace. Cannot contain any leading or trailing slashes.
-  *Available only for Vault Enterprise*
+  _Available only for Vault Enterprise_
 
-* `method` - (Optional) When configured, will enable auth method specific operations.
+- `method` - (Optional) When configured, will enable auth method specific operations.
   For example, when set to `aws`, the provider will automatically sign login requests
   for AWS authentication. Valid values include: `aws`.
 
-* `parameters` - (Optional) A map of key-value parameters to send when authenticating
+- `parameters` - (Optional) A map of key-value parameters to send when authenticating
   against the auth backend. Refer to [Vault API documentation](https://www.vaultproject.io/api-docs/auth) for a particular auth method
   to see what can go here.
 
 The `client_auth` configuration block accepts the following arguments:
 
-* `cert_file` - (Required) Path to a file on local disk that contains the
+- `cert_file` - (Required) Path to a file on local disk that contains the
   PEM-encoded certificate to present to the server.
 
-* `key_file` - (Required) Path to a file on local disk that contains the
+- `key_file` - (Required) Path to a file on local disk that contains the
   PEM-encoded private key for which the authentication certificate was issued.
 
 The `headers` configuration block accepts the following arguments:
 
-* `name` - (Required) The name of the header.
+- `name` - (Required) The name of the header.
 
-* `value` - (Required) The value of the header.
+- `value` - (Required) The value of the header.
 
 ## Example Usage
 
@@ -218,6 +222,7 @@ EOT
 ```
 
 ### Example `auth_login` Usage
+
 With the `userpass` backend:
 
 ```hcl
@@ -275,7 +280,7 @@ provider "vault" {
 The Vault provider supports managing [Namespaces][namespaces] (a feature of
 Vault Enterprise), as well as creating resources in those namespaces by
 utilizing [Provider Aliasing][aliasing]. The `namespace` option in the [provider
-block][provider-block] enables the management of  resources in the specified
+block][provider-block] enables the management of resources in the specified
 namespace.
 
 ### Using Provider Aliases
@@ -335,7 +340,6 @@ root
 A more complex example of nested namespaces is show below. Each provider blocks
 uses interpolation of the `ID` of namespace it belongs in to ensure the namespace
 exists before that provider gets configured:
-
 
 ```hcl
 # main provider block with no namespace
@@ -442,7 +446,6 @@ $ vault policy list -namespace=everyone/engineering/vault-team
 default
 vault_team_policy
 ```
-
 
 [namespaces]: https://www.vaultproject.io/docs/enterprise/namespaces#vault-enterprise-namespaces
 [aliasing]: https://www.terraform.io/docs/configuration/providers.html#alias-multiple-provider-configurations

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -153,6 +153,9 @@ variables in order to keep credential information out of the configuration.
 * `namespace` - (Optional) Set the namespace to use. May be set via the
   `VAULT_NAMESPACE` environment variable. *Available only for Vault Enterprise*.
 
+* `policies` - (Optional) A list a policies to attach to the child token.
+  Needs sudo capability to `auth/token/create`.
+
 * `headers` - (Optional) A configuration block, described below, that provides headers
 to be sent along with all requests to the Vault server.  This block can be specified
 multiple times.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -154,7 +154,7 @@ variables in order to keep credential information out of the configuration.
   `VAULT_NAMESPACE` environment variable. *Available only for Vault Enterprise*.
 
 * `policies` - (Optional) A list a policies to attach to the child token.
-  Needs sudo capability to `auth/token/create`.
+  Needs sudo capability on `auth/token/create`.
 
 * `headers` - (Optional) A configuration block, described below, that provides headers
 to be sent along with all requests to the Vault server.  This block can be specified


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #1042

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add policies argument to provider configuration to manage Intermediate (child) token policies.
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./...) -v -run=TestAccXXX -timeout 120m
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/codegen   0.004s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    0.011s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    0.011s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    0.011s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        0.011s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    0.010s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      0.011s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/util      0.011s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     0.009s [no tests to run]

```
