### PR TITLE
Set parent client's token on its clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.1 (Unreleased)
+BUGS:
+* Prevent new `entity` read failures when the `VAULT_TOKEN` environment variable is not set.
+
 ## 3.1.0 (December 22, 2021)
 FEATURES:
 * `provider`: Add support retrying entity reads for `Client Controlled Consistency` type operations ([#1263](https://github.com/hashicorp/terraform-provider-vault/pull/1263))

--- a/vault/resource_identity_entity.go
+++ b/vault/resource_identity_entity.go
@@ -268,10 +268,13 @@ func readEntity(client *api.Client, path string, retry bool) (*api.Secret, error
 
 	var err error
 	if retry {
+		token := client.Token()
+
 		client, err = client.Clone()
 		if err != nil {
 			return nil, err
 		}
+		client.SetToken(token)
 		util.SetupCCCRetryClient(client, maxHTTPRetriesCCC)
 	}
 


### PR DESCRIPTION
During new entity type resource creation, the parent's token was not
being set on the retry clone client. Setting the token is required since
`client.Clone()` does not include the token.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1269 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
