### PR TITLE
Add support for patch to vault_policy_document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.1.0 (Unreleased)
+
+IMPROVEMENTS:
+* `data/policy_document`: Add support for `patch` capability for vault-1.9+. ([#1238](https://github.com/hashicorp/terraform-provider-vault/pull/1238))
+
 ## 3.0.1 (November 23, 2021)
 
 BUGS:

--- a/vault/data_source_policy_document.go
+++ b/vault/data_source_policy_document.go
@@ -27,7 +27,16 @@ type PolicyRule struct {
 	DeniedParameters   map[string][]string
 }
 
-var allowedCapabilities = []string{"create", "read", "update", "delete", "list", "sudo", "deny"}
+var allowedCapabilities = []string{
+	"create",
+	"read",
+	"update",
+	"delete",
+	"list",
+	"sudo",
+	"deny",
+	"patch",
+}
 
 func policyDocumentDataSource() *schema.Resource {
 	return &schema.Resource{
@@ -136,7 +145,7 @@ func policyDocumentDataSourceRead(d *schema.ResourceData, meta interface{}) erro
 	policy := &Policy{}
 
 	if rawRules, hasRawRules := d.GetOk("rule"); hasRawRules {
-		var rawRuleIntfs = rawRules.([]interface{})
+		rawRuleIntfs := rawRules.([]interface{})
 		rules := make([]*PolicyRule, len(rawRuleIntfs))
 
 		for i, ruleI := range rawRuleIntfs {

--- a/vault/data_source_policy_document_test.go
+++ b/vault/data_source_policy_document_test.go
@@ -19,14 +19,13 @@ func TestDataSourcePolicyDocument(t *testing.T) {
 			},
 		},
 	})
-
 }
 
 var testDataSourcePolicyDocument_config = `
 data "vault_policy_document" "test" {
   rule {
     path                = "secret/test1/*"
-    capabilities        = ["create", "read", "update", "delete", "list"]
+    capabilities        = ["create", "read", "update", "delete", "list", "patch"]
     description         = "test rule 1"
     required_parameters = ["test_param1"]
 
@@ -86,7 +85,7 @@ data "vault_policy_document" "test" {
 
 var testResultPolicyHCLDocument = `# test rule 1
 path "secret/test1/*" {
-  capabilities = ["create", "read", "update", "delete", "list"]
+  capabilities = ["create", "read", "update", "delete", "list", "patch"]
   required_parameters = ["test_param1"]
   allowed_parameters = {
     "eggs" = ["foo", "bar"]


### PR DESCRIPTION
Update `vault_policy_document` data source to support the `patch` capability.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1227

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

Output from acceptance testing:

```
$ make dev testacc TESTARGS='-v -test.run TestDataSourcePol'            
==> Checking that code complies with gofmt requirements...
go build -o terraform-provider-vault
mv terraform-provider-vault ~/.terraform.d/plugins/
TF_ACC=1 go test $(go list ./...) -v -v -test.run TestDataSourcePol -timeout 20m

=== RUN   TestDataSourcePolicyDocument
--- PASS: TestDataSourcePolicyDocument (1.94s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     4.881s

...
```
