### PR TITLE
feat: kv-v2 generic secret metadata

### DIFF
--- a/vault/data_source_generic_secret_metadata.go
+++ b/vault/data_source_generic_secret_metadata.go
@@ -1,0 +1,83 @@
+package vault
+
+import (
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/hashicorp/vault/api"
+)
+
+func genericSecretMetadataDataSource() *schema.Resource {
+	return &schema.Resource{
+		Read: genericSecretMetadataSourceRead,
+
+		Schema: map[string]*schema.Schema{
+			"path": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Full path from which a secret will be read.",
+			},
+			casRequiredKeyName: {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			customMetadataKeyName: {
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
+			deleteVersionAfterKeyName: {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			maxVersionsKeyName: {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"lease_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Lease identifier assigned by vault.",
+			},
+			"lease_duration": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Lease duration in seconds relative to the time in lease_start_time.",
+			},
+			"lease_start_time": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Time at which the lease was read, using the clock of the system where Terraform was running",
+			},
+			"lease_renewable": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "True if the duration of this lease can be extended through renewal.",
+			},
+		},
+	}
+}
+
+func genericSecretMetadataSourceRead(d *schema.ResourceData, meta interface{}) error {
+	path := d.Get("path").(string)
+	client := meta.(*api.Client)
+	secretMetadata, err := readKVMetadata(path, client)
+
+	if err != nil {
+		return err
+	}
+	d.SetId(path)
+	d.Set(casRequiredKeyName, secretMetadata.Data[casRequiredKeyName].(bool))
+	if val, ok := secretMetadata.Data[customMetadataKeyName]; ok {
+		d.Set(customMetadataKeyName, val.(map[string]interface{}))
+	}
+	d.Set(deleteVersionAfterKeyName, secretMetadata.Data[deleteVersionAfterKeyName].(string))
+	d.Set(maxVersionsKeyName, secretMetadata.Data[maxVersionsKeyName])
+
+	d.Set("lease_id", secretMetadata.LeaseID)
+	d.Set("lease_duration", secretMetadata.LeaseDuration)
+	d.Set("lease_start_time", time.Now().UTC().Format(time.RFC3339))
+	d.Set("lease_renewable", secretMetadata.Renewable)
+
+	return nil
+}

