### PR TITLE
[VAULT-3380] Add field to disable comma separation on `bound_claims` in `jwt_auth_backend_role` resource

### DIFF
--- a/vault/resource_jwt_auth_backend_role.go
+++ b/vault/resource_jwt_auth_backend_role.go
@@ -241,6 +241,10 @@ func jwtAuthBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("bound_claims_type", v)
 	}
 
+	if v, ok := resp.Data["disable_claims_comma_separation"]; ok {
+		d.Set("disable_claims_comma_separation", v)
+	}
+
 	if resp.Data["bound_claims"] != nil {
 		boundClaims := make(map[string]interface{})
 		respBoundClaims := resp.Data["bound_claims"].(map[string]interface{})

--- a/vault/resource_jwt_auth_backend_role.go
+++ b/vault/resource_jwt_auth_backend_role.go
@@ -99,7 +99,7 @@ func jwtAuthBackendRoleResource() *schema.Resource {
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Default:     false,
-			Description: "If set, treats all bound claims map values as strings and disables comma separation while parsing.",
+			Description: "Disable bound claim value parsing. Useful when values contain commas.",
 		},
 		"claim_mappings": {
 			Type:        schema.TypeMap,

--- a/vault/resource_jwt_auth_backend_role_test.go
+++ b/vault/resource_jwt_auth_backend_role_test.go
@@ -73,7 +73,7 @@ func TestAccJWTAuthBackendRole_import(t *testing.T) {
 				ResourceName:            "vault_jwt_auth_backend_role.role",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"disable_claims_comma_separation"},
+				ImportStateVerifyIgnore: []string{"disable_bound_claims_parsing"},
 			},
 		},
 	})

--- a/vault/resource_jwt_auth_backend_role_test.go
+++ b/vault/resource_jwt_auth_backend_role_test.go
@@ -70,9 +70,10 @@ func TestAccJWTAuthBackendRole_import(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "vault_jwt_auth_backend_role.role",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "vault_jwt_auth_backend_role.role",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"disable_claims_comma_separation"},
 			},
 		},
 	})

--- a/vault/resource_jwt_auth_backend_role_test.go
+++ b/vault/resource_jwt_auth_backend_role_test.go
@@ -328,6 +328,40 @@ func TestAccJWTAuthBackendRoleOIDC_full(t *testing.T) {
 	})
 }
 
+func TestAccJWTAuthBackendRoleOIDC_disableParsing(t *testing.T) {
+	backend := acctest.RandomWithPrefix("jwt")
+	role := acctest.RandomWithPrefix("test-role")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckJWTAuthBackendRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJWTAuthBackendRoleConfigOIDC_disableParsing(backend, role),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"backend", backend),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"role_name", role),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"user_claim", "https://vault/user"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_claims_type", "string"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_claims.%", "2"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_claims.department", "engineering,admin"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"bound_claims.sector", "7g"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"disable_bound_claims_parsing", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccJWTAuthBackendRole_fullUpdate(t *testing.T) {
 	backend := acctest.RandomWithPrefix("jwt")
 	role := acctest.RandomWithPrefix("test-role")
@@ -569,6 +603,38 @@ resource "vault_jwt_auth_backend_role" "role" {
   }
 
   verbose_oidc_logging = true
+}`, backend, role)
+}
+
+func testAccJWTAuthBackendRoleConfigOIDC_disableParsing(backend, role string) string {
+	return fmt.Sprintf(`
+resource "vault_jwt_auth_backend" "jwt" {
+  type = "oidc"
+  path = "%s"
+  oidc_discovery_url = "https://myco.auth0.com/"
+  oidc_client_id = "client"
+  oidc_client_secret = "secret"
+  lifecycle {
+  ignore_changes = [
+     # Ignore changes to oidc_client_secret inside the tests
+     "oidc_client_secret"
+    ]
+  }
+}
+
+resource "vault_jwt_auth_backend_role" "role" {
+  backend = vault_jwt_auth_backend.jwt.path
+  role_name = "%s"
+  role_type = "jwt"
+
+  user_claim = "https://vault/user"
+  token_policies = ["default", "dev", "prod"]
+  bound_claims_type = "string"
+  bound_claims = {
+    department = "engineering,admin"
+    sector = "7g"
+  }
+  disable_bound_claims_parsing = true
 }`, backend, role)
 }
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes https://github.com/hashicorp/terraform-provider-vault/issues/956

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/jwt_auth_backend_role: Allow users to disable comma separation in bound claims map values with a boolean operator
```

Test TF Config:
```
resource "vault_auth_backend" "jwt" {
  type = "jwt"
  path = "jwt"
}

resource "vault_jwt_auth_backend_role" "role" {
  backend = vault_auth_backend.jwt.path
        role_name = "test-role"
        role_type = "jwt"

  bound_audiences = ["https://myco.test"]
  bound_claims = { "groups" = "/cn=example,ou=security,ou=groups,o=example" }
  disable_claims_comma_separation = true
  user_claim = "https://vault/user"
  token_policies = ["default", "dev"]
}
```

Output: 
```
$ vault read auth/oidc/role/example
Key                        Value
---                        -----
bound_claims               map[groups:[/cn=example,ou=security,ou=groups,o=example]]
...
```

After removing `disable_claims_comma_separation`:
```
$ vault read auth/oidc/role/example
Key                        Value
---                        -----
bound_claims               map[groups:[/cn=example ou=security ou=groups o=example]]
...
```