### PR TITLE
Update skip_child_token docs.

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -142,9 +142,8 @@ variables in order to keep credential information out of the configuration.
 
 * `skip_child_token` - (Optional) Set this to `true` to disable
   creation of an intermediate ephemeral Vault token for Terraform to
-  use. This is strongly discouraged in most cases and environments because it
-  can result in the provided Vault token being exposed by Terraform's output
-  when `TF_LOG` is set to `debug`.
+  use. Enabling this is strongly discouraged since it increases
+  the potential for a renewable Vault token being exposed in clear text.
   Only change this setting when the provided token cannot be permitted to
   create child tokens and there is no risk of exposure from the output of
   Terraform. May be set via the `TERRAFORM_VAULT_SKIP_CHILD_TOKEN` environment


### PR DESCRIPTION
Since #1250, we no longer need to mention the possible token exposure
when running Terraform with a log level of DEBUG or higher.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #775 #1250

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
