### PR TITLE
r/rabbitmq_secret_backend_role - add support for `vhost_topics`

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,11 @@ services:
       VAULT_TOKEN: "TEST"
       MYSQL_URL: "vault:vault@tcp(mysql:3306)/"
 
+  rabbit:
+    image: rabbitmq:3.9.10-management-alpine
+    ports:
+      - "15672:15672"
+
   mysql:
     image: mysql:5.7
     command: --default-authentication-plugin=mysql_native_password

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,11 +13,6 @@ services:
       VAULT_TOKEN: "TEST"
       MYSQL_URL: "vault:vault@tcp(mysql:3306)/"
 
-  rabbit:
-    image: rabbitmq:3.9.10-management-alpine
-    ports:
-      - "15672:15672"
-
   mysql:
     image: mysql:5.7
     command: --default-authentication-plugin=mysql_native_password

--- a/vault/resource_rabbitmq_secret_backend_role.go
+++ b/vault/resource_rabbitmq_secret_backend_role.go
@@ -69,6 +69,44 @@ func rabbitmqSecretBackendRoleResource() *schema.Resource {
 					},
 				},
 			},
+			"vhost_topic": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Specifies a map of virtual hosts and exchanges to topic permissions. This option requires RabbitMQ 3.7.0 or later.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"vhost": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: "Specifies a map of virtual hosts to permissions.",
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"topic": {
+										Type:        schema.TypeString,
+										Required:    true,
+										Description: "The vhost to set permissions for.",
+									},
+									"read": {
+										Type:        schema.TypeString,
+										Required:    true,
+										Description: "The read permissions for this vhost.",
+									},
+									"write": {
+										Type:        schema.TypeString,
+										Required:    true,
+										Description: "The write permissions for this vhost.",
+									},
+								},
+							},
+						},
+						"host": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "The vhost to set permissions for.",
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -79,50 +117,29 @@ func rabbitmqSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) er
 	backend := d.Get("backend").(string)
 	name := d.Get("name").(string)
 	tags := d.Get("tags").(string)
-	vhost := d.Get("vhost").([]interface{})
 
-	log.Printf("[DEBUG] Vhosts as list from ResourceData: %+v", vhost)
-
-	vhosts := make(map[string]interface{}, len(vhost))
-
-	for _, host := range vhost {
-		h := map[string]interface{}{}
-		var id string
-		for k, v := range host.(map[string]interface{}) {
-			if k == "host" {
-				id = v.(string)
-				continue
-			}
-			h[k] = v
-		}
-		vhosts[id] = h
-	}
-
-	log.Printf("[DEBUG] vhosts after munging: %+v", vhosts)
-
-	vhostsJSON, err := json.Marshal(vhosts)
+	vhostsJSON, _, err := expandRabbitmqSecretBackendRoleVhost(d.Get("vhost").([]interface{}), "host")
 	if err != nil {
-		return fmt.Errorf("error serializing vhosts: %s", err)
+		return err
 	}
-
-	log.Printf("[DEBUG] vhosts as JSON: %+v", vhostsJSON)
+	vhostTopicsJSON, err := expandRabbitmqSecretBackendRoleVhostTopic(d.Get("vhost_topic").([]interface{}))
+	if err != nil {
+		return err
+	}
 
 	data := map[string]interface{}{
-		"tags":   tags,
-		"vhosts": string(vhostsJSON),
+		"tags":         tags,
+		"vhosts":       vhostsJSON,
+		"vhost_topics": vhostTopicsJSON,
 	}
 	log.Printf("[DEBUG] Creating role %q on Rabbitmq backend %q", name, backend)
 	_, err = client.Logical().Write(backend+"/roles/"+name, data)
 	if err != nil {
-		return fmt.Errorf("error creating role %q for backend %q: %s", name, backend, err)
+		return fmt.Errorf("error creating role %q for backend %q: %w", name, backend, err)
 	}
 	log.Printf("[DEBUG] Created role %q on Rabbitmq backend %q", name, backend)
 
 	d.SetId(backend + "/roles/" + name)
-	d.Set("name", name)
-	d.Set("tags", tags)
-	d.Set("vhost", vhost)
-	d.Set("backend", backend)
 	return rabbitmqSecretBackendRoleRead(d, meta)
 }
 
@@ -146,25 +163,19 @@ func rabbitmqSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) err
 		d.SetId("")
 		return nil
 	}
