### PR TITLE
Add provider tests and fix S3 secret issue

### DIFF
--- a/vault/resource_raft_snapshot_agent_config.go
+++ b/vault/resource_raft_snapshot_agent_config.go
@@ -213,6 +213,9 @@ func buildConfigFromResourceData(d *schema.ResourceData) (map[string]interface{}
 		if v, ok := d.GetOk("aws_access_key_id"); ok {
 			data["aws_access_key_id"] = v
 		}
+		if v, ok := d.GetOk("aws_secret_access_key"); ok {
+			data["aws_secret_access_key"] = v
+		}
 		if v, ok := d.GetOk("aws_session_token"); ok {
 			data["aws_session_token"] = v
 		}
@@ -429,7 +432,8 @@ func readSnapshotAgentConfigResource(d *schema.ResourceData, meta interface{}) e
 		}
 	}
 
-	if val, ok := resp.Data["google_endpoint"]; ok {
+	// Vault is returning 'false' for this instead of null.
+	if val, ok := resp.Data["google_endpoint"]; ok && val != false {
 		if err := d.Set("google_endpoint", val); err != nil {
 			return fmt.Errorf("error setting state key 'google_endpoint': %s", err)
 		}

--- a/vault/resource_raft_snapshot_agent_config_test.go
+++ b/vault/resource_raft_snapshot_agent_config_test.go
@@ -42,6 +42,51 @@ func TestAccRaftSnapshotAgentConfig_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_raft_snapshot_agent_config.test", "local_max_space", "4096"),
 				),
 			},
+			{
+				Config: testAccRaftSnapshotAgentConfig_aws(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_raft_snapshot_agent_config.aws_backups", "name", name),
+					resource.TestCheckResourceAttr("vault_raft_snapshot_agent_config.aws_backups", "interval_seconds", "7200"),
+					resource.TestCheckResourceAttr("vault_raft_snapshot_agent_config.aws_backups", "retain", "1"),
+					resource.TestCheckResourceAttr("vault_raft_snapshot_agent_config.aws_backups", "path_prefix", "/path/in/bucket"),
+					resource.TestCheckResourceAttr("vault_raft_snapshot_agent_config.aws_backups", "file_prefix", "vault-snapshot"),
+					resource.TestCheckResourceAttr("vault_raft_snapshot_agent_config.aws_backups", "aws_s3_bucket", "my-bucket"),
+					resource.TestCheckResourceAttr("vault_raft_snapshot_agent_config.aws_backups", "aws_s3_region", "us-east-1"),
+					resource.TestCheckResourceAttr("vault_raft_snapshot_agent_config.aws_backups", "aws_access_key_id", "aws-access-key-id"),
+					resource.TestCheckResourceAttr("vault_raft_snapshot_agent_config.aws_backups", "aws_secret_access_key", "aws-secret-access-key"),
+					resource.TestCheckResourceAttr("vault_raft_snapshot_agent_config.aws_backups", "aws_session_token", "aws-session-token"),
+					resource.TestCheckResourceAttr("vault_raft_snapshot_agent_config.aws_backups", "aws_s3_enable_kms", "true"),
+					resource.TestCheckResourceAttr("vault_raft_snapshot_agent_config.aws_backups", "aws_s3_kms_key", "alias/VaultBackupKMS"),
+				),
+			},
+			{
+				Config: testAccRaftSnapshotAgentConfig_google(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_raft_snapshot_agent_config.google_backups", "name", name),
+					resource.TestCheckResourceAttr("vault_raft_snapshot_agent_config.google_backups", "interval_seconds", "7200"),
+					resource.TestCheckResourceAttr("vault_raft_snapshot_agent_config.google_backups", "retain", "1"),
+					resource.TestCheckResourceAttr("vault_raft_snapshot_agent_config.google_backups", "path_prefix", "/path/in/bucket"),
+					resource.TestCheckResourceAttr("vault_raft_snapshot_agent_config.google_backups", "file_prefix", "vault-snapshot"),
+					resource.TestCheckResourceAttr("vault_raft_snapshot_agent_config.google_backups", "storage_type", "google-gcs"),
+					resource.TestCheckResourceAttr("vault_raft_snapshot_agent_config.google_backups", "google_gcs_bucket", "my-bucket"),
+					resource.TestCheckResourceAttr("vault_raft_snapshot_agent_config.google_backups", "google_service_account_key", "{}"),
+				),
+			},
+			{
+				Config: testAccRaftSnapshotAgentConfig_azure(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_raft_snapshot_agent_config.azure_backups", "name", name),
+					resource.TestCheckResourceAttr("vault_raft_snapshot_agent_config.azure_backups", "interval_seconds", "7200"),
+					resource.TestCheckResourceAttr("vault_raft_snapshot_agent_config.azure_backups", "retain", "1"),
+					resource.TestCheckResourceAttr("vault_raft_snapshot_agent_config.azure_backups", "path_prefix", "/path/in/bucket"),
+					resource.TestCheckResourceAttr("vault_raft_snapshot_agent_config.azure_backups", "file_prefix", "vault-snapshot"),
+					resource.TestCheckResourceAttr("vault_raft_snapshot_agent_config.azure_backups", "storage_type", "azure-blob"),
+					resource.TestCheckResourceAttr("vault_raft_snapshot_agent_config.azure_backups", "azure_container_name", "my-bucket"),
+					resource.TestCheckResourceAttr("vault_raft_snapshot_agent_config.azure_backups", "azure_account_name", "azure-account-name"),
+					resource.TestCheckResourceAttr("vault_raft_snapshot_agent_config.azure_backups", "azure_account_key", "azure-account-key"),
+					resource.TestCheckResourceAttr("vault_raft_snapshot_agent_config.azure_backups", "azure_blob_environment", "azure-env"),
+				),
+			},
 		},
 	})
 }
