### PR TITLE
Added example of AWS auth method with `header_value`

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -267,7 +267,7 @@ provider "vault" {
 }
 ```
 
-If the `X-Vault-AWS-IAM-Server-ID` was configured as part of the AWS auth method, specify the `header_value` within the `parameters` block:
+If the Vault server's AWS auth method requires the `X-Vault-AWS-IAM-Server-ID` header to be set by clients, specify the server ID in `header_value` within the `parameters` block:
 
 ```hcl
 provider "vault" {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -267,6 +267,22 @@ provider "vault" {
 }
 ```
 
+If the `X-Vault-AWS-IAM-Server-ID` was configured as part of the AWS auth method, specify the `header_value` within the `parameters` block:
+
+```hcl
+provider "vault" {
+  address = "http://127.0.0.1:8200"
+  auth_login {
+    path = "auth/aws/login"
+    method = "aws"
+    parameters = {
+      role = "dev-role-iam"
+      header_value = "vault.example.com"
+    }
+  }
+}
+```
+
 ## Namespace support
 
 The Vault provider supports managing [Namespaces][namespaces] (a feature of


### PR DESCRIPTION
Currently, none of the parameters mentioned in the Vault API docs specify how to pass in the `X-Vault-AWS-IAM-Server-ID` as part of the provider block.  There is a mention of `iam_server_id_header_value` in the API doc, but that key does not work in the provider's parameters.  

We identified that `header_value` is what the provider's parameter block needs and validated with a customer that it works.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Update Vault provider doc to include an example of the AWS method that has been configured to require an X-Vault-AWS-IAM-Server-ID header.
```