-	var vhosts []map[string]interface{}
-	if v, ok := secret.Data["vhosts"]; ok && v != nil {
-		hosts := v.(map[string]interface{})
-		for id, val := range hosts {
-			vals := val.(map[string]interface{})
-			vhosts = append(vhosts, map[string]interface{}{
-				"host":      id,
-				"configure": vals["configure"],
-				"write":     vals["write"],
-				"read":      vals["read"],
-			})
-		}
-	}
+
 	d.Set("tags", secret.Data["tags"])
-	if err := d.Set("vhost", vhosts); err != nil {
-		return fmt.Errorf("Error setting vhosts in state: %s", err)
-	}
 	d.Set("backend", strings.Join(pathPieces[:len(pathPieces)-2], "/"))
 	d.Set("name", pathPieces[len(pathPieces)-1])
+
+	if err := d.Set("vhost", flattenRabbitmqSecretBackendRoleVhost(secret.Data["vhosts"].(map[string]interface{}))); err != nil {
+		return fmt.Errorf("Error setting vhosts in state: %w", err)
+	}
+
+	if err := d.Set("vhost_topic", flattenRabbitmqSecretBackendRoleVhostTopics(secret.Data["vhost_topics"].(map[string]interface{}))); err != nil {
+		return fmt.Errorf("Error setting vhosts topics in state: %w", err)
+	}
+
 	return nil
 }
 
@@ -175,7 +186,7 @@ func rabbitmqSecretBackendRoleDelete(d *schema.ResourceData, meta interface{}) e
 	log.Printf("[DEBUG] Deleting role %q", path)
 	_, err := client.Logical().Delete(path)
 	if err != nil {
-		return fmt.Errorf("error deleting role %q: %s", path, err)
+		return fmt.Errorf("error deleting role %q: %w", path, err)
 	}
 	log.Printf("[DEBUG] Deleted role %q", path)
 	return nil
@@ -192,4 +203,109 @@ func rabbitmqSecretBackendRoleExists(d *schema.ResourceData, meta interface{}) (
 	}
 	log.Printf("[DEBUG] Checked if %q exists", path)
 	return secret != nil, nil
+}
+
+func expandRabbitmqSecretBackendRoleVhost(vhost []interface{}, typ string) (string, map[string]interface{}, error) {
+	log.Printf("[DEBUG] Vhosts as list from ResourceData: %+v", vhost)
+
+	vhosts := make(map[string]interface{}, len(vhost))
+
+	for _, host := range vhost {
+		h := map[string]interface{}{}
+		var id string
+		for k, v := range host.(map[string]interface{}) {
+			if k == typ {
+				id = v.(string)
+				continue
+			}
+			h[k] = v
+		}
+		vhosts[id] = h
+	}
+
+	log.Printf("[DEBUG] vhosts after munging: %+v", vhosts)
+
+	vhostsJSON, err := json.Marshal(vhosts)
+	if err != nil {
+		return "", nil, fmt.Errorf("error serializing vhosts: %w", err)
+	}
+
+	log.Printf("[DEBUG] vhosts as JSON: %+v", string(vhostsJSON))
+
+	return string(vhostsJSON), vhosts, nil
+}
+
+func expandRabbitmqSecretBackendRoleVhostTopic(vhost []interface{}) (string, error) {
+	log.Printf("[DEBUG] Vhosts as list from ResourceData: %+v", vhost)
+
+	vhosts := make(map[string]interface{}, len(vhost))
+
+	for _, host := range vhost {
+		vv := host.(map[string]interface{})
+		id := vv["host"].(string)
+
+		_, topics, err := expandRabbitmqSecretBackendRoleVhost(vv["vhost"].([]interface{}), "topic")
+		if err != nil {
+			return "", err
+		}
+
+		vhosts[id] = topics
+	}
+
+	log.Printf("[DEBUG] vhost topics after munging: %+v", vhosts)
+
+	vhostsJSON, err := json.Marshal(vhosts)
+	if err != nil {
+		return "", fmt.Errorf("error serializing vhosts: %w", err)
+	}
+
+	log.Printf("[DEBUG] vhost topics as JSON: %+v", string(vhostsJSON))
+
+	return string(vhostsJSON), nil
+}
+
+func flattenRabbitmqSecretBackendRoleVhost(vhost map[string]interface{}) []map[string]interface{} {
+	var vhosts []map[string]interface{}
+	for id, val := range vhost {
+		vals := val.(map[string]interface{})
+		vhosts = append(vhosts, map[string]interface{}{
+			"host":      id,
+			"configure": vals["configure"],
+			"write":     vals["write"],
+			"read":      vals["read"],
+		})
+	}
+
+	return vhosts
+}
+
+func flattenRabbitmqSecretBackendRoleVhostTopics(vhostTopic map[string]interface{}) []map[string]interface{} {
+	var vhostTopics []map[string]interface{}
+	for id, val := range vhostTopic {
+		vals := val.(map[string]interface{})
+
+		log.Printf("lol: %+v", vals)
+		log.Printf("lol2: %+v", id)
+
+		vhostTopics = append(vhostTopics, map[string]interface{}{
+			"host":  id,
+			"vhost": flattenRabbitmqSecretBackendRoleVhostTopic(vals),
+		})
+	}
+
+	return vhostTopics
+}
+
+func flattenRabbitmqSecretBackendRoleVhostTopic(topic map[string]interface{}) []map[string]interface{} {
+	var topics []map[string]interface{}
+	for id, val := range topic {
+		vals := val.(map[string]interface{})
+		topics = append(topics, map[string]interface{}{
+			"topic": id,
+			"write": vals["write"],
+			"read":  vals["read"],
+		})
+	}
+
+	return topics
 }

