### PR TITLE
Add the aws_auth_backend_config_identity resource

### DIFF
--- a/vault/provider.go
+++ b/vault/provider.go
@@ -332,6 +332,10 @@ var (
 			Resource:      awsAuthBackendClientResource(),
 			PathInventory: []string{"/auth/aws/config/client"},
 		},
+		"vault_aws_auth_backend_config_identity": {
+			Resource:      awsAuthBackendConfigIdentityResource(),
+			PathInventory: []string{"/auth/aws/config/identity"},
+		},
 		"vault_aws_auth_backend_identity_whitelist": {
 			Resource:      awsAuthBackendIdentityWhitelistResource(),
 			PathInventory: []string{"/auth/aws/config/tidy/identity-whitelist"},

--- a/vault/resource_aws_auth_backend_config_identity.go
+++ b/vault/resource_aws_auth_backend_config_identity.go
@@ -1,0 +1,175 @@
+package vault
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-vault/util"
+	"github.com/hashicorp/vault/api"
+)
+
+var (
+	awsAuthBackendConfigIdentityBackendFromPathRegex = regexp.MustCompile("^auth/(.+)/config/identity$")
+)
+
+func awsAuthBackendConfigIdentityResource() *schema.Resource {
+	return &schema.Resource{
+		Create: awsAuthBackendConfigIdentityWrite,
+		Update: awsAuthBackendConfigIdentityWrite,
+		Read:   awsAuthBackendConfigIdentityRead,
+		Delete: awsAuthBackendConfigIdentityDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"iam_alias": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "role_id",
+				Description:  "How to generate the identity alias when using the iam auth method.",
+				ValidateFunc: validation.StringInSlice([]string{"role_id", "unique_id", "full_arn"}, false),
+			},
+			"iam_metadata": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "The metadata to include on the token returned by the login endpoint.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"ec2_alias": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "Configures how to generate the identity alias when using the ec2 auth method.",
+				Default:      "role_id",
+				ValidateFunc: validation.StringInSlice([]string{"role_id", "instance_id", "image_id"}, false),
+			},
+			"ec2_metadata": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "The metadata to include on the token returned by the login endpoint.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"backend": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Unique name of the auth backend to configure.",
+				ForceNew:    true,
+				Default:     "aws",
+				// standardise on no beginning or trailing slashes
+				StateFunc: func(v interface{}) string {
+					return strings.Trim(v.(string), "/")
+				},
+			},
+		},
+	}
+}
+
+func awsAuthBackendConfigIdentityWrite(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	var iamMetadata, ec2Metadata []string
+	backend := d.Get("backend").(string)
+	iamAlias := d.Get("iam_alias").(string)
+	ec2Alias := d.Get("ec2_alias").(string)
+
+	if iamMetadataConfig, ok := d.GetOk("iam_metadata"); ok {
+		iamMetadata = util.TerraformSetToStringArray(iamMetadataConfig)
+	}
+
+	if ec2MetadataConfig, ok := d.GetOk("ec2_metadata"); ok {
+		ec2Metadata = util.TerraformSetToStringArray(ec2MetadataConfig)
+	}
+
+	path := awsAuthBackendConfigIdentityPath(backend)
+	data := map[string]interface{}{
+		"iam_alias":    iamAlias,
+		"iam_metadata": iamMetadata,
+		"ec2_alias":    ec2Alias,
+		"ec2_metadata": ec2Metadata,
+	}
+
+	log.Printf("[DEBUG] Writing AWS identity config to %q", path)
+	_, err := client.Logical().Write(path, data)
+
+	if err != nil {
+		return fmt.Errorf("error configuring AWS auth identity config %q: %s", path, err)
+	}
+	d.SetId(path)
+
+	log.Printf("[DEBUG] Wrote AWS identity config to %q", path)
+
+	return awsAuthBackendConfigIdentityRead(d, meta)
+}
+
+func awsAuthBackendConfigIdentityRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	path := d.Id()
+
+	backend, err := awsAuthBackendConfigIdentityBackendFromPath(path)
+	if err != nil {
+		return fmt.Errorf("invalid path %q for AWS auth identity config:  %s", path, err)
+	}
+
+	log.Printf("[DEBUG] Reading identity config %q from AWS auth backend", path)
+	resp, err := client.Logical().Read(path)
+	if err != nil {
+		return fmt.Errorf("error reading AWS auth backend identity config %q: %s", path, err)
+	}
+	log.Printf("[DEBUG] Read identity config %q from AWS auth backend", path)
+	if resp == nil {
+		log.Printf("[WARN] AWS auth backend identity config %q not found, removing it from state", path)
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("iam_alias", resp.Data["iam_alias"])
+	d.Set("iam_metadata", resp.Data["iam_metadata"])
+	d.Set("ec2_alias", resp.Data["ec2_alias"])
+	d.Set("ec2_metadata", resp.Data["ec2_metadata"])
+	d.Set("backend", backend)
+
+	return nil
+}
+
+func awsAuthBackendConfigIdentityDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Deleting AWS identity config from state file")
+	return nil
+}
+
+func awsAuthBackendConfigIdentityExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	client := meta.(*api.Client)
+
+	path := d.Id()
+
+	log.Printf("[DEBUG] Checking if identity config %q exists in AWS auth backend", path)
+	resp, err := client.Logical().Read(path)
+	if err != nil {
+		return true, fmt.Errorf("error checking for existence of AWS auth backend identity config %q: %s", path, err)
+	}
+	log.Printf("[DEBUG] Checked if identity config %q exists in AWS auth backend", path)
+	return resp != nil, nil
+}
+
+func awsAuthBackendConfigIdentityPath(backend string) string {
+	return "auth/" + strings.Trim(backend, "/") + "/config/identity"
+}
+
+func awsAuthBackendConfigIdentityBackendFromPath(path string) (string, error) {
+	if !awsAuthBackendConfigIdentityBackendFromPathRegex.MatchString(path) {
+		return "", fmt.Errorf("no backend found")
+	}
+	res := awsAuthBackendConfigIdentityBackendFromPathRegex.FindStringSubmatch(path)
+	if len(res) != 2 {
+		return "", fmt.Errorf("unexpected number of matches (%d) for backend", len(res))
+	}
+	return res[1], nil
+}

