### PR TITLE
Encrypt logged HTTP secret header values.

### DIFF
--- a/helper/transport.go
+++ b/helper/transport.go
@@ -1,0 +1,70 @@
+package logging
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"strings"
+)
+
+type transport struct {
+	name      string
+	transport http.RoundTripper
+}
+
+func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if IsDebugOrHigher() {
+		reqData, err := httputil.DumpRequestOut(req, true)
+		if err == nil {
+			log.Printf("[DEBUG] "+logReqMsg, t.name, prettyPrintJsonLines(reqData))
+		} else {
+			log.Printf("[ERROR] %s API Request error: %#v", t.name, err)
+		}
+	}
+
+	resp, err := t.transport.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+
+	if IsDebugOrHigher() {
+		respData, err := httputil.DumpResponse(resp, true)
+		if err == nil {
+			log.Printf("[DEBUG] "+logRespMsg, t.name, prettyPrintJsonLines(respData))
+		} else {
+			log.Printf("[ERROR] %s API Response error: %#v", t.name, err)
+		}
+	}
+
+	return resp, nil
+}
+
+func NewTransport(name string, t http.RoundTripper) *transport {
+	return &transport{name, t}
+}
+
+// prettyPrintJsonLines iterates through a []byte line-by-line,
+// transforming any lines that are complete json into pretty-printed json.
+func prettyPrintJsonLines(b []byte) string {
+	parts := strings.Split(string(b), "\n")
+	for i, p := range parts {
+		if b := []byte(p); json.Valid(b) {
+			var out bytes.Buffer
+			json.Indent(&out, b, "", " ")
+			parts[i] = out.String()
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+const logReqMsg = `%s API Request Details:
+---[ REQUEST ]---------------------------------------
+%s
+-----------------------------------------------------`
+
+const logRespMsg = `%s API Response Details:
+---[ RESPONSE ]--------------------------------------
+%s
+-----------------------------------------------------`

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
 	awsauth "github.com/hashicorp/vault/builtin/credential/aws"
@@ -747,7 +746,14 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		return nil, fmt.Errorf("failed to configure TLS for Vault API: %s", err)
 	}
 
-	clientConfig.HttpClient.Transport = logging.NewTransport("Vault", clientConfig.HttpClient.Transport)
+	clientConfig.HttpClient.Transport = helper.NewTransport(
+		"Vault",
+		clientConfig.HttpClient.Transport,
+		&helper.TransportOptions{
+			HMACRequestHeaders: []string{
+				"X-Vault-Token",
+			},
+		})
 
 	// enable ReadYourWrites to support read-after-write on Vault Enterprise
 	clientConfig.ReadYourWrites = true


### PR DESCRIPTION
When Terraform is executed with `TF_LOG=debug` all HTTP requests to Vault are logged in clear text. With the recently merged #775  it is possible that a long lived "non-batch" authentication token might be revealed. This PR adds support logging the HMAC'd header value for `X-Vault-Token` 

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