--- a/vault/resource_rabbitmq_secret_backend_role_test.go
+++ b/vault/resource_rabbitmq_secret_backend_role_test.go
@@ -111,7 +111,7 @@ func TestAccRabbitmqSecretBackendRole_topic(t *testing.T) {
 	connectionUri, username, password := testutil.GetTestRMQCreds(t)
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
-		PreCheck:     func() { testutil.testAccPreCheck(t) },
+		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		CheckDestroy: testAccRabbitmqSecretBackendRoleCheckDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/vault/resource_rabbitmq_secret_backend_role_test.go
+++ b/vault/resource_rabbitmq_secret_backend_role_test.go
@@ -21,6 +21,7 @@ const (
 func TestAccRabbitmqSecretBackendRole_basic(t *testing.T) {
 	backend := acctest.RandomWithPrefix("tf-test-rabbitmq")
 	name := acctest.RandomWithPrefix("tf-test-rabbitmq")
+	resourceName := "vault_rabbitmq_secret_backend_role.test"
 	connectionUri, username, password := testutil.GetTestRMQCreds(t)
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
@@ -30,56 +31,31 @@ func TestAccRabbitmqSecretBackendRole_basic(t *testing.T) {
 			{
 				Config: testAccRabbitmqSecretBackendRoleConfig_basic(name, backend, connectionUri, username, password),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "name", fmt.Sprintf("%s", name)),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "tags", testAccRabbitmqSecretBackendRoleTags_basic),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "vhost.0.host", "/"),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "vhost.0.configure", ""),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "vhost.0.read", ".*"),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "vhost.0.write", ""),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s", name)),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "tags", testAccRabbitmqSecretBackendRoleTags_basic),
+					resource.TestCheckResourceAttr(resourceName, "vhost.0.host", "/"),
+					resource.TestCheckResourceAttr(resourceName, "vhost.0.configure", ""),
+					resource.TestCheckResourceAttr(resourceName, "vhost.0.read", ".*"),
+					resource.TestCheckResourceAttr(resourceName, "vhost.0.write", ""),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccRabbitmqSecretBackendRoleConfig_updated(name, backend, connectionUri, username, password),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "name", fmt.Sprintf("%s", name)),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "tags", testAccRabbitmqSecretBackendRoleTags_updated),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "vhost.0.host", "/"),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "vhost.0.configure", ".*"),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "vhost.0.read", ".*"),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "vhost.0.write", ".*"),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s", name)),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "tags", testAccRabbitmqSecretBackendRoleTags_updated),
+					resource.TestCheckResourceAttr(resourceName, "vhost.0.host", "/"),
+					resource.TestCheckResourceAttr(resourceName, "vhost.0.configure", ".*"),
+					resource.TestCheckResourceAttr(resourceName, "vhost.0.read", ".*"),
+					resource.TestCheckResourceAttr(resourceName, "vhost.0.write", ".*"),
 				),
