### PR TITLE
Add more configuration options for JWT Auth Backend

### DIFF
--- a/vault/resource_jwt_auth_backend.go
+++ b/vault/resource_jwt_auth_backend.go
@@ -158,7 +158,7 @@ func jwtAuthBackendResource() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     true,
-				Description: "Pass namespace in the OIDC state parameter instead of as a separate query parameter. With this setting, the allowed redirect URL(s) in Vault and on the provider side should not contain a namespace query parameter. This means only one redirect URL entry needs to be maintained on the provider side for all vault namespaces that will be authenticating against it. Defaults to true for new configs.",
+				Description: "Pass namespace in the OIDC state parameter instead of as a separate query parameter. With this setting, the allowed redirect URL(s) in Vault and on the provider side should not contain a namespace query parameter. This means only one redirect URL entry needs to be maintained on the OIDC provider side for all vault namespaces that will be authenticating against it. Defaults to true for new configs.",
 			},
 
 			"tune": authMountTuneSchema(),

--- a/vault/resource_jwt_auth_backend.go
+++ b/vault/resource_jwt_auth_backend.go
@@ -78,6 +78,19 @@ func jwtAuthBackendResource() *schema.Resource {
 				Description: "Client Secret used for OIDC",
 			},
 
+			"oidc_response_mode": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The response mode to be used in the OAuth2 request. Allowed values are 'query' and 'form_post'. Defaults to 'query'. If using Vault namespaces, and oidc_response_mode is 'form_post', then 'namespace_in_state' should be set to false.",
+			},
+
+			"oidc_response_types": {
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Optional:    true,
+				Description: "The response types to request. Allowed values are 'code' and 'id_token'. Defaults to 'code'. Note: 'id_token' may only be used if 'oidc_response_mode' is set to 'form_post'.",
+			},
+
 			"jwks_url": {
 				Type:          schema.TypeString,
 				Optional:      true,
@@ -123,6 +136,7 @@ func jwtAuthBackendResource() *schema.Resource {
 				Computed:    true,
 				Description: "The accessor of the JWT auth backend",
 			},
+
 			"local": {
 				Type:        schema.TypeBool,
 				ForceNew:    true,
@@ -130,6 +144,7 @@ func jwtAuthBackendResource() *schema.Resource {
 				Default:     false,
 				Description: "Specifies if the auth method is local only",
 			},
+
 			"provider_config": {
 				Type:        schema.TypeMap,
 				Optional:    true,
@@ -138,6 +153,14 @@ func jwtAuthBackendResource() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+
+			"namespace_in_state": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Pass namespace in the OIDC state parameter instead of as a separate query parameter. With this setting, the allowed redirect URL(s) in Vault and on the provider side should not contain a namespace query parameter. This means only one redirect URL entry needs to be maintained on the provider side for all vault namespaces that will be authenticating against it. Defaults to true for new configs.",
+			},
+
 			"tune": authMountTuneSchema(),
 		},
 	}
@@ -171,6 +194,8 @@ var (
 		"oidc_discovery_ca_pem",
 		"oidc_client_id",
 		"oidc_client_secret",
+		"oidc_response_mode",
+		"oidc_response_types",
 		"jwks_url",
 		"jwks_ca_pem",
 		"jwt_validation_pubkeys",
@@ -178,6 +203,7 @@ var (
 		"jwt_supported_algs",
 		"default_role",
 		"provider_config",
+		"namespace_in_state",
 	}
 )
 

