### PR TITLE
Add mount options to read/write config

### DIFF
--- a/vault/auth_mount.go
+++ b/vault/auth_mount.go
@@ -11,65 +11,15 @@ import (
 )
 
 func authMountTuneSchema() *schema.Schema {
-	return &schema.Schema{
-		Type:       schema.TypeSet,
-		Optional:   true,
-		Computed:   true,
-		MaxItems:   1,
-		ConfigMode: schema.SchemaConfigModeAttr,
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"default_lease_ttl": {
-					Type:         schema.TypeString,
-					Optional:     true,
-					Description:  "Specifies the default time-to-live duration. This overrides the global default. A value of 0 is equivalent to the system default TTL",
-					ValidateFunc: validateDuration,
-				},
-				"max_lease_ttl": {
-					Type:         schema.TypeString,
-					Optional:     true,
-					Description:  "Specifies the maximum time-to-live duration. This overrides the global default. A value of 0 are equivalent and set to the system max TTL.",
-					ValidateFunc: validateDuration,
-				},
-				"audit_non_hmac_request_keys": {
-					Type:        schema.TypeList,
-					Optional:    true,
-					Description: "Specifies the list of keys that will not be HMAC'd by audit devices in the request data object.",
-					Elem:        &schema.Schema{Type: schema.TypeString},
-				},
-				"audit_non_hmac_response_keys": {
-					Type:        schema.TypeList,
-					Optional:    true,
-					Description: "Specifies the list of keys that will not be HMAC'd by audit devices in the response data object.",
-					Elem:        &schema.Schema{Type: schema.TypeString},
-				},
-				"listing_visibility": {
-					Type:         schema.TypeString,
-					Optional:     true,
-					Description:  "Specifies whether to show this mount in the UI-specific listing endpoint. Valid values are \"unauth\" or \"hidden\". If not set, behaves like \"hidden\".",
-					ValidateFunc: validation.StringInSlice([]string{"unauth", "hidden"}, false),
-				},
-				"passthrough_request_headers": {
-					Type:        schema.TypeList,
-					Optional:    true,
-					Description: "List of headers to whitelist and pass from the request to the backend.",
-					Elem:        &schema.Schema{Type: schema.TypeString},
-				},
-				"allowed_response_headers": {
-					Type:        schema.TypeList,
-					Optional:    true,
-					Description: "List of headers to whitelist and allowing a plugin to include them in the response.",
-					Elem:        &schema.Schema{Type: schema.TypeString},
-				},
-				"token_type": {
-					Type:         schema.TypeString,
-					Optional:     true,
-					Description:  "Specifies the type of tokens that should be returned by the mount.",
-					ValidateFunc: validation.StringInSlice([]string{"default-service", "default-batch", "service", "batch"}, false),
-				},
-			},
+	additionalFields := map[string]*schema.Schema{
+		"token_type": {
+			Type:         schema.TypeString,
+			Optional:     true,
+			Description:  "Specifies the type of tokens that should be returned by the mount.",
+			ValidateFunc: validation.StringInSlice([]string{"default-service", "default-batch", "service", "batch"}, false),
 		},
 	}
+	return sharedAuthAndMountSchema(additionalFields)
 }
 
 func authMountInfoGet(client *api.Client, path string) (*api.AuthMount, error) {
@@ -86,7 +36,7 @@ func authMountInfoGet(client *api.Client, path string) (*api.AuthMount, error) {
 }
 
 func authMountTune(client *api.Client, path string, configured interface{}) error {
-	tune := expandAuthMethodTune(configured.(*schema.Set).List())
+	tune := expandMountConfigInput(configured.(*schema.Set).List())
 
 	err := client.Sys().TuneMount(path, tune)
 	if err != nil {
@@ -95,14 +45,13 @@ func authMountTune(client *api.Client, path string, configured interface{}) erro
 	return nil
 }
 
-func authMountTuneGet(client *api.Client, path string) (map[string]interface{}, error) {
+func authMountConfigGet(client *api.Client, path string) (map[string]interface{}, error) {
 	tune, err := client.Sys().MountConfig(path)
 	if err != nil {
 		log.Printf("[ERROR] Error when reading tune config from path %q: %s", path+"/tune", err)
 		return nil, err
 	}
-
-	return flattenAuthMethodTune(tune), nil
+	return flattenAuthMountConfig(tune), nil
 }
 
 func authMountDisable(client *api.Client, path string) error {

--- a/vault/mount_config.go
+++ b/vault/mount_config.go
@@ -1,0 +1,16 @@
+package vault
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func mountConfigSchema() *schema.Schema {
+	additionalFields := map[string]*schema.Schema{
+		"force_no_cache": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Disable caching.",
+		},
+	}
+	return sharedAuthAndMountSchema(additionalFields)
+}

--- a/vault/resource_github_auth_backend.go
+++ b/vault/resource_github_auth_backend.go
@@ -166,7 +166,7 @@ func githubAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Reading github auth tune from '%q/tune'", path)
-	rawTune, err := authMountTuneGet(client, path)
+	rawTune, err := authMountConfigGet(client, path)
 	if err != nil {
 		return fmt.Errorf("error reading tune information from Vault: %s", err)
 	}

--- a/vault/resource_jwt_auth_backend.go
+++ b/vault/resource_jwt_auth_backend.go
@@ -281,7 +281,7 @@ func jwtAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Reading jwt auth tune from %q", path+"/tune")
-	rawTune, err := authMountTuneGet(client, "auth/"+path)
+	rawTune, err := authMountConfigGet(client, "auth/"+path)
 	if err != nil {
 		return fmt.Errorf("error reading tune information from Vault: %s", err)
 	}

--- a/vault/resource_mount_test.go
+++ b/vault/resource_mount_test.go
@@ -114,8 +114,10 @@ func TestResourceMount_KVV2(t *testing.T) {
 				path = "%s"
 				type = "kv-v2"
 				description = "Example mount for testing"
-				default_lease_ttl_seconds = 3600
-				max_lease_ttl_seconds = 36000
+				config {
+					default_lease_ttl = "1h"
+					max_lease_ttl = "10h"
+				}
 			}`, path)
 	resource.Test(t, resource.TestCase{
 
@@ -176,8 +178,10 @@ resource "vault_mount" "test" {
 	path = "%s"
 	type = "%s"
 	description = "Example mount for testing"
-	default_lease_ttl_seconds = 3600
-	max_lease_ttl_seconds = 36000
+	config {
+		default_lease_ttl = "1h"
+		max_lease_ttl = "10h"
+	}
 	options = {
 		version = "1"
 	}
@@ -242,8 +246,10 @@ resource "vault_mount" "test" {
 	path = "remountingExample"
 	type = "kv"
 	description = "Updated example mount for testing"
-	default_lease_ttl_seconds = 7200
-	max_lease_ttl_seconds = 72000
+	config {
+		default_lease_ttl = "2h"
+		max_lease_ttl = "20h"
+	}
 	options = {
 		version = "1"
 	}
@@ -299,8 +305,10 @@ resource "vault_mount" "test" {
 	path = "%s"
 	type = "kv"
 	description = "Example local mount for testing"
-	default_lease_ttl_seconds = 3600
-	max_lease_ttl_seconds = 36000
+	config {
+		default_lease_ttl = "1h"
+		max_lease_ttl = "10h"
+	}
 	local = true
 	options = {
 		version = "1"
@@ -350,8 +358,10 @@ resource "vault_mount" "test" {
 	path = "remountingExample"
 	type = "kv"
 	description = "Example mount for testing"
-	default_lease_ttl_seconds = 7200
-	max_lease_ttl_seconds = 72000
+	config {
+		default_lease_ttl = "2h"
+		max_lease_ttl = "20h"
+	}
 	local = false
 	options = {
 		version = "1"
@@ -392,8 +402,10 @@ resource "vault_mount" "test" {
 	path = "%s"
 	type = "kv"
 	description = "Example local mount for testing"
-	default_lease_ttl_seconds = 3600
-	max_lease_ttl_seconds = 36000
+	config {
+		default_lease_ttl = "1h"
+		max_lease_ttl = "10h"
+	}
 	options = {
 		version = "1"
 	}
@@ -443,8 +455,10 @@ resource "vault_mount" "test" {
 	path = "remountingExample"
 	type = "kv"
 	description = "Example mount for testing"
-	default_lease_ttl_seconds = 7200
-	max_lease_ttl_seconds = 72000
+	config {
+		default_lease_ttl = "2h"
+		max_lease_ttl = "20h"
+	}
 	options = {
 		version = "1"
 	}
@@ -521,8 +535,10 @@ resource "vault_mount" "test" {
 	path = "%s"
 	type = "transit"
 	description = "Example mount for testing"
-	default_lease_ttl_seconds = 3600
-	max_lease_ttl_seconds = 36000
+	config {
+		default_lease_ttl = "1h"
+		max_lease_ttl = "10h"
+	}
 }
 `, path)
 }
@@ -533,8 +549,10 @@ resource "vault_mount" "test" {
 	path = "%s"
 	type = "transit"
 	description = "Example mount for testing"
-	default_lease_ttl_seconds = 3600
-	max_lease_ttl_seconds = 36000
+	config {
+		default_lease_ttl = "1h"
+		max_lease_ttl = "10h"
+	}
 	external_entropy_access = %t
 }
 `, path, externalEntropyAccess)

--- a/vault/resource_pki_secret_backend_crl_config_test.go
+++ b/vault/resource_pki_secret_backend_crl_config_test.go
@@ -60,8 +60,10 @@ resource "vault_mount" "test-root" {
   path = "%s"
   type = "pki"
   description = "test root"
-  default_lease_ttl_seconds = "8640000"
-  max_lease_ttl_seconds = "8640000"
+  config {
+	  default_lease_ttl = "2400h"
+  	  max_lease_ttl = "2400h"
+  }
 }
 
 resource "vault_pki_secret_backend_root_cert" "test-ca" {

--- a/vault/structures_test.go
+++ b/vault/structures_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/vault/api"
 )
 
-func TestExpandAuthMethodTune(t *testing.T) {
+func TestExpandMountConfigInput(t *testing.T) {
 	flattened := []interface{}{
 		map[string]interface{}{
 			"default_lease_ttl":           "10m",
@@ -17,9 +17,10 @@ func TestExpandAuthMethodTune(t *testing.T) {
 			"passthrough_request_headers": []interface{}{"X-Custom", "X-Mas"},
 			"allowed_response_headers":    []interface{}{"X-Response-Custom", "X-Response-Mas"},
 			"token_type":                  "default-batch",
+			"force_no_cache":              true,
 		},
 	}
-	actual := expandAuthMethodTune(flattened)
+	actual := expandMountConfigInput(flattened)
 	expected := api.MountConfigInput{
 		DefaultLeaseTTL:           "10m",
 		MaxLeaseTTL:               "20m",
@@ -29,6 +30,7 @@ func TestExpandAuthMethodTune(t *testing.T) {
 		PassthroughRequestHeaders: []string{"X-Custom", "X-Mas"},
 		AllowedResponseHeaders:    []string{"X-Response-Custom", "X-Response-Mas"},
 		TokenType:                 "default-batch",
+		ForceNoCache:              true,
 	}
 
 	if !reflect.DeepEqual(actual, expected) {
@@ -39,7 +41,7 @@ func TestExpandAuthMethodTune(t *testing.T) {
 	}
 }
 
-func TestFlattenAuthMethodTune(t *testing.T) {
+func TestFlattenAuthMountConfig(t *testing.T) {
 	expanded := &api.MountConfigOutput{
 		DefaultLeaseTTL:           600,
 		MaxLeaseTTL:               1200,
@@ -60,7 +62,38 @@ func TestFlattenAuthMethodTune(t *testing.T) {
 		"token_type":                  "default-service",
 	}
 
-	actual := flattenAuthMethodTune(expanded)
+	actual := flattenAuthMountConfig(expanded)
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf(
+			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
+			actual,
+			expected)
+	}
+}
+
+func TestFlattenMountConfig(t *testing.T) {
+	expanded := &api.MountConfigOutput{
+		DefaultLeaseTTL:           600,
+		MaxLeaseTTL:               1200,
+		AuditNonHMACRequestKeys:   []string{"foo", "bar"},
+		ListingVisibility:         "",
+		PassthroughRequestHeaders: []string{"X-Custom", "X-Mas"},
+		AllowedResponseHeaders:    []string{"X-Response-Custom", "X-Response-Mas"},
+		ForceNoCache:              true,
+	}
+
+	expected := map[string]interface{}{
+		"default_lease_ttl":           "10m",
+		"max_lease_ttl":               "20m",
+		"audit_non_hmac_request_keys": []interface{}{"foo", "bar"},
+		"passthrough_request_headers": []interface{}{"X-Custom", "X-Mas"},
+		"listing_visibility":          "",
+		"allowed_response_headers":    []interface{}{"X-Response-Custom", "X-Response-Mas"},
+		"force_no_cache":              true,
+	}
+
+	actual := flattenMountConfig(expanded)
 
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf(


### PR DESCRIPTION
Add options as per https://www.vaultproject.io/api-docs/system/mounts\#parameters

This is a backwards incompatible change and should not be released in v2 of the provider.

Partly sets the tone for #1204

More to follow as separate PRs to  update the secret mounts to use the config option instead of
the inline params

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #1204 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`vault_mount` now accepts the config block to add mount tuning options at creation time. 
Removes the inconsistent `default_lease_ttl_seconds` and `max_lease_ttl_seconds` in favor of 
`config.default_lease_ttl` and `config.max_lease_ttl`.
It is now possible to set additional config options on the mount directly via `config.audit_non_hmac_request_keys`
and other options specified at https://www.vaultproject.io/api-docs/system/mounts#config
```

Output from acceptance testing:

The test failures are don't seem related to the change.  Run against vault mainline.
```
$ make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./...) -v  -timeout 20m
?   	github.com/hashicorp/terraform-provider-vault	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/generate	[no test files]
=== RUN   TestCodeFilePath
--- PASS: TestCodeFilePath (0.00s)
=== RUN   TestDocFilePath
--- PASS: TestDocFilePath (0.00s)
=== RUN   TestStripCurlyBraces
=== RUN   TestStripCurlyBraces/{test}
=== RUN   TestStripCurlyBraces/{{name}}
=== RUN   TestStripCurlyBraces/name
=== RUN   TestStripCurlyBraces/{name
--- PASS: TestStripCurlyBraces (0.00s)
    --- PASS: TestStripCurlyBraces/{test} (0.00s)
    --- PASS: TestStripCurlyBraces/{{name}} (0.00s)
    --- PASS: TestStripCurlyBraces/name (0.00s)
    --- PASS: TestStripCurlyBraces/{name (0.00s)
=== RUN   TestFormat
=== RUN   TestFormat/alphabet
=== RUN   TestFormat/{name}
=== RUN   TestFormat/{role_name}
=== RUN   TestFormat/{name}#01
=== RUN   TestFormat/{version}
=== RUN   TestFormat/unlikely
=== RUN   TestFormat/{role_name_}
=== RUN   TestFormat/{role__name}
=== RUN   TestFormat/{role_name_here}
=== RUN   TestFormat/{rOlE_nAmE}
=== RUN   TestFormat/{ROLE_NAME}
--- PASS: TestFormat (0.00s)
    --- PASS: TestFormat/alphabet (0.00s)
    --- PASS: TestFormat/{name} (0.00s)
    --- PASS: TestFormat/{role_name} (0.00s)
    --- PASS: TestFormat/{name}#01 (0.00s)
    --- PASS: TestFormat/{version} (0.00s)
    --- PASS: TestFormat/unlikely (0.00s)
    --- PASS: TestFormat/{role_name_} (0.00s)
    --- PASS: TestFormat/{role__name} (0.00s)
    --- PASS: TestFormat/{role_name_here} (0.00s)
    --- PASS: TestFormat/{rOlE_nAmE} (0.00s)
    --- PASS: TestFormat/{ROLE_NAME} (0.00s)
=== RUN   TestValidate
=== RUN   TestValidate/nil_inputs_error
=== RUN   TestValidate/blank_endpoints_error
=== RUN   TestValidate/blank_dirnames_error
=== RUN   TestValidate/blank_upper_case_differentiators_error
=== RUN   TestValidate/blank_lower_case_differentiators_error
=== RUN   TestValidate/valid_endpoint
=== RUN   TestValidate/bad_parameter_type
=== RUN   TestValidate/good_parameter_type
=== RUN   TestValidate/array_of_strings_param
=== RUN   TestValidate/array_of_objects_param
--- PASS: TestValidate (0.00s)
    --- PASS: TestValidate/nil_inputs_error (0.00s)
    --- PASS: TestValidate/blank_endpoints_error (0.00s)
    --- PASS: TestValidate/blank_dirnames_error (0.00s)
    --- PASS: TestValidate/blank_upper_case_differentiators_error (0.00s)
    --- PASS: TestValidate/blank_lower_case_differentiators_error (0.00s)
    --- PASS: TestValidate/valid_endpoint (0.00s)
    --- PASS: TestValidate/bad_parameter_type (0.00s)
    --- PASS: TestValidate/good_parameter_type (0.00s)
    --- PASS: TestValidate/array_of_strings_param (0.00s)
    --- PASS: TestValidate/array_of_objects_param (0.00s)
=== RUN   TestToTemplatableParam
--- PASS: TestToTemplatableParam (0.00s)
=== RUN   TestParseParameters
=== RUN   TestParseParameters//transform/role/{name}
=== RUN   TestParseParameters//transform/alphabet/{name}
--- PASS: TestParseParameters (0.00s)
    --- PASS: TestParseParameters//transform/role/{name} (0.00s)
    --- PASS: TestParseParameters//transform/alphabet/{name} (0.00s)
=== RUN   TestTemplateHandler
--- PASS: TestTemplateHandler (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/codegen	(cached)
?   	github.com/hashicorp/terraform-provider-vault/generated	[no test files]
=== RUN   TestDecodeBasic
    util.go:112: TF_ACC_ENTERPRISE is not set, test is applicable only for Enterprise version of Vault
--- SKIP: TestDecodeBasic (0.00s)
=== RUN   TestDecodeBatch
    util.go:112: TF_ACC_ENTERPRISE is not set, test is applicable only for Enterprise version of Vault
--- SKIP: TestDecodeBatch (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode	(cached)
=== RUN   TestEncodeBasic
    util.go:112: TF_ACC_ENTERPRISE is not set, test is applicable only for Enterprise version of Vault
--- SKIP: TestEncodeBasic (0.00s)
=== RUN   TestEncodeBatch
    util.go:112: TF_ACC_ENTERPRISE is not set, test is applicable only for Enterprise version of Vault
--- SKIP: TestEncodeBatch (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode	(cached)
=== RUN   TestAlphabetName
    util.go:112: TF_ACC_ENTERPRISE is not set, test is applicable only for Enterprise version of Vault
--- SKIP: TestAlphabetName (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet	(cached)
=== RUN   TestRoleName
    util.go:112: TF_ACC_ENTERPRISE is not set, test is applicable only for Enterprise version of Vault
--- SKIP: TestRoleName (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role	(cached)
=== RUN   TestTemplateName
    util.go:112: TF_ACC_ENTERPRISE is not set, test is applicable only for Enterprise version of Vault
--- SKIP: TestTemplateName (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template	(cached)
=== RUN   TestTransformationName
    util.go:112: TF_ACC_ENTERPRISE is not set, test is applicable only for Enterprise version of Vault
--- SKIP: TestTransformationName (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation	(cached)
?   	github.com/hashicorp/terraform-provider-vault/helper	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/schema	[no test files]
=== RUN   TestExpiredTokenError
--- PASS: TestExpiredTokenError (0.00s)
=== RUN   TestSliceHasElement_scalar
--- PASS: TestSliceHasElement_scalar (0.00s)
=== RUN   TestSliceHasElement_struct
--- PASS: TestSliceHasElement_struct (0.00s)
=== RUN   TestSliceAppendIfMissing_scalar
--- PASS: TestSliceAppendIfMissing_scalar (0.00s)
=== RUN   TestSliceAppendIfMissing_struct
--- PASS: TestSliceAppendIfMissing_struct (0.00s)
=== RUN   TestSliceRemoveIfPresent_scalar
--- PASS: TestSliceRemoveIfPresent_scalar (0.00s)
=== RUN   TestSliceRemoveIfPresent_struct
--- PASS: TestSliceRemoveIfPresent_struct (0.00s)
=== RUN   TestParsePath
=== RUN   TestParsePath/my/transform/hello
=== RUN   TestParsePath/jwt-1914071788362821795
=== RUN   TestParsePath/accounting-transit
--- PASS: TestParsePath (0.00s)
    --- PASS: TestParsePath/my/transform/hello (0.00s)
    --- PASS: TestParsePath/jwt-1914071788362821795 (0.00s)
    --- PASS: TestParsePath/accounting-transit (0.00s)
=== RUN   TestPathParameters
=== RUN   TestPathParameters//transform/role/{name}
=== RUN   TestPathParameters//transit/sign/{name}/{urlalgorithm}
=== RUN   TestPathParameters//transit/sign/{name}/{urlalgorithm}#01
=== RUN   TestPathParameters//auth/approle/tidy/secret-id
=== RUN   TestPathParameters//sys/mfa/method/totp/{name}/admin-generate
--- PASS: TestPathParameters (0.00s)
    --- PASS: TestPathParameters//transform/role/{name} (0.00s)
    --- PASS: TestPathParameters//transit/sign/{name}/{urlalgorithm} (0.00s)
    --- PASS: TestPathParameters//transit/sign/{name}/{urlalgorithm}#01 (0.00s)
    --- PASS: TestPathParameters//auth/approle/tidy/secret-id (0.00s)
    --- PASS: TestPathParameters//sys/mfa/method/totp/{name}/admin-generate (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/util	(cached)
=== RUN   TestDataSourceIdentityEntityName
--- PASS: TestDataSourceIdentityEntityName (1.15s)
=== RUN   TestDataSourceIdentityEntityAlias
--- PASS: TestDataSourceIdentityEntityAlias (1.17s)
=== RUN   TestDataSourceIdentityGroupName
--- PASS: TestDataSourceIdentityGroupName (1.08s)
=== RUN   TestDataSourceIdentityGroupAlias
--- PASS: TestDataSourceIdentityGroupAlias (1.17s)
=== RUN   TestAccDataSourceADAccessCredentials_basic
    util.go:128: AD_BINDDN not set
--- SKIP: TestAccDataSourceADAccessCredentials_basic (0.00s)
=== RUN   TestAccAppRoleAuthBackendRoleID_basic
--- PASS: TestAccAppRoleAuthBackendRoleID_basic (1.82s)
=== RUN   TestAccAppRoleAuthBackendRoleID_customID
--- PASS: TestAccAppRoleAuthBackendRoleID_customID (1.85s)
=== RUN   TestDataSourceAuthBackend
--- PASS: TestDataSourceAuthBackend (1.91s)
=== RUN   TestAccDataSourceAWSAccessCredentials_basic
    provider_test.go:73: AWS_ACCESS_KEY_ID not set
--- SKIP: TestAccDataSourceAWSAccessCredentials_basic (0.00s)
=== RUN   TestAccDataSourceAWSAccessCredentials_sts
    provider_test.go:73: AWS_ACCESS_KEY_ID not set
--- SKIP: TestAccDataSourceAWSAccessCredentials_sts (0.00s)
=== RUN   TestAccDataSourceAWSAccessCredentials_sts_ttl
    provider_test.go:73: AWS_ACCESS_KEY_ID not set
--- SKIP: TestAccDataSourceAWSAccessCredentials_sts_ttl (0.00s)
=== RUN   TestAccDataSourceAzureAccessCredentials_basic
    provider_test.go:102: AZURE_SUBSCRIPTION_ID not set
--- SKIP: TestAccDataSourceAzureAccessCredentials_basic (0.00s)
=== RUN   TestAccGCPAuthBackendRoleDataSource_basic
--- PASS: TestAccGCPAuthBackendRoleDataSource_basic (1.89s)
=== RUN   TestAccGCPAuthBackendRoleDataSource_gce
--- PASS: TestAccGCPAuthBackendRoleDataSource_gce (1.86s)
=== RUN   TestAccGCPAuthBackendRoleDataSource_none
--- PASS: TestAccGCPAuthBackendRoleDataSource_none (0.29s)
=== RUN   TestDataSourceGenericSecret
--- PASS: TestDataSourceGenericSecret (1.14s)
=== RUN   TestV2Secret
--- PASS: TestV2Secret (2.71s)
=== RUN   TestAccKubernetesAuthBackendConfigDataSource_basic
--- PASS: TestAccKubernetesAuthBackendConfigDataSource_basic (1.93s)
=== RUN   TestAccKubernetesAuthBackendConfigDataSource_full
--- PASS: TestAccKubernetesAuthBackendConfigDataSource_full (1.89s)
=== RUN   TestAccKubernetesAuthBackendRoleDataSource_basic
--- PASS: TestAccKubernetesAuthBackendRoleDataSource_basic (1.88s)
=== RUN   TestAccKubernetesAuthBackendRoleDataSource_full
--- PASS: TestAccKubernetesAuthBackendRoleDataSource_full (1.99s)
=== RUN   TestAccDataSourceNomadAccessCredentialsClientBasic
    util.go:144: NOMAD_ADDR not set
--- SKIP: TestAccDataSourceNomadAccessCredentialsClientBasic (0.00s)
=== RUN   TestAccDataSourceNomadAccessCredentialsManagementBasic
    util.go:144: NOMAD_ADDR not set
--- SKIP: TestAccDataSourceNomadAccessCredentialsManagementBasic (0.00s)
=== RUN   TestDataSourcePolicyDocument
--- PASS: TestDataSourcePolicyDocument (1.00s)
=== RUN   TestDataSourceTransitDecrypt
--- PASS: TestDataSourceTransitDecrypt (1.20s)
=== RUN   TestDataSourceTransitEncrypt
--- PASS: TestDataSourceTransitEncrypt (1.20s)
=== RUN   TestAccAuthBackend_importBasic
--- PASS: TestAccAuthBackend_importBasic (1.27s)
=== RUN   TestAccConsulSecretBackend_import
--- PASS: TestAccConsulSecretBackend_import (1.29s)
=== RUN   TestAccGenericSecret_importBasic
--- PASS: TestAccGenericSecret_importBasic (1.35s)
=== RUN   TestAccMount_importBasic
--- PASS: TestAccMount_importBasic (1.28s)
=== RUN   TestAccPolicy_importBasic
--- PASS: TestAccPolicy_importBasic (1.28s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestAccAuthLoginProviderConfigure
    provider_test.go:177: Step 1/1 error: Error running apply: exit status 1
        
        Error: unknown type <nil> for cidr_list in response for SecretID "02a0721f-d16e-7da2-070f-2fe8ec431a2b"
        
          with vault_approle_auth_backend_role_secret_id.admin,
          on terraform_plugin_test.tf line 20, in resource "vault_approle_auth_backend_role_secret_id" "admin":
          20: resource "vault_approle_auth_backend_role_secret_id" "admin" {
        
--- FAIL: TestAccAuthLoginProviderConfigure (0.74s)
=== RUN   TestTokenReadProviderConfigureWithHeaders
--- PASS: TestTokenReadProviderConfigureWithHeaders (1.01s)
=== RUN   TestAccNamespaceProviderConfigure
    provider_test.go:222: TF_ACC_ENTERPRISE is not set, test is applicable only for Enterprise version of Vault
--- SKIP: TestAccNamespaceProviderConfigure (0.00s)
=== RUN   TestAccProviderToken
=== RUN   TestAccProviderToken/None
=== RUN   TestAccProviderToken/File
=== RUN   TestAccProviderToken/CustomHelper
=== RUN   TestAccProviderToken/Schema
--- PASS: TestAccProviderToken (0.21s)
    --- PASS: TestAccProviderToken/None (0.00s)
    --- PASS: TestAccProviderToken/File (0.00s)
    --- PASS: TestAccProviderToken/CustomHelper (0.21s)
    --- PASS: TestAccProviderToken/Schema (0.00s)
=== RUN   TestAccTokenName
--- PASS: TestAccTokenName (8.11s)
=== RUN   TestAccProviderVaultAddrEnv
=== RUN   TestAccProviderVaultAddrEnv/AddAddressToEnvNotConfigured
=== RUN   TestAccProviderVaultAddrEnv/AddAddressToEnvIsFalse
=== RUN   TestAccProviderVaultAddrEnv/AddAddressToEnvIsTrue
--- PASS: TestAccProviderVaultAddrEnv (0.23s)
    --- PASS: TestAccProviderVaultAddrEnv/AddAddressToEnvNotConfigured (0.13s)
    --- PASS: TestAccProviderVaultAddrEnv/AddAddressToEnvIsFalse (0.06s)
    --- PASS: TestAccProviderVaultAddrEnv/AddAddressToEnvIsTrue (0.04s)
=== RUN   TestADSecretBackend
    util.go:128: AD_BINDDN not set
--- SKIP: TestADSecretBackend (0.00s)
=== RUN   TestAccADSecretBackendLibrary_basic
    util.go:128: AD_BINDDN not set
--- SKIP: TestAccADSecretBackendLibrary_basic (0.00s)
=== RUN   TestAccADSecretBackendLibrary_import
    util.go:128: AD_BINDDN not set
--- SKIP: TestAccADSecretBackendLibrary_import (0.00s)
=== RUN   TestAccADSecretBackendRole_basic
    util.go:128: AD_BINDDN not set
--- SKIP: TestAccADSecretBackendRole_basic (0.00s)
=== RUN   TestAccADSecretBackendRole_import
    util.go:128: AD_BINDDN not set
--- SKIP: TestAccADSecretBackendRole_import (0.00s)
=== RUN   TestAlicloudAuthBackendRole_basic
--- PASS: TestAlicloudAuthBackendRole_basic (2.19s)
=== RUN   TestAccAppRoleAuthBackendLogin_basic
    resource_approle_auth_backend_login_test.go:15: Step 1/1 error: Error running apply: exit status 1
        
        Error: unknown type <nil> for cidr_list in response for SecretID "6077da1a-14c5-c1cf-b28f-535a1c4c8005"
        
          with vault_approle_auth_backend_role_secret_id.secret,
          on terraform_plugin_test.tf line 13, in resource "vault_approle_auth_backend_role_secret_id" "secret":
          13: resource "vault_approle_auth_backend_role_secret_id" "secret" {
        
--- FAIL: TestAccAppRoleAuthBackendLogin_basic (0.73s)
=== RUN   TestAccAppRoleAuthBackendRoleSecretID_basic
    resource_approle_auth_backend_role_secret_id_test.go:22: Step 1/1 error: Error running apply: exit status 1
        
        Error: unknown type <nil> for cidr_list in response for SecretID "e60e2bc0-9d92-9e52-49d4-2fb654953eaa"
        
          with vault_approle_auth_backend_role_secret_id.secret_id,
          on terraform_plugin_test.tf line 13, in resource "vault_approle_auth_backend_role_secret_id" "secret_id":
          13: resource "vault_approle_auth_backend_role_secret_id" "secret_id" {
        
--- FAIL: TestAccAppRoleAuthBackendRoleSecretID_basic (0.77s)
=== RUN   TestAccAppRoleAuthBackendRoleSecretID_wrapped
--- PASS: TestAccAppRoleAuthBackendRoleSecretID_wrapped (1.17s)
=== RUN   TestAccAppRoleAuthBackendRoleSecretID_wrapped_namespace
    util.go:112: TF_ACC_ENTERPRISE is not set, test is applicable only for Enterprise version of Vault
--- SKIP: TestAccAppRoleAuthBackendRoleSecretID_wrapped_namespace (0.00s)
=== RUN   TestAccAppRoleAuthBackendRoleSecretID_full
--- PASS: TestAccAppRoleAuthBackendRoleSecretID_full (1.17s)
=== RUN   TestAccAppRoleAuthBackendRole_import
--- PASS: TestAccAppRoleAuthBackendRole_import (1.39s)
=== RUN   TestAccAppRoleAuthBackendRole_basic
--- PASS: TestAccAppRoleAuthBackendRole_basic (1.11s)
=== RUN   TestAccAppRoleAuthBackendRole_update
--- PASS: TestAccAppRoleAuthBackendRole_update (1.89s)
=== RUN   TestAccAppRoleAuthBackendRole_full
--- PASS: TestAccAppRoleAuthBackendRole_full (1.14s)
=== RUN   TestAccAppRoleAuthBackendRole_fullUpdate
--- PASS: TestAccAppRoleAuthBackendRole_fullUpdate (2.70s)
=== RUN   TestResourceAudit
--- PASS: TestResourceAudit (1.06s)
=== RUN   TestAuthBackendMigrateState
--- PASS: TestAuthBackendMigrateState (0.00s)
=== RUN   TestResourceAuth
--- PASS: TestResourceAuth (1.88s)
=== RUN   TestResourceAuthTune
--- PASS: TestResourceAuthTune (1.80s)
=== RUN   TestAccAWSAuthBackendCert_import
--- PASS: TestAccAWSAuthBackendCert_import (1.53s)
=== RUN   TestAccAWSAuthBackendCert_basic
--- PASS: TestAccAWSAuthBackendCert_basic (1.10s)
=== RUN   TestAccAWSAuthBackendClient_import
--- PASS: TestAccAWSAuthBackendClient_import (1.35s)
=== RUN   TestAccAWSAuthBackendClient_basic
--- PASS: TestAccAWSAuthBackendClient_basic (1.83s)
=== RUN   TestAccAWSAuthBackendClient_nested
--- PASS: TestAccAWSAuthBackendClient_nested (1.85s)
=== RUN   TestAccAWSAuthBackendClient_withoutSecretKey
--- PASS: TestAccAWSAuthBackendClient_withoutSecretKey (1.88s)
=== RUN   TestAccAWSAuthBackendClientStsRegionNoEndpoint
--- PASS: TestAccAWSAuthBackendClientStsRegionNoEndpoint (0.67s)
=== RUN   TestAccAWSAuthBackendIdentityWhitelist_import
--- PASS: TestAccAWSAuthBackendIdentityWhitelist_import (1.35s)
=== RUN   TestAccAWSAuthBackendIdentityWhitelist_basic
--- PASS: TestAccAWSAuthBackendIdentityWhitelist_basic (1.09s)
=== RUN   TestAccAWSAuthBackendLogin_iamIdentity
    provider_test.go:73: AWS_ACCESS_KEY_ID not set
--- SKIP: TestAccAWSAuthBackendLogin_iamIdentity (0.00s)
=== RUN   TestAccAWSAuthBackendLogin_pkcs7
    resource_aws_auth_backend_login_test.go:63: Not running on EC2 instance, can't test EC2 auth methods
--- SKIP: TestAccAWSAuthBackendLogin_pkcs7 (0.00s)
=== RUN   TestAccAWSAuthBackendLogin_ec2Identity
    resource_aws_auth_backend_login_test.go:115: Not running on EC2 instance, can't test EC2 auth methods
--- SKIP: TestAccAWSAuthBackendLogin_ec2Identity (0.00s)
=== RUN   TestAccAWSAuthBackendRoleTag_basic
--- PASS: TestAccAWSAuthBackendRoleTag_basic (1.16s)
=== RUN   TestAccAWSAuthBackendRole_importInferred
--- PASS: TestAccAWSAuthBackendRole_importInferred (1.38s)
=== RUN   TestAccAWSAuthBackendRole_importEC2
--- PASS: TestAccAWSAuthBackendRole_importEC2 (1.38s)
=== RUN   TestAccAWSAuthBackendRole_importIAM
--- PASS: TestAccAWSAuthBackendRole_importIAM (1.42s)
=== RUN   TestAccAWSAuthBackendRole_inferred
--- PASS: TestAccAWSAuthBackendRole_inferred (1.13s)
=== RUN   TestAccAWSAuthBackendRole_ec2
--- PASS: TestAccAWSAuthBackendRole_ec2 (1.13s)
=== RUN   TestAccAWSAuthBackendRole_iam
--- PASS: TestAccAWSAuthBackendRole_iam (1.11s)
=== RUN   TestAccAWSAuthBackendRole_iam_resolve_aws_unique_ids
--- PASS: TestAccAWSAuthBackendRole_iam_resolve_aws_unique_ids (1.14s)
=== RUN   TestAccAWSAuthBackendRole_iamUpdate
--- PASS: TestAccAWSAuthBackendRole_iamUpdate (3.49s)
=== RUN   TestAccAWSAuthBackendRoleTagBlacklist_import
--- PASS: TestAccAWSAuthBackendRoleTagBlacklist_import (1.38s)
=== RUN   TestAccAWSAuthBackendRoleTagBlacklist_basic
--- PASS: TestAccAWSAuthBackendRoleTagBlacklist_basic (1.09s)
=== RUN   TestAccAWSAuthBackendRoleTagBlacklist_updated
--- PASS: TestAccAWSAuthBackendRoleTagBlacklist_updated (2.61s)
=== RUN   TestAccAWSAuthBackendSTSRole_import
--- PASS: TestAccAWSAuthBackendSTSRole_import (1.36s)
=== RUN   TestAccAWSAuthBackendSTSRole_basic
--- PASS: TestAccAWSAuthBackendSTSRole_basic (1.87s)
=== RUN   TestAccAWSSecretBackendRole_basic
    provider_test.go:73: AWS_ACCESS_KEY_ID not set
--- SKIP: TestAccAWSSecretBackendRole_basic (0.00s)
=== RUN   TestAccAWSSecretBackendRole_import
    provider_test.go:73: AWS_ACCESS_KEY_ID not set
--- SKIP: TestAccAWSSecretBackendRole_import (0.00s)
=== RUN   TestAccAWSSecretBackendRole_nested
    provider_test.go:73: AWS_ACCESS_KEY_ID not set
--- SKIP: TestAccAWSSecretBackendRole_nested (0.00s)
=== RUN   TestAccAWSSecretBackend_basic
    provider_test.go:73: AWS_ACCESS_KEY_ID not set
--- SKIP: TestAccAWSSecretBackend_basic (0.00s)
=== RUN   TestAccAWSSecretBackend_import
    provider_test.go:73: AWS_ACCESS_KEY_ID not set
--- SKIP: TestAccAWSSecretBackend_import (0.00s)
=== RUN   TestAccAzureAuthBackendConfig_import
--- PASS: TestAccAzureAuthBackendConfig_import (1.38s)
=== RUN   TestAccAzureAuthBackendConfig_basic
--- PASS: TestAccAzureAuthBackendConfig_basic (1.85s)
=== RUN   TestAzureAuthBackendRole_basic
--- PASS: TestAzureAuthBackendRole_basic (1.11s)
=== RUN   TestAzureAuthBackendRole
--- PASS: TestAzureAuthBackendRole (1.87s)
=== RUN   TestAzureSecretBackendRole
    resource_azure_secret_backend_role_test.go:18: ARM_SUBSCRIPTION_ID not set
--- SKIP: TestAzureSecretBackendRole (0.00s)
=== RUN   TestAzureSecretBackend
--- PASS: TestAzureSecretBackend (1.86s)
=== RUN   TestCertAuthBackend
--- PASS: TestCertAuthBackend (1.95s)
=== RUN   TestConsulSecretBackendRole
--- PASS: TestConsulSecretBackendRole (1.87s)
=== RUN   TestConsulSecretBackendRoleNameFromPath
--- PASS: TestConsulSecretBackendRoleNameFromPath (0.00s)
=== RUN   TestConsulSecretBackendRoleBackendFromPath
--- PASS: TestConsulSecretBackendRoleBackendFromPath (0.00s)
=== RUN   TestConsulSecretBackend
--- PASS: TestConsulSecretBackend (4.26s)
=== RUN   TestAccDatabaseSecretBackendConnection_import
    resource_database_secret_backend_connection_test.go:20: POSTGRES_URL not set
--- SKIP: TestAccDatabaseSecretBackendConnection_import (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_cassandra
    resource_database_secret_backend_connection_test.go:61: CASSANDRA_HOST not set
--- SKIP: TestAccDatabaseSecretBackendConnection_cassandra (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_cassandraProtocol
    resource_database_secret_backend_connection_test.go:104: CASSANDRA_HOST not set
--- SKIP: TestAccDatabaseSecretBackendConnection_cassandraProtocol (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_mongodbatlas
    resource_database_secret_backend_connection_test.go:147: MONGODB_ATLAS_PUBLIC_KEY not set
--- SKIP: TestAccDatabaseSecretBackendConnection_mongodbatlas (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_mongodb
    resource_database_secret_backend_connection_test.go:182: MONGODB_URL not set
--- SKIP: TestAccDatabaseSecretBackendConnection_mongodb (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_mssql
    resource_database_secret_backend_connection_test.go:212: MSSQL_URL not set
--- SKIP: TestAccDatabaseSecretBackendConnection_mssql (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_mysql
    resource_database_secret_backend_connection_test.go:245: MYSQL_URL not set
--- SKIP: TestAccDatabaseSecretBackendConnection_mysql (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnectionUpdate_mysql
    resource_database_secret_backend_connection_test.go:332: MYSQL_URL not set
--- SKIP: TestAccDatabaseSecretBackendConnectionUpdate_mysql (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnectionTemplatedUpdateExcludePassword_mysql
    resource_database_secret_backend_connection_test.go:385: MYSQL_CONNECTION_URL not set
--- SKIP: TestAccDatabaseSecretBackendConnectionTemplatedUpdateExcludePassword_mysql (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_mysql_tls
    resource_database_secret_backend_connection_test.go:468: MYSQL_CA not set
--- SKIP: TestAccDatabaseSecretBackendConnection_mysql_tls (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_postgresql
    resource_database_secret_backend_connection_test.go:514: POSTGRES_URL not set
--- SKIP: TestAccDatabaseSecretBackendConnection_postgresql (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_elasticsearch
    resource_database_secret_backend_connection_test.go:549: ELASTIC_URL not set
--- SKIP: TestAccDatabaseSecretBackendConnection_elasticsearch (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_snowflake
    resource_database_secret_backend_connection_test.go:581: SNOWFLAKE_URL not set
--- SKIP: TestAccDatabaseSecretBackendConnection_snowflake (0.00s)
=== RUN   TestAccDatabaseSecretBackendRole_import
    resource_database_secret_backend_role_test.go:17: MYSQL_URL not set
--- SKIP: TestAccDatabaseSecretBackendRole_import (0.00s)
=== RUN   TestAccDatabaseSecretBackendRole_basic
    resource_database_secret_backend_role_test.go:50: MYSQL_URL not set
--- SKIP: TestAccDatabaseSecretBackendRole_basic (0.00s)
=== RUN   TestAccDatabaseSecretBackendStaticRole_import
    resource_database_secret_backend_static_role_test.go:20: MYSQL_URL not set
--- SKIP: TestAccDatabaseSecretBackendStaticRole_import (0.00s)
=== RUN   TestAccDatabaseSecretBackendStaticRole_basic
    resource_database_secret_backend_static_role_test.go:58: MYSQL_URL not set
--- SKIP: TestAccDatabaseSecretBackendStaticRole_basic (0.00s)
=== RUN   TestAccEndpointGoverningPolicy
    resource_egp_policy_test.go:16: TF_ACC_ENTERPRISE is not set, test is applicable only for Enterprise version of Vault
--- SKIP: TestAccEndpointGoverningPolicy (0.00s)
=== RUN   TestGCPAuthBackend_pathRegex
=== RUN   TestGCPAuthBackend_pathRegex/nested_with_double_'role'
=== RUN   TestGCPAuthBackend_pathRegex/no_nesting
=== RUN   TestGCPAuthBackend_pathRegex/nested
--- PASS: TestGCPAuthBackend_pathRegex (0.00s)
    --- PASS: TestGCPAuthBackend_pathRegex/nested_with_double_'role' (0.00s)
    --- PASS: TestGCPAuthBackend_pathRegex/no_nesting (0.00s)
    --- PASS: TestGCPAuthBackend_pathRegex/nested (0.00s)
=== RUN   TestGCPAuthBackendRole_basic
=== RUN   TestGCPAuthBackendRole_basic/simple_backend_path
=== RUN   TestGCPAuthBackendRole_basic/nested_backend_path
--- PASS: TestGCPAuthBackendRole_basic (4.41s)
    --- PASS: TestGCPAuthBackendRole_basic/simple_backend_path (2.24s)
    --- PASS: TestGCPAuthBackendRole_basic/nested_backend_path (2.17s)
=== RUN   TestGCPAuthBackendRole_gce
--- PASS: TestGCPAuthBackendRole_gce (1.10s)
=== RUN   TestGCPAuthBackend_basic
--- PASS: TestGCPAuthBackend_basic (1.07s)
=== RUN   TestGCPAuthBackend_import
--- PASS: TestGCPAuthBackend_import (1.34s)
=== RUN   TestGCPSecretBackend
--- PASS: TestGCPSecretBackend (1.82s)
=== RUN   TestGCPSecretRoleset
    provider_test.go:124: GOOGLE_CREDENTIALS not set
--- SKIP: TestGCPSecretRoleset (0.00s)
=== RUN   TestGCPSecretStaticAccount
    provider_test.go:124: GOOGLE_CREDENTIALS not set
--- SKIP: TestGCPSecretStaticAccount (0.00s)
=== RUN   TestResourceGenericEndpoint
--- PASS: TestResourceGenericEndpoint (1.47s)
=== RUN   TestGenericSecretMigrateState
--- PASS: TestGenericSecretMigrateState (0.00s)
=== RUN   TestResourceGenericSecret
--- PASS: TestResourceGenericSecret (1.98s)
=== RUN   TestResourceGenericSecret_deleted
--- PASS: TestResourceGenericSecret_deleted (1.94s)
=== RUN   TestAccGithubAuthBackend_basic
--- PASS: TestAccGithubAuthBackend_basic (1.85s)
=== RUN   TestAccGithubAuthBackend_tuning
--- PASS: TestAccGithubAuthBackend_tuning (1.91s)
=== RUN   TestAccGithubAuthBackend_description
--- PASS: TestAccGithubAuthBackend_description (1.83s)
=== RUN   TestAccGithubAuthBackend_importTuning
--- PASS: TestAccGithubAuthBackend_importTuning (1.36s)
=== RUN   TestAccGithubTeam_basic
--- PASS: TestAccGithubTeam_basic (1.88s)
=== RUN   TestAccGithubTeam_teamConfigError
--- PASS: TestAccGithubTeam_teamConfigError (0.28s)
=== RUN   TestAccGithubTeam_importBasic
--- PASS: TestAccGithubTeam_importBasic (1.39s)
=== RUN   TestGithubTeamBackEndPath
=== RUN   TestGithubTeamBackEndPath/With_default_mount
=== RUN   TestGithubTeamBackEndPath/With_custom_mount
--- PASS: TestGithubTeamBackEndPath (0.00s)
    --- PASS: TestGithubTeamBackEndPath/With_default_mount (0.00s)
    --- PASS: TestGithubTeamBackEndPath/With_custom_mount (0.00s)
=== RUN   TestAccGithubUser_basic
--- PASS: TestAccGithubUser_basic (1.93s)
=== RUN   TestAccGithubUser_importBasic
--- PASS: TestAccGithubUser_importBasic (1.41s)
=== RUN   TestGithubUserBackEndPath
=== RUN   TestGithubUserBackEndPath/With_default_mount
=== RUN   TestGithubUserBackEndPath/With_custom_mount
--- PASS: TestGithubUserBackEndPath (0.00s)
    --- PASS: TestGithubUserBackEndPath/With_default_mount (0.00s)
    --- PASS: TestGithubUserBackEndPath/With_custom_mount (0.00s)
=== RUN   TestAccIdentityEntityAlias
--- PASS: TestAccIdentityEntityAlias (1.69s)
=== RUN   TestAccIdentityEntityAlias_Update
--- PASS: TestAccIdentityEntityAlias_Update (2.05s)
=== RUN   TestAccIdentityEntityPoliciesExclusive
--- PASS: TestAccIdentityEntityPoliciesExclusive (1.90s)
=== RUN   TestAccIdentityEntityPoliciesNonExclusive
--- PASS: TestAccIdentityEntityPoliciesNonExclusive (1.94s)
=== RUN   TestAccIdentityEntity
--- PASS: TestAccIdentityEntity (1.07s)
=== RUN   TestAccIdentityEntityUpdate
--- PASS: TestAccIdentityEntityUpdate (1.88s)
=== RUN   TestAccIdentityEntityUpdateRemoveValues
--- PASS: TestAccIdentityEntityUpdateRemoveValues (1.84s)
=== RUN   TestAccIdentityEntityUpdateRemovePolicies
--- PASS: TestAccIdentityEntityUpdateRemovePolicies (1.86s)
=== RUN   TestAccIdentityGroupAlias
--- PASS: TestAccIdentityGroupAlias (1.19s)
=== RUN   TestAccIdentityGroupAliasUpdate
--- PASS: TestAccIdentityGroupAliasUpdate (2.02s)
=== RUN   TestAccIdentityGroupMemberEntityIdsExclusiveEmpty
--- PASS: TestAccIdentityGroupMemberEntityIdsExclusiveEmpty (2.79s)
=== RUN   TestAccIdentityGroupMemberEntityIdsExclusive
    resource_identity_group_member_entity_ids_test.go:52: &{{{{0 0} 0 0 0 0} [] {0x14003fcf380} false false false false map[] map[] []  [] false 0x14000798cc0 false 0 0 testing.tRunner 0x14000395d40 1 [4338885584 4338875188 4338885260 4338880764 4349800300 4338004052 4338215252] TestAccIdentityGroupMemberEntityIdsExclusive {13859359652979241536 164561154209 0x1040b4ca0} 0 0x14004898300 0x1400482f880 [] {0 0}  <nil> 0} false false 0x14000032140}
--- SKIP: TestAccIdentityGroupMemberEntityIdsExclusive (0.00s)
=== RUN   TestAccIdentityGroupMemberEntityIdsNonExclusiveEmpty
--- PASS: TestAccIdentityGroupMemberEntityIdsNonExclusiveEmpty (2.85s)
=== RUN   TestAccIdentityGroupMemberEntityIdsNonExclusive
    resource_identity_group_member_entity_ids_test.go:122: &{{{{0 0} 0 0 0 0} [] {0x14004812820} false false false false map[] map[] []  [] false 0x14000798cc0 false 0 0 testing.tRunner 0x14000395d40 1 [4338885584 4338875188 4338885260 4338880764 4349800300 4338004052 4338215252] TestAccIdentityGroupMemberEntityIdsNonExclusive {13859359656051600008 167412254292 0x1040b4ca0} 0 0x14001135b00 0x14003baeb60 [] {0 0}  <nil> 0} false false 0x14000032140}
--- SKIP: TestAccIdentityGroupMemberEntityIdsNonExclusive (0.00s)
=== RUN   TestAccIdentityGroupPoliciesExclusive
--- PASS: TestAccIdentityGroupPoliciesExclusive (1.93s)
=== RUN   TestAccIdentityGroupPoliciesNonExclusive
--- PASS: TestAccIdentityGroupPoliciesNonExclusive (1.95s)
=== RUN   TestAccIdentityGroup
--- PASS: TestAccIdentityGroup (1.05s)
=== RUN   TestAccIdentityGroupUpdate
--- PASS: TestAccIdentityGroupUpdate (4.24s)
=== RUN   TestAccIdentityGroupExternal
--- PASS: TestAccIdentityGroupExternal (1.05s)
=== RUN   TestAccIdentityOidcKeyAllowedClientId
--- PASS: TestAccIdentityOidcKeyAllowedClientId (3.16s)
=== RUN   TestAccIdentityOidcKey
--- PASS: TestAccIdentityOidcKey (1.81s)
=== RUN   TestAccIdentityOidcKeyUpdate
--- PASS: TestAccIdentityOidcKeyUpdate (3.35s)
=== RUN   TestAccIdentityOidcRole
--- PASS: TestAccIdentityOidcRole (1.79s)
=== RUN   TestAccIdentityOidcRoleWithClientId
--- PASS: TestAccIdentityOidcRoleWithClientId (1.61s)
=== RUN   TestAccIdentityOidcRoleUpdate
--- PASS: TestAccIdentityOidcRoleUpdate (2.89s)
=== RUN   TestAccIdentityOidc
--- PASS: TestAccIdentityOidc (1.85s)
=== RUN   TestAccJWTAuthBackendRole_import
--- PASS: TestAccJWTAuthBackendRole_import (1.41s)
=== RUN   TestAccJWTAuthBackendRole_basic
--- PASS: TestAccJWTAuthBackendRole_basic (1.13s)
=== RUN   TestAccJWTAuthBackendRole_update
--- PASS: TestAccJWTAuthBackendRole_update (1.92s)
=== RUN   TestAccJWTAuthBackendRole_full
--- PASS: TestAccJWTAuthBackendRole_full (1.15s)
=== RUN   TestAccJWTAuthBackendRoleOIDC_full
--- PASS: TestAccJWTAuthBackendRoleOIDC_full (1.48s)
=== RUN   TestAccJWTAuthBackendRole_fullUpdate
--- PASS: TestAccJWTAuthBackendRole_fullUpdate (1.92s)
=== RUN   TestAccJWTAuthBackend
--- PASS: TestAccJWTAuthBackend (3.87s)
=== RUN   TestAccJWTAuthBackendProviderConfig
--- PASS: TestAccJWTAuthBackendProviderConfig (1.14s)
=== RUN   TestAccJWTAuthBackend_OIDC
--- PASS: TestAccJWTAuthBackend_OIDC (1.22s)
=== RUN   TestAccJWTAuthBackend_invalid
--- PASS: TestAccJWTAuthBackend_invalid (0.39s)
=== RUN   TestAccJWTAuthBackend_missingMandatory
--- PASS: TestAccJWTAuthBackend_missingMandatory (1.92s)
=== RUN   TestAccJWTAuthBackendProviderConfigConversionBool
--- PASS: TestAccJWTAuthBackendProviderConfigConversionBool (0.00s)
=== RUN   TestAccJWTAuthBackendProviderConfigConversionInt
--- PASS: TestAccJWTAuthBackendProviderConfigConversionInt (0.00s)
=== RUN   TestAccJWTAuthBackendProviderConfig_negative
    resource_jwt_auth_backend_test.go:374: true
--- SKIP: TestAccJWTAuthBackendProviderConfig_negative (0.00s)
=== RUN   TestAccKubernetesAuthBackendConfig_import
--- PASS: TestAccKubernetesAuthBackendConfig_import (2.49s)
=== RUN   TestAccKubernetesAuthBackendConfig_basic
--- PASS: TestAccKubernetesAuthBackendConfig_basic (1.13s)
=== RUN   TestAccKubernetesAuthBackendConfig_update
--- PASS: TestAccKubernetesAuthBackendConfig_update (1.91s)
=== RUN   TestAccKubernetesAuthBackendConfig_full
--- PASS: TestAccKubernetesAuthBackendConfig_full (1.13s)
=== RUN   TestAccKubernetesAuthBackendConfig_fullUpdate
--- PASS: TestAccKubernetesAuthBackendConfig_fullUpdate (1.94s)
=== RUN   TestAccKubernetesAuthBackendRole_import
--- PASS: TestAccKubernetesAuthBackendRole_import (1.37s)
=== RUN   TestAccKubernetesAuthBackendRole_basic
--- PASS: TestAccKubernetesAuthBackendRole_basic (1.14s)
=== RUN   TestAccKubernetesAuthBackendRole_update
--- PASS: TestAccKubernetesAuthBackendRole_update (1.91s)
=== RUN   TestAccKubernetesAuthBackendRole_full
--- PASS: TestAccKubernetesAuthBackendRole_full (1.12s)
=== RUN   TestAccKubernetesAuthBackendRole_fullUpdate
--- PASS: TestAccKubernetesAuthBackendRole_fullUpdate (4.27s)
=== RUN   TestLDAPAuthBackendGroup_import
--- PASS: TestLDAPAuthBackendGroup_import (1.38s)
=== RUN   TestLDAPAuthBackendGroup_basic
--- PASS: TestLDAPAuthBackendGroup_basic (1.12s)
=== RUN   TestLDAPAuthBackend_import
--- PASS: TestLDAPAuthBackend_import (1.34s)
=== RUN   TestLDAPAuthBackend_basic
--- PASS: TestLDAPAuthBackend_basic (4.21s)
=== RUN   TestLDAPAuthBackend_tls
--- PASS: TestLDAPAuthBackend_tls (4.39s)
=== RUN   TestLDAPAuthBackendUser_import
--- PASS: TestLDAPAuthBackendUser_import (1.41s)
=== RUN   TestLDAPAuthBackendUser_basic
--- PASS: TestLDAPAuthBackendUser_basic (1.12s)
=== RUN   TestLDAPAuthBackendUser_noGroups
--- PASS: TestLDAPAuthBackendUser_noGroups (1.12s)
=== RUN   TestLDAPAuthBackendUser_oneGroup
--- PASS: TestLDAPAuthBackendUser_oneGroup (1.12s)
=== RUN   TestMFADuoBasic
    resource_mfa_duo_test.go:17: TF_ACC_ENTERPRISE is not set, test is applicable only for Enterprise version of Vault
--- SKIP: TestMFADuoBasic (0.00s)
=== RUN   TestZeroTTLDoesNotCauseUpdate
--- PASS: TestZeroTTLDoesNotCauseUpdate (1.58s)
=== RUN   TestResourceMount
--- PASS: TestResourceMount (1.88s)
=== RUN   TestResourceMount_Local
--- PASS: TestResourceMount_Local (1.88s)
=== RUN   TestResourceMount_SealWrap
--- PASS: TestResourceMount_SealWrap (1.87s)
=== RUN   TestResourceMount_KVV2
--- PASS: TestResourceMount_KVV2 (1.59s)
=== RUN   TestResourceMount_ExternalEntropyAccess
--- PASS: TestResourceMount_ExternalEntropyAccess (4.27s)
=== RUN   TestNamespace_basic
    resource_namespace_test.go:19: TF_ACC_ENTERPRISE is not set, test is applicable only for Enterprise version of Vault
--- SKIP: TestNamespace_basic (0.00s)
=== RUN   TestAccNomadSecretBackend
    util.go:144: NOMAD_ADDR not set
--- SKIP: TestAccNomadSecretBackend (0.00s)
=== RUN   TestAccNomadSecretBackendRoleClientBasic
    util.go:144: NOMAD_ADDR not set
--- SKIP: TestAccNomadSecretBackendRoleClientBasic (0.00s)
=== RUN   TestAccNomadSecretBackendRoleManagementBasic
    util.go:144: NOMAD_ADDR not set
--- SKIP: TestAccNomadSecretBackendRoleManagementBasic (0.00s)
=== RUN   TestAccNomadSecretBackendRoleImport
    util.go:144: NOMAD_ADDR not set
--- SKIP: TestAccNomadSecretBackendRoleImport (0.00s)
=== RUN   TestAccOktaAuthBackendGroup_basic
--- PASS: TestAccOktaAuthBackendGroup_basic (1.40s)
=== RUN   TestAccOktaAuthBackendGroup_specialChar
--- PASS: TestAccOktaAuthBackendGroup_specialChar (1.40s)
=== RUN   TestAccOktaAuthBackend_basic
--- PASS: TestAccOktaAuthBackend_basic (1.88s)
=== RUN   TestAccOktaAuthBackend_import
--- PASS: TestAccOktaAuthBackend_import (2.49s)
=== RUN   TestAccOktaAuthBackend_invalid_ttl
--- PASS: TestAccOktaAuthBackend_invalid_ttl (0.29s)
=== RUN   TestAccOktaAuthBackend_invalid_max_ttl
--- PASS: TestAccOktaAuthBackend_invalid_max_ttl (0.29s)
=== RUN   TestAccOktaAuthBackendUser
--- PASS: TestAccOktaAuthBackendUser (1.13s)
=== RUN   TestAccPasswordPolicy
--- PASS: TestAccPasswordPolicy (1.82s)
=== RUN   TestAccPasswordPolicy_import
--- PASS: TestAccPasswordPolicy_import (1.32s)
=== RUN   TestPkiSecretBackendCert_basic
--- PASS: TestPkiSecretBackendCert_basic (2.89s)
=== RUN   TestPkiSecretBackendCert_renew
--- PASS: TestPkiSecretBackendCert_renew (10.96s)
=== RUN   TestPkiSecretBackendConfigCA_basic
--- PASS: TestPkiSecretBackendConfigCA_basic (1.13s)
=== RUN   TestPkiSecretBackendConfigUrls_basic
--- PASS: TestPkiSecretBackendConfigUrls_basic (1.89s)
=== RUN   TestPkiSecretBackendCrlConfig_basic
--- PASS: TestPkiSecretBackendCrlConfig_basic (2.66s)
=== RUN   TestPkiSecretBackendIntermediateCertRequest_basic
--- PASS: TestPkiSecretBackendIntermediateCertRequest_basic (1.26s)
=== RUN   TestPkiSecretBackendIntermediateSetSigned_basic
--- PASS: TestPkiSecretBackendIntermediateSetSigned_basic (1.84s)
=== RUN   TestPkiSecretBackendRole_basic
--- PASS: TestPkiSecretBackendRole_basic (1.93s)
=== RUN   TestPkiSecretBackendRootCertificate_basic
--- PASS: TestPkiSecretBackendRootCertificate_basic (3.92s)
=== RUN   TestPkiSecretBackendRootSignIntermediate_basic
--- PASS: TestPkiSecretBackendRootSignIntermediate_basic (2.72s)
=== RUN   TestPkiSecretBackendSign_basic
--- PASS: TestPkiSecretBackendSign_basic (2.40s)
=== RUN   TestPkiSecretBackendSign_renew
--- PASS: TestPkiSecretBackendSign_renew (10.36s)
=== RUN   TestPkiSecretBackend_basic
--- PASS: TestPkiSecretBackend_basic (1.82s)
=== RUN   TestPkiSecretBackend_import
--- PASS: TestPkiSecretBackend_import (1.32s)
=== RUN   TestResourcePolicy
--- PASS: TestResourcePolicy (1.82s)
=== RUN   TestQuotaLeaseCount
    resource_quota_lease_count_test.go:23: TF_ACC_ENTERPRISE is not set, test is applicable only for Enterprise version of Vault
--- SKIP: TestQuotaLeaseCount (0.00s)
=== RUN   TestQuotaRateLimit
--- PASS: TestQuotaRateLimit (2.61s)
=== RUN   TestAccRabbitmqSecretBackendRole_basic
    provider_test.go:156: RMQ_CONNECTION_URI not set
--- SKIP: TestAccRabbitmqSecretBackendRole_basic (0.00s)
=== RUN   TestAccRabbitmqSecretBackendRole_import
    provider_test.go:156: RMQ_CONNECTION_URI not set
--- SKIP: TestAccRabbitmqSecretBackendRole_import (0.00s)
=== RUN   TestAccRabbitmqSecretBackendRole_nested
    provider_test.go:156: RMQ_CONNECTION_URI not set
--- SKIP: TestAccRabbitmqSecretBackendRole_nested (0.00s)
=== RUN   TestAccRabbitmqSecretBackend_basic
    provider_test.go:156: RMQ_CONNECTION_URI not set
--- SKIP: TestAccRabbitmqSecretBackend_basic (0.00s)
=== RUN   TestAccRabbitmqSecretBackend_import
    provider_test.go:156: RMQ_CONNECTION_URI not set
--- SKIP: TestAccRabbitmqSecretBackend_import (0.00s)
=== RUN   TestAccRaftSnapshotAgentConfig_basic
    util.go:112: TF_ACC_ENTERPRISE is not set, test is applicable only for Enterprise version of Vault
--- SKIP: TestAccRaftSnapshotAgentConfig_basic (0.00s)
=== RUN   TestAccRaftSnapshotAgentConfig_import
    util.go:112: TF_ACC_ENTERPRISE is not set, test is applicable only for Enterprise version of Vault
--- SKIP: TestAccRaftSnapshotAgentConfig_import (0.00s)
=== RUN   TestAccRoleGoverningPolicy
    resource_rgp_policy_test.go:16: TF_ACC_ENTERPRISE is not set, test is applicable only for Enterprise version of Vault
--- SKIP: TestAccRoleGoverningPolicy (0.00s)
=== RUN   TestAccSSHSecretBackendCA_basic
--- PASS: TestAccSSHSecretBackendCA_basic (1.83s)
=== RUN   TestAccSSHSecretBackendCA_provided
--- PASS: TestAccSSHSecretBackendCA_provided (1.12s)
=== RUN   TestAccSSHSecretBackend_import
--- PASS: TestAccSSHSecretBackend_import (2.49s)
=== RUN   TestAccSSHSecretBackendRole_basic
--- PASS: TestAccSSHSecretBackendRole_basic (1.96s)
=== RUN   TestAccSSHSecretBackendRoleOTP_basic
--- PASS: TestAccSSHSecretBackendRoleOTP_basic (1.16s)
=== RUN   TestAccSSHSecretBackendRole_import
--- PASS: TestAccSSHSecretBackendRole_import (1.43s)
=== RUN   TestTerraformCloudSecretBackend
--- PASS: TestTerraformCloudSecretBackend (1.95s)
=== RUN   TestAccResourceTerraformCloudSecretCredsOrganizationBasic
    resource_terraform_cloud_secret_creds_test.go:27: TEST_TF_TOKEN and TEST_TF_ORGANIZATION must be set. Are currently  and  respectively
--- SKIP: TestAccResourceTerraformCloudSecretCredsOrganizationBasic (0.00s)
=== RUN   TestAccResourceTerraformCloudSecretCredsTeamBasic
    resource_terraform_cloud_secret_creds_test.go:56: TEST_TF_TOKEN, TEST_TF_ORGANIZATION, and TEST_TF_TEAM_ID must be set. Are currently ,  and  respectively
--- SKIP: TestAccResourceTerraformCloudSecretCredsTeamBasic (0.00s)
=== RUN   TestAccResourceTerraformCloudSecretCredsUserBasic
    resource_terraform_cloud_secret_creds_test.go:85: TEST_TF_TOKEN and TEST_TF_USER_ID must be set. Are currently  and  respectively
--- SKIP: TestAccResourceTerraformCloudSecretCredsUserBasic (0.00s)
=== RUN   TestTerraformCloudSecretRole
    resource_terraform_cloud_secret_role_test.go:26: TEST_TF_TOKEN, TEST_TF_TEAM_ID and TEST_TF_USER_ID must be set.
--- SKIP: TestTerraformCloudSecretRole (0.00s)
=== RUN   TestTerraformCloudSecretBackendRoleNameFromPath
--- PASS: TestTerraformCloudSecretBackendRoleNameFromPath (0.00s)
=== RUN   TestTerraformCloudSecretBackendRoleBackendFromPath
--- PASS: TestTerraformCloudSecretBackendRoleBackendFromPath (0.00s)
=== RUN   TestAccTokenAuthBackendRoleImport
--- PASS: TestAccTokenAuthBackendRoleImport (1.44s)
=== RUN   TestAccTokenAuthBackendRole
--- PASS: TestAccTokenAuthBackendRole (1.09s)
=== RUN   TestAccTokenAuthBackendRoleUpdate
--- PASS: TestAccTokenAuthBackendRoleUpdate (3.47s)
=== RUN   TestResourceToken_basic
--- PASS: TestResourceToken_basic (1.11s)
=== RUN   TestResourceToken_import
--- PASS: TestResourceToken_import (1.42s)
=== RUN   TestResourceToken_full
--- PASS: TestResourceToken_full (1.14s)
=== RUN   TestResourceToken_lookup
--- PASS: TestResourceToken_lookup (1.12s)
=== RUN   TestResourceToken_expire
--- PASS: TestResourceToken_expire (14.01s)
=== RUN   TestResourceToken_renew
--- PASS: TestResourceToken_renew (24.00s)
=== RUN   TestAccTransitCacheConfig
--- PASS: TestAccTransitCacheConfig (3.50s)
=== RUN   TestTransitSecretBackendKey_basic
--- PASS: TestTransitSecretBackendKey_basic (2.06s)
=== RUN   TestTransitSecretBackendKey_rsa4096
--- PASS: TestTransitSecretBackendKey_rsa4096 (2.42s)
=== RUN   TestTransitSecretBackendKey_import
--- PASS: TestTransitSecretBackendKey_import (1.42s)
=== RUN   TestExpandMountConfigInput
--- PASS: TestExpandMountConfigInput (0.00s)
=== RUN   TestFlattenAuthMountConfig
--- PASS: TestFlattenAuthMountConfig (0.00s)
=== RUN   TestFlattenMountConfig
--- PASS: TestFlattenMountConfig (0.00s)
=== RUN   TestValidateNoTrailingSlash
--- PASS: TestValidateNoTrailingSlash (0.00s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-vault/vault	394.254s
FAIL

...
```