-			},
-		},
-	})
-}
-
-func TestAccRabbitmqSecretBackendRole_import(t *testing.T) {
-	backend := acctest.RandomWithPrefix("tf-test-rabbitmq")
-	name := acctest.RandomWithPrefix("tf-test-rabbitmq")
-	connectionUri, username, password := testutil.GetTestRMQCreds(t)
-	resource.Test(t, resource.TestCase{
-		Providers:    testProviders,
-		PreCheck:     func() { testutil.TestAccPreCheck(t) },
-		CheckDestroy: testAccRabbitmqSecretBackendRoleCheckDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccRabbitmqSecretBackendRoleConfig_basic(name, backend, connectionUri, username, password),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "name", fmt.Sprintf("%s", name)),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "tags", testAccRabbitmqSecretBackendRoleTags_basic),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "vhost.0.host", "/"),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "vhost.0.configure", ""),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "vhost.0.read", ".*"),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "vhost.0.write", ""),
-				),
-			},
-			{
-				ResourceName:      "vault_rabbitmq_secret_backend_role.test",
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})
@@ -88,6 +64,7 @@ func TestAccRabbitmqSecretBackendRole_import(t *testing.T) {
 func TestAccRabbitmqSecretBackendRole_nested(t *testing.T) {
 	backend := acctest.RandomWithPrefix("tf-test-rabbitmq")
 	name := acctest.RandomWithPrefix("tf-test-rabbitmq")
+	resourceName := "vault_rabbitmq_secret_backend_role.test"
 	connectionUri, username, password := testutil.GetTestRMQCreds(t)
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
@@ -97,25 +74,77 @@ func TestAccRabbitmqSecretBackendRole_nested(t *testing.T) {
 			{
 				Config: testAccRabbitmqSecretBackendRoleConfig_basic(name, backend, connectionUri, username, password),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "name", fmt.Sprintf("%s", name)),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "tags", testAccRabbitmqSecretBackendRoleTags_basic),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "vhost.0.host", "/"),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "vhost.0.configure", ""),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "vhost.0.read", ".*"),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "vhost.0.write", ""),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s", name)),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "tags", testAccRabbitmqSecretBackendRoleTags_basic),