--- a/vault/data_source_generic_secret_metadata_test.go
+++ b/vault/data_source_generic_secret_metadata_test.go
@@ -1,0 +1,155 @@
+package vault
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestDataSourceGenericSecretMetadata(t *testing.T) {
+	mount := acctest.RandomWithPrefix("tf-acctest-kv-metadata")
+	path := acctest.RandomWithPrefix("foo")
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceSecretMetadataCreateSecretAndMetadata(mount, path),
+				Check:  testDataSourceGenericSecretMetadata_check,
+			},
+		},
+		//PreventPostDestroyRefresh: true,
+	})
+}
+
+func testDataSourceSecretMetadataCreateSecretMount(mount string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "test" {
+  path        = "%s"
+  type        = "kv"
+  description = "This is an example mount for metadata testing"
+  options = {
+    version = "2"
+  }
+}
+
+
+`, mount)
+}
+
+func testDataSourceSecretMetadataCreateSecretAndMetadata(mount, path string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "test" {
+  path        = "%s"
+  type        = "kv"
+  description = "This is an example mount for metadata testing"
+  options = {
+    version = "2"
+  }
+}
+
+resource "vault_generic_secret" "test" {
+    path = "${vault_mount.test.path}/%s"
+    data_json = jsonencode({blah = "diblah"})
+}
+
+resource "vault_generic_secret_metadata" "test" {
+   depends_on = [vault_generic_secret.test]
+   path = vault_generic_secret.test.path
+   custom_metadata = {
+		some_key = "some_value"
+		blah = "diblah"
+   } 
+   delete_version_after = "730h"
+   max_versions = 17
+   cas_required = false
+}
+
+data "vault_generic_secret_metadata" "test" {
+  path = vault_generic_secret_metadata.test.path
+}
+`, mount, path)
+}
+
+func testDataSourceGenericSecretMetadata_check(s *terraform.State) error {
+	resourceState := s.Modules[0].Resources["data.vault_generic_secret_metadata.test"]
+	if resourceState == nil {
+		return fmt.Errorf("resource not found in state %v", s.Modules[0].Resources)
+	}
+
+	iState := resourceState.Primary
+	if iState == nil {
+		return fmt.Errorf("resource has no primary instance")
+	}
+
+	// Lease information
+	ts, ok := iState.Attributes["lease_start_time"]
+	if !ok {
+		return fmt.Errorf("lease_start_time not set")
+	}
+
+	t, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		return fmt.Errorf("lease_start_time value %q is not in the expected format, err=%s", ts, err)
+	}
+
+	elapsed := time.Now().UTC().Unix() - t.Unix()
+	// give a reasonable amount of buffer to allow for any system contention.
+	maxElapsed := int64(30)
+	if elapsed > maxElapsed {
+		return fmt.Errorf("elapsed lease_start_time %ds exceeds maximum %ds", elapsed, maxElapsed)
+	}
+
+	// Custom Metadata
+	wantCustomMetadata := map[string]string{"some_key": "some_value", "blah": "diblah"}
+	fmt.Printf("[DEBUG] state Attributes is %+v\n", iState.Attributes)
+	var errorString string
+	for key, value := range wantCustomMetadata {
+		path := fmt.Sprintf("%s.%s", customMetadataKeyName, key)
+		fmt.Printf("[DEBUG] checking for %s, value is %s\n", path, value)
+		if got := iState.Attributes[path]; got != value {
+			errorString += fmt.Sprintf("* key %s is %s. Want %s\n", path, got, value)
+		}
+	}
+	if errorString != "" {
+		return fmt.Errorf("Issue while checking datasource secret_metadata: \n%s", errorString)
+	}
+
+	// cas required
+	casRequired, err := strconv.ParseBool(iState.Attributes[casRequiredKeyName])
+	if err != nil {
+		return fmt.Errorf("unable to parse bool string %v. err=%w", iState.Attributes[casRequiredKeyName], err)
+	}
+	if casRequired != false {
+		return fmt.Errorf("cas_required value %v is not the expected one %v, err=%s", casRequired, false, err)
+	}
+
+	// delete_version_after
+	deleteVersionAfter, err := time.ParseDuration(iState.Attributes[deleteVersionAfterKeyName])
+	if err != nil {
+		return fmt.Errorf("unable to parse time duration %v. err=%w", iState.Attributes[deleteVersionAfterKeyName], err)
+	}
+	wantDeleteVersionAfter, _ := time.ParseDuration("730h")
+	if deleteVersionAfter != wantDeleteVersionAfter {
+		return fmt.Errorf("delete_version_after value %q is not the expected one %v, err=%s", deleteVersionAfter, wantDeleteVersionAfter, err)
+	}
+
+	// delete_version_after
+	maxVersions, err := strconv.Atoi(iState.Attributes[maxVersionsKeyName])
+	if err != nil {
+		return fmt.Errorf("unable to parse %v as string. err=%w", iState.Attributes[maxVersionsKeyName], err)
+	}
+
+	// max_versions
+	wantMaxVersions := 17
+	if maxVersions != wantMaxVersions {
+		return fmt.Errorf("max_versions value %q is not the expected one %v, err=%s", maxVersions, wantMaxVersions, err)
+	}
+
+	return nil
+}

--- a/vault/kv_helpers.go
+++ b/vault/kv_helpers.go
@@ -48,6 +48,23 @@ func versionedSecret(requestedVersion int, path string, client *api.Client) (*ap
 	return secret, nil
 }
 
