### PR TITLE
Add reuse_wrapping_token functionality.

### DIFF
--- a/vault/resource_approle_auth_backend_role_secret_id.go
+++ b/vault/resource_approle_auth_backend_role_secret_id.go
@@ -80,6 +80,13 @@ func approleAuthBackendRoleSecretIDResource() *schema.Resource {
 				},
 			},
 
+			"reuse_wrapping_token": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Reuse the wrapping token if the wrapped secret-id is still valid.",
+				ForceNew:    true,
+			},
+
 			"accessor": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -141,6 +148,8 @@ func approleAuthBackendRoleSecretIDCreate(d *schema.ResourceData, meta interface
 	} else {
 		data["metadata"] = ""
 	}
+	var reuseWrappingToken bool
+	reuseWrappingToken = d.Get("reuse_wrapping_token").(bool)
 
 	wrappingTTL, wrapped := d.GetOk("wrapping_ttl")
 
@@ -167,7 +176,11 @@ func approleAuthBackendRoleSecretIDCreate(d *schema.ResourceData, meta interface
 	var accessor string
 
 	if wrapped {
-		accessor = resp.WrapInfo.Accessor
+		if reuseWrappingToken {
+			accessor = resp.WrapInfo.WrappedAccessor
+		} else {
+			accessor = resp.WrapInfo.Accessor
+		}
 		d.Set("wrapping_token", resp.WrapInfo.Token)
 		d.Set("wrapping_accessor", accessor)
 	} else {
@@ -176,7 +189,7 @@ func approleAuthBackendRoleSecretIDCreate(d *schema.ResourceData, meta interface
 		d.Set("accessor", accessor)
 	}
 
-	d.SetId(approleAuthBackendRoleSecretIDID(backend, role, accessor, wrapped))
+	d.SetId(approleAuthBackendRoleSecretIDID(backend, role, accessor, wrapped, reuseWrappingToken))
 
 	return approleAuthBackendRoleSecretIDRead(d, meta)
 }
@@ -191,8 +204,10 @@ func approleAuthBackendRoleSecretIDRead(d *schema.ResourceData, meta interface{}
 	}
 
 	// If the ID is wrapped, there is no information available other than whether
-	// the wrapping token is still valid.
-	if wrapped {
+	// the wrapping token is still valid, unless we are planning to re-use it.
+	reuseWrappingToken := d.Get("reuse_wrapping_token").(bool)
+
+	if wrapped && !reuseWrappingToken {
 		valid, err := approleAuthBackendRoleSecretIDExists(d, meta)
 		if err != nil {
 			return err
@@ -326,8 +341,8 @@ func approleAuthBackendRoleSecretIDExists(d *schema.ResourceData, meta interface
 	return resp != nil, nil
 }
 
-func approleAuthBackendRoleSecretIDID(backend, role, accessor string, wrapped bool) string {
-	if wrapped {
+func approleAuthBackendRoleSecretIDID(backend, role, accessor string, wrapped bool, reuse_wrapping_token bool) string {
+	if wrapped && !reuse_wrapping_token {
 		accessor = "wrapped-" + accessor
 	}
 	return fmt.Sprintf("backend=%s::role=%s::accessor=%s", strings.Trim(backend, "/"), strings.Trim(role, "/"), accessor)

--- a/vault/resource_approle_auth_backend_role_secret_id_test.go
+++ b/vault/resource_approle_auth_backend_role_secret_id_test.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -51,6 +52,30 @@ func TestAccAppRoleAuthBackendRoleSecretID_wrapped(t *testing.T) {
 					resource.TestCheckResourceAttr(secretIDResource, "role_name", role),
 					resource.TestCheckResourceAttrSet(secretIDResource, "wrapping_accessor"),
 					resource.TestCheckResourceAttrSet(secretIDResource, "wrapping_token"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAppRoleAuthBackendRoleSecretID_wrapped_reuse(t *testing.T) {
+	backend := acctest.RandomWithPrefix("approle")
+	role := acctest.RandomWithPrefix("test-role")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { util.TestAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckAppRoleAuthBackendRoleSecretIDDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAppRoleAuthBackendRoleSecretIDConfig_wrapped_reuse(backend, role),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(secretIDResource, "backend", backend),
+					resource.TestCheckResourceAttr(secretIDResource, "role_name", role),
+					resource.TestCheckResourceAttrSet(secretIDResource, "wrapping_accessor"),
+					resource.TestCheckResourceAttrSet(secretIDResource, "wrapping_token"),
+					resource.TestCheckResourceAttrSet(secretIDResource, "accessor"),
+					resource.TestMatchResourceAttr(secretIDResource, "accessor", regexp.MustCompile("^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$")),
 				),
 			},
 		},
@@ -196,6 +221,27 @@ resource "vault_approle_auth_backend_role_secret_id" "secret_id" {
   role_name = "${vault_approle_auth_backend_role.role.role_name}"
   backend = "${vault_auth_backend.approle.path}"
   wrapping_ttl = "60s"
+}`, backend, role)
+}
+
+func testAccAppRoleAuthBackendRoleSecretIDConfig_wrapped_reuse(backend, role string) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "approle" {
+  type = "approle"
+  path = "%s"
+}
+
+resource "vault_approle_auth_backend_role" "role" {
+  backend = "${vault_auth_backend.approle.path}"
+  role_name = "%s"
+  token_policies = ["default", "dev", "prod"]
+}
+
+resource "vault_approle_auth_backend_role_secret_id" "secret_id" {
+  role_name = "${vault_approle_auth_backend_role.role.role_name}"
+  backend = "${vault_auth_backend.approle.path}"
+  wrapping_ttl = "60s"
+  reuse_wrapping_token = true
 }`, backend, role)
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #976 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/approle_auth_backend_role_secret_id: Add support for re-using a wrapped secret id (#976)
```

Output from acceptance testing:

```
$ make testacc TESTARGS="--run TestAccAppRoleAuthBackendRoleSecretID"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./...) -v --run TestAccAppRoleAuthBackendRoleSecretID -timeout 120m
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/codegen   (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
=== RUN   TestAccAppRoleAuthBackendRoleSecretID_basic
--- PASS: TestAccAppRoleAuthBackendRoleSecretID_basic (0.22s)
=== RUN   TestAccAppRoleAuthBackendRoleSecretID_wrapped
--- PASS: TestAccAppRoleAuthBackendRoleSecretID_wrapped (0.20s)
=== RUN   TestAccAppRoleAuthBackendRoleSecretID_wrapped_reuse
--- PASS: TestAccAppRoleAuthBackendRoleSecretID_wrapped_reuse (0.20s)
=== RUN   TestAccAppRoleAuthBackendRoleSecretID_wrapped_namespace
    util.go:112: TF_ACC_ENTERPRISE is not set, test is applicable only for Enterprise version of Vault
--- SKIP: TestAccAppRoleAuthBackendRoleSecretID_wrapped_namespace (0.00s)
=== RUN   TestAccAppRoleAuthBackendRoleSecretID_full
--- PASS: TestAccAppRoleAuthBackendRoleSecretID_full (0.20s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     2.038s
```

NOTE - This functionality relies on Vault updates in https://github.com/hashicorp/vault/pull/12425 

I'm not sure if I'm supposed to wait for that code to be merged/rejected before raising this PR, but I figured this way I can at least get some potential feedback and address any issues in this PR so it's ready to go when/if that other code is available.
