### PR TITLE
Handle nil cidr_list from Vault response in approle_auth_backend_secret_id

### DIFF
--- a/vault/resource_approle_auth_backend_role_secret_id.go
+++ b/vault/resource_approle_auth_backend_role_secret_id.go
@@ -223,20 +223,20 @@ func approleAuthBackendRoleSecretIDRead(d *schema.ResourceData, meta interface{}
 	}
 
 	var cidrs []string
-	if cidrList := resp.Data["cidr_list"]; cidrList != nil {
-		switch data := cidrList.(type) {
-		case string:
-			if data != "" {
-				cidrs = strings.Split(data, ",")
-			}
-		case []interface{}:
-			cidrs = make([]string, 0, len(data))
-			for _, i := range data {
-				cidrs = append(cidrs, i.(string))
-			}
-		default:
-			return fmt.Errorf("unknown type %T for cidr_list in response for SecretID %q", cidrList, accessor)
+	switch data := resp.Data["cidr_list"].(type) {
+	case string:
+		if data != "" {
+			cidrs = strings.Split(data, ",")
 		}
+	case []interface{}:
+		cidrs = make([]string, 0, len(data))
+		for _, i := range data {
+			cidrs = append(cidrs, i.(string))
+		}
+	case nil:
+		cidrs = make([]string, 0)
+	default:
+		return fmt.Errorf("unknown type %T for cidr_list in response for SecretID %q", data, accessor)
 	}
 
 	metadata, err := json.Marshal(resp.Data["metadata"])

--- a/vault/resource_approle_auth_backend_role_secret_id.go
+++ b/vault/resource_approle_auth_backend_role_secret_id.go
@@ -224,15 +224,14 @@ func approleAuthBackendRoleSecretIDRead(d *schema.ResourceData, meta interface{}
 
 	var cidrs []string
 	if cidrList := resp.Data["cidr_list"]; cidrList != nil {
-		switch cidrList.(type) {
+		switch data := cidrList.(type) {
 		case string:
-			if cidrList.(string) != "" {
-				cidrs = strings.Split(cidrList.(string), ",")
+			if data != "" {
+				cidrs = strings.Split(data, ",")
 			}
 		case []interface{}:
-			v := cidrList.([]interface{})
-			cidrs = make([]string, 0, len(v))
-			for _, i := range v {
+			cidrs = make([]string, 0, len(data))
+			for _, i := range data {
 				cidrs = append(cidrs, i.(string))
 			}
 		default:

--- a/vault/resource_approle_auth_backend_role_secret_id.go
+++ b/vault/resource_approle_auth_backend_role_secret_id.go
@@ -8,13 +8,12 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
-var (
-	approleAuthBackendRoleSecretIDIDRegex = regexp.MustCompile("^backend=(.+)::role=(.+)::accessor=(.+)$")
-)
+var approleAuthBackendRoleSecretIDIDRegex = regexp.MustCompile("^backend=(.+)::role=(.+)::accessor=(.+)$")
 
 func approleAuthBackendRoleSecretIDResource() *schema.Resource {
 	return &schema.Resource{
@@ -158,7 +157,6 @@ func approleAuthBackendRoleSecretIDCreate(d *schema.ResourceData, meta interface
 	}
 
 	resp, err := client.Logical().Write(path, data)
-
 	if err != nil {
 		return fmt.Errorf("error writing AppRole auth backend role SecretID %q: %s", path, err)
 	}
@@ -225,19 +223,21 @@ func approleAuthBackendRoleSecretIDRead(d *schema.ResourceData, meta interface{}
 	}
 
 	var cidrs []string
-	switch resp.Data["cidr_list"].(type) {
-	case string:
-		if resp.Data["cidr_list"].(string) != "" {
-			cidrs = strings.Split(resp.Data["cidr_list"].(string), ",")
+	if cidrList := resp.Data["cidr_list"]; cidrList != nil {
+		switch cidrList.(type) {
+		case string:
+			if cidrList.(string) != "" {
+				cidrs = strings.Split(cidrList.(string), ",")
+			}
+		case []interface{}:
+			v := cidrList.([]interface{})
+			cidrs = make([]string, 0, len(v))
+			for _, i := range v {
+				cidrs = append(cidrs, i.(string))
+			}
+		default:
+			return fmt.Errorf("unknown type %T for cidr_list in response for SecretID %q", cidrList, accessor)
 		}
-	case []interface{}:
-		v := resp.Data["cidr_list"].([]interface{})
-		cidrs = make([]string, 0, len(v))
-		for _, i := range v {
-			cidrs = append(cidrs, i.(string))
-		}
-	default:
-		return fmt.Errorf("unknown type %T for cidr_list in response for SecretID %q", resp.Data["cidr_list"], accessor)
 	}
 
 	metadata, err := json.Marshal(resp.Data["metadata"])


### PR DESCRIPTION
As of vault-1.9 the `cidr_list` field may have `nil` value. The `approle_auth_backend_secret_id` resource does not properly handle this case.

This PR should resolve the issue documented above, and relates to https://github.com/hashicorp/vault/issues/13226

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make dev testacc TESTARGS='-v -test.run TestAccAppRoleAuthBackendRole'
==> Checking that code complies with gofmt requirements...
go build -o terraform-provider-vault
mv terraform-provider-vault ~/.terraform.d/plugins/
TF_ACC=1 go test $(go list ./...) -v -v -test.run TestAccAppRoleAuthBackendRole -timeout 20m

[...]

=== RUN   TestAccAppRoleAuthBackendRoleID_basic
--- PASS: TestAccAppRoleAuthBackendRoleID_basic (2.95s)
=== RUN   TestAccAppRoleAuthBackendRoleID_customID
--- PASS: TestAccAppRoleAuthBackendRoleID_customID (3.00s)
=== RUN   TestAccAppRoleAuthBackendRoleSecretID_basic
--- PASS: TestAccAppRoleAuthBackendRoleSecretID_basic (1.81s)
=== RUN   TestAccAppRoleAuthBackendRoleSecretID_wrapped
--- PASS: TestAccAppRoleAuthBackendRoleSecretID_wrapped (1.82s)
=== RUN   TestAccAppRoleAuthBackendRoleSecretID_wrapped_namespace
--- PASS: TestAccAppRoleAuthBackendRoleSecretID_wrapped_namespace (3.05s)
=== RUN   TestAccAppRoleAuthBackendRoleSecretID_full
--- PASS: TestAccAppRoleAuthBackendRoleSecretID_full (1.80s)
=== RUN   TestAccAppRoleAuthBackendRole_import
--- PASS: TestAccAppRoleAuthBackendRole_import (2.17s)
=== RUN   TestAccAppRoleAuthBackendRole_basic
--- PASS: TestAccAppRoleAuthBackendRole_basic (1.74s)
=== RUN   TestAccAppRoleAuthBackendRole_update
--- PASS: TestAccAppRoleAuthBackendRole_update (3.00s)
=== RUN   TestAccAppRoleAuthBackendRole_full
--- PASS: TestAccAppRoleAuthBackendRole_full (1.73s)
=== RUN   TestAccAppRoleAuthBackendRole_fullUpdate
--- PASS: TestAccAppRoleAuthBackendRole_fullUpdate (4.28s)
PASS

...
```
