### PR TITLE
fix: d_gcp_auth_backend_role: error on nonexistent role

### DIFF
--- a/vault/data_source_gcp_auth_backend_role.go
+++ b/vault/data_source_gcp_auth_backend_role.go
@@ -122,7 +122,7 @@ func gcpAuthBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Read gcp auth backend role %q ID", path)
 
 	if resp == nil {
-		return nil
+		return fmt.Errorf("role not found at %q", path)
 	}
 
 	d.SetId(path)

--- a/vault/data_source_gcp_auth_backend_role_test.go
+++ b/vault/data_source_gcp_auth_backend_role_test.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -84,6 +85,24 @@ func TestAccGCPAuthBackendRoleDataSource_gce(t *testing.T) {
 						"role_id"),
 					resource.TestCheckResourceAttr("data.vault_gcp_auth_backend_role.gcp_role",
 						"bound_labels.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGCPAuthBackendRoleDataSource_none(t *testing.T) {
+	backend := acctest.RandomWithPrefix("gcp")
+	name := acctest.RandomWithPrefix("tf-test-gcp-role")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGCPAuthBackendRoleDataSourceConfig(backend, name),
+				ExpectError: regexp.MustCompile(
+					fmt.Sprintf("role not found at %q", gcpRoleResourcePath(backend, name)),
 				),
 			},
 		},


### PR DESCRIPTION
Ensure that an error is reported whenever the gcp-auth-backend-role data source does not exist in Vault.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
bug: data/gcp_auth_backend_role Report an error when attempting to access a nonexistent Vault role.
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
make dev testacc TESTARGS='-run=TestAccGCPAuthBackendRoleDataSource -v' ; TZ=UTC date 
==> Checking that code complies with gofmt requirements...
go build -o terraform-provider-vault
mv terraform-provider-vault ~/.terraform.d/plugins/
TF_ACC=1 go test $(go list ./...) -v -run=TestAccGCPAuthBackendRoleDataSource -v -timeout 20m

[...]

=== RUN   TestAccGCPAuthBackendRoleDataSource_basic
--- PASS: TestAccGCPAuthBackendRoleDataSource_basic (4.92s)
=== RUN   TestAccGCPAuthBackendRoleDataSource_gce
--- PASS: TestAccGCPAuthBackendRoleDataSource_gce (3.97s)
=== RUN   TestAccGCPAuthBackendRoleDataSource_none
--- PASS: TestAccGCPAuthBackendRoleDataSource_none (0.49s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     10.111s
Fri Oct  1 19:27:52 UTC 2021
```
