### PR TITLE
Add username_template support for mongodbatlas in database_secret_backend_connection

### DIFF
--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -276,6 +276,11 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 							Required:    true,
 							Description: "The Project ID the Database User should be created within.",
 						},
+						"username_template": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Username generation template.",
+						},
 					},
 				},
 				MaxItems:      1,
@@ -545,6 +550,9 @@ func getDatabaseAPIData(d *schema.ResourceData) (map[string]interface{}, error) 
 		}
 		if v, ok := d.GetOk("mongodbatlas.0.project_id"); ok {
 			data["project_id"] = v.(string)
+		}
+		if v, ok := d.GetOkExists("mongodbatlas.0.username_template"); ok {
+			data["username_template"] = v.(string)
 		}
 	case "mssql-database-plugin":
 		setDatabaseConnectionData(d, "mssql.0.", data)

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -1010,6 +1010,9 @@ func databaseSecretBackendConnectionRead(d *schema.ResourceData, meta interface{
 			if v, ok := data["project_id"]; ok {
 				result["project_id"] = v.(string)
 			}
+			if v, ok := data["username_template"]; ok {
+				result["username_template"] = v.(string)
+			}
 			d.Set("mongodbatlas", []map[string]interface{}{result})
 		}
 	case "mssql-database-plugin":

--- a/website/docs/r/database_secret_backend_connection.md
+++ b/website/docs/r/database_secret_backend_connection.md
@@ -158,6 +158,10 @@ See the [Vault
 
 * `project_id` - (Required) The Project ID the Database User should be created within.
 
+* `username_template` - (Optional) For Vault v1.7+. The template to use for username generation.
+See the [Vault
+  docs](https://www.vaultproject.io/docs/concepts/username-templating)
+
 
 ### SAP HanaDB Configuration Options
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

This change adds `username_template` field to mongodbatlas block in `vault_database_secret_backend_connection` resource. 

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1240

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add username_template to vault_database_secret_backend_connection for mongodbatlas block
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./...) -v -run=TestAccXXX -timeout 20m
?   	github.com/hashicorp/terraform-provider-vault	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/generate	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/codegen	0.369s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/generated	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode	0.927s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode	1.451s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet	0.664s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role	1.190s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template	0.352s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation	1.740s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/helper	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/schema	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/util	0.602s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/vault	1.469s [no tests to run]
...
```
