### PR TITLE
Update vault/api for token cloning and other fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.2
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.0
 	github.com/hashicorp/vault v1.2.1-0.20211214161113-fcc5f22bea02
-	github.com/hashicorp/vault/api v1.3.0
+	github.com/hashicorp/vault/api v1.3.2-0.20211222220726-b046cd9f80eb
 	github.com/hashicorp/vault/sdk v0.3.1-0.20211214161113-fcc5f22bea02
 	github.com/mitchellh/go-homedir v1.1.0
 	golang.org/x/oauth2 v0.0.0-20211005180243-6b3c2da341f1

--- a/go.sum
+++ b/go.sum
@@ -927,8 +927,9 @@ github.com/hashicorp/vault/api v1.0.5-0.20200215224050-f6547fa8e820/go.mod h1:3f
 github.com/hashicorp/vault/api v1.0.5-0.20200519221902-385fac77e20f/go.mod h1:euTFbi2YJgwcju3imEt919lhJKF68nN1cQPq3aA+kBE=
 github.com/hashicorp/vault/api v1.1.1/go.mod h1:29UXcn/1cLOPHQNMWA7bCz2By4PSd0VKPAydKXS5yN0=
 github.com/hashicorp/vault/api v1.2.0/go.mod h1:dAjw0T5shMnrfH7Q/Mst+LrcTKvStZBVs1PICEDpUqY=
-github.com/hashicorp/vault/api v1.3.0 h1:uDy39PLSvy6gtKyjOCRPizy2QdFiIYSWBR2pxCEzYL8=
 github.com/hashicorp/vault/api v1.3.0/go.mod h1:EabNQLI0VWbWoGlA+oBLC8PXmR9D60aUVgQGvangFWQ=
+github.com/hashicorp/vault/api v1.3.2-0.20211222220726-b046cd9f80eb h1:NktdZyRSJuhZGdOdGmqXWqvYeYQ4tZymN/P8vMHRlt0=
+github.com/hashicorp/vault/api v1.3.2-0.20211222220726-b046cd9f80eb/go.mod h1:QeJoWxMFt+MsuWcYhmwRLwKEXrjwAFFywzhptMsTIUw=
 github.com/hashicorp/vault/api/auth/approle v0.1.0/go.mod h1:mHOLgh//xDx4dpqXoq6tS8Ob0FoCFWLU2ibJ26Lfmag=
 github.com/hashicorp/vault/api/auth/userpass v0.1.0/go.mod h1:0orUbtkEwbEPmaQ+wvfrOddGBimLJnuN8A/J0PNfBks=
 github.com/hashicorp/vault/sdk v0.1.14-0.20190730042320-0dc007d98cc8/go.mod h1:B+hVj7TpuQY1Y/GPbCpffmgd+tSEwvhkWnjtSYCaS2M=

--- a/util/util.go
+++ b/util/util.go
@@ -355,10 +355,7 @@ func StatusCheckRetry(statusCodes ...int) retryablehttp.CheckRetry {
 // SetupCCCRetryClient for handling Client Controlled Consistency related
 // requests.
 func SetupCCCRetryClient(client *api.Client, maxRetry int) {
-	if !client.ReadYourWrites() {
-		client.SetReadYourWrites(true)
-	}
-
+	client.SetReadYourWrites(true)
 	client.SetMaxRetries(maxRetry)
 	client.SetCheckRetry(StatusCheckRetry(http.StatusNotFound))
 

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -778,7 +778,11 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		return nil, fmt.Errorf("failed to configure Vault API: %s", err)
 	}
 
+	// setting this is critical for proper namespace handling
 	client.SetCloneHeaders(true)
+
+	// setting this is critical for proper client cloning
+	client.SetCloneToken(true)
 
 	// Set headers if provided
 	headers := d.Get("headers").([]interface{})

--- a/vault/resource_approle_auth_backend_role_secret_id.go
+++ b/vault/resource_approle_auth_backend_role_secret_id.go
@@ -153,11 +153,9 @@ func approleAuthBackendRoleSecretIDCreate(d *schema.ResourceData, meta interface
 	if wrapped {
 		var err error
 
-		token := client.Token()
 		if client, err = client.Clone(); err != nil {
-			return fmt.Errorf("error cloning client: %s", err)
+			return fmt.Errorf("error cloning client: %w", err)
 		}
-		client.SetToken(token)
 		client.SetWrappingLookupFunc(func(_, _ string) string {
 			return wrappingTTL.(string)
 		})

--- a/vault/resource_identity_entity.go
+++ b/vault/resource_identity_entity.go
@@ -268,13 +268,10 @@ func readEntity(client *api.Client, path string, retry bool) (*api.Secret, error
 
 	var err error
 	if retry {
-		token := client.Token()
-
 		client, err = client.Clone()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error cloning client: %w", err)
 		}
-		client.SetToken(token)
 		util.SetupCCCRetryClient(client, maxHTTPRetriesCCC)
 	}
 

--- a/vault/resource_token.go
+++ b/vault/resource_token.go
@@ -160,7 +160,7 @@ func tokenCreate(d *schema.ResourceData, meta interface{}) error {
 		policies = append(policies, iPolicy.(string))
 	}
 
-	var createRequest = &api.TokenCreateRequest{}
+	createRequest := &api.TokenCreateRequest{}
 
 	if len(policies) > 0 {
 		createRequest.Policies = policies
@@ -201,13 +201,11 @@ func tokenCreate(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("wrapping_ttl"); ok {
 		wrappingTTL := v.(string)
-		token := client.Token()
 
 		client, err = client.Clone()
 		if err != nil {
-			return fmt.Errorf("error cloning client: %s", err)
+			return fmt.Errorf("error cloning client: %w", err)
 		}
-		client.SetToken(token)
 
 		client.SetWrappingLookupFunc(func(operation, path string) string {
 			return wrappingTTL


### PR DESCRIPTION
- rely on `api.Client.Clone()` to clone the parent's token to its clone
- remove workaround for issue when calling
  `client.SetReadYourWrites(true)` multiple times.
- gofumpt reformatting

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #1270 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