+					resource.TestCheckResourceAttr(resourceName, "vhost.0.host", "/"),
+					resource.TestCheckResourceAttr(resourceName, "vhost.0.configure", ""),
+					resource.TestCheckResourceAttr(resourceName, "vhost.0.read", ".*"),
+					resource.TestCheckResourceAttr(resourceName, "vhost.0.write", ""),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccRabbitmqSecretBackendRoleConfig_updated(name, backend, connectionUri, username, password),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "name", fmt.Sprintf("%s", name)),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "tags", testAccRabbitmqSecretBackendRoleTags_updated),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "vhost.0.host", "/"),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "vhost.0.configure", ".*"),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "vhost.0.read", ".*"),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend_role.test", "vhost.0.write", ".*"),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s", name)),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "tags", testAccRabbitmqSecretBackendRoleTags_updated),
+					resource.TestCheckResourceAttr(resourceName, "vhost.0.host", "/"),
+					resource.TestCheckResourceAttr(resourceName, "vhost.0.configure", ".*"),
+					resource.TestCheckResourceAttr(resourceName, "vhost.0.read", ".*"),
+					resource.TestCheckResourceAttr(resourceName, "vhost.0.write", ".*"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRabbitmqSecretBackendRole_topic(t *testing.T) {
+	backend := acctest.RandomWithPrefix("tf-test-rabbitmq")
+	name := acctest.RandomWithPrefix("tf-test-rabbitmq")
+	resourceName := "vault_rabbitmq_secret_backend_role.test"
+	connectionUri, username, password := testutil.GetTestRMQCreds(t)
+	resource.Test(t, resource.TestCase{
+		Providers:    testProviders,
+		PreCheck:     func() { testutil.testAccPreCheck(t) },
+		CheckDestroy: testAccRabbitmqSecretBackendRoleCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRabbitmqSecretBackendRoleConfig_topics(name, backend, connectionUri, username, password),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s", name)),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "tags", testAccRabbitmqSecretBackendRoleTags_basic),
+					resource.TestCheckResourceAttr(resourceName, "vhost_topic.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vhost_topic.0.host", "/"),
+					resource.TestCheckResourceAttr(resourceName, "vhost_topic.0.vhost.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vhost_topic.0.vhost.0.topic", "amq.topic"),
+					resource.TestCheckResourceAttr(resourceName, "vhost_topic.0.vhost.0.read", ".*"),
+					resource.TestCheckResourceAttr(resourceName, "vhost_topic.0.vhost.0.write", ""),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccRabbitmqSecretBackendRoleConfig_topicUpdated(name, backend, connectionUri, username, password),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s", name)),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "tags", testAccRabbitmqSecretBackendRoleTags_updated),
+					resource.TestCheckResourceAttr(resourceName, "vhost_topic.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vhost_topic.0.host", "/"),
+					resource.TestCheckResourceAttr(resourceName, "vhost_topic.0.vhost.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "vhost_topic.0.vhost.0.topic", "amq.topic"),
+					resource.TestCheckResourceAttr(resourceName, "vhost_topic.0.vhost.0.read", ""),
+					resource.TestCheckResourceAttr(resourceName, "vhost_topic.0.vhost.0.write", ".*"),
 				),
 			},
 		},
@@ -187,6 +216,65 @@ resource "vault_rabbitmq_secret_backend_role" "test" {
     configure = ".*"
     read = ".*"
     write = ".*"
+  }
+}
+`, path, connectionUri, username, password, name, testAccRabbitmqSecretBackendRoleTags_updated)
+}
+
+func testAccRabbitmqSecretBackendRoleConfig_topics(name, path, connectionUri, username, password string) string {
+	return fmt.Sprintf(`
+resource "vault_rabbitmq_secret_backend" "test" {
+  path = "%s"
+  description = "test description"
+  default_lease_ttl_seconds = 3600
+  max_lease_ttl_seconds = 86400
+  connection_uri = "%s"
+  username = "%s"
+  password = "%s"
+}
+
+resource "vault_rabbitmq_secret_backend_role" "test" {
+  backend = vault_rabbitmq_secret_backend.test.path
+  name = "%s"
+  tags = %q
+    
+  vhost_topic {
+    vhost {
+		topic = "amq.topic"
+		read = ".*"
+		write = ""
+	}
+	
+	host = "/"
+  }
+}
+`, path, connectionUri, username, password, name, testAccRabbitmqSecretBackendRoleTags_basic)
+}
+
+func testAccRabbitmqSecretBackendRoleConfig_topicUpdated(name, path, connectionUri, username, password string) string {
+	return fmt.Sprintf(`
+resource "vault_rabbitmq_secret_backend" "test" {
+  path = "%s"
+  description = "test description"
+  default_lease_ttl_seconds = 1800
+  max_lease_ttl_seconds = 43200
+  connection_uri = "%s"
+  username = "%s"
+  password = "%s"
+}
+
+resource "vault_rabbitmq_secret_backend_role" "test" {
+  backend = vault_rabbitmq_secret_backend.test.path
+  name = "%s"
+  tags = %q
+  vhost_topic {
+    vhost {
+		topic = "amq.topic"
+		read = ""
+		write = ".*"
+	}
+	
+	host = "/"
   }
 }
 `, path, connectionUri, username, password, name, testAccRabbitmqSecretBackendRoleTags_updated)

--- a/website/docs/r/rabbitmq_secret_backend_role.html.md
+++ b/website/docs/r/rabbitmq_secret_backend_role.html.md
@@ -32,11 +32,22 @@ resource "vault_rabbitmq_secret_backend_role" "role" {
   name    = "deploy"
 
   tags = "tag1,tag2"
+
   vhost {
-    host      = "/"
-    configure = ".*"
-    write     = ".*"
-    read      = ".*"
+    host = "/"
+    configure = ""
+    read = ".*"
+    write = ""
+  }
+
+  vhost_topic {
+    vhost {
+      topic = "amq.topic"
+      read = ".*"
+      write = ""
+    }
+
+    host = "/"
   }
 }
 ```
@@ -54,6 +65,8 @@ Must be unique within the backend.
 * `tags` - (Optional) Specifies a comma-separated RabbitMQ management tags.
 
 * `vhost` - (Optional) Specifies a map of virtual hosts to permissions.
+
+* `vhost topics` - (Optional) Specifies a map of virtual hosts and exchanges to topic permissions. This option requires RabbitMQ 3.7.0 or later.
 
 ## Attributes Reference
 

--- a/website/docs/r/rabbitmq_secret_backend_role.html.md
+++ b/website/docs/r/rabbitmq_secret_backend_role.html.md
@@ -66,7 +66,7 @@ Must be unique within the backend.
 
 * `vhost` - (Optional) Specifies a map of virtual hosts to permissions.
 
-* `vhost topics` - (Optional) Specifies a map of virtual hosts and exchanges to topic permissions. This option requires RabbitMQ 3.7.0 or later.
+* `vhost_topic` - (Optional) Specifies a map of virtual hosts and exchanges to topic permissions. This option requires RabbitMQ 3.7.0 or later.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/rabbitmq_secret_backend_role - add support for `vhost_topics`
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccRabbitmqSecretBackendRole_'
--- PASS: TestAccRabbitmqSecretBackendRole_basic (53.22s)
--- PASS: TestAccRabbitmqSecretBackendRole_nested (48.46s)
--- PASS: TestAccRabbitmqSecretBackendRole_topic (56.39s)
```
