### PR TITLE
docs: jwt auth role bound_claims list format

### DIFF
--- a/website/docs/r/jwt_auth_backend_role.html.md
+++ b/website/docs/r/jwt_auth_backend_role.html.md
@@ -72,8 +72,9 @@ The following arguments are supported:
 * `bound_subject` - (Optional) If set, requires that the `sub` claim matches
   this value.
 
-* `bound_claims` - (Optional) If set, a map of claims/values to match against.
-  A claim's value may be a single string or a comma-separated string list.
+* `bound_claims` - (Optional) If set, a map of claims to values to match against.
+  A claim's value must be a string, which may contain one value or multiple
+  comma-separated values, e.g. `"red"` or `"red,green,blue"`.
 
 * `bound_claims_type` - (Optional) How to interpret values in the claims/values
   map (`bound_claims`): can be either `string` (exact match) or `glob` (wildcard

--- a/website/docs/r/jwt_auth_backend_role.html.md
+++ b/website/docs/r/jwt_auth_backend_role.html.md
@@ -27,6 +27,9 @@ resource "vault_jwt_auth_backend_role" "example" {
   token_policies  = ["default", "dev", "prod"]
 
   bound_audiences = ["https://myco.test"]
+  bound_claims = {
+    color = "red,green,blue"
+  }
   user_claim      = "https://vault/user"
   role_type       = "jwt"
 }
@@ -70,7 +73,7 @@ The following arguments are supported:
   this value.
 
 * `bound_claims` - (Optional) If set, a map of claims/values to match against.
-  The expected value may be a single string or a list of strings.
+  A claim's value may be a single string or a comma-separated string list.
 
 * `bound_claims_type` - (Optional) How to interpret values in the claims/values
   map (`bound_claims`): can be either `string` (exact match) or `glob` (wildcard


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

Updates the docs for jwt auth role `bound_claims` since a claim's value can be a list, but must be a comma-separated string (not an HCL list).

See code references:
https://github.com/hashicorp/terraform-provider-vault/blob/6542620d5584264074bb00d002cba87f8e460f9f/vault/resource_jwt_auth_backend_role.go#L92-L96
https://github.com/hashicorp/terraform-provider-vault/blob/6542620d5584264074bb00d002cba87f8e460f9f/vault/resource_jwt_auth_backend_role_test.go#L650-L653

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1019

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
