### PR TITLE
Update changelog and add tests for the generic_secret data source.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ IMPROVEMENTS:
 * Add support for client controlled consistency on Vault Enterprise ([#1188](https://github.com/hashicorp/terraform-provider-vault/pull/1188))
 * `resource/jwt_auth_backend_role`: Add field `disable_bound_claims_parsing` to disable bound claim value parsing, which is useful when values contain commas ([#1200](https://github.com/hashicorp/terraform-provider-vault/pull/1200))
 * `resource/transform_template`: Add `encode_format` and `decode_formats` fields for `Vault Enterprise` with the `Advanced Data Protection Transform Module` ([#1214](https://github.com/hashicorp/terraform-provider-vault/pull/1214))
+* `data/generic_secret`: Store `lease_start_time` UTC. ([#1216](https://github.com/hashicorp/terraform-provider-vault/pull/1216))
 
 BUGS:
 * `data/gcp_auth_backend_role`: Report an error when attempting to access a nonexistent role. ([#1184](https://github.com/hashicorp/terraform-provider-vault/pull/1184))
+* `data/generic_secret`: Ensure `lease_start_time` is stored in RFC3339 format. ([#770](https://github.com/hashicorp/terraform-provider-vault/pull/770))
 
 ## 2.24.0 (September 15, 2021)
 

--- a/vault/data_source_generic_secret.go
+++ b/vault/data_source_generic_secret.go
@@ -113,7 +113,7 @@ func genericSecretDataSourceRead(d *schema.ResourceData, meta interface{}) error
 
 	d.Set("lease_id", secret.LeaseID)
 	d.Set("lease_duration", secret.LeaseDuration)
-	d.Set("lease_start_time", time.Now().Format(time.RFC3339))
+	d.Set("lease_start_time", time.Now().UTC().Format(time.RFC3339))
 	d.Set("lease_renewable", secret.Renewable)
 
 	return nil

--- a/vault/data_source_generic_secret_test.go
+++ b/vault/data_source_generic_secret_test.go
@@ -23,7 +23,7 @@ func TestDataSourceGenericSecret(t *testing.T) {
 	})
 }
 
-func TestV2Secret(t *testing.T) {
+func TestDataSourceGenericSecret_v2(t *testing.T) {
 	mount := acctest.RandomWithPrefix("tf-acctest-kv/")
 	path := acctest.RandomWithPrefix("foo")
 	resource.Test(t, resource.TestCase{
@@ -31,22 +31,22 @@ func TestV2Secret(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: testv2DataSourceGenericSecret_config(mount, path),
+				Config: testDataSourceV2Secret_config(mount, path),
 				Check:  testDataSourceGenericSecret_check,
 			},
 			{
-				Config: testv2DataSourceGenericSecretUpdated_config(mount, path),
+				Config: testDataSourceV2SecretUpdated_config(mount, path),
 				Check:  testDataSourceGenericSecret_check,
 			},
 			{
-				Config: testv2DataSourceGenericSecretUpdatedLatest_config(mount, path),
+				Config: testDataSourceV2SecretUpdatedLatest_config(mount, path),
 				Check:  testDataSourceGenericSecretUpdated_check,
 			},
 		},
 	})
 }
 
-func testv2DataSourceGenericSecret_config(mount, path string) string {
+func testDataSourceV2Secret_config(mount, path string) string {
 	return fmt.Sprintf(`
 resource "vault_mount" "test" {
   path        = "%s"
@@ -73,7 +73,7 @@ data "vault_generic_secret" "test" {
 `, mount, path)
 }
 
-func testv2DataSourceGenericSecretUpdated_config(mount, path string) string {
+func testDataSourceV2SecretUpdated_config(mount, path string) string {
 	return fmt.Sprintf(`
 resource "vault_mount" "test" {
   path        = "%s"
@@ -100,7 +100,7 @@ data "vault_generic_secret" "test" {
 `, mount, path)
 }
 
-func testv2DataSourceGenericSecretUpdatedLatest_config(mount, path string) string {
+func testDataSourceV2SecretUpdatedLatest_config(mount, path string) string {
 	return fmt.Sprintf(`
 resource "vault_mount" "test" {
   path        = "%s"

--- a/vault/data_source_generic_secret_test.go
+++ b/vault/data_source_generic_secret_test.go
@@ -177,8 +177,7 @@ func testDataSourceGenericSecret_check(s *terraform.State) error {
 	// give a reasonable amount of buffer to allow for any system contention.
 	maxElapsed := int64(30)
 	if elapsed > maxElapsed {
-		return fmt.Errorf(
-			"elapsed lease_start_time %ds exceeds maximum %ds", elapsed, maxElapsed)
+		return fmt.Errorf("elapsed lease_start_time %ds exceeds maximum %ds", elapsed, maxElapsed)
 	}
 
 	wantJson := `{"zip":"zap"}`

--- a/website/docs/d/generic_secret.html.md
+++ b/website/docs/d/generic_secret.html.md
@@ -76,11 +76,12 @@ serialized as JSON.
 to the time the data was requested. Once this time has passed any plan
 generated with this data may fail to apply.
 
-* `lease_start_time` - As a convenience, this records the current time
-on the computer where Terraform is running when the data is requested.
+* `lease_start_time` - The date and time of Terraform execution.
+It is derived from the local machine's clock, and is
+recorded in RFC3339 format UTC.
 This can be used to approximate the absolute time represented by
 `lease_duration`, though users must allow for any clock drift and response
-latency relative to to the Vault server.
+latency relative to the Vault server. (_provided only as a convenience_).
 
 * `lease_renewable` - `true` if the lease can be renewed using Vault's
 `sys/renew/{lease-id}` endpoint. Terraform does not currently support lease

--- a/website/docs/d/generic_secret.html.md
+++ b/website/docs/d/generic_secret.html.md
@@ -81,7 +81,7 @@ It is derived from the local machine's clock, and is
 recorded in RFC3339 format UTC.
 This can be used to approximate the absolute time represented by
 `lease_duration`, though users must allow for any clock drift and response
-latency relative to the Vault server. (_provided only as a convenience_).
+latency relative to the Vault server. _Provided only as a convenience_.
 
 * `lease_renewable` - `true` if the lease can be renewed using Vault's
 `sys/renew/{lease-id}` endpoint. Terraform does not currently support lease


### PR DESCRIPTION
This PR adds test for the `generic_secret`'s `lease_start_time` field. Its value is now stored in UTC.


<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #770 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
make dev testacc TESTARGS='-v -test.run TestDataSource.*Secret' TF_LOG=error
==> Checking that code complies with gofmt requirements...
go build -o terraform-provider-vault
mv terraform-provider-vault ~/.terraform.d/plugins/
TF_ACC=1 go test $(go list ./...) -v -v -test.run TestDataSource.*Secret -timeout 20m

[...]

=== RUN   TestDataSourceGenericSecret
--- PASS: TestDataSourceGenericSecret (2.21s)
=== RUN   TestDataSourceGenericSecret_v2
--- PASS: TestDataSourceGenericSecret_v2 (4.65s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     7.504s
...
```
