### PR TITLE
Add audit non HMAC'd request / response keys to mount resource

### DIFF
--- a/vault/resource_mount.go
+++ b/vault/resource_mount.go
@@ -60,6 +60,20 @@ func MountResource() *schema.Resource {
 				Description: "Maximum possible lease duration for tokens and secrets in seconds",
 			},
 
+			"audit_non_hmac_request_keys": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Specifies the list of keys that will not be HMAC'd by audit devices in the request data object.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+
+			"audit_non_hmac_response_keys": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Specifies the list of keys that will not be HMAC'd by audit devices in the response data object.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+
 			"accessor": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -111,8 +125,10 @@ func mountWrite(d *schema.ResourceData, meta interface{}) error {
 		Type:        d.Get("type").(string),
 		Description: d.Get("description").(string),
 		Config: api.MountConfigInput{
-			DefaultLeaseTTL: fmt.Sprintf("%ds", d.Get("default_lease_ttl_seconds")),
-			MaxLeaseTTL:     fmt.Sprintf("%ds", d.Get("max_lease_ttl_seconds")),
+			DefaultLeaseTTL:          fmt.Sprintf("%ds", d.Get("default_lease_ttl_seconds")),
+			MaxLeaseTTL:              fmt.Sprintf("%ds", d.Get("max_lease_ttl_seconds")),
+			AuditNonHMACRequestKeys:  expandStringSliceWithEmpty(d.Get("audit_non_hmac_request_keys").([]interface{}), false),
+			AuditNonHMACResponseKeys: expandStringSliceWithEmpty(d.Get("audit_non_hmac_response_keys").([]interface{}), false),
 		},
 		Local:                 d.Get("local").(bool),
 		Options:               opts(d),
@@ -140,6 +156,14 @@ func mountUpdate(d *schema.ResourceData, meta interface{}) error {
 		DefaultLeaseTTL: fmt.Sprintf("%ds", d.Get("default_lease_ttl_seconds")),
 		MaxLeaseTTL:     fmt.Sprintf("%ds", d.Get("max_lease_ttl_seconds")),
 		Options:         opts(d),
+	}
+
+	if d.HasChange("audit_non_hmac_request_keys") {
+		config.AuditNonHMACRequestKeys = expandStringSliceWithEmpty(d.Get("audit_non_hmac_request_keys").([]interface{}), false)
+	}
+
+	if d.HasChange("audit_non_hmac_response_keys") {
+		config.AuditNonHMACResponseKeys = expandStringSliceWithEmpty(d.Get("audit_non_hmac_response_keys").([]interface{}), false)
 	}
 
 	if d.HasChange("description") {
@@ -228,6 +252,8 @@ func mountRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("description", mount.Description)
 	d.Set("default_lease_ttl_seconds", mount.Config.DefaultLeaseTTL)
 	d.Set("max_lease_ttl_seconds", mount.Config.MaxLeaseTTL)
+	d.Set("audit_non_hmac_request_keys", mount.Config.AuditNonHMACRequestKeys)
+	d.Set("audit_non_hmac_response_keys", mount.Config.AuditNonHMACResponseKeys)
 	d.Set("accessor", mount.Accessor)
 	d.Set("local", mount.Local)
 	d.Set("options", mount.Options)

--- a/vault/resource_mount_test.go
+++ b/vault/resource_mount_test.go
@@ -107,6 +107,26 @@ func TestResourceMount_SealWrap(t *testing.T) {
 	})
 }
 