--- a/vault/resource_jwt_auth_backend_test.go
+++ b/vault/resource_jwt_auth_backend_test.go
@@ -98,6 +98,9 @@ func TestAccJWTAuthBackend_OIDC(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_jwt_auth_backend.oidc", "bound_issuer", "api://default"),
 					resource.TestCheckResourceAttr("vault_jwt_auth_backend.oidc", "oidc_client_id", "client"),
 					resource.TestCheckResourceAttr("vault_jwt_auth_backend.oidc", "oidc_client_secret", "secret"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend.oidc", "oidc_response_mode", "query"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend.oidc", "oidc_response_types.#", "1"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend.oidc", "oidc_response_types.0", "code"),
 					resource.TestCheckResourceAttr("vault_jwt_auth_backend.oidc", "type", "oidc"),
 					resource.TestCheckResourceAttr("vault_jwt_auth_backend.oidc", "default_role", "api"),
 				),
@@ -201,6 +204,8 @@ resource "vault_jwt_auth_backend" "oidc" {
   path = "%s"
   type = "oidc"
   default_role = "api"
+  oidc_response_mode  = "query"
+  oidc_response_types = ["code"]
 }
 `, path)
 }

--- a/website/docs/r/jwt_auth_backend.html.md
+++ b/website/docs/r/jwt_auth_backend.html.md
@@ -77,6 +77,10 @@ The following arguments are supported:
 
 * `oidc_client_secret` - (Optional) Client Secret used for OIDC backends
 
+* `oidc_response_mode` - (Optional) The response mode to be used in the OAuth2 request. Allowed values are 'query' and 'form_post'. Defaults to 'query'. If using Vault namespaces, and oidc_response_mode is 'form_post', then 'namespace_in_state' should be set to false.
+
+* `oidc_response_types` - (Optional) List of response types to request. Allowed values are 'code' and 'id_token'. Defaults to `["code"]`. Note: 'id_token' may only be used if 'oidc_response_mode' is set to 'form_post'.
+
 * `jwks_url` - (Optional) JWKS URL to use to authenticate signatures. Cannot be used with "oidc_discovery_url" or "jwt_validation_pubkeys".
 
 * `jwks_ca_pem` - (Optional) The CA certificate or chain of certificates, in PEM format, to use to validate connections to the JWKS URL. If not set, system certificates are used.
@@ -92,6 +96,8 @@ The following arguments are supported:
 * `provider_config` - (Optional) Provider specific handling configuration. All values may be strings, and the provider will convert to the appropriate type when configuring Vault.
 
 * `local` - (Optional) Specifies if the auth method is local only.
+
+* `namespace_in_state` - (Optional) Pass namespace in the OIDC state parameter instead of as a separate query parameter. With this setting, the allowed redirect URL(s) in Vault and on the provider side should not contain a namespace query parameter. This means only one redirect URL entry needs to be maintained on the provider side for all vault namespaces that will be authenticating against it. Defaults to true for new configs
 
 * tune - (Optional) Extra configuration block. Structure is documented below.
 

--- a/website/docs/r/jwt_auth_backend.html.md
+++ b/website/docs/r/jwt_auth_backend.html.md
@@ -77,9 +77,9 @@ The following arguments are supported:
 
 * `oidc_client_secret` - (Optional) Client Secret used for OIDC backends
 
-* `oidc_response_mode` - (Optional) The response mode to be used in the OAuth2 request. Allowed values are 'query' and 'form_post'. Defaults to 'query'. If using Vault namespaces, and oidc_response_mode is 'form_post', then 'namespace_in_state' should be set to false.
+* `oidc_response_mode` - (Optional) The response mode to be used in the OAuth2 request. Allowed values are `query` and `form_post`. Defaults to `query`. If using Vault namespaces, and `oidc_response_mode` is `form_post`, then `namespace_in_state` should be set to `false`.
 
-* `oidc_response_types` - (Optional) List of response types to request. Allowed values are 'code' and 'id_token'. Defaults to `["code"]`. Note: 'id_token' may only be used if 'oidc_response_mode' is set to 'form_post'.
+* `oidc_response_types` - (Optional) List of response types to request. Allowed values are 'code' and 'id_token'. Defaults to `["code"]`. Note: `id_token` may only be used if `oidc_response_mode` is set to `form_post`.
 
 * `jwks_url` - (Optional) JWKS URL to use to authenticate signatures. Cannot be used with "oidc_discovery_url" or "jwt_validation_pubkeys".
 
@@ -97,7 +97,7 @@ The following arguments are supported:
 
 * `local` - (Optional) Specifies if the auth method is local only.
 
-* `namespace_in_state` - (Optional) Pass namespace in the OIDC state parameter instead of as a separate query parameter. With this setting, the allowed redirect URL(s) in Vault and on the provider side should not contain a namespace query parameter. This means only one redirect URL entry needs to be maintained on the provider side for all vault namespaces that will be authenticating against it. Defaults to true for new configs
+* `namespace_in_state` - (Optional) Pass namespace in the OIDC state parameter instead of as a separate query parameter. With this setting, the allowed redirect URL(s) in Vault and on the provider side should not contain a namespace query parameter. This means only one redirect URL entry needs to be maintained on the OIDC provider side for all vault namespaces that will be authenticating against it. Defaults to true for new configs
 
 * tune - (Optional) Extra configuration block. Structure is documented below.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
-  Add `oidc_response_mode`, `oidc_response_types`, and `namespace_in_state` fields to `vault_jwt_auth_backend`
```

Output from acceptance testing:

```
$ VAULT_ADDR=http://127.0.0.1:8200 VAULT_TOKEN=12345 TESTARGS="--run TestAccJWTAuthBackend" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./...) -v --run TestAccJWTAuthBackend -timeout 20m
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/codegen   (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    0.009s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    0.009s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    0.009s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        0.009s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    0.010s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      0.008s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
=== RUN   TestAccJWTAuthBackendRole_import
--- PASS: TestAccJWTAuthBackendRole_import (0.94s)
=== RUN   TestAccJWTAuthBackendRole_basic
--- PASS: TestAccJWTAuthBackendRole_basic (0.73s)
=== RUN   TestAccJWTAuthBackendRole_update
--- PASS: TestAccJWTAuthBackendRole_update (1.27s)
=== RUN   TestAccJWTAuthBackendRole_full
--- PASS: TestAccJWTAuthBackendRole_full (0.73s)
=== RUN   TestAccJWTAuthBackendRoleOIDC_full
--- PASS: TestAccJWTAuthBackendRoleOIDC_full (1.43s)
=== RUN   TestAccJWTAuthBackendRoleOIDC_disableParsing
--- PASS: TestAccJWTAuthBackendRoleOIDC_disableParsing (1.50s)
=== RUN   TestAccJWTAuthBackendRole_fullUpdate
--- PASS: TestAccJWTAuthBackendRole_fullUpdate (1.28s)
=== RUN   TestAccJWTAuthBackend
--- PASS: TestAccJWTAuthBackend (2.95s)
=== RUN   TestAccJWTAuthBackendProviderConfig
--- PASS: TestAccJWTAuthBackendProviderConfig (0.79s)
=== RUN   TestAccJWTAuthBackend_OIDC
--- PASS: TestAccJWTAuthBackend_OIDC (1.44s)
=== RUN   TestAccJWTAuthBackend_invalid
--- PASS: TestAccJWTAuthBackend_invalid (0.35s)
=== RUN   TestAccJWTAuthBackend_missingMandatory
--- PASS: TestAccJWTAuthBackend_missingMandatory (1.34s)
=== RUN   TestAccJWTAuthBackendProviderConfigConversionBool
--- PASS: TestAccJWTAuthBackendProviderConfigConversionBool (0.00s)
=== RUN   TestAccJWTAuthBackendProviderConfigConversionInt
--- PASS: TestAccJWTAuthBackendProviderConfigConversionInt (0.00s)
=== RUN   TestAccJWTAuthBackendProviderConfig_negative
    resource_jwt_auth_backend_test.go:379: true
--- SKIP: TestAccJWTAuthBackendProviderConfig_negative (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     14.758s

```