+func readKVMetadata(path string, client *api.Client) (*api.Secret, error) {
+	mountPath, v2, err := isKVv2(path, client)
+	if err != nil {
+		return nil, err
+	}
+	if !v2 {
+		return nil, fmt.Errorf("secret metadata requires a kv-v2 secret")
+	}
+	path = addPrefixToVKVPath(path, mountPath, "metadata")
+	secretMetadata, err := kvReadRequest(client, path, map[string]string{})
+
+	if err != nil {
+		return nil, err
+	}
+	return secretMetadata, nil
+}
+
 func kvReadRequest(client *api.Client, path string, params map[string]string) (*api.Secret, error) {
 	r := client.NewRequest("GET", "/v1/"+path)
 	for k, v := range params {

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -253,6 +253,10 @@ var (
 			Resource:      genericSecretDataSource(),
 			PathInventory: []string{"/secret/data/{path}"},
 		},
+		"vault_generic_secret_metadata": {
+			Resource:      genericSecretMetadataDataSource(),
+			PathInventory: []string{"/secret/data/{path}"},
+		},
 		"vault_policy_document": {
 			Resource:      policyDocumentDataSource(),
 			PathInventory: []string{"/sys/policy/{name}"},
@@ -442,6 +446,10 @@ var (
 		},
 		"vault_generic_secret": {
 			Resource:      genericSecretResource(),
+			PathInventory: []string{GenericPath},
+		},
+		"vault_generic_secret_metadata": {
+			Resource:      genericSecretMetadataResource(),
 			PathInventory: []string{GenericPath},
 		},
 		"vault_jwt_auth_backend": {

--- a/vault/resource_generic_secret_metadata.go
+++ b/vault/resource_generic_secret_metadata.go
@@ -1,0 +1,166 @@
+package vault
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/vault/api"
+)
+
+const (
+	customMetadataKeyName     = "custom_metadata"
+	deleteVersionAfterKeyName = "delete_version_after"
+	maxVersionsKeyName        = "max_versions"
+	casRequiredKeyName        = "cas_required"
+)
+
+func genericSecretMetadataResource() *schema.Resource {
+	return &schema.Resource{
+		SchemaVersion: 1,
+
+		CreateContext: genericSecretMetadataResourceWrite,
+		UpdateContext: genericSecretMetadataResourceWrite,
+		DeleteContext: genericSecretMetadataResourceDelete,
+		ReadContext:   genericSecretMetadataResourceRead,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"path": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Full path where the generic secret will be written.",
+			},
+
+			casRequiredKeyName: {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			customMetadataKeyName: {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Default:  nil,
+			},
+			deleteVersionAfterKeyName: {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "0s",
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					told, err := time.ParseDuration(old)
+					if err != nil {
+						return false
+					}
+					tnew, err := time.ParseDuration(new)
+					if err != nil {
+						return false
+					}
+					return told == tnew
+				},
+				ValidateFunc: func(i interface{}, s string) (e []string, es []error) {
+					_, err := time.ParseDuration(i.(string))
+					if err != nil {
+						es = append(es, fmt.Errorf("unable to parse duration %s. err=%w", i, err))
+					}
+					return
+				},
+			},
+			maxVersionsKeyName: {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  0,
+			},
+		},
+	}
+}
+
+func genericSecretMetadataResourceWrite(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	var metadata = map[string]interface{}{}
+	client := meta.(*api.Client)
+
+	path := d.Get("path").(string)
+	originalPath := path
+
+	mountPath, v2, err := isKVv2(path, client)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error determining if it's a v2 path: %s", err))
+	}
+	if !v2 {
+		return diag.FromErr(fmt.Errorf("secret metadata requires a kv-v2 secret"))
+	}
+	path = addPrefixToVKVPath(path, mountPath, "metadata")
+
+	// process metadata
+	metadata[casRequiredKeyName] = d.Get(casRequiredKeyName).(bool)
+	metadata[customMetadataKeyName] = d.Get(customMetadataKeyName).(map[string]interface{})
+	metadata[deleteVersionAfterKeyName] = d.Get(deleteVersionAfterKeyName).(string)
+	metadata[maxVersionsKeyName] = d.Get(maxVersionsKeyName).(int)
+
+	_, err = client.Logical().Write(path, metadata)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error writing to Vault: %s", err))
+	}
+
+	d.SetId(originalPath)
+
+	genericSecretMetadataResourceRead(ctx, d, meta)
+
+	return diags
+}
+
+func genericSecretMetadataResourceDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	client := meta.(*api.Client)
+
+	path := d.Id()
+
+	mountPath, _, err := isKVv2(path, client)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error determining if it's a v2 path: %s", err))
+	}
+	path = addPrefixToVKVPath(path, mountPath, "metadata")
+
+	log.Printf("[DEBUG] Deleting vault_generic_metadata_secret from %q", path)
+	_, err = client.Logical().Write(path, map[string]interface{}{
+		casRequiredKeyName:        false,
+		customMetadataKeyName:     nil,
+		deleteVersionAfterKeyName: "0s",
+		maxVersionsKeyName:        0,
+	})
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("error deleting %q from Vault: %q", path, err))
+	}
+
+	return diags
+}
+
+func genericSecretMetadataResourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	path := d.Id()
+	client := meta.(*api.Client)
+	secretMetadata, err := readKVMetadata(path, client)
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.Set("path", path)
+	d.Set(casRequiredKeyName, secretMetadata.Data[casRequiredKeyName].(bool))
+	if val, ok := secretMetadata.Data[customMetadataKeyName]; ok {
+		d.Set(customMetadataKeyName, val.(map[string]interface{}))
+	}
+	d.Set(deleteVersionAfterKeyName, secretMetadata.Data[deleteVersionAfterKeyName].(string))
+	d.Set(maxVersionsKeyName, secretMetadata.Data[maxVersionsKeyName])
+
+	return diags
+}

