### PR TITLE
[VAULT-4074] Include `custom_metadata` support for entity aliases

### DIFF
--- a/vault/resource_identity_entity_alias_test.go
+++ b/vault/resource_identity_entity_alias_test.go
@@ -29,6 +29,7 @@ func TestAccIdentityEntityAlias(t *testing.T) {
 					resource.TestCheckResourceAttrPair(nameEntityAlias, "name", nameEntity, "name"),
 					resource.TestCheckResourceAttrPair(nameEntityAlias, "canonical_id", nameEntity, "id"),
 					resource.TestCheckResourceAttrPair(nameEntityAlias, "mount_accessor", nameGithubA, "accessor"),
+					resource.TestCheckResourceAttrPair(nameEntityAlias, "custom_metadata", nameEntity, "metadata"),
 				),
 			},
 			{
@@ -59,6 +60,7 @@ func TestAccIdentityEntityAlias_Update(t *testing.T) {
 					resource.TestCheckResourceAttrPair(nameEntityAlias, "name", nameEntityA, "name"),
 					resource.TestCheckResourceAttrPair(nameEntityAlias, "canonical_id", nameEntityA, "id"),
 					resource.TestCheckResourceAttrPair(nameEntityAlias, "mount_accessor", nameGithubA, "accessor"),
+					resource.TestCheckResourceAttrPair(nameEntityAlias, "custom_metadata", nameEntityA, "metadata"),
 				),
 			},
 			{
@@ -67,6 +69,7 @@ func TestAccIdentityEntityAlias_Update(t *testing.T) {
 					resource.TestCheckResourceAttrPair(nameEntityAlias, "name", nameEntityB, "name"),
 					resource.TestCheckResourceAttrPair(nameEntityAlias, "canonical_id", nameEntityB, "id"),
 					resource.TestCheckResourceAttrPair(nameEntityAlias, "mount_accessor", nameGithubB, "accessor"),
+					resource.TestCheckResourceAttrPair(nameEntityAlias, "custom_metadata", nameEntityA, "metadata"),
 				),
 			},
 		},
@@ -101,11 +104,17 @@ func testAccIdentityEntityAliasConfig(entityName string, dupeAlias bool, altTarg
 resource "vault_identity_entity" "entityA" {
   name = "%s-A"
   policies = ["test"]
+  metadata = {
+    version = "1"
+  }
 }
 
 resource "vault_identity_entity" "entityB" {
   name = "%s-B"
   policies = ["test"]
+  metadata = {
+    version = "1"
+  }
 }
 
 resource "vault_auth_backend" "githubA" {
@@ -122,8 +131,9 @@ resource "vault_identity_entity_alias" "entity-alias" {
   name = vault_identity_entity.entity%s.name
   mount_accessor = vault_auth_backend.github%s.accessor
   canonical_id = vault_identity_entity.entity%s.id
+  custom_metadata = vault_identity_entity.entity%s.metadata
 }
-`, entityName, entityName, entityName, entityName, entityId, entityId, entityId)
+`, entityName, entityName, entityName, entityName, entityId, entityId, entityId, entityId)
 
 	// This duplicate alias tests the provider's handling of aliases that already exist but aren't
 	// known to the provider.
@@ -133,6 +143,9 @@ resource "vault_identity_entity_alias" "entity-alias-dupe" {
   name = vault_identity_entity.entity%s.name
   mount_accessor = vault_auth_backend.githubA.accessor
   canonical_id = vault_identity_entity.entity%s.id
+  custom_metadata = {
+    version = "1"
+  }
 }
 `, entityId, entityId)
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes [#4074](https://hashicorp.atlassian.net/browse/VAULT-4074)

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/vault_identity_entity_alias: Add `custom_metadata` support for entity aliases.
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-v -run TestAccIdentityEntityAlias'
=== RUN   TestAccIdentityEntityAlias
--- PASS: TestAccIdentityEntityAlias (2.43s)
=== RUN   TestAccIdentityEntityAlias_Update
--- PASS: TestAccIdentityEntityAlias_Update (3.15s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault
...
```
