### PR TITLE
transform/template: add encode_format and decode_formats options.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ IMPROVEMENTS:
 * Upgrade Terraform Plugin SDK to v2
 * Add support for client controlled consistency on Vault Enterprise ([#1188](https://github.com/hashicorp/terraform-provider-vault/pull/1188))
 * `resource/jwt_auth_backend_role`: Add field `disable_bound_claims_parsing` to disable bound claim value parsing, which is useful when values contain commas ([#1200](https://github.com/hashicorp/terraform-provider-vault/pull/1200))
+* `resource/transform_template`: Add `encode_format` and `decode_formats` fields for `Vault Enterprise` with the `Advanced Data Protection Transform Module` ([#1214](https://github.com/hashicorp/terraform-provider-vault/pull/1214))
 
 BUGS:
 * `data/gcp_auth_backend_role`: Report an error when attempting to access a nonexistent role. ([#1184](https://github.com/hashicorp/terraform-provider-vault/pull/1184))

--- a/cmd/generate/main.go
+++ b/cmd/generate/main.go
@@ -1,41 +1,15 @@
 package main
 
 import (
-	"bytes"
-	"encoding/json"
 	"flag"
-	"io/ioutil"
 	"os"
-
-	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/terraform-provider-vault/codegen"
-	"github.com/hashicorp/vault/sdk/framework"
 )
 
 var pathToOpenAPIDoc = flag.String("openapi-doc", "", "path/to/openapi.json")
 
 func main() {
-	logger := hclog.Default()
-	flag.Parse()
-	if pathToOpenAPIDoc == nil || *pathToOpenAPIDoc == "" {
-		logger.Error("'openapi-doc' is required")
-		os.Exit(1)
-	}
-	doc, err := ioutil.ReadFile(*pathToOpenAPIDoc)
-	if err != nil {
-		logger.Error("Unable to read file [%s]: %s", *pathToOpenAPIDoc, err.Error())
-		os.Exit(1)
-	}
-
-	// Read in Vault's description of all the supported endpoints, their methods, and more.
-	oasDoc := &framework.OASDocument{}
-	if err := json.NewDecoder(bytes.NewBuffer(doc)).Decode(oasDoc); err != nil {
-		logger.Error("Failed to decode JSON from file [%s]: %s", *pathToOpenAPIDoc, err.Error())
-		os.Exit(1)
-	}
-
-	if err := codegen.Run(logger, oasDoc.Paths); err != nil {
-		logger.Error("Failed to generate code: %s", err.Error())
-		os.Exit(1)
-	}
+	// TODO: revisit resource and data generation strategy after v3 release
+	os.Stderr.WriteString("resource generation has been disabled, " +
+		"please manually update previously generated resources\n")
+	os.Exit(1)
 }

--- a/generated/resources/transform/template/name.go
+++ b/generated/resources/transform/template/name.go
@@ -1,7 +1,7 @@
 package template
 
-// DO NOT EDIT
-// This code is generated.
+// Code generation has been disabled for now.
+// It is okay to edit this file.
 
 import (
 	"fmt"
@@ -9,15 +9,37 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
-const nameEndpoint = "/transform/template/{name}"
+const (
+	nameEndpoint = "/transform/template/{name}"
+
+	// schema field names
+	pathField          = "path"
+	alphabetField      = "alphabet"
+	nameField          = "name"
+	patternField       = "pattern"
+	typeField          = "type"
+	encodeFormatField  = "encode_format"
+	decodeFormatsField = "decode_formats"
+)
+
+var requestFields = []string{
+	pathField,
+	alphabetField,
+	nameField,
+	patternField,
+	typeField,
+	encodeFormatField,
+	decodeFormatsField,
+}
 
 func NameResource() *schema.Resource {
 	fields := map[string]*schema.Schema{
-		"path": {
+		pathField: {
 			Type:        schema.TypeString,
 			Required:    true,
 			ForceNew:    true,
@@ -26,26 +48,38 @@ func NameResource() *schema.Resource {
 				return strings.Trim(v.(string), "/")
 			},
 		},
-		"alphabet": {
+		alphabetField: {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Description: `The alphabet to use for this template. This is only used during FPE transformations.`,
 		},
-		"name": {
+		nameField: {
 			Type:        schema.TypeString,
 			Required:    true,
 			Description: `The name of the template.`,
 			ForceNew:    true,
 		},
-		"pattern": {
+		patternField: {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Description: `The pattern used for matching. Currently, only regular expression pattern is supported.`,
 		},
-		"type": {
+		typeField: {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Description: `The pattern type to use for match detection. Currently, only regex is supported.`,
+		},
+		encodeFormatField: {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: `The regular expression template used for encoding values.
+Only applicable to FPE transformations.`,
+		},
+		decodeFormatsField: {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Description: `The map of regular expression templates used to customize decoded outputs.
+Only applicable to FPE transformations.`,
 		},
 	}
 	return &schema.Resource{
@@ -60,26 +94,15 @@ func NameResource() *schema.Resource {
 		Schema: fields,
 	}
 }
+
 func createNameResource(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*api.Client)
 	path := d.Get("path").(string)
 	vaultPath := util.ParsePath(path, nameEndpoint, d)
 	log.Printf("[DEBUG] Creating %q", vaultPath)
 
-	data := map[string]interface{}{}
-	if v, ok := d.GetOkExists("alphabet"); ok {
-		data["alphabet"] = v
-	}
-	data["name"] = d.Get("name")
-	if v, ok := d.GetOkExists("pattern"); ok {
-		data["pattern"] = v
-	}
-	if v, ok := d.GetOkExists("type"); ok {
-		data["type"] = v
-	}
-
 	log.Printf("[DEBUG] Writing %q", vaultPath)
-	if _, err := client.Logical().Write(vaultPath, data); err != nil {
+	if _, err := client.Logical().Write(vaultPath, requestData(d, requestFields)); err != nil {
 		return fmt.Errorf("error writing %q: %s", vaultPath, err)
 	}
 	d.SetId(vaultPath)
@@ -111,21 +134,15 @@ func readNameResource(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("error setting state %q, %q: %s", paramName, paramVal, err)
 		}
 	}
-	if val, ok := resp.Data["alphabet"]; ok {
-		if err := d.Set("alphabet", val); err != nil {
-			return fmt.Errorf("error setting state key 'alphabet': %s", err)
+
+	for _, field := range requestFields {
+		if val, ok := resp.Data[field]; ok {
+			if err := d.Set(field, val); err != nil {
+				return fmt.Errorf("error setting state key 'type': %s", err)
+			}
 		}
 	}
-	if val, ok := resp.Data["pattern"]; ok {
-		if err := d.Set("pattern", val); err != nil {
-			return fmt.Errorf("error setting state key 'pattern': %s", err)
-		}
-	}
-	if val, ok := resp.Data["type"]; ok {
-		if err := d.Set("type", val); err != nil {
-			return fmt.Errorf("error setting state key 'type': %s", err)
-		}
-	}
+
 	return nil
 }
 
@@ -134,21 +151,22 @@ func updateNameResource(d *schema.ResourceData, meta interface{}) error {
 	vaultPath := d.Id()
 	log.Printf("[DEBUG] Updating %q", vaultPath)
 
-	data := map[string]interface{}{}
-	if raw, ok := d.GetOk("alphabet"); ok {
-		data["alphabet"] = raw
-	}
-	if raw, ok := d.GetOk("pattern"); ok {
-		data["pattern"] = raw
-	}
-	if raw, ok := d.GetOk("type"); ok {
-		data["type"] = raw
-	}
-	if _, err := client.Logical().Write(vaultPath, data); err != nil {
+	if _, err := client.Logical().Write(vaultPath, requestData(d, requestFields)); err != nil {
 		return fmt.Errorf("error updating template auth backend role %q: %s", vaultPath, err)
 	}
+
 	log.Printf("[DEBUG] Updated %q", vaultPath)
 	return readNameResource(d, meta)
+}
+
+func requestData(d *schema.ResourceData, fields []string) map[string]interface{} {
+	data := make(map[string]interface{})
+	for _, field := range fields {
+		if raw, ok := d.GetOk(field); ok {
+			data[field] = raw
+		}
+	}
+	return data
 }
 
 func deleteNameResource(d *schema.ResourceData, meta interface{}) error {

--- a/generated/resources/transform/template/name.go
+++ b/generated/resources/transform/template/name.go
@@ -138,7 +138,7 @@ func readNameResource(d *schema.ResourceData, meta interface{}) error {
 	for _, field := range requestFields {
 		if val, ok := resp.Data[field]; ok {
 			if err := d.Set(field, val); err != nil {
-				return fmt.Errorf("error setting state key 'type': %s", err)
+				return fmt.Errorf("error setting state key %q: %s", field, err)
 			}
 		}
 	}

--- a/website/docs/r/transform_template.html.md
+++ b/website/docs/r/transform_template.html.md
@@ -8,10 +8,14 @@ description: |-
 
 # vault\_transform\_template
 
-This resource supports the "/transform/template/{name}" Vault endpoint.
+This resource supports the `/transform/template/{name}` Vault endpoint.
 
 It creates or updates a template with the given name. If a template with the name does not exist,
 it will be created. If the template exists, it will be updated with the new attributes.
+
+-> Requires _Vault Enterprise with the Advanced Data Protection Transform Module_.
+See [Transform Secrets Engine](https://www.vaultproject.io/docs/secrets/transform)
+for more information.
 
 ## Example Usage
 
@@ -26,17 +30,23 @@ resource "vault_mount" "transform" {
   path = "transform"
   type = "transform"
 }
+
 resource "vault_transform_alphabet" "numerics" {
   path      = vault_mount.transform.path
   name      = "numerics"
   alphabet  = "0123456789"
 }
+
 resource "vault_transform_template" "test" {
-  path      = vault_transform_alphabet.numerics.path
-  name      = "ccn"
-  type      = "regex"
-  pattern   = "(\\d{4})-(\\d{4})-(\\d{4})-(\\d{4})"
-  alphabet  = "numerics"
+  path           = vault_transform_alphabet.numerics.path
+  name           = "ccn"
+  type           = "regex"
+  pattern        = "(\\d{4})[- ](\\d{4})[- ](\\d{4})[- ](\\d{4})"
+  alphabet       = "numerics"
+  encode_format  = "$1-$2-$3-$4"
+  decode_formats = {
+    "last-four-digits" = "$4"
+  }
 }
 ```
 
@@ -49,3 +59,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the template.
 * `pattern` - (Optional) The pattern used for matching. Currently, only regular expression pattern is supported.
 * `type` - (Optional) The pattern type to use for match detection. Currently, only regex is supported.
+* `encode_format` - (Optional) - The regular expression template used to format encoded values.
+  (requires Vault 1.9+)
+* `decode_formats` - (Optional) - Optional mapping of name to regular expression template, used to customize
+  the decoded output. (requires Vault 1.9+)

--- a/website/docs/r/transform_template.html.md
+++ b/website/docs/r/transform_template.html.md
@@ -60,6 +60,6 @@ The following arguments are supported:
 * `pattern` - (Optional) The pattern used for matching. Currently, only regular expression pattern is supported.
 * `type` - (Optional) The pattern type to use for match detection. Currently, only regex is supported.
 * `encode_format` - (Optional) - The regular expression template used to format encoded values.
-  (requires Vault 1.9+)
+  (requires Vault Enterprise 1.9+)
 * `decode_formats` - (Optional) - Optional mapping of name to regular expression template, used to customize
-  the decoded output. (requires Vault 1.9+)
+  the decoded output. (requires Vault Enterprise 1.9+)

--- a/website/vault.erb
+++ b/website/vault.erb
@@ -422,7 +422,7 @@
                         </li>
 
                         <li<%= sidebar_current("docs-vault-resource-transform-template") %>>
-                            <a href="/docs/providers/vault/generated/resources/transform/template/name.html">vault_transform_template</a>
+                            <a href="/docs/providers/vault/r/transform_template.html">vault_transform_template</a>
                         </li>
 
                         <li<%= sidebar_current("docs-vault-resource-transform-transformation") %>>


### PR DESCRIPTION

- add encode_format and decode_formats fields to
  vault_transform_template
- temporarily disable broken resource generation code
- ensure true resource name is used in template tests.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/transform_template:  Add add encode_format and decode_formats fields
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

make dev testacc TESTARGS='-v -test.run TestTemplateName'
==> Checking that code complies with gofmt requirements...
go build -o terraform-provider-vault
mv terraform-provider-vault ~/.terraform.d/plugins/
TF_ACC=1 go test $(go list ./...) -v -v -test.run TestTemplateName -timeout 20m

[...]

=== RUN   TestTemplateName
--- PASS: TestTemplateName (4.07s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template 
...
```