@@ -113,5 +158,51 @@ resource "vault_raft_snapshot_agent_config" "test" {
   path_prefix = "/tmp"
   storage_type = "local"
   local_max_space = 4096
+}`, name)
+}
+
+func testAccRaftSnapshotAgentConfig_aws(name string) string {
+	return fmt.Sprintf(`
+resource "vault_raft_snapshot_agent_config" "aws_backups" {
+  name = "%s"
+  interval_seconds = 7200
+  retain = 1
+  path_prefix = "/path/in/bucket"
+  storage_type = "aws-s3"
+  aws_s3_bucket = "my-bucket"
+  aws_s3_region = "us-east-1"
+  aws_access_key_id = "aws-access-key-id"
+  aws_secret_access_key = "aws-secret-access-key"
+  aws_session_token = "aws-session-token"
+  aws_s3_enable_kms = true
+  aws_s3_kms_key = "alias/VaultBackupKMS"
+}`, name)
+}
+
+func testAccRaftSnapshotAgentConfig_google(name string) string {
+	return fmt.Sprintf(`
+resource "vault_raft_snapshot_agent_config" "google_backups" {
+  name = "%s"
+  interval_seconds = 7200
+  retain = 1
+  path_prefix = "/path/in/bucket"
+  storage_type = "google-gcs"
+  google_gcs_bucket = "my-bucket"
+  google_service_account_key = "{}"
+}`, name)
+}
+
+func testAccRaftSnapshotAgentConfig_azure(name string) string {
+	return fmt.Sprintf(`
+resource "vault_raft_snapshot_agent_config" "azure_backups" {
+  name = "%s"
+  interval_seconds = 7200
+  retain = 1
+  path_prefix = "/path/in/bucket"
+  storage_type = "azure-blob"
+  azure_container_name = "my-bucket"
+  azure_account_name = "azure-account-name"
+  azure_account_key = "azure-account-key"
+  azure_blob_environment = "azure-env"
 }`, name)
 }


### PR DESCRIPTION
There was an attribute left out of my initial merge request (#1139) that is preventing the complete setup of resources with those changes. Fixing that error and adding tests to catch similar issues in the future.
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #1139

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUGS:
- `resource/vault_raft_snapshot_agent_config`: Fixed issue where AWS Secret Access Key was ignored.
```

Output from acceptance testing:

```
$ TESTARGS="--run RaftSnapshotAgentConfig" TF_ACC_ENTERPRISE="true" make testacc
...
=== RUN   TestAccRaftSnapshotAgentConfig_basic
--- PASS: TestAccRaftSnapshotAgentConfig_basic (1.46s)
=== RUN   TestAccRaftSnapshotAgentConfig_import
--- PASS: TestAccRaftSnapshotAgentConfig_import (0.48s)
PASS
```
