### PR TITLE
Fix `nil` panic with `vault_identity_group_policies`

### DIFF
--- a/vault/resource_identity_group_policies.go
+++ b/vault/resource_identity_group_policies.go
@@ -117,7 +117,13 @@ func identityGroupPoliciesRead(d *schema.ResourceData, meta interface{}) error {
 	} else {
 		userPolicies := d.Get("policies").(*schema.Set).List()
 		newPolicies := make([]string, 0)
-		apiPolicies := resp.Data["policies"].([]interface{})
+
+		var apiPolicies []interface{}
+		if val, ok := resp.Data["policies"]; ok && val != nil {
+			apiPolicies = val.([]interface{})
+		} else {
+			apiPolicies = make([]interface{}, 0)
+		}
 
 		for _, policy := range userPolicies {
 			if found, _ := util.SliceHasElement(apiPolicies, policy); found {


### PR DESCRIPTION
Fixes the following possible panic

```
Stack trace from the terraform-provider-vault_v2.24.1_x4 plugin:

panic: interface conversion: interface {} is nil, not []interface {}

goroutine 166 [running]:
github.com/hashicorp/terraform-provider-vault/vault.identityGroupPoliciesRead(0xc000726b60, 0x119aa00, 0xc00071c640, 0xc000726b60, 0x0)
        /opt/teamcity-agent/work/5d79fe75d4460a2f/src/github.com/hashicorp/terraform-provider-vault/vault/resource_identity_group_policies.go:120 +0x9ac
github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Resource).RefreshWithoutUpgrade(0xc000278a20, 0xc000477220, 0x119aa00, 0xc00071c640, 0xc000738538, 0x0, 0x0)
        /opt/teamcity-agent/work/5d79fe75d4460a2f/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.9.0/helper/schema/resource.go:460 +0x12e
github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin.(*GRPCProviderServer).ReadResource(0xc000286020, 0x13c3450, 0xc0007d2570, 0xc000650d80, 0xc000286020, 0xc0007d2570, 0xc0002beba0)
        /opt/teamcity-agent/work/5d79fe75d4460a2f/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.9.0/internal/helper/plugin/grpc_provider.go:525 +0x3dd
github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5._Provider_ReadResource_Handler(0x1168220, 0xc000286020, 0x13c3450, 0xc0007d2570, 0xc000650d20, 0x0, 0x13c3450, 0xc0007d2570, 0xc0009d6410, 0xc5)
        /opt/teamcity-agent/work/5d79fe75d4460a2f/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.9.0/internal/tfplugin5/tfplugin5.pb.go:3269 +0x214
google.golang.org/grpc.(*Server).processUnaryRPC(0xc00079c340, 0x13ce238, 0xc000782c00, 0xc000438800, 0xc000117470, 0x19de4b0, 0x0, 0x0, 0x0)
        /opt/teamcity-agent/work/5d79fe75d4460a2f/pkg/mod/google.golang.org/grpc@v1.29.1/server.go:1082 +0x52b
google.golang.org/grpc.(*Server).handleStream(0xc00079c340, 0x13ce238, 0xc000782c00, 0xc000438800, 0x0)
        /opt/teamcity-agent/work/5d79fe75d4460a2f/pkg/mod/google.golang.org/grpc@v1.29.1/server.go:1405 +0xccf
google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc00028e170, 0xc00079c340, 0x13ce238, 0xc000782c00, 0xc000438800)
        /opt/teamcity-agent/work/5d79fe75d4460a2f/pkg/mod/google.golang.org/grpc@v1.29.1/server.go:746 +0xab
created by google.golang.org/grpc.(*Server).serveStreams.func1
        /opt/teamcity-agent/work/5d79fe75d4460a2f/pkg/mod/google.golang.org/grpc@v1.29.1/server.go:744 +0xa5

Error: The terraform-provider-vault_v2.24.1_x4 plugin crashed!
```

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix `nil` panic with `vault_identity_group_policies`
```

Output from acceptance testing:

```
$ VAULT_ADDR=http://127.0.0.1:8200 VAULT_TOKEN=12345 TESTARGS="--run TestAccIdentityGroup" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./...) -v --run TestAccIdentityGroup -timeout 20m
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/codegen   0.004s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    0.012s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    0.012s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    0.012s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        0.012s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    0.012s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      0.011s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/util      0.011s [no tests to run]
=== RUN   TestAccIdentityGroupAlias
--- PASS: TestAccIdentityGroupAlias (0.92s)
=== RUN   TestAccIdentityGroupAliasUpdate
--- PASS: TestAccIdentityGroupAliasUpdate (1.47s)
=== RUN   TestAccIdentityGroupMemberEntityIdsExclusiveEmpty
--- PASS: TestAccIdentityGroupMemberEntityIdsExclusiveEmpty (2.08s)
=== RUN   TestAccIdentityGroupMemberEntityIdsExclusive
    resource_identity_group_member_entity_ids_test.go:52: &{{{{0 0} 0 0 0 0} [] {0xc00061eb60} false false false false map[] map[] []  [] false 0xc0007ca0f0 false 0 0 testing.tRunner 0xc000602680 1 [5325710 5315362 5325375 5320605 16252171 4431335 4631809] TestAccIdentityGroupMemberEntityIdsExclusive {13862684127506463928 4474244901 0x1c1e380} 0 0xc0006fc180 0xc000e20070 [] {0 0}  <nil> 0} false false 0xc0007d20a0}
--- SKIP: TestAccIdentityGroupMemberEntityIdsExclusive (0.00s)
=== RUN   TestAccIdentityGroupMemberEntityIdsNonExclusiveEmpty
--- PASS: TestAccIdentityGroupMemberEntityIdsNonExclusiveEmpty (1.85s)
=== RUN   TestAccIdentityGroupMemberEntityIdsNonExclusive
    resource_identity_group_member_entity_ids_test.go:122: &{{{{0 0} 0 0 0 0} [] {0xc0003b9a00} false false false false map[] map[] []  [] false 0xc0007ca0f0 false 0 0 testing.tRunner 0xc000602680 1 [5325710 5315362 5325375 5320605 16252171 4431335 4631809] TestAccIdentityGroupMemberEntityIdsNonExclusive {13862684129506149876 6326447201 0x1c1e380} 0 0xc00027f020 0xc0000c4310 [] {0 0}  <nil> 0} false false 0xc0007d20a0}
--- SKIP: TestAccIdentityGroupMemberEntityIdsNonExclusive (0.00s)
=== RUN   TestAccIdentityGroupPoliciesExclusive
--- PASS: TestAccIdentityGroupPoliciesExclusive (1.25s)
=== RUN   TestAccIdentityGroupPoliciesNonExclusive
--- PASS: TestAccIdentityGroupPoliciesNonExclusive (1.48s)
=== RUN   TestAccIdentityGroup
--- PASS: TestAccIdentityGroup (0.69s)
=== RUN   TestAccIdentityGroupUpdate
--- PASS: TestAccIdentityGroupUpdate (3.18s)
=== RUN   TestAccIdentityGroupExternal
--- PASS: TestAccIdentityGroupExternal (0.69s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     13.616s
```