+// Test Audit HMAC Request Keys attributes
+
+func TestResourceMount_AuditNonHMACRequestKeys(t *testing.T) {
+	path := "example-" + acctest.RandString(10)
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceMount_InitialConfigAuditNonHMACRequestKeys(path),
+				Check:  testResourceMount_InitialCheckAuditNonHMACRequestKeys(path),
+			},
+			{
+				Config: testResourceMount_UpdateConfigAuditNonHMACRequestKeys,
+				Check:  testResourceMount_UpdateAuditNonHMACRequestKeys,
+			},
+		},
+	})
+}
+
 func TestResourceMount_KVV2(t *testing.T) {
 	path := acctest.RandomWithPrefix("example")
 	kvv2Cfg := fmt.Sprintf(`
@@ -474,6 +494,109 @@ func testResourceMount_UpdateCheckSealWrap(s *terraform.State) error {
 
 	if wanted := false; mount.SealWrap != wanted {
 		return fmt.Errorf("seal_wrap is %v; wanted %t", mount.SealWrap, wanted)
+	}
+
+	return nil
+}
+
+func testResourceMount_InitialConfigAuditNonHMACRequestKeys(path string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "test" {
+	path = "%s"
+	type = "kv"
+	description = "Example local mount for testing"
+	default_lease_ttl_seconds = 3600
+	max_lease_ttl_seconds = 36000
+	options = {
+		version = "1"
+	}
+	audit_non_hmac_request_keys = ["test1request", "test2request"]
+	audit_non_hmac_response_keys = ["test1response", "test2response"]
+}
+`, path)
+}
+
+func testResourceMount_InitialCheckAuditNonHMACRequestKeys(expectedPath string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourceState := s.Modules[0].Resources["vault_mount.test"]
+		if resourceState == nil {
+			return fmt.Errorf("resource not found in state")
+		}
+
+		instanceState := resourceState.Primary
+		if instanceState == nil {
+			return fmt.Errorf("resource has no primary instance")
+		}
+
+		path := instanceState.ID
+
+		if path != instanceState.Attributes["path"] {
+			return fmt.Errorf("id %q doesn't match path %q", path, instanceState.Attributes["path"])
+		}
+
+		if path != expectedPath {
+			return fmt.Errorf("unexpected path %q, expected %q", path, expectedPath)
+		}
+
+		mount, err := findMount(path)
+		if err != nil {
+			return fmt.Errorf("error reading back mount %q: %s", path, err)
+		}
+
+		if len(mount.Config.AuditNonHMACRequestKeys) < 2 || mount.Config.AuditNonHMACRequestKeys[0] != "test1request" || mount.Config.AuditNonHMACRequestKeys[1] != "test2request" {
+			return fmt.Errorf("audit_non_hmac_request_keys is %v; expected [\"test1request\", \"test2request\"]", mount.Config.AuditNonHMACRequestKeys)
+		}
+
+		if len(mount.Config.AuditNonHMACResponseKeys) < 2 || mount.Config.AuditNonHMACResponseKeys[0] != "test1response" || mount.Config.AuditNonHMACResponseKeys[1] != "test2response" {
+			return fmt.Errorf("audit_non_hmac_response_keys is %v; expected [\"test1response\", \"test2response\"]", mount.Config.AuditNonHMACRequestKeys)
+		}
+
+		return nil
+	}
+}
+
+var testResourceMount_UpdateConfigAuditNonHMACRequestKeys = `
+
+resource "vault_mount" "test" {
+	path = "remountingExample"
+	type = "kv"
+	description = "Example mount for testing"
+	default_lease_ttl_seconds = 7200
+	max_lease_ttl_seconds = 72000
+	options = {
+		version = "1"
+	}
+	audit_non_hmac_request_keys = ["test3request", "test4request"]
+	audit_non_hmac_response_keys = ["test3response", "test4response"]
+}
+
+`
+
+func testResourceMount_UpdateAuditNonHMACRequestKeys(s *terraform.State) error {
+	resourceState := s.Modules[0].Resources["vault_mount.test"]
+	instanceState := resourceState.Primary
+
+	path := instanceState.ID
+
+	if path != instanceState.Attributes["path"] {
+		return fmt.Errorf("id doesn't match path")
+	}
+
+	if path != "remountingExample" {
+		return fmt.Errorf("unexpected path value")
+	}
+
+	mount, err := findMount(path)
+	if err != nil {
+		return fmt.Errorf("error reading back mount: %s", err)
+	}
+
+	if len(mount.Config.AuditNonHMACRequestKeys) < 2 || mount.Config.AuditNonHMACRequestKeys[0] != "test3request" || mount.Config.AuditNonHMACRequestKeys[1] != "test4request" {
+		return fmt.Errorf("audit_non_hmac_request_keys is %v; expected [\"test3request\", \"test4request\"]", mount.Config.AuditNonHMACRequestKeys)
+	}
+
+	if len(mount.Config.AuditNonHMACResponseKeys) < 2 || mount.Config.AuditNonHMACResponseKeys[0] != "test3response" || mount.Config.AuditNonHMACResponseKeys[1] != "test4response" {
+		return fmt.Errorf("audit_non_hmac_response_keys is %v; expected [\"test3response\", \"test4response\"]", mount.Config.AuditNonHMACRequestKeys)
 	}
 
 	return nil

--- a/website/docs/r/mount.html.md
+++ b/website/docs/r/mount.html.md
@@ -64,6 +64,10 @@ The following arguments are supported:
 
 * `max_lease_ttl_seconds` - (Optional) Maximum possible lease duration for tokens and secrets in seconds
 
+* `audit_non_hmac_response_keys` - (Optional) Specifies the list of keys that will not be HMAC'd by audit devices in the response data object.
+
+* `audit_non_hmac_request_keys` - (Optional) Specifies the list of keys that will not be HMAC'd by audit devices in the request data object.
+
 * `local` - (Optional) Boolean flag that can be explicitly set to true to enforce local mount in HA environment
 
 * `options` - (Optional) Specifies mount type specific options that are passed to the backend


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Closes #667

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
```release-note
`resource/vault_mount`: Added support for `audit_non_hmac_request_keys` and `audit_non_hmac_response_keys` when mounting secret backends ([#667](https://github.com/hashicorp/terraform-provider-vault/issues/667))
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestResourceMount'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./...) -v -run=TestResourceMount -timeout 20m
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/codegen   (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
=== RUN   TestResourceMount
--- PASS: TestResourceMount (1.57s)
=== RUN   TestResourceMount_Local
--- PASS: TestResourceMount_Local (1.61s)
=== RUN   TestResourceMount_SealWrap
--- PASS: TestResourceMount_SealWrap (1.68s)
=== RUN   TestResourceMount_AuditNonHMACRequestKeys
--- PASS: TestResourceMount_AuditNonHMACRequestKeys (1.59s)
=== RUN   TestResourceMount_KVV2
--- PASS: TestResourceMount_KVV2 (1.66s)
=== RUN   TestResourceMount_ExternalEntropyAccess
--- PASS: TestResourceMount_ExternalEntropyAccess (3.51s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     (cached)
```
