### PR TITLE
Add a `TestRaftPrecheck` in util to enable Raft tests using env var

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ jobs:
             export MYSQL_CONNECTION_USERNAME="root"
             export MYSQL_CONNECTION_PASSWORD="mysql"
             export MONGODB_URL="mongodb://root:mongodb@localhost:27017/admin?ssl=false"
+            export SKIP_RAFT_TESTS="true"
             make testacc TESTARGS='-v'
       - run:
           name: "Run Build"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,8 @@ jobs:
             export MYSQL_CONNECTION_USERNAME="root"
             export MYSQL_CONNECTION_PASSWORD="mysql"
             export MONGODB_URL="mongodb://root:mongodb@localhost:27017/admin?ssl=false"
-            export SKIP_RAFT_TESTS="true"
+            # This will be removed after VAULT-4324 is fixed
+            export SKIP_RAFT_TESTS='true'
             make testacc TESTARGS='-v'
       - run:
           name: "Run Build"

--- a/util/util.go
+++ b/util/util.go
@@ -119,20 +119,6 @@ func TestEntPreCheck(t *testing.T) {
 	}
 }
 
-func TestRaftPreCheck(t *testing.T) {
-	isRaft := os.Getenv("TF_RAFT_ENABLED")
-
-	if isRaft == "" {
-		t.Skip("TF_RAFT_ENABLED is not set, test is applicable only with a Raft Cluster setup")
-	}
-	if v := os.Getenv("VAULT_ADDR"); v == "" {
-		t.Fatal("VAULT_ADDR must be set for acceptance tests")
-	}
-	if v := os.Getenv("VAULT_TOKEN"); v == "" {
-		t.Fatal("VAULT_TOKEN must be set for acceptance tests")
-	}
-}
-
 func GetTestADCreds(t *testing.T) (string, string, string) {
 	adBindDN := os.Getenv("AD_BINDDN")
 	adBindPass := os.Getenv("AD_BINDPASS")

--- a/util/util.go
+++ b/util/util.go
@@ -119,6 +119,20 @@ func TestEntPreCheck(t *testing.T) {
 	}
 }
 
+func TestRaftPreCheck(t *testing.T) {
+	isRaft := os.Getenv("TF_RAFT_ENABLED")
+
+	if isRaft == "" {
+		t.Skip("TF_RAFT_ENABLED is not set, test is applicable only with a Raft Cluster setup")
+	}
+	if v := os.Getenv("VAULT_ADDR"); v == "" {
+		t.Fatal("VAULT_ADDR must be set for acceptance tests")
+	}
+	if v := os.Getenv("VAULT_TOKEN"); v == "" {
+		t.Fatal("VAULT_TOKEN must be set for acceptance tests")
+	}
+}
+
 func GetTestADCreds(t *testing.T) (string, string, string) {
 	adBindDN := os.Getenv("AD_BINDDN")
 	adBindPass := os.Getenv("AD_BINDPASS")

--- a/vault/resource_raft_autopilot_test.go
+++ b/vault/resource_raft_autopilot_test.go
@@ -1,6 +1,7 @@
 package vault
 
 import (
+	"os"
 	"strconv"
 	"testing"
 
@@ -14,8 +15,13 @@ import (
 
 func TestAccRaftAutopilotConfig_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		Providers:    testProviders,
-		PreCheck:     func() { util.TestRaftPreCheck(t) },
+		Providers: testProviders,
+		PreCheck: func() {
+			util.TestAccPreCheck(t)
+			if _, ok := os.LookupEnv("SKIP_RAFT_TESTS"); ok {
+				t.Skip("Warning: SKIP_RAFT_TESTS set, skipping test")
+			}
+		},
 		CheckDestroy: testAccRaftAutopilotConfigCheckDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/vault/resource_raft_autopilot_test.go
+++ b/vault/resource_raft_autopilot_test.go
@@ -5,15 +5,17 @@ import (
 	"testing"
 
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
 )
 
 func TestAccRaftAutopilotConfig_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { util.TestRaftPreCheck(t) },
 		CheckDestroy: testAccRaftAutopilotConfigCheckDestroy,
 		Steps: []resource.TestStep{
 			{


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```
release-note: Add a PreCheck to enable Raft tests using an environment variable
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-v -run TestAccRaftAutopilotConfig_basic'
RUN   TestAccRaftAutopilotConfig_basic
    util.go:126: TF_RAFT_ENABLED is not set, test is applicable only with a Raft Cluster setup
--- SKIP: TestAccRaftAutopilotConfig_basic (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     (cached)
...
