### PR TITLE
Disable logging HTTP request/response body

### DIFF
--- a/vault/provider.go
+++ b/vault/provider.go
@@ -749,11 +749,8 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	clientConfig.HttpClient.Transport = helper.NewTransport(
 		"Vault",
 		clientConfig.HttpClient.Transport,
-		&helper.TransportOptions{
-			HMACRequestHeaders: []string{
-				"X-Vault-Token",
-			},
-		})
+		helper.DefaultTransportOptions(),
+	)
 
 	// enable ReadYourWrites to support read-after-write on Vault Enterprise
 	clientConfig.ReadYourWrites = true

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -203,6 +203,21 @@ The `headers` configuration block accepts the following arguments:
 
 * `value` - (Required) The value of the header.
 
+## Provider Debugging
+
+Terraform supports various logging options by default.
+These are documented [here](https://www.terraform.io/docs/internals/debugging.html).
+
+~> The environment variables below can be configured to provide extended log output and require log level `DEBUG`
+or higher. It's important to note that any extended log output may ```reveal secrets```, so please exercise caution
+when enabling any of the following:
+
+* `TERRAFORM_VAULT_LOG_BODY` - when set to `true` both the request and response body will be logged.
+
+* `TERRAFORM_VAULT_LOG_REQUEST_BODY` - when set to `true` the request body will be logged.
+
+* `TERRAFORM_VAULT_LOG_RESPONSE_BODY` - when set to `true` the response body will be logged.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
Logging either the request or response body exposes secrets when
Terraform is executed with a log level of DEBUG or higher. For Vault,
this exposes secrets in clear text which should be avoided. However It
is still possible to log request/response body via the following
environment variables:

* `TERRAFORM_VAULT_LOG_BODY` - when set to `true` both the request and
  response body will be logged.

* `TERRAFORM_VAULT_LOG_REQUEST_BODY` - when set to `true` the request
body will be logged.

* `TERRAFORM_VAULT_LOG_RESPONSE_BODY` - when set to `true` the
response body will be logged.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1040 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
