### PR TITLE
 Add support for case_sensitive_names in the vault_ldap_auth_backend

### DIFF
--- a/vault/resource_ldap_auth_backend.go
+++ b/vault/resource_ldap_auth_backend.go
@@ -58,6 +58,7 @@ func ldapAuthBackendResource() *schema.Resource {
 			Type:     schema.TypeBool,
 			Optional: true,
 			Computed: true,
+			Default: false,
 		},
 		"userdn": {
 			Type:     schema.TypeString,

--- a/vault/resource_ldap_auth_backend.go
+++ b/vault/resource_ldap_auth_backend.go
@@ -209,7 +209,7 @@ func ldapAuthBackendUpdate(d *schema.ResourceData, meta interface{}) error {
 		data["bindpass"] = v.(string)
 	}
 
-	if v, ok := d.GetOk("case_sensitive_names"); ok {
+	if v, ok := d.GetOkExists("case_sensitive_names"); ok {
 		data["case_sensitive_names"] = v.(bool)
 	}
 	

--- a/vault/resource_ldap_auth_backend.go
+++ b/vault/resource_ldap_auth_backend.go
@@ -58,7 +58,6 @@ func ldapAuthBackendResource() *schema.Resource {
 			Type:     schema.TypeBool,
 			Optional: true,
 			Computed: true,
-			Default: false,
 		},
 		"userdn": {
 			Type:     schema.TypeString,

--- a/vault/resource_ldap_auth_backend.go
+++ b/vault/resource_ldap_auth_backend.go
@@ -54,6 +54,11 @@ func ldapAuthBackendResource() *schema.Resource {
 			Computed:  true,
 			Sensitive: true,
 		},
+		"case_sensitive_names": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Computed: true,
+		},
 		"userdn": {
 			Type:     schema.TypeString,
 			Optional: true,
@@ -204,6 +209,10 @@ func ldapAuthBackendUpdate(d *schema.ResourceData, meta interface{}) error {
 		data["bindpass"] = v.(string)
 	}
 
+	if v, ok := d.GetOk("case_sensitive_names"); ok {
+		data["case_sensitive_names"] = v.(bool)
+	}
+	
 	if v, ok := d.GetOk("userdn"); ok {
 		data["userdn"] = v.(string)
 	}
@@ -299,6 +308,7 @@ func ldapAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("insecure_tls", resp.Data["insecure_tls"])
 	d.Set("certificate", resp.Data["certificate"])
 	d.Set("binddn", resp.Data["binddn"])
+	d.Set("case_sensitive_names", resp.Data["case_sensitive_names"])
 	d.Set("userdn", resp.Data["userdn"])
 	d.Set("userattr", resp.Data["userattr"])
 	d.Set("discoverdn", resp.Data["discoverdn"])

--- a/vault/resource_ldap_auth_backend.go
+++ b/vault/resource_ldap_auth_backend.go
@@ -212,7 +212,6 @@ func ldapAuthBackendUpdate(d *schema.ResourceData, meta interface{}) error {
 	if v, ok := d.GetOkExists("case_sensitive_names"); ok {
 		data["case_sensitive_names"] = v.(bool)
 	}
-	
 	if v, ok := d.GetOk("userdn"); ok {
 		data["userdn"] = v.(string)
 	}

--- a/vault/resource_ldap_auth_backend_test.go
+++ b/vault/resource_ldap_auth_backend_test.go
@@ -126,22 +126,23 @@ func testLDAPAuthBackendCheck_attrs(path string) resource.TestCheckFunc {
 		}
 
 		attrs := map[string]string{
-			"url":              "url",
-			"starttls":         "starttls",
-			"tls_min_version":  "tls_min_version",
-			"tls_max_version":  "tls_max_version",
-			"insecure_tls":     "insecure_tls",
-			"certificate":      "certificate",
-			"binddn":           "binddn",
-			"userdn":           "userdn",
-			"userattr":         "userattr",
-			"discoverdn":       "discoverdn",
-			"deny_null_bind":   "deny_null_bind",
-			"upndomain":        "upndomain",
-			"groupfilter":      "groupfilter",
-			"groupdn":          "groupdn",
-			"groupattr":        "groupattr",
-			"use_token_groups": "use_token_groups",
+			"url":                  "url",
+			"starttls":             "starttls",
+			"case_sensitive_names": "case_sensitive_names",
+			"tls_min_version":      "tls_min_version",
+			"tls_max_version":      "tls_max_version",
+			"insecure_tls":         "insecure_tls",
+			"certificate":          "certificate",
+			"binddn":               "binddn",
+			"userdn":               "userdn",
+			"userattr":             "userattr",
+			"discoverdn":           "discoverdn",
+			"deny_null_bind":       "deny_null_bind",
+			"upndomain":            "upndomain",
+			"groupfilter":          "groupfilter",
+			"groupdn":              "groupdn",
+			"groupattr":            "groupattr",
+			"use_token_groups":     "use_token_groups",
 		}
 
 		for stateAttr, apiAttr := range attrs {
@@ -216,6 +217,7 @@ resource "vault_ldap_auth_backend" "test" {
     path                   = "%s"
     url                    = "ldaps://example.org"
     starttls               = true
+    case_sensitive_names   = false
     tls_min_version        = "tls11"
     tls_max_version        = "tls12"
     insecure_tls           = false

--- a/website/docs/r/ldap_auth_backend.html.md
+++ b/website/docs/r/ldap_auth_backend.html.md
@@ -33,6 +33,8 @@ The following arguments are supported:
 
 * `starttls` - (Optional) Control use of TLS when conecting to LDAP
 
+* `case_sensitive_names` - (Optional) Control case senstivity of objects fetched from LDAP, this is used for object matching in vault
+
 * `tls_min_version` - (Optional) Minimum acceptable version of TLS
 
 * `tls_max_version` - (Optional) Maximum acceptable version of TLS


### PR DESCRIPTION
Fixes #894

This PR is an extension of @stokkie90 fix that was proposed in https://github.com/hashicorp/terraform-provider-vault/pull/895

I've updated the docs and tests, plus added switched to GetOkExists when checking `case_sensitive_names` as recommended by @catsby.

I've also set the default to `false` to be consistent with Vault's behaviour.