### PR TITLE
Add support for retrying identity entity reads

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-hclog v1.0.0
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/hashicorp/go-retryablehttp v0.7.0
 	github.com/hashicorp/go-secure-stdlib/awsutil v0.1.5
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.2
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.0

--- a/util/util.go
+++ b/util/util.go
@@ -355,7 +355,10 @@ func StatusCheckRetry(statusCodes ...int) retryablehttp.CheckRetry {
 // SetupCCCRetryClient for handling Client Controlled Consistency related
 // requests.
 func SetupCCCRetryClient(client *api.Client, maxRetry int) {
-	client.SetReadYourWrites(true)
+	if !client.ReadYourWrites() {
+		client.SetReadYourWrites(true)
+	}
+
 	client.SetMaxRetries(maxRetry)
 	client.SetCheckRetry(StatusCheckRetry(http.StatusNotFound))
 

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -29,6 +29,12 @@ const (
 	// versions of Vault.
 	// We aim to deprecate items in this category.
 	UnknownPath = "unknown"
+
+	// DefaultMaxHTTPRetries is used for configuring the api.Client's MaxRetries.
+	DefaultMaxHTTPRetries = 2
+
+	// MaxGetRetriesMultiplier is used
+	MaxGetRetriesMultiplier = 1.5
 )
 
 // This is a global MutexKV for use within this provider.
@@ -164,7 +170,7 @@ func Provider() *schema.Provider {
 				Type:     schema.TypeInt,
 				Optional: true,
 
-				DefaultFunc: schema.EnvDefaultFunc("VAULT_MAX_RETRIES", 2),
+				DefaultFunc: schema.EnvDefaultFunc("VAULT_MAX_RETRIES", DefaultMaxHTTPRetries),
 				Description: "Maximum number of retries when a 5xx error code is encountered.",
 			},
 			"namespace": {
@@ -756,6 +762,9 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 
 	// enable ReadYourWrites to support read-after-write on Vault Enterprise
 	clientConfig.ReadYourWrites = true
+
+	// set default MaxRetries
+	clientConfig.MaxRetries = DefaultMaxHTTPRetries
 
 	client, err := api.NewClient(clientConfig)
 	if err != nil {

--- a/vault/resource_identity_entity.go
+++ b/vault/resource_identity_entity.go
@@ -274,15 +274,28 @@ func readEntity(client *api.Client, path string, retry bool) (*api.Secret, error
 		if err != nil {
 			return nil, err
 		}
-
 		client.SetMaxRetries(maxHTTPRetriesCCC)
 		client.SetCheckRetry(util.StatusCheckRetry(http.StatusNotFound))
-		client.SetClientTimeout(time.Second * 120)
+
+		// ensure that the clone has the reasonable backoff min/max durations set.
+		if client.MinRetryWait() == 0 {
+			client.SetMinRetryWait(time.Millisecond * 1000)
+		}
+		if client.MaxRetryWait() == 0 {
+			client.SetMaxRetryWait(time.Millisecond * 1500)
+		}
+		if client.MaxRetryWait() < client.MinRetryWait() {
+			client.SetMaxRetryWait(client.MinRetryWait())
+		}
+		// ensure that retries are not failed due to context deadline being exceeded.
+		dt := time.Duration(client.MaxRetries())
+		d := ((client.MaxRetryWait() * dt) * dt) + time.Second + 30
+		client.SetClientTimeout(d)
 	}
 
 	resp, err := client.Logical().Read(path)
 	if err != nil {
-		return resp, fmt.Errorf("failed reading %q, err=%q", path, err)
+		return resp, fmt.Errorf("failed reading %q", path)
 	}
 
 	if resp == nil {

--- a/vault/resource_identity_entity.go
+++ b/vault/resource_identity_entity.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"math"
 	"net/http"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
@@ -16,7 +15,7 @@ import (
 
 const identityEntityPath = "/identity/entity"
 
-var entityNotFoundError = errors.New("entity not found")
+var errEntityNotFound = errors.New("entity not found")
 
 func identityEntityResource() *schema.Resource {
 	return &schema.Resource{
@@ -291,14 +290,14 @@ func readEntity(client *api.Client, path string, retry bool) (*api.Secret, error
 	}
 
 	if resp == nil {
-		return nil, fmt.Errorf("%s: %q", entityNotFoundError, path)
+		return nil, fmt.Errorf("%w: %q", errEntityNotFound, path)
 	}
 
 	return resp, nil
 }
 
 func isIdentityNotFoundError(err error) bool {
-	return err != nil && strings.HasPrefix(err.Error(), entityNotFoundError.Error())
+	return err != nil && errors.Is(err, errEntityNotFound)
 }
 
 func getMaxGETRetries(maxRetries int) int {

--- a/vault/resource_identity_entity.go
+++ b/vault/resource_identity_entity.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
 
@@ -287,7 +288,9 @@ func readEntity(client *api.Client, path string, retry bool) (*api.Secret, error
 		if client.MaxRetryWait() < client.MinRetryWait() {
 			client.SetMaxRetryWait(client.MinRetryWait())
 		}
+
 		// ensure that retries are not failed due to context deadline being exceeded.
+		client.SetBackoff(retryablehttp.LinearJitterBackoff)
 		dt := time.Duration(client.MaxRetries())
 		d := ((client.MaxRetryWait() * dt) * dt) + time.Second + 30
 		client.SetClientTimeout(d)

--- a/vault/resource_identity_entity_policies.go
+++ b/vault/resource_identity_entity_policies.go
@@ -5,8 +5,9 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
 func identityEntityPoliciesResource() *schema.Resource {
@@ -96,7 +97,7 @@ func identityEntityPoliciesRead(d *schema.ResourceData, meta interface{}) error 
 	client := meta.(*api.Client)
 	id := d.Id()
 
-	resp, err := readIdentityEntity(client, id)
+	resp, err := readIdentityEntity(client, id, d.IsNewResource())
 	if err != nil {
 		return err
 	}

--- a/vault/resource_identity_entity_policies_test.go
+++ b/vault/resource_identity_entity_policies_test.go
@@ -77,13 +77,13 @@ func testAccCheckidentityEntityPoliciesDestroy(s *terraform.State) error {
 			continue
 		}
 
-		entity, err := readIdentityEntity(client, rs.Primary.ID)
-		if err != nil {
+		if _, err := readIdentityEntity(client, rs.Primary.ID, false); err != nil {
+			if isIdentityNotFoundError(err) {
+				continue
+			}
 			return err
 		}
-		if entity == nil {
-			continue
-		}
+
 		apiPolicies, err := readIdentityEntityPolicies(client, rs.Primary.ID)
 		if err != nil {
 			return err

--- a/vault/resource_identity_entity_test.go
+++ b/vault/resource_identity_entity_test.go
@@ -367,8 +367,6 @@ func TestReadEntity(t *testing.T) {
 			defer ln.Close()
 
 			config.Address = fmt.Sprintf("http://%s", ln.Addr())
-			// config.MinRetryWait = 10 * time.Millisecond
-			// config.MaxRetryWait = 10 * time.Millisecond
 			c, err := api.NewClient(config)
 			if err != nil {
 				t.Fatal(err)

--- a/vault/resource_identity_group_member_entity_ids_test.go
+++ b/vault/resource_identity_group_member_entity_ids_test.go
@@ -216,14 +216,14 @@ func testAccCheckidentityGroupMemberEntityIdsDestroy(s *terraform.State) error {
 			continue
 		}
 
-		group, err := readIdentityGroup(client, rs.Primary.ID)
-		if err != nil {
+		if _, err := readIdentityGroup(client, rs.Primary.ID, false); err != nil {
+			if isIdentityNotFoundError(err) {
+				continue
+			}
 			return err
 		}
-		if group == nil {
-			continue
-		}
-		apiMemberEntityIds, err := readIdentityGroupMemberEntityIds(client, rs.Primary.ID)
+
+		apiMemberEntityIds, err := readIdentityGroupMemberEntityIds(client, rs.Primary.ID, false)
 		if err != nil {
 			return err
 		}

--- a/vault/resource_identity_group_policies.go
+++ b/vault/resource_identity_group_policies.go
@@ -5,8 +5,9 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
 func identityGroupPoliciesResource() *schema.Resource {
@@ -64,7 +65,7 @@ func identityGroupPoliciesUpdate(d *schema.ResourceData, meta interface{}) error
 	if d.Get("exclusive").(bool) {
 		data["policies"] = policies
 	} else {
-		apiPolicies, err := readIdentityGroupPolicies(client, id)
+		apiPolicies, err := readIdentityGroupPolicies(client, id, d.IsNewResource())
 		if err != nil {
 			return err
 		}
@@ -96,7 +97,7 @@ func identityGroupPoliciesRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*api.Client)
 	id := d.Id()
 
-	resp, err := readIdentityGroup(client, id)
+	resp, err := readIdentityGroup(client, id, d.IsNewResource())
 	if err != nil {
 		return err
 	}
@@ -152,7 +153,7 @@ func identityGroupPoliciesDelete(d *schema.ResourceData, meta interface{}) error
 	if d.Get("exclusive").(bool) {
 		data["policies"] = make([]string, 0)
 	} else {
-		apiPolicies, err := readIdentityGroupPolicies(client, id)
+		apiPolicies, err := readIdentityGroupPolicies(client, id, false)
 		if err != nil {
 			return err
 		}

--- a/vault/resource_identity_group_policies_test.go
+++ b/vault/resource_identity_group_policies_test.go
@@ -74,14 +74,14 @@ func testAccCheckidentityGroupPoliciesDestroy(s *terraform.State) error {
 			continue
 		}
 
-		group, err := readIdentityGroup(client, rs.Primary.ID)
-		if err != nil {
+		if _, err := readIdentityGroup(client, rs.Primary.ID, false); err != nil {
+			if isIdentityNotFoundError(err) {
+				continue
+			}
 			return err
 		}
-		if group == nil {
-			continue
-		}
-		apiPolicies, err := readIdentityGroupPolicies(client, rs.Primary.ID)
+
+		apiPolicies, err := readIdentityGroupPolicies(client, rs.Primary.ID, false)
 		if err != nil {
 			return err
 		}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -160,8 +160,14 @@ variables in order to keep credential information out of the configuration.
   for the implications of this setting.
 
 * `max_retries` - (Optional) Used as the maximum number of retries when a 5xx
-  error code is encountered. Defaults to 2 retries and may be set via the
+  error code is encountered. Defaults to `2` retries and may be set via the
   `VAULT_MAX_RETRIES` environment variable.
+
+* `max_retries_ccc` - (Optional) Maximum number of retries for _Client Controlled Consistency_
+  related operations. Defaults to `10` retries and may also be set via the
+  `VAULT_MAX_RETRIES_CCC` environment variable. See
+  [Vault Eventual Consistency](https://www.vaultproject.io/docs/enterprise/consistency#vault-eventual-consistency)
+  for more information.
 
 * `namespace` - (Optional) Set the namespace to use. May be set via the
   `VAULT_NAMESPACE` environment variable. *Available only for Vault Enterprise*.


### PR DESCRIPTION
This fix contains a mitigation that retries stale reads from a
performance standby on new resource creation.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'


$ make dev testacc TESTARGS='-v -test.run TestAccIdentit'                                                    
==> Checking that code complies with gofmt requirements...
go build -o terraform-provider-vault
mv terraform-provider-vault ~/.terraform.d/plugins/
TF_ACC=1 go test $(go list ./...) -v -v -test.run TestAccIdentit -timeout 20m

[...]

ok      github.com/hashicorp/terraform-provider-vault/util      1.200s [no tests to run]
=== RUN   TestAccIdentityEntityAlias
--- PASS: TestAccIdentityEntityAlias (3.48s)
=== RUN   TestAccIdentityEntityAlias_Update
--- PASS: TestAccIdentityEntityAlias_Update (3.38s)
=== RUN   TestAccIdentityEntityAlias_Metadata
--- PASS: TestAccIdentityEntityAlias_Metadata (3.40s)
=== RUN   TestAccIdentityEntityPoliciesExclusive
--- PASS: TestAccIdentityEntityPoliciesExclusive (3.23s)
=== RUN   TestAccIdentityEntityPoliciesNonExclusive
--- PASS: TestAccIdentityEntityPoliciesNonExclusive (4.06s)
=== RUN   TestAccIdentityEntity
--- PASS: TestAccIdentityEntity (2.16s)
=== RUN   TestAccIdentityEntityUpdate
--- PASS: TestAccIdentityEntityUpdate (3.21s)
=== RUN   TestAccIdentityEntityUpdateRemoveValues
--- PASS: TestAccIdentityEntityUpdateRemoveValues (3.16s)
=== RUN   TestAccIdentityEntityUpdateRemovePolicies
--- PASS: TestAccIdentityEntityUpdateRemovePolicies (7.63s)
=== RUN   TestAccIdentityGroupAlias
--- PASS: TestAccIdentityGroupAlias (1.92s)
=== RUN   TestAccIdentityGroupAliasUpdate
--- PASS: TestAccIdentityGroupAliasUpdate (3.36s)
=== RUN   TestAccIdentityGroupMemberEntityIdsExclusiveEmpty
--- PASS: TestAccIdentityGroupMemberEntityIdsExclusiveEmpty (4.53s)
=== RUN   TestAccIdentityGroupMemberEntityIdsExclusive
    resource_identity_group_member_entity_ids_test.go:52: &{{{{0 0} 0 0 0 0} [] {0xc001239040} false false false false map[] map[] []  [] false 0xc0002ada70 false 0 0 testing.tRunner 0xc000682ea0 1 [17888078 17877730 17887743 17882973 28984395 17012103 17213889] TestAccIdentityGroupMemberEntityIdsExclusive {13864046867648191152 43551867250 0x2877960} 0 0xc000f91ec0 0xc000f3c380 [] {0 0}  <nil> 0} false false 0xc00014cb90}
--- SKIP: TestAccIdentityGroupMemberEntityIdsExclusive (0.00s)
=== RUN   TestAccIdentityGroupMemberEntityIdsNonExclusiveEmpty
--- PASS: TestAccIdentityGroupMemberEntityIdsNonExclusiveEmpty (19.15s)
=== RUN   TestAccIdentityGroupMemberEntityIdsNonExclusive
    resource_identity_group_member_entity_ids_test.go:122: &{{{{0 0} 0 0 0 0} [] {0xc001831040} false false false false map[] map[] []  [] false 0xc0002ada70 false 0 0 testing.tRunner 0xc000682ea0 1 [17888078 17877730 17887743 17882973 28984395 17012103 17213889] TestAccIdentityGroupMemberEntityIdsNonExclusive {13864046888195704808 62697963013 0x2877960} 0 0xc0004e9b00 0xc00057c070 [] {0 0}  <nil> 0} false false 0xc00014cb90}
--- SKIP: TestAccIdentityGroupMemberEntityIdsNonExclusive (0.00s)
=== RUN   TestAccIdentityGroupPoliciesExclusive
--- PASS: TestAccIdentityGroupPoliciesExclusive (3.50s)
=== RUN   TestAccIdentityGroupPoliciesNonExclusive
--- PASS: TestAccIdentityGroupPoliciesNonExclusive (3.42s)
=== RUN   TestAccIdentityGroup
--- PASS: TestAccIdentityGroup (1.85s)
=== RUN   TestAccIdentityGroupUpdate
--- PASS: TestAccIdentityGroupUpdate (7.83s)
=== RUN   TestAccIdentityGroupExternal
--- PASS: TestAccIdentityGroupExternal (1.87s)
=== RUN   TestAccIdentityOidcKeyAllowedClientId
--- PASS: TestAccIdentityOidcKeyAllowedClientId (5.45s)
=== RUN   TestAccIdentityOidcKey
--- PASS: TestAccIdentityOidcKey (3.24s)
=== RUN   TestAccIdentityOidcKeyUpdate
--- PASS: TestAccIdentityOidcKeyUpdate (10.92s)
=== RUN   TestAccIdentityOidcRole
--- PASS: TestAccIdentityOidcRole (2.85s)
=== RUN   TestAccIdentityOidcRoleWithClientId
--- PASS: TestAccIdentityOidcRoleWithClientId (11.51s)
=== RUN   TestAccIdentityOidcRoleUpdate
--- PASS: TestAccIdentityOidcRoleUpdate (5.00s)
=== RUN   TestAccIdentityOidc
--- PASS: TestAccIdentityOidc (3.14s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     123.995s

$ make dev testacc TESTARGS='-v -test.run TestReadEntity'
==> Checking that code complies with gofmt requirements...
go build -o terraform-provider-vault
mv terraform-provider-vault ~/.terraform.d/plugins/
TF_ACC=1 go test $(go list ./...) -v -v -test.run TestReadEntity -timeout 20m

=== RUN   TestReadEntity
=== RUN   TestReadEntity/retry-none
2021/12/16 12:57:27 [DEBUG] Reading Entity from "retry-none"
=== RUN   TestReadEntity/retry-ok-404
2021/12/16 12:57:27 [DEBUG] Reading Entity from "retry-ok-404"
=== RUN   TestReadEntity/retry-ok-412
2021/12/16 12:57:27 [DEBUG] Reading Entity from "retry-ok-412"
=== RUN   TestReadEntity/retry-exhausted-default-max-404
2021/12/16 12:57:27 [DEBUG] Reading Entity from "/identity/entity/id/retry-exhausted-default-max-404"
=== RUN   TestReadEntity/retry-exhausted-default-max-412
2021/12/16 12:57:27 [DEBUG] Reading Entity from "/identity/entity/id/retry-exhausted-default-max-412"
=== RUN   TestReadEntity/retry-exhausted-custom-max-404
2021/12/16 12:57:27 [DEBUG] Reading Entity from "/identity/entity/id/retry-exhausted-custom-max-404"
=== RUN   TestReadEntity/retry-exhausted-custom-max-412
2021/12/16 12:57:27 [DEBUG] Reading Entity from "/identity/entity/id/retry-exhausted-custom-max-412"
--- PASS: TestReadEntity (0.98s)
    --- PASS: TestReadEntity/retry-none (0.00s)
    --- PASS: TestReadEntity/retry-ok-404 (0.04s)
    --- PASS: TestReadEntity/retry-ok-412 (0.03s)
    --- PASS: TestReadEntity/retry-exhausted-default-max-404 (0.07s)
    --- PASS: TestReadEntity/retry-exhausted-default-max-412 (0.07s)
    --- PASS: TestReadEntity/retry-exhausted-custom-max-404 (0.38s)
    --- PASS: TestReadEntity/retry-exhausted-custom-max-412 (0.38s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     2.579s


...
```