--- a/vault/resource_generic_secret_metadata_test.go
+++ b/vault/resource_generic_secret_metadata_test.go
@@ -1,0 +1,118 @@
+package vault
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/vault/api"
+)
+
+func TestResourceGenericSecretMetadata(t *testing.T) {
+	mount := acctest.RandomWithPrefix("tf-acc-tests-metadata")
+	path := acctest.RandomWithPrefix("foo")
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testresourcegenericsecretmetadataInitialconfig(mount, path),
+				Check:  testresourcegenericsecretInitialcheck(mount, path),
+			},
+		},
+	})
+}
+
+func testresourcegenericsecretmetadataInitialconfig(mount, path string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "test" {
+	path = "%s"
+	type = "kv"
+	options = {
+		version = "2"
+	}
+}
+
+resource "vault_generic_secret" "test" {
+    path = "${vault_mount.test.path}/%s"
+    data_json = jsonencode({blah = "diblah"})
+}
+
+resource "vault_generic_secret_metadata" "test" {
+   depends_on = [vault_generic_secret.test]
+   path = vault_generic_secret.test.path
+   custom_metadata = {
+		some_key = "some_value"
+		blah = "diblah"
+   } 
+   delete_version_after = "730h"
+   max_versions = 17
+   cas_required = false
+}
+`, mount, path)
+}
+
+func testresourcegenericsecretInitialcheck(mount, expectedPath string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourceState := s.Modules[0].Resources["vault_generic_secret_metadata.test"]
+		if resourceState == nil {
+			return fmt.Errorf("resource not found in state")
+		}
+
+		instanceState := resourceState.Primary
+		if instanceState == nil {
+			return fmt.Errorf("resource has no primary instance")
+		}
+
+		path := instanceState.ID
+
+		if path != instanceState.Attributes["path"] {
+			return fmt.Errorf("id doesn't match path")
+		}
+		if path != fmt.Sprintf("%s/%s", mount, expectedPath) {
+			return fmt.Errorf("unexpected secret path. got=%s want=%s", path, expectedPath)
+		}
+
+		client := testProvider.Meta().(*api.Client)
+		path = addPrefixToVKVPath(expectedPath, mount, "metadata")
+		secret, err := client.Logical().Read(path)
+
+		if err != nil {
+			return fmt.Errorf("error reading back secret: %s", err)
+		}
+
+		// Test custom_metadata
+		wantCustomMetadata := map[string]interface{}{"some_key": "some_value", "blah": "diblah"}
+		if got, want := secret.Data[customMetadataKeyName], wantCustomMetadata; !reflect.DeepEqual(got, want) {
+			return fmt.Errorf("custom_metadata is not as expected. got=%#v, want=%#v", got, want)
+		}
+
+		// Test delete_version_after
+		wantDeleteVersionAfter, _ := time.ParseDuration("730h")
+		parsedGotDeleteVersionAfter, err := time.ParseDuration(secret.Data[deleteVersionAfterKeyName].(string))
+		if err != nil {
+			return fmt.Errorf("unable to parse time duration from %v. err=%w", secret.Data[deleteVersionAfterKeyName], err)
+		}
+		if parsedGotDeleteVersionAfter != wantDeleteVersionAfter {
+			return fmt.Errorf("delete_version_after is not as expected. got=%+v, want=%+v", parsedGotDeleteVersionAfter, wantDeleteVersionAfter)
+		}
+
+		// test max_versions
+		wantMaxVersions := 17
+		parsedGotMaxVersions, err := strconv.Atoi(secret.Data[maxVersionsKeyName].(json.Number).String())
+		if err != nil {
+			return fmt.Errorf("unable to parse int value from %v. err=%w", secret.Data[maxVersionsKeyName], err)
+		}
+		if parsedGotMaxVersions != wantMaxVersions {
+			return fmt.Errorf("max_versions is not as expected. got=%+v, want=%+v", parsedGotMaxVersions, wantMaxVersions)
+		}
+
+		return nil
+	}
+}

--- a/website/docs/d/generic_secret_metadata.html.md
+++ b/website/docs/d/generic_secret_metadata.html.md
@@ -1,0 +1,81 @@
+---
+layout: "vault"
+page_title: "Vault: vault_generic_secret_metadata data source"
+sidebar_current: "docs-vault-datasource-generic-secret-metadata"
+description: |-
+  Reads KVv2 Secret metadata from a given path in Vault
+---
+
+# vault\_generic\_secret\_metadata
+
+Reads KVv2 Secret metadata from a given path in Vault.
+
+This data source is solely intended to be used with
+[Vault's "generic" secret backend](https://www.vaultproject.io/docs/secrets/generic/index.html),
+kv version 2. In kv v1 there are no metadata.
+
+~> **Important** the `custom_metadata` metadata requires vault v1.9.0
+
+## Example Usage
+
+```hcl
+data "vault_generic_secret_metadata" "some_secret" {
+  path = "secret/some_secret"
+}
+
+output "all_metadata" {
+  value = data.vault_generic_secret_metadata.some_secret
+}
+
+output "custom_metadata" {
+  value = data.vault_generic_secret_metadata.some_secret.custom_metadata
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `path` - (Required) The full logical path from which to request data.
+To read data from the "generic" secret backend mounted in Vault by
+default, this should be prefixed with `secret/`. Reading from other backends
+with this data source is possible; consult each backend's documentation
+to see which endpoints support the `GET` method.
+
+## Required Vault Capabilities
+
+Use of this resource requires the `read` capability on the given path. (metadata)
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `cas_required` - Boolean. When `true`, writes will only be allowed if the key’s current 
+  version matches the version specified in the cas parameter.
+
+* `custom_metadata` - A map of strings. This map can only represent string data.
+
+* `delete_version_after` - String duration, Lifetime for a given version of a secret. eg. `17h23m12s`.
+ This string will be parsed with [ParseDuration](https://pkg.go.dev/time#ParseDuration)
+
+* `max_version` - Integer, maximum number of available versions
+
+* `lease_id` - The lease identifier assigned by Vault, if any.
+
+* `lease_duration` - The duration of the secret lease, in seconds relative
+to the time the data was requested. Once this time has passed any plan
+generated with this data may fail to apply.
+
+* `lease_start_time` - The date and time of Terraform execution.
+It is derived from the local machine's clock, and is
+recorded in RFC3339 format UTC.
+This can be used to approximate the absolute time represented by
+`lease_duration`, though users must allow for any clock drift and response
+latency relative to the Vault server. _Provided only as a convenience_.
+
+* `lease_renewable` - `true` if the lease can be renewed using Vault's
+`sys/renew/{lease-id}` endpoint. Terraform does not currently support lease
+renewal, and so it will request a new lease each time this data source is
+refreshed.
+  
+

--- a/website/docs/r/generic_secret_metadata.html.md
+++ b/website/docs/r/generic_secret_metadata.html.md
@@ -1,0 +1,82 @@
+---
+layout: "vault"
+page_title: "Vault: vault_generic_secret_metadata resource"
+sidebar_current: "docs-vault-resource-generic-secret-metadata"
+description: |- Set kvv2 secret's metadata for a given path in Vault
+---
+
+# vault\_generic\_secret\_metadata
+
+Writes and manages secrets metadata stored in a given path in the vault.
+
+This resource is solely intented to be used with kvv2 secret engine.
+[Vault's "generic" secret backend](https://www.vaultproject.io/docs/secrets/generic/index.html)
+kv version 2. In kv v1 there are no metadata.
+
+~> **Important** the `custom_metadata` metadata requires vault v1.9.0
+
+## Example Usage
+
+```hcl
+resource "vault_generic_secret" "example" {
+  path = "secret/foo"
+
+  data_json = jsonencode({
+    foo   = "bar",
+    pizza = "cheese"
+  })
+}
+
+resource "vault_generic_secret_metadata" "example" {
+  path = vault_generic_secret.example.path
+  
+  custom_metadata = {
+    owners   = "teamA"
+    some_key = "some_value"
+    blah     = "diblah"
+  }
+  
+  cas_required         = true
+  delete_version_after = "12h"
+  max_version          = 3
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `path` - (Required) The full logical path at which to write the given metadata. To write data into the "generic" secret
+  backend mounted in Vault by default, this should be prefixed with `secret/`. Writing to other backends with this
+  resource is not possible.
+
+* `cas_required` - (Optional) Boolean. When `true`, writes will only be allowed if the key’s current
+  version matches the version specified in the cas parameter. Default to `false` (vault's value)
+
+* `custom_metadata` - (Optional) A map of strings representing the `custom_metadata` metadata field.
+
+* `delete_version_after` - (Optional) A string representing a `time.Duration`. eg: `730h`. This string will be parsed 
+  with [ParseDuration](https://pkg.go.dev/time#ParseDuration). Lifetime for a secret's version
+
+* `max_version` - (Optional) A Integer representing the maximum number of version for a given secret. 
+  default to 0 (vault's value), unlimited
+
+## Required Vault Capabilities
+
+Use of this resource requires the `create` or `update` capability
+(depending on whether the resource already exists) on the given path, the `delete` capability if the resource is removed
+from configuration, and the `read` capability for drift detection (by default).
+
+### Drift Detection
+
+This resource does not necessarily need to *read* the secret data back from Terraform on refresh. To avoid the need
+for `read` access on the given path set the `disable_read` argument to `true`. This means that Terraform *will not*
+be able to detect and repair "drift" on this resource, should the data be updated or deleted outside of Terraform.
+
+## Import
+
+Generic secrets can be imported using the `path`, e.g.
+
+```
+$ terraform import vault_generic_secret_metadata.example secret/foo
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

Added support for kv-v2 secret's metadata:

* cas_required

* custom_metadata

* delete_version_after

* max_versions


Thought `cas_required` can be set (via the http api `options` block), none of the above settings could be set with the regular resources.

It might become handy to read/write the secret metadata, to set per secret these settings.


usage example:

_resource_ 
```hcl
resource "vault_generic_secret" "foo" {
  path          = "secrets/foo"
  data_json = jsonencode({"blah": "diblah"})
}

resource "vault_generic_secret_metadata" "foo" {
  path = vault_generic_secret.foo.path
  custom_metadata = {
    blah = "diblah"
    foo  = "bar"
  }
  cas_required         = true
  delete_version_after = "730h"
  max_versions         = 17
}
```
_data source_

```hcl
data "vault_generic_secret_metadata" "foo" {
  path = "secrets/foo"
}

output "foo_metadata" {
  value = vault_generic_secret_metadata.foo
}

output "foo_custom_metadata" "foo" {
  value = vault_generic_secret_metadata.foo.custom_metadata
}
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates to #491 to #1156

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* **New Resource** `vault_generic_secret_metadata`: Configure Vault's KVv2 secret metadata
* **New Data Source** `vault_generic_secret_metadata`: read Vault's KVv2 secret metadata
```

Output from acceptance testing:

```
$ ==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./...) -v -run=TestResourceGenericSecretMetadata -run=genericSecretMetadataDataSource -timeout 20m
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/codegen   0.359s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    0.299s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    0.980s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    0.899s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        0.480s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    0.687s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      1.177s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/util      0.264s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     0.739s [no tests to run]
```
