### PR TITLE
fix vault_ad_secret_role resource documentation

### DIFF
--- a/website/docs/r/ad_secret_role.html.md
+++ b/website/docs/r/ad_secret_role.html.md
@@ -1,12 +1,12 @@
 ---
 layout: "vault"
-page_title: "Vault: vault_ad_secret_backend_role resource"
-sidebar_current: "docs-vault-resource-ad-secret-backend-role"
+page_title: "Vault: vault_ad_secret_role resource"
+sidebar_current: "docs-vault-resource-ad-secret-role"
 description: |-
   Creates a role on the Active Directory Secret Backend for Vault.
 ---
 
-# vault\ad\_secret\_backend\_role
+# vault\ad\_secret\_role
 
 Creates a role on an Active Directory Secret Backend for Vault. Roles are
 used to map credentials to existing Active Directory service accounts.
@@ -65,5 +65,5 @@ account mapped to this role.
 AD secret backend roles can be imported using the `path`, e.g.
 
 ```
-$ terraform import vault_ad_secret_backend_role.role ad/roles/bob
+$ terraform import vault_ad_secret_role.role ad/roles/bob
 ```

--- a/website/vault.erb
+++ b/website/vault.erb
@@ -141,8 +141,8 @@
                             <a href="/docs/providers/vault/r/ad_secret_backend_library.html">vault_ad_secret_backend_library</a>
                         </li>
 
-                        <li<%= sidebar_current("docs-vault-resource-ad-secret-backend-role") %>>
-                            <a href="/docs/providers/vault/r/ad_secret_backend_role.html">vault_ad_secret_backend_role</a>
+                        <li<%= sidebar_current("docs-vault-resource-ad-secret-role") %>>
+                            <a href="/docs/providers/vault/r/ad_secret_role.html">vault_ad_secret_role</a>
                         </li>
 
                         <li<%= sidebar_current("docs-vault-resource-aws-secret-backend") %>>


### PR DESCRIPTION
The current documentation references `vault_ad_secret_backend_role` when the resource is `vault_ad_secret_role`. This PR updates the documentation references to use the correct role name.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
- `resource/vault_ad_secret_role:` fix resource name in documentation 
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
