### PR TITLE
Update Golang Docker image in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,10 @@ jobs:
     steps:
       - checkout
       - run:
+          name: "Create /tmp/go"
+          command: |
+            mkdir -p /tmp/go
+      - run:
           name: Wait for containers to starts
           command: dockerize -wait http://127.0.0.1:8200 -wait tcp://127.0.0.1:3306 -timeout 30s
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ workflows:
 jobs:
   build:
     docker:
-      - image: docker.mirror.hashicorp.services/circleci/golang:1.17.2
+      - image: docker.mirror.hashicorp.services/cimg/go:1.17.2
       - image: circleci/mongo:latest
         environment:
           - MONGO_INITDB_ROOT_USERNAME: root

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
       - image: hashicorp/vault:latest
         environment:
           - VAULT_DEV_ROOT_TOKEN_ID=root
-    working_directory: /go/src/github.com/hashicorp/terraform-provider-vault
+    working_directory: /tmp/go/src/github.com/hashicorp/terraform-provider-vault
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,4 +57,4 @@ jobs:
           command: |
             cd cmd/coverage/
             go build
-            ./coverage -openapi-doc=/go/src/github.com/hashicorp/terraform-provider-vault/testdata/openapi.json
+            ./coverage -openapi-doc=/tmp/go/src/github.com/hashicorp/terraform-provider-vault/testdata/openapi.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,10 +26,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: "Create /tmp/go"
-          command: |
-            mkdir -p /tmp/go
-      - run:
           name: Wait for containers to starts
           command: dockerize -wait http://127.0.0.1:8200 -wait tcp://127.0.0.1:3306 -timeout 30s
       - run:


### PR DESCRIPTION
The circleci/ namespaced Docker images will be deprecated on December 31st, 2021, and the image `circleci/golang` is deprecated for `cimg/go`. This PR makes the necessary updates to the circle CI config