--- a/vault/resource_aws_auth_backend_config_identity_test.go
+++ b/vault/resource_aws_auth_backend_config_identity_test.go
@@ -1,0 +1,156 @@
+package vault
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/vault/api"
+)
+
+func TestAccAwsAuthBackendConfigIdentity_import(t *testing.T) {
+	backend := acctest.RandomWithPrefix("aws")
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckAwsAuthBackendConfigIdentityDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsAuthBackendConfigIdentity_basic(backend),
+				Check:  testAccAwsAuthBackendConfigIdentityCheck_attrs(backend),
+			},
+			{
+				ResourceName:      "vault_aws_auth_backend_config_identity.config",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsAuthBackendConfigIdentity_basic(t *testing.T) {
+	backend := acctest.RandomWithPrefix("aws")
+	resource.Test(t, resource.TestCase{
+		Providers:    testProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckAwsAuthBackendConfigIdentityDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsAuthBackendConfigIdentity_basic(backend),
+				Check:  testAccAwsAuthBackendConfigIdentityCheck_attrs(backend),
+			},
+			{
+				Config: testAccAwsAuthBackendConfigIdentity_updated(backend),
+				Check:  testAccAwsAuthBackendConfigIdentityCheck_attrs(backend),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsAuthBackendConfigIdentityDestroy(s *terraform.State) error {
+	config := testProvider.Meta().(*api.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "vault_aws_auth_backend_config_identity" {
+			continue
+		}
+		secret, err := config.Logical().Read(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error checking for AWS auth backend %q config: %s", rs.Primary.ID, err)
+		}
+		if secret != nil {
+			return fmt.Errorf("AWS auth backend %q still configured", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testAccAwsAuthBackendConfigIdentity_basic(backend string) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "aws" {
+  type = "aws"
+  path = "%s"
+  description = "Test auth backend for AWS backend config"
+}
+
+resource "vault_aws_auth_backend_config_identity" "config" {
+  backend = vault_auth_backend.aws.path
+  iam_alias = "unique_id"
+  iam_metadata = ["inferred_aws_region", "client_arn"]
+}
+`, backend)
+}
+
+func testAccAwsAuthBackendConfigIdentityCheck_attrs(backend string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourceState := s.Modules[0].Resources["vault_aws_auth_backend_config_identity.config"]
+		if resourceState == nil {
+			return fmt.Errorf("resource not found in state")
+		}
+
+		instanceState := resourceState.Primary
+		if instanceState == nil {
+			return fmt.Errorf("resource has no primary instance")
+		}
+
+		endpoint := instanceState.ID
+
+		if endpoint != "auth/"+backend+"/config/identity" {
+			return fmt.Errorf("expected ID to be %q, got %q", "auth/"+backend+"/config/identity", endpoint)
+		}
+
+		config := testProvider.Meta().(*api.Client)
+		resp, err := config.Logical().Read(endpoint)
+		if err != nil {
+			return fmt.Errorf("error reading back AWS auth identity config from %q: %s", endpoint, err)
+		}
+		if resp == nil {
+			return fmt.Errorf("AWS auth not configured at %q", endpoint)
+		}
+		attrs := map[string]string{
+			"iam_alias":    "iam_alias",
+			"iam_metadata": "iam_metadata",
+			"ec2_alias":    "ec2_alias",
+			"ec2_metadata": "ec2_metadata",
+		}
+		for stateAttr, apiAttr := range attrs {
+			if resp.Data[apiAttr] == nil && instanceState.Attributes[stateAttr] == "" {
+				continue
+			}
+
+			if stateStringVal, ok := instanceState.Attributes[stateAttr]; ok {
+				if resp.Data[apiAttr] != stateStringVal {
+					return fmt.Errorf("expected %s (%s) of %q to be %q, got %q", apiAttr, stateAttr, endpoint, stateStringVal, resp.Data[apiAttr])
+				}
+			} else if listLength, ok := instanceState.Attributes[stateAttr+".#"]; ok {
+				compLen, _ := strconv.Atoi(listLength)
+				for i := 0; i < compLen; i++ {
+					stateVal := instanceState.Attributes[fmt.Sprintf("%s.%d", stateAttr, i)]
+					respVal := resp.Data[apiAttr].([]interface{})[i]
+					if respVal != stateVal {
+						return fmt.Errorf("expected %s (%s) of %q to be %q, got %q", apiAttr, stateAttr, endpoint, stateVal, respVal)
+					}
+				}
+			}
+		}
+		return nil
+	}
+}
+
+func testAccAwsAuthBackendConfigIdentity_updated(backend string) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "aws" {
+  path = "%s"
+  type = "aws"
+  description = "Test auth backend for AWS backend config"
+}
+
+resource "vault_aws_auth_backend_config_identity" "config" {
+  backend = vault_auth_backend.aws.path
+  iam_alias = "full_arn"
+  iam_metadata = ["client_user_id"]
+}`, backend)
+}

--- a/website/docs/r/aws_auth_backend_config_identity.html.md
+++ b/website/docs/r/aws_auth_backend_config_identity.html.md
@@ -1,0 +1,55 @@
+---
+layout: "vault"
+page_title: "Vault: vault_aws_auth_backend_config_identity resource"
+sidebar_current: "docs-vault-resource-aws-auth-backend-config-identity"
+description: |-
+  Manages AWS auth backend identity configuration in Vault.
+---
+
+# vault\_aws\_auth\_backend\_config_identity
+
+Manages an AWS auth backend identity configuration in a Vault server. This configuration defines how Vault interacts
+with the identity store. See the [Vault documentation](https://www.vaultproject.io/docs/auth/aws.html) for more
+information.
+
+## Example Usage
+
+```hcl
+resource "vault_auth_backend" "aws" {
+  type = "aws"
+}
+
+resource "vault_aws_auth_backend_config_identity" "example" {
+  backend      = vault_auth_backend.aws.path
+  iam_alias    = "full_arn"
+  iam_metadata = ["canonical_arn", "account_id"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `iam_alias` - (Optional) How to generate the identity alias when using the iam auth method. Valid choices are
+  `role_id`, `unique_id`, and `full_arn`. Defaults to `role_id`
+
+* `iam_metadata` - (Optional) The metadata to include on the token returned by the `login` endpoint. This metadata will be
+  added to both audit logs, and on the `iam_alias`
+
+* `ec2_alias` - (Optional) How to generate the identity alias when using the ec2 auth method. Valid choices are
+  `role_id`, `instance_id`, and `image_id`. Defaults to `role_id`
+
+* `ec2_metadata` - (Optional) The metadata to include on the token returned by the `login` endpoint. This metadata will be
+  added to both audit logs, and on the `ec2_alias`
+
+## Attributes Reference
+
+No additional attributes are exported by this resource.
+
+## Import
+
+AWS auth backend identity config can be imported using `auth/`, the `backend` path, and `/config/identity` e.g.
+
+```
+$ terraform import vault_aws_auth_backend_role.example auth/aws/config/identity
+```

--- a/website/vault.erb
+++ b/website/vault.erb
@@ -110,6 +110,10 @@
                             <a href="/docs/providers/vault/r/aws_auth_backend_client.html">vault_aws_auth_backend_client</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-vault-resource-aws-auth-backend-config-identity") %>>
+                            <a href="/docs/providers/vault/r/aws_auth_backend_config_identity.html">vault_aws_auth_backend_config_identity</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-vault-resource-aws-auth-backend-identity-whitelist") %>>
                             <a href="/docs/providers/vault/r/aws_auth_backend_identity_whitelist.html">vault_aws_auth_backend_identity_whitelist</a>
                         </li>


### PR DESCRIPTION
This change introduces the `aws_auth_backend_config_identity` resource so that users can configure the way the AWS auth backend interacts with the Identity store.


<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #733 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`resource/aws_auth_backend_config_identity`: Configure how Vault interacts with the Identity store for AWS authentication
```

Output from acceptance testing:

```
$ TESTARGS="--run TestAccAwsAuthBackendConfigIdentity" make testacc
...
=== RUN   TestAccAwsAuthBackendConfigIdentity_import
--- PASS: TestAccAwsAuthBackendConfigIdentity_import (42.78s)
=== RUN   TestAccAwsAuthBackendConfigIdentity_basic
--- PASS: TestAccAwsAuthBackendConfigIdentity_basic (50.16s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     94.278s
```