### PR TITLE
r/database_secret_backend_connection- add support for Couchbase db plugin

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,9 +4,9 @@ services:
   vault:
     image: vault:latest
     cap_add:
-      - "IPC_LOCK"
+    - "IPC_LOCK"
     ports:
-      - "8200:8200"
+    - "8200:8200"
     environment:
       VAULT_DEV_ROOT_TOKEN_ID: "TEST"
       VAULT_ADDR: "http://localhost:8200"
@@ -17,7 +17,7 @@ services:
     image: mysql:5.7
     command: --default-authentication-plugin=mysql_native_password
     ports:
-      - "3306:3306"
+    - "3306:3306"
     environment:
       MYSQL_ROOT_PASSWORD: "root"
       MYSQL_DATABASE: "main"
@@ -27,16 +27,16 @@ services:
   elastic:
     image: elasticsearch:7.6.0
     ports:
-      - "9200:9200"
+    - "9200:9200"
     environment:
       "discovery.type": "single-node"
       "xpack.security.enabled": "true"
       "ELASTIC_PASSWORD": "elastic"
 
   influxdb:
-    image: influxdb:1.8.10
+    image: influxdb:1.7.11-alpine
     ports:
-      - "8086:8086"
+    - "8086:8086"
     environment:
       "DOCKER_INFLUXDB_INIT_USERNAME": "admin"
       "DOCKER_INFLUXDB_INIT_PASSWORD": "password"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,9 +4,9 @@ services:
   vault:
     image: vault:latest
     cap_add:
-    - "IPC_LOCK"
+      - "IPC_LOCK"
     ports:
-    - "8200:8200"
+      - "8200:8200"
     environment:
       VAULT_DEV_ROOT_TOKEN_ID: "TEST"
       VAULT_ADDR: "http://localhost:8200"
@@ -17,7 +17,7 @@ services:
     image: mysql:5.7
     command: --default-authentication-plugin=mysql_native_password
     ports:
-    - "3306:3306"
+      - "3306:3306"
     environment:
       MYSQL_ROOT_PASSWORD: "root"
       MYSQL_DATABASE: "main"
@@ -27,16 +27,16 @@ services:
   elastic:
     image: elasticsearch:7.6.0
     ports:
-    - "9200:9200"
+      - "9200:9200"
     environment:
       "discovery.type": "single-node"
       "xpack.security.enabled": "true"
       "ELASTIC_PASSWORD": "elastic"
 
   influxdb:
-    image: influxdb:1.7.11-alpine
+    image: influxdb:1.8.10
     ports:
-    - "8086:8086"
+      - "8086:8086"
     environment:
       "DOCKER_INFLUXDB_INIT_USERNAME": "admin"
       "DOCKER_INFLUXDB_INIT_PASSWORD": "password"

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -893,17 +893,16 @@ func getInfluxDBConnectionDetailsFromResponse(d *schema.ResourceData, prefix str
 	} else if v, ok := d.GetOk(prefix + "pem_json"); ok {
 		result["pem_json"] = v.(string)
 	}
+	if v, ok := data["protocol_version"]; ok {
+		protocol, _ := v.(json.Number).Int64()
+		result["protocol_version"] = int64(protocol)
+	}
 	if v, ok := data["connect_timeout"]; ok {
 		timeout, _ := v.(json.Number).Int64()
 		result["connect_timeout"] = timeout
 	}
 	if v, ok := data["username_template"]; ok {
 		result["username_template"] = v.(string)
-	}
-
-	if v, ok := data["protocol_version"]; ok {
-		protocol, _ := v.(json.Number).Int64()
-		result["protocol_version"] = int64(protocol)
 	}
 
 	return []map[string]interface{}{result}

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -901,6 +901,11 @@ func getInfluxDBConnectionDetailsFromResponse(d *schema.ResourceData, prefix str
 		result["username_template"] = v.(string)
 	}
 
+	if v, ok := data["protocol_version"]; ok {
+		protocol, _ := v.(json.Number).Int64()
+		result["protocol_version"] = int64(protocol)
+	}
+
 	return []map[string]interface{}{result}
 }
 
@@ -1139,8 +1144,6 @@ func databaseSecretBackendConnectionRead(d *schema.ResourceData, meta interface{
 		d.SetId("")
 		return nil
 	}
-
-	log.Printf("[DEBUG] Database connection response: %v", resp)
 
 	switch resp.Data["plugin_name"].(string) {
 	case "cassandra-database-plugin":

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -226,7 +226,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 								Type: schema.TypeString,
 							},
 							Required:    true,
-							Description: "Specifies a set of comma-delimited Couchbase hosts to connect to. Must use couchbases:// scheme if `tls` is `true`.",
+							Description: "A set of Couchbase URIs to connect to. Must use `couchbases://` scheme if `tls` is `true`.",
 						},
 						"username": {
 							Type:        schema.TypeString,

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -24,6 +24,7 @@ type connectionStringConfig struct {
 
 const (
 	dbBackendCassandra     = "cassandra"
+	dbBackendCouchbase     = "couchbase"
 	dbBackendElasticSearch = "elasticsearch"
 	dbBackendHana          = "hana"
 	dbBackendInfluxDB      = "influxdb"
@@ -45,6 +46,7 @@ var (
 	databaseSecretBackendConnectionNameFromPathRegex    = regexp.MustCompile("^.+/config/(.+$)")
 	dbBackendTypes                                      = []string{
 		dbBackendCassandra,
+		dbBackendCouchbase,
 		dbBackendElasticSearch,
 		dbBackendHana,
 		dbBackendInfluxDB,
@@ -210,6 +212,65 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				},
 				MaxItems:      1,
 				ConflictsWith: util.CalculateConflictsWith(dbBackendCassandra, dbBackendTypes),
+			},
+
+			"couchbase": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Connection parameters for the couchbase-database-plugin plugin.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"hosts": {
+							Type: schema.TypeList,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+							Required:    true,
+							Description: "Specifies a set of comma-delimited Couchbase hosts to connect to. Must use couchbases:// scheme if `tls` is `true`.",
+						},
+						"username": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Specifies the username for Vault to use.",
+						},
+						"password": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: "Specifies the password corresponding to the given username.",
+							Sensitive:   true,
+						},
+						"tls": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: "Specifies whether to use TLS when connecting to Couchbase.",
+							Default:     false,
+						},
+						"insecure_tls": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: " Specifies whether to skip verification of the server certificate when using TLS.",
+							Default:     false,
+						},
+						"base64_pem": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Required if `tls` is `true`. Specifies the certificate authority of the Couchbase server, as a PEM certificate that has been base64 encoded.",
+							Sensitive:   true,
+						},
+						"bucket_name": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Required for Couchbase versions prior to 6.5.0. This is only used to verify vault's connection to the server.",
+						},
+						"username_template": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "Template describing how dynamic usernames are generated.",
+						},
+					},
+				},
+				MaxItems:      1,
+				ConflictsWith: util.CalculateConflictsWith(dbBackendCouchbase, dbBackendTypes),
 			},
 
 			"influxdb": {
@@ -504,6 +565,8 @@ func getDatabasePluginName(d *schema.ResourceData) (string, error) {
 	switch {
 	case len(d.Get(dbBackendCassandra).([]interface{})) > 0:
 		return "cassandra-database-plugin", nil
+	case len(d.Get(dbBackendCouchbase).([]interface{})) > 0:
+		return "couchbase-database-plugin", nil
 	case len(d.Get(dbBackendInfluxDB).([]interface{})) > 0:
 		return "influxdb-database-plugin", nil
 	case len(d.Get(dbBackendHana).([]interface{})) > 0:
@@ -586,6 +649,8 @@ func getDatabaseAPIData(d *schema.ResourceData) (map[string]interface{}, error) 
 		if v, ok := d.GetOkExists("cassandra.0.connect_timeout"); ok {
 			data["connect_timeout"] = v.(int)
 		}
+	case "couchbase-database-plugin":
+		setCouchbaseDatabaseConnectionData(d, "couchbase.0.", data)
 	case "influxdb-database-plugin":
 		setInfluxDBDatabaseConnectionData(d, "influxdb.0.", data)
 	case "hana-database-plugin":
@@ -747,6 +812,47 @@ func getElasticsearchConnectionDetailsFromResponse(d *schema.ResourceData, prefi
 	return []map[string]interface{}{result}
 }
 
+func getCouchbaseConnectionDetailsFromResponse(d *schema.ResourceData, prefix string, resp *api.Secret) []map[string]interface{} {
+	details := resp.Data["connection_details"]
+	data, ok := details.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	result := map[string]interface{}{}
+
+	if v, ok := data["hosts"]; ok {
+		result["hosts"] = strings.Split(v.(string), ",")
+	}
+	if v, ok := data["username"]; ok {
+		result["username"] = v.(string)
+	}
+	if v, ok := data["password"]; ok {
+		result["password"] = v.(string)
+	} else if v, ok := d.GetOk(prefix + "password"); ok {
+		// keep the password we have in state/config if the API doesn't return one
+		result["password"] = v.(string)
+	}
+	if v, ok := data["tls"]; ok {
+		result["tls"] = v.(bool)
+	}
+	if v, ok := data["insecure_tls"]; ok {
+		result["insecure_tls"] = v.(bool)
+	}
+	if v, ok := data["base64_pem"]; ok {
+		result["base64_pem"] = v.(string)
+	} else if v, ok := d.GetOk(prefix + "base64_pem"); ok {
+		result["base64_pem"] = v.(string)
+	}
+	if v, ok := data["bucket_name"]; ok {
+		result["bucket_name"] = v.(string)
+	}
+	if v, ok := data["username_template"]; ok {
+		result["username_template"] = v.(string)
+	}
+
+	return []map[string]interface{}{result}
+}
+
 func getInfluxDBConnectionDetailsFromResponse(d *schema.ResourceData, prefix string, resp *api.Secret) []map[string]interface{} {
 	details := resp.Data["connection_details"]
 	data, ok := details.(map[string]interface{})
@@ -786,10 +892,6 @@ func getInfluxDBConnectionDetailsFromResponse(d *schema.ResourceData, prefix str
 		result["pem_json"] = v.(string)
 	} else if v, ok := d.GetOk(prefix + "pem_json"); ok {
 		result["pem_json"] = v.(string)
-	}
-	if v, ok := data["protocol_version"]; ok {
-		protocol, _ := v.(json.Number).Int64()
-		result["protocol_version"] = int64(protocol)
 	}
 	if v, ok := data["connect_timeout"]; ok {
 		timeout, _ := v.(json.Number).Int64()
@@ -884,6 +986,40 @@ func setElasticsearchDatabaseConnectionData(d *schema.ResourceData, prefix strin
 
 	if v, ok := d.GetOk(prefix + "password"); ok {
 		data["password"] = v.(string)
+	}
+}
+
+func setCouchbaseDatabaseConnectionData(d *schema.ResourceData, prefix string, data map[string]interface{}) {
+	if v, ok := d.GetOkExists(prefix + "hosts"); ok {
+		var hosts []string
+		for _, host := range v.([]interface{}) {
+			if v == nil {
+				continue
+			}
+			hosts = append(hosts, host.(string))
+		}
+		data["hosts"] = strings.Join(hosts, ",")
+	}
+	if v, ok := d.GetOk(prefix + "username"); ok {
+		data["username"] = v.(string)
+	}
+	if v, ok := d.GetOk(prefix + "password"); ok {
+		data["password"] = v.(string)
+	}
+	if v, ok := d.GetOkExists(prefix + "tls"); ok {
+		data["tls"] = v.(bool)
+	}
+	if v, ok := d.GetOkExists(prefix + "insecure_tls"); ok {
+		data["insecure_tls"] = v.(bool)
+	}
+	if v, ok := d.GetOkExists(prefix + "base64_pem"); ok {
+		data["base64_pem"] = v.(string)
+	}
+	if v, ok := d.GetOkExists(prefix + "bucket_name"); ok {
+		data["bucket_name"] = v.(string)
+	}
+	if v, ok := d.GetOkExists(prefix + "username_template"); ok {
+		data["username_template"] = v.(int)
 	}
 }
 
@@ -1004,6 +1140,8 @@ func databaseSecretBackendConnectionRead(d *schema.ResourceData, meta interface{
 		return nil
 	}
 
+	log.Printf("[DEBUG] Database connection response: %v", resp)
+
 	switch resp.Data["plugin_name"].(string) {
 	case "cassandra-database-plugin":
 		details := resp.Data["connection_details"]
@@ -1062,6 +1200,8 @@ func databaseSecretBackendConnectionRead(d *schema.ResourceData, meta interface{
 			}
 			d.Set("cassandra", []map[string]interface{}{result})
 		}
+	case "couchbase-database-plugin":
+		d.Set("couchbase", getCouchbaseConnectionDetailsFromResponse(d, "couchbase.0.", resp))
 	case "influxdb-database-plugin":
 		d.Set("influxdb", getInfluxDBConnectionDetailsFromResponse(d, "influxdb.0.", resp))
 	case "hana-database-plugin":

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -997,9 +997,6 @@ func setCouchbaseDatabaseConnectionData(d *schema.ResourceData, prefix string, d
 	if v, ok := d.GetOkExists(prefix + "hosts"); ok && v != nil {
 		var hosts []string
 		for _, host := range v.([]interface{}) {
-			if v == nil {
-				continue
-			}
 			hosts = append(hosts, host.(string))
 		}
 		data["hosts"] = strings.Join(hosts, ",")

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -990,7 +990,7 @@ func setElasticsearchDatabaseConnectionData(d *schema.ResourceData, prefix strin
 }
 
 func setCouchbaseDatabaseConnectionData(d *schema.ResourceData, prefix string, data map[string]interface{}) {
-	if v, ok := d.GetOkExists(prefix + "hosts"); ok {
+	if v, ok := d.GetOkExists(prefix + "hosts"); ok && v != nil {
 		var hosts []string
 		for _, host := range v.([]interface{}) {
 			if v == nil {

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -28,7 +28,6 @@ func TestAccDatabaseSecretBackendConnection_import(t *testing.T) {
 
 	backend := acctest.RandomWithPrefix("tf-test-db")
 	name := acctest.RandomWithPrefix("db")
-	resourceName := "vault_database_secret_backend_connection.test"
 	userTempl := "{{.DisplayName}}"
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
@@ -38,23 +37,23 @@ func TestAccDatabaseSecretBackendConnection_import(t *testing.T) {
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfig_postgresql(name, backend, connURL, userTempl),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "backend", backend),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.0", "FOOBAR"),
-					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
-					resource.TestCheckResourceAttr(resourceName, "postgresql.0.connection_url", connURL),
-					resource.TestCheckResourceAttr(resourceName, "postgresql.0.max_open_connections", "2"),
-					resource.TestCheckResourceAttr(resourceName, "postgresql.0.max_idle_connections", "0"),
-					resource.TestCheckResourceAttr(resourceName, "postgresql.0.max_connection_lifetime", "0"),
-					resource.TestCheckResourceAttr(resourceName, "postgresql.0.username_template", userTempl),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "postgresql.0.connection_url", connURL),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "postgresql.0.max_open_connections", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "postgresql.0.max_idle_connections", "0"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "postgresql.0.max_connection_lifetime", "0"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "postgresql.0.username_template", userTempl),
 				),
 			},
 			{
-				ResourceName:            resourceName,
+				ResourceName:            "vault_database_secret_backend_connection.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"verify_connection", "postgresql.0.connection_url"},
@@ -72,7 +71,6 @@ func TestAccDatabaseSecretBackendConnection_cassandra(t *testing.T) {
 
 	username := os.Getenv("CASSANDRA_USERNAME")
 	password := os.Getenv("CASSANDRA_PASSWORD")
-	resourceName := "vault_database_secret_backend_connection.test"
 	backend := acctest.RandomWithPrefix("tf-test-db")
 	name := acctest.RandomWithPrefix("db")
 	resource.Test(t, resource.TestCase{
@@ -83,25 +81,25 @@ func TestAccDatabaseSecretBackendConnection_cassandra(t *testing.T) {
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfig_cassandra(name, backend, host, username, password),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "backend", backend),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.0", "FOOBAR"),
-					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
-					resource.TestCheckResourceAttr(resourceName, "cassandra.0.hosts.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "cassandra.0.hosts.0", host),
-					resource.TestCheckResourceAttr(resourceName, "cassandra.0.port", "9042"),
-					resource.TestCheckResourceAttr(resourceName, "cassandra.0.username", username),
-					resource.TestCheckResourceAttr(resourceName, "cassandra.0.password", password),
-					resource.TestCheckResourceAttr(resourceName, "cassandra.0.tls", "false"),
-					resource.TestCheckResourceAttr(resourceName, "cassandra.0.insecure_tls", "false"),
-					resource.TestCheckResourceAttr(resourceName, "cassandra.0.pem_bundle", ""),
-					resource.TestCheckResourceAttr(resourceName, "cassandra.0.pem_json", ""),
-					resource.TestCheckResourceAttr(resourceName, "cassandra.0.protocol_version", "4"),
-					resource.TestCheckResourceAttr(resourceName, "cassandra.0.connect_timeout", "5"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.hosts.#", "1"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.hosts.0", host),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.port", "9042"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.username", username),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.password", password),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.tls", "false"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.insecure_tls", "false"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.pem_bundle", ""),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.pem_json", ""),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.protocol_version", "4"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.connect_timeout", "5"),
 				),
 			},
 		},
@@ -119,7 +117,6 @@ func TestAccDatabaseSecretBackendConnection_cassandraProtocol(t *testing.T) {
 	password := os.Getenv("CASSANDRA_PASSWORD")
 	backend := acctest.RandomWithPrefix("tf-test-db")
 	name := acctest.RandomWithPrefix("db")
-	resourceName := "vault_database_secret_backend_connection.test"
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
@@ -128,25 +125,25 @@ func TestAccDatabaseSecretBackendConnection_cassandraProtocol(t *testing.T) {
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfig_cassandraProtocol(name, backend, host, username, password),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "backend", backend),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.0", "FOOBAR"),
-					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
-					resource.TestCheckResourceAttr(resourceName, "cassandra.0.hosts.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "cassandra.0.hosts.0", host),
-					resource.TestCheckResourceAttr(resourceName, "cassandra.0.port", "9042"),
-					resource.TestCheckResourceAttr(resourceName, "cassandra.0.username", username),
-					resource.TestCheckResourceAttr(resourceName, "cassandra.0.password", password),
-					resource.TestCheckResourceAttr(resourceName, "cassandra.0.tls", "false"),
-					resource.TestCheckResourceAttr(resourceName, "cassandra.0.insecure_tls", "false"),
-					resource.TestCheckResourceAttr(resourceName, "cassandra.0.pem_bundle", ""),
-					resource.TestCheckResourceAttr(resourceName, "cassandra.0.pem_json", ""),
-					resource.TestCheckResourceAttr(resourceName, "cassandra.0.protocol_version", "5"),
-					resource.TestCheckResourceAttr(resourceName, "cassandra.0.connect_timeout", "5"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.hosts.#", "1"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.hosts.0", host),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.port", "9042"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.username", username),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.password", password),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.tls", "false"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.insecure_tls", "false"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.pem_bundle", ""),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.pem_json", ""),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.protocol_version", "5"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.connect_timeout", "5"),
 				),
 			},
 		},
@@ -239,12 +236,6 @@ func TestAccDatabaseSecretBackendConnection_influxdb(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "influxdb.0.connect_timeout", "5"),
 				),
 			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"verify_connection", "influxdb.0.password"},
-			},
 		},
 	})
 }
@@ -255,7 +246,6 @@ func TestAccDatabaseSecretBackendConnection_mongodbatlas(t *testing.T) {
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "MONGODB_ATLAS_PUBLIC_KEY")
 	publicKey := values[0]
-	resourceName := "vault_database_secret_backend_connection.test"
 
 	privateKey := os.Getenv("MONGODB_ATLAS_PRIVATE_KEY")
 	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
@@ -269,17 +259,17 @@ func TestAccDatabaseSecretBackendConnection_mongodbatlas(t *testing.T) {
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfig_mongodbatlas(name, backend, publicKey, privateKey, projectID),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "backend", backend),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.0", "FOOBAR"),
-					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
-					resource.TestCheckResourceAttr(resourceName, "mongodbatlas.0.public_key", publicKey),
-					resource.TestCheckResourceAttr(resourceName, "mongodbatlas.0.private_key", publicKey),
-					resource.TestCheckResourceAttr(resourceName, "mongodbatlas.0.project_id", projectID),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mongodbatlas.0.public_key", publicKey),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mongodbatlas.0.private_key", privateKey),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mongodbatlas.0.project_id", projectID),
 				),
 			},
 		},
@@ -292,7 +282,7 @@ func TestAccDatabaseSecretBackendConnection_mongodb(t *testing.T) {
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "MONGODB_URL")
 	connURL := values[0]
-	resourceName := "vault_database_secret_backend_connection.test"
+
 	backend := acctest.RandomWithPrefix("tf-test-db")
 	name := acctest.RandomWithPrefix("db")
 	resource.Test(t, resource.TestCase{
@@ -303,15 +293,15 @@ func TestAccDatabaseSecretBackendConnection_mongodb(t *testing.T) {
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfig_mongodb(name, backend, connURL),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "backend", backend),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.0", "FOOBAR"),
-					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
-					resource.TestCheckResourceAttr(resourceName, "mongodb.0.connection_url", connURL),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mongodb.0.connection_url", connURL),
 				),
 			},
 		},
@@ -324,7 +314,7 @@ func TestAccDatabaseSecretBackendConnection_mssql(t *testing.T) {
 	cleanupFunc, connURL := mssqlhelper.PrepareMSSQLTestContainer(t)
 
 	t.Cleanup(cleanupFunc)
-	resourceName := "vault_database_secret_backend_connection.test"
+
 	backend := acctest.RandomWithPrefix("tf-test-db")
 	name := acctest.RandomWithPrefix("db")
 	resource.Test(t, resource.TestCase{
@@ -335,37 +325,37 @@ func TestAccDatabaseSecretBackendConnection_mssql(t *testing.T) {
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfig_mssql(name, backend, connURL, false),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "backend", backend),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.0", "FOOBAR"),
-					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
-					resource.TestCheckResourceAttr(resourceName, "mssql.0.connection_url", connURL),
-					resource.TestCheckResourceAttr(resourceName, "mssql.0.max_open_connections", "2"),
-					resource.TestCheckResourceAttr(resourceName, "mssql.0.max_idle_connections", "0"),
-					resource.TestCheckResourceAttr(resourceName, "mssql.0.max_connection_lifetime", "0"),
-					resource.TestCheckResourceAttr(resourceName, "mssql.0.contained_db", "false"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mssql.0.connection_url", connURL),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mssql.0.max_open_connections", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mssql.0.max_idle_connections", "0"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mssql.0.max_connection_lifetime", "0"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mssql.0.contained_db", "false"),
 				),
 			},
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfig_mssql(name, backend, connURL, true),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "backend", backend),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.0", "FOOBAR"),
-					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
-					resource.TestCheckResourceAttr(resourceName, "mssql.0.connection_url", connURL),
-					resource.TestCheckResourceAttr(resourceName, "mssql.0.max_open_connections", "2"),
-					resource.TestCheckResourceAttr(resourceName, "mssql.0.max_idle_connections", "0"),
-					resource.TestCheckResourceAttr(resourceName, "mssql.0.max_connection_lifetime", "0"),
-					resource.TestCheckResourceAttr(resourceName, "mssql.0.contained_db", "true"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mssql.0.connection_url", connURL),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mssql.0.max_open_connections", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mssql.0.max_idle_connections", "0"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mssql.0.max_connection_lifetime", "0"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mssql.0.contained_db", "true"),
 				),
 			},
 		},
@@ -374,7 +364,6 @@ func TestAccDatabaseSecretBackendConnection_mssql(t *testing.T) {
 
 func TestAccDatabaseSecretBackendConnection_mysql(t *testing.T) {
 	MaybeSkipDBTests(t, dbBackendMySQL)
-	resourceName := "vault_database_secret_backend_connection.test"
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "MYSQL_URL")
@@ -391,71 +380,71 @@ func TestAccDatabaseSecretBackendConnection_mysql(t *testing.T) {
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfig_mysql(name, backend, connURL, password),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "backend", backend),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.0", "FOOBAR"),
-					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
-					resource.TestCheckResourceAttr(resourceName, "mysql.0.connection_url", connURL),
-					resource.TestCheckResourceAttr(resourceName, "mysql.0.max_open_connections", "2"),
-					resource.TestCheckResourceAttr(resourceName, "mysql.0.max_idle_connections", "0"),
-					resource.TestCheckResourceAttr(resourceName, "mysql.0.max_connection_lifetime", "0"),
-					resource.TestCheckResourceAttr(resourceName, "data.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "data.password", password),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.connection_url", connURL),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.max_open_connections", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.max_idle_connections", "0"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.max_connection_lifetime", "0"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.%", "1"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.password", password),
 				),
 			},
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfig_mysql_rds(name, backend, connURL),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "backend", backend),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.0", "FOOBAR"),
-					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
-					resource.TestCheckResourceAttr(resourceName, "mysql_rds.0.connection_url", connURL),
-					resource.TestCheckResourceAttr(resourceName, "mysql_rds.0.max_open_connections", "2"),
-					resource.TestCheckResourceAttr(resourceName, "mysql_rds.0.max_idle_connections", "0"),
-					resource.TestCheckResourceAttr(resourceName, "mysql_rds.0.max_connection_lifetime", "0"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql_rds.0.connection_url", connURL),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql_rds.0.max_open_connections", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql_rds.0.max_idle_connections", "0"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql_rds.0.max_connection_lifetime", "0"),
 				),
 			},
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfig_mysql_aurora(name, backend, connURL),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "backend", backend),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.0", "FOOBAR"),
-					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
-					resource.TestCheckResourceAttr(resourceName, "mysql_aurora.0.connection_url", connURL),
-					resource.TestCheckResourceAttr(resourceName, "mysql_aurora.0.max_open_connections", "2"),
-					resource.TestCheckResourceAttr(resourceName, "mysql_aurora.0.max_idle_connections", "0"),
-					resource.TestCheckResourceAttr(resourceName, "mysql_aurora.0.max_connection_lifetime", "0"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql_aurora.0.connection_url", connURL),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql_aurora.0.max_open_connections", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql_aurora.0.max_idle_connections", "0"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql_aurora.0.max_connection_lifetime", "0"),
 				),
 			},
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfig_mysql_legacy(name, backend, connURL),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "backend", backend),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.0", "FOOBAR"),
-					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
-					resource.TestCheckResourceAttr(resourceName, "mysql_legacy.0.connection_url", connURL),
-					resource.TestCheckResourceAttr(resourceName, "mysql_legacy.0.max_open_connections", "2"),
-					resource.TestCheckResourceAttr(resourceName, "mysql_legacy.0.max_idle_connections", "0"),
-					resource.TestCheckResourceAttr(resourceName, "mysql_legacy.0.max_connection_lifetime", "0"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql_legacy.0.connection_url", connURL),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql_legacy.0.max_open_connections", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql_legacy.0.max_idle_connections", "0"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql_legacy.0.max_connection_lifetime", "0"),
 				),
 			},
 		},
@@ -464,7 +453,6 @@ func TestAccDatabaseSecretBackendConnection_mysql(t *testing.T) {
 
 func TestAccDatabaseSecretBackendConnectionUpdate_mysql(t *testing.T) {
 	MaybeSkipDBTests(t, dbBackendMySQL)
-	resourceName := "vault_database_secret_backend_connection.test"
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "MYSQL_URL")
@@ -481,37 +469,37 @@ func TestAccDatabaseSecretBackendConnectionUpdate_mysql(t *testing.T) {
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfigUpdate_mysql(name, backend, connURL, password, 0),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "backend", backend),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.0", "FOOBAR"),
-					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
-					resource.TestCheckResourceAttr(resourceName, "mysql.0.connection_url", connURL),
-					resource.TestCheckResourceAttr(resourceName, "mysql.0.max_open_connections", "2"),
-					resource.TestCheckResourceAttr(resourceName, "mysql.0.max_connection_lifetime", "0"),
-					resource.TestCheckResourceAttr(resourceName, "data.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "data.password", password),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.connection_url", connURL),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.max_open_connections", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.max_connection_lifetime", "0"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.%", "1"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.password", password),
 				),
 			},
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfigUpdate_mysql(name, backend, connURL, password, 10),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "backend", backend),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.0", "FOOBAR"),
-					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
-					resource.TestCheckResourceAttr(resourceName, "mysql.0.connection_url", connURL),
-					resource.TestCheckResourceAttr(resourceName, "mysql.0.max_open_connections", "2"),
-					resource.TestCheckResourceAttr(resourceName, "mysql.0.max_connection_lifetime", "10"),
-					resource.TestCheckResourceAttr(resourceName, "data.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "data.password", password),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.connection_url", connURL),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.max_open_connections", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.max_connection_lifetime", "10"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.%", "1"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.password", password),
 				),
 			},
 		},
@@ -520,7 +508,6 @@ func TestAccDatabaseSecretBackendConnectionUpdate_mysql(t *testing.T) {
 
 func TestAccDatabaseSecretBackendConnectionTemplatedUpdateExcludePassword_mysql(t *testing.T) {
 	MaybeSkipDBTests(t, dbBackendMySQL)
-	resourceName := "vault_database_secret_backend_connection.test"
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t,
@@ -557,17 +544,17 @@ func TestAccDatabaseSecretBackendConnectionTemplatedUpdateExcludePassword_mysql(
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfigTemplated_mysql(name, backend, testConnURL, testUsername, testPassword, 0),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "backend", backend),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
-					resource.TestCheckResourceAttr(resourceName, "mysql.0.connection_url", testConnURL),
-					resource.TestCheckResourceAttr(resourceName, "mysql.0.max_connection_lifetime", "0"),
-					resource.TestCheckResourceAttr(resourceName, "data.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "data.username", testUsername),
-					resource.TestCheckResourceAttr(resourceName, "data.password", testPassword),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.connection_url", testConnURL),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.max_connection_lifetime", "0"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.%", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.username", testUsername),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.password", testPassword),
 				),
 			},
 			{
@@ -582,17 +569,17 @@ func TestAccDatabaseSecretBackendConnectionTemplatedUpdateExcludePassword_mysql(
 					log.Printf("rotate-root: %v", resp)
 				},
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "backend", backend),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
-					resource.TestCheckResourceAttr(resourceName, "mysql.0.connection_url", testConnURL),
-					resource.TestCheckResourceAttr(resourceName, "mysql.0.max_connection_lifetime", "10"),
-					resource.TestCheckResourceAttr(resourceName, "data.%", "2"),
-					resource.TestCheckResourceAttr(resourceName, "data.username", testUsername),
-					resource.TestCheckResourceAttr(resourceName, "data.password", testPassword),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.connection_url", testConnURL),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.max_connection_lifetime", "10"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.%", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.username", testUsername),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.password", testPassword),
 				),
 			},
 		},
@@ -601,7 +588,6 @@ func TestAccDatabaseSecretBackendConnectionTemplatedUpdateExcludePassword_mysql(
 
 func TestAccDatabaseSecretBackendConnection_mysql_tls(t *testing.T) {
 	MaybeSkipDBTests(t, dbBackendMySQL)
-	resourceName := "vault_database_secret_backend_connection.test"
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "MYSQL_CA", "MYSQL_URL", "MYSQL_CERTIFICATE_KEY")
@@ -618,22 +604,22 @@ func TestAccDatabaseSecretBackendConnection_mysql_tls(t *testing.T) {
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfig_mysql_tls(name, backend, connURL, password, tlsCA, tlsCertificateKey),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "backend", backend),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.0", "FOOBAR"),
-					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
-					resource.TestCheckResourceAttr(resourceName, "mysql.0.connection_url", connURL),
-					resource.TestCheckResourceAttr(resourceName, "mysql.0.max_open_connections", "2"),
-					resource.TestCheckResourceAttr(resourceName, "mysql.0.max_idle_connections", "0"),
-					resource.TestCheckResourceAttr(resourceName, "mysql.0.max_connection_lifetime", "0"),
-					resource.TestCheckResourceAttr(resourceName, "data.%", "1"),
-					resource.TestCheckResourceAttr(resourceName, "data.password", password),
-					resource.TestCheckResourceAttr(resourceName, "mysql.0.tls_ca", tlsCA+"\n"),
-					resource.TestCheckResourceAttr(resourceName, "mysql.0.tls_certificate_key", tlsCertificateKey+"\n"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.connection_url", connURL),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.max_open_connections", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.max_idle_connections", "0"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.max_connection_lifetime", "0"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.%", "1"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.password", password),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.tlsCA", tlsCA+"\n"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.tls_certificate_key", tlsCertificateKey+"\n"),
 				),
 			},
 		},
@@ -642,7 +628,6 @@ func TestAccDatabaseSecretBackendConnection_mysql_tls(t *testing.T) {
 
 func TestAccDatabaseSecretBackendConnection_postgresql(t *testing.T) {
 	MaybeSkipDBTests(t, dbBackendPostgres)
-	resourceName := "vault_database_secret_backend_connection.test"
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "POSTGRES_URL")
@@ -659,19 +644,19 @@ func TestAccDatabaseSecretBackendConnection_postgresql(t *testing.T) {
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfig_postgresql(name, backend, connURL, userTempl),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "backend", backend),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.0", "FOOBAR"),
-					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
-					resource.TestCheckResourceAttr(resourceName, "postgresql.0.connection_url", connURL),
-					resource.TestCheckResourceAttr(resourceName, "postgresql.0.max_open_connections", "2"),
-					resource.TestCheckResourceAttr(resourceName, "postgresql.0.max_idle_connections", "0"),
-					resource.TestCheckResourceAttr(resourceName, "postgresql.0.max_connection_lifetime", "0"),
-					resource.TestCheckResourceAttr(resourceName, "postgresql.0.username_template", userTempl),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "postgresql.0.connection_url", connURL),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "postgresql.0.max_open_connections", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "postgresql.0.max_idle_connections", "0"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "postgresql.0.max_connection_lifetime", "0"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "postgresql.0.username_template", userTempl),
 				),
 			},
 		},
@@ -680,7 +665,6 @@ func TestAccDatabaseSecretBackendConnection_postgresql(t *testing.T) {
 
 func TestAccDatabaseSecretBackendConnection_elasticsearch(t *testing.T) {
 	MaybeSkipDBTests(t, dbBackendElasticSearch)
-	resourceName := "vault_database_secret_backend_connection.test"
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "ELASTIC_URL")
@@ -699,13 +683,13 @@ func TestAccDatabaseSecretBackendConnection_elasticsearch(t *testing.T) {
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfig_elasticsearch(name, backend, connURL, username, password),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "backend", backend),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
-					resource.TestCheckResourceAttr(resourceName, "elasticsearch.0.url", connURL),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "elasticsearch.0.url", connURL),
 				),
 			},
 		},
@@ -714,7 +698,6 @@ func TestAccDatabaseSecretBackendConnection_elasticsearch(t *testing.T) {
 
 func TestAccDatabaseSecretBackendConnection_snowflake(t *testing.T) {
 	MaybeSkipDBTests(t, dbBackendSnowflake)
-	resourceName := "vault_database_secret_backend_connection.test"
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "SNOWFLAKE_URL")
@@ -735,16 +718,16 @@ func TestAccDatabaseSecretBackendConnection_snowflake(t *testing.T) {
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "backend", backend),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
-					resource.TestCheckResourceAttr(resourceName, "snowflake.0.connection_url", connURL),
-					resource.TestCheckResourceAttr(resourceName, "snowflake.0.username", username),
-					resource.TestCheckResourceAttr(resourceName, "snowflake.0.password", password),
-					resource.TestCheckResourceAttr(resourceName, "snowflake.0.username_template", userTempl),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "snowflake.0.connection_url", connURL),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "snowflake.0.username", username),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "snowflake.0.password", password),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "snowflake.0.username_template", userTempl),
 				),
 			},
 		},
@@ -851,28 +834,6 @@ resource "vault_database_secret_backend_connection" "test" {
 `, path, name, host, username, password)
 }
 
-func testAccDatabaseSecretBackendConnectionConfig_couchbase(name, path, host, username, password string) string {
-	return fmt.Sprintf(`
-resource "vault_mount" "db" {
-  path = "%s"
-  type = "database"
-}
-
-resource "vault_database_secret_backend_connection" "test" {
-  backend                  = vault_mount.db.path
-  name                     = "%s"
-  allowed_roles            = ["dev", "prod"]
-  root_rotation_statements = ["FOOBAR"]
-
-  couchbase {
-    hosts    = ["%s"]
-    username = "%s"
-    password = "%s"
-  }
-}
-`, path, name, host, username, password)
-}
-
 func testAccDatabaseSecretBackendConnectionConfig_influxdb(name, path, host, username, password string) string {
 	return fmt.Sprintf(`
 resource "vault_mount" "db" {
@@ -891,6 +852,26 @@ resource "vault_database_secret_backend_connection" "test" {
     username = "%s"
     password = "%s"
     tls      = false
+  }
+}
+`, path, name, host, username, password)
+}
+
+func testAccDatabaseSecretBackendConnectionConfig_couchbase(name, path, host, username, password string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "db" {
+  path = "%s"
+  type = "database"
+}
+resource "vault_database_secret_backend_connection" "test" {
+  backend                  = vault_mount.db.path
+  name                     = "%s"
+  allowed_roles            = ["dev", "prod"]
+  root_rotation_statements = ["FOOBAR"]
+  couchbase {
+    hosts    = ["%s"]
+    username = "%s"
+    password = "%s"
   }
 }
 `, path, name, host, username, password)

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -868,7 +868,6 @@ resource "vault_database_secret_backend_connection" "test" {
     hosts    = ["%s"]
     username = "%s"
     password = "%s"
-	bucket_name = "beer-sample"
   }
 }
 `, path, name, host, username, password)

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -28,6 +28,7 @@ func TestAccDatabaseSecretBackendConnection_import(t *testing.T) {
 
 	backend := acctest.RandomWithPrefix("tf-test-db")
 	name := acctest.RandomWithPrefix("db")
+	resourceName := "vault_database_secret_backend_connection.test"
 	userTempl := "{{.DisplayName}}"
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
@@ -37,23 +38,23 @@ func TestAccDatabaseSecretBackendConnection_import(t *testing.T) {
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfig_postgresql(name, backend, connURL, userTempl),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.#", "1"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.0", "FOOBAR"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "postgresql.0.connection_url", connURL),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "postgresql.0.max_open_connections", "2"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "postgresql.0.max_idle_connections", "0"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "postgresql.0.max_connection_lifetime", "0"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "postgresql.0.username_template", userTempl),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
+					resource.TestCheckResourceAttr(resourceName, "postgresql.0.connection_url", connURL),
+					resource.TestCheckResourceAttr(resourceName, "postgresql.0.max_open_connections", "2"),
+					resource.TestCheckResourceAttr(resourceName, "postgresql.0.max_idle_connections", "0"),
+					resource.TestCheckResourceAttr(resourceName, "postgresql.0.max_connection_lifetime", "0"),
+					resource.TestCheckResourceAttr(resourceName, "postgresql.0.username_template", userTempl),
 				),
 			},
 			{
-				ResourceName:            "vault_database_secret_backend_connection.test",
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"verify_connection", "postgresql.0.connection_url"},
@@ -71,6 +72,7 @@ func TestAccDatabaseSecretBackendConnection_cassandra(t *testing.T) {
 
 	username := os.Getenv("CASSANDRA_USERNAME")
 	password := os.Getenv("CASSANDRA_PASSWORD")
+	resourceName := "vault_database_secret_backend_connection.test"
 	backend := acctest.RandomWithPrefix("tf-test-db")
 	name := acctest.RandomWithPrefix("db")
 	resource.Test(t, resource.TestCase{
@@ -81,25 +83,25 @@ func TestAccDatabaseSecretBackendConnection_cassandra(t *testing.T) {
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfig_cassandra(name, backend, host, username, password),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.#", "1"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.0", "FOOBAR"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.hosts.#", "1"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.hosts.0", host),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.port", "9042"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.username", username),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.password", password),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.tls", "false"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.insecure_tls", "false"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.pem_bundle", ""),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.pem_json", ""),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.protocol_version", "4"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.connect_timeout", "5"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.hosts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.hosts.0", host),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.port", "9042"),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.username", username),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.password", password),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.tls", "false"),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.insecure_tls", "false"),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.pem_bundle", ""),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.pem_json", ""),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.protocol_version", "4"),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.connect_timeout", "5"),
 				),
 			},
 		},
@@ -117,6 +119,7 @@ func TestAccDatabaseSecretBackendConnection_cassandraProtocol(t *testing.T) {
 	password := os.Getenv("CASSANDRA_PASSWORD")
 	backend := acctest.RandomWithPrefix("tf-test-db")
 	name := acctest.RandomWithPrefix("db")
+	resourceName := "vault_database_secret_backend_connection.test"
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
@@ -125,26 +128,73 @@ func TestAccDatabaseSecretBackendConnection_cassandraProtocol(t *testing.T) {
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfig_cassandraProtocol(name, backend, host, username, password),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.#", "1"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.0", "FOOBAR"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.hosts.#", "1"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.hosts.0", host),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.port", "9042"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.username", username),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.password", password),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.tls", "false"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.insecure_tls", "false"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.pem_bundle", ""),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.pem_json", ""),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.protocol_version", "5"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "cassandra.0.connect_timeout", "5"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.hosts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.hosts.0", host),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.port", "9042"),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.username", username),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.password", password),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.tls", "false"),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.insecure_tls", "false"),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.pem_bundle", ""),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.pem_json", ""),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.protocol_version", "5"),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.connect_timeout", "5"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccDatabaseSecretBackendConnection_couchbase(t *testing.T) {
+	MaybeSkipDBTests(t, dbBackendInfluxDB)
+
+	host := os.Getenv("COUCHBASE_HOST")
+	if host == "" {
+		t.Skip("COUCHBASE_HOST not set")
+	}
+	username := os.Getenv("COUCHBASE_USERNAME")
+	password := os.Getenv("COUCHBASE_PASSWORD")
+	backend := acctest.RandomWithPrefix("tf-test-db")
+	name := acctest.RandomWithPrefix("db")
+	resourceName := "vault_database_secret_backend_connection.test"
+	resource.Test(t, resource.TestCase{
+		Providers:    testProviders,
+		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		CheckDestroy: testAccDatabaseSecretBackendConnectionCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseSecretBackendConnectionConfig_couchbase(name, backend, host, username, password),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
+					resource.TestCheckResourceAttr(resourceName, "couchbase.0.hosts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "couchbase.0.hosts.0", host),
+					resource.TestCheckResourceAttr(resourceName, "couchbase.0.username", username),
+					resource.TestCheckResourceAttr(resourceName, "couchbase.0.password", password),
+					resource.TestCheckResourceAttr(resourceName, "couchbase.0.tls", "false"),
+					resource.TestCheckResourceAttr(resourceName, "couchbase.0.insecure_tls", "false"),
+					resource.TestCheckResourceAttr(resourceName, "couchbase.0.base64_pem", ""),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"verify_connection", "couchbase.0.password"},
 			},
 		},
 	})
@@ -189,6 +239,12 @@ func TestAccDatabaseSecretBackendConnection_influxdb(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "influxdb.0.connect_timeout", "5"),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"verify_connection", "influxdb.0.password"},
+			},
 		},
 	})
 }
@@ -199,6 +255,7 @@ func TestAccDatabaseSecretBackendConnection_mongodbatlas(t *testing.T) {
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "MONGODB_ATLAS_PUBLIC_KEY")
 	publicKey := values[0]
+	resourceName := "vault_database_secret_backend_connection.test"
 
 	privateKey := os.Getenv("MONGODB_ATLAS_PRIVATE_KEY")
 	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
@@ -212,17 +269,17 @@ func TestAccDatabaseSecretBackendConnection_mongodbatlas(t *testing.T) {
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfig_mongodbatlas(name, backend, publicKey, privateKey, projectID),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.#", "1"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.0", "FOOBAR"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mongodbatlas.0.public_key", publicKey),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mongodbatlas.0.private_key", privateKey),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mongodbatlas.0.project_id", projectID),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
+					resource.TestCheckResourceAttr(resourceName, "mongodbatlas.0.public_key", publicKey),
+					resource.TestCheckResourceAttr(resourceName, "mongodbatlas.0.private_key", publicKey),
+					resource.TestCheckResourceAttr(resourceName, "mongodbatlas.0.project_id", projectID),
 				),
 			},
 		},
@@ -235,7 +292,7 @@ func TestAccDatabaseSecretBackendConnection_mongodb(t *testing.T) {
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "MONGODB_URL")
 	connURL := values[0]
-
+	resourceName := "vault_database_secret_backend_connection.test"
 	backend := acctest.RandomWithPrefix("tf-test-db")
 	name := acctest.RandomWithPrefix("db")
 	resource.Test(t, resource.TestCase{
@@ -246,15 +303,15 @@ func TestAccDatabaseSecretBackendConnection_mongodb(t *testing.T) {
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfig_mongodb(name, backend, connURL),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.#", "1"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.0", "FOOBAR"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mongodb.0.connection_url", connURL),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
+					resource.TestCheckResourceAttr(resourceName, "mongodb.0.connection_url", connURL),
 				),
 			},
 		},
@@ -267,7 +324,7 @@ func TestAccDatabaseSecretBackendConnection_mssql(t *testing.T) {
 	cleanupFunc, connURL := mssqlhelper.PrepareMSSQLTestContainer(t)
 
 	t.Cleanup(cleanupFunc)
-
+	resourceName := "vault_database_secret_backend_connection.test"
 	backend := acctest.RandomWithPrefix("tf-test-db")
 	name := acctest.RandomWithPrefix("db")
 	resource.Test(t, resource.TestCase{
@@ -278,37 +335,37 @@ func TestAccDatabaseSecretBackendConnection_mssql(t *testing.T) {
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfig_mssql(name, backend, connURL, false),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.#", "1"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.0", "FOOBAR"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mssql.0.connection_url", connURL),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mssql.0.max_open_connections", "2"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mssql.0.max_idle_connections", "0"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mssql.0.max_connection_lifetime", "0"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mssql.0.contained_db", "false"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.connection_url", connURL),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.max_open_connections", "2"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.max_idle_connections", "0"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.max_connection_lifetime", "0"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.contained_db", "false"),
 				),
 			},
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfig_mssql(name, backend, connURL, true),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.#", "1"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.0", "FOOBAR"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mssql.0.connection_url", connURL),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mssql.0.max_open_connections", "2"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mssql.0.max_idle_connections", "0"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mssql.0.max_connection_lifetime", "0"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mssql.0.contained_db", "true"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.connection_url", connURL),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.max_open_connections", "2"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.max_idle_connections", "0"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.max_connection_lifetime", "0"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.contained_db", "true"),
 				),
 			},
 		},
@@ -317,6 +374,7 @@ func TestAccDatabaseSecretBackendConnection_mssql(t *testing.T) {
 
 func TestAccDatabaseSecretBackendConnection_mysql(t *testing.T) {
 	MaybeSkipDBTests(t, dbBackendMySQL)
+	resourceName := "vault_database_secret_backend_connection.test"
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "MYSQL_URL")
@@ -333,71 +391,71 @@ func TestAccDatabaseSecretBackendConnection_mysql(t *testing.T) {
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfig_mysql(name, backend, connURL, password),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.#", "1"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.0", "FOOBAR"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.connection_url", connURL),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.max_open_connections", "2"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.max_idle_connections", "0"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.max_connection_lifetime", "0"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.%", "1"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.password", password),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
+					resource.TestCheckResourceAttr(resourceName, "mysql.0.connection_url", connURL),
+					resource.TestCheckResourceAttr(resourceName, "mysql.0.max_open_connections", "2"),
+					resource.TestCheckResourceAttr(resourceName, "mysql.0.max_idle_connections", "0"),
+					resource.TestCheckResourceAttr(resourceName, "mysql.0.max_connection_lifetime", "0"),
+					resource.TestCheckResourceAttr(resourceName, "data.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "data.password", password),
 				),
 			},
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfig_mysql_rds(name, backend, connURL),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.#", "1"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.0", "FOOBAR"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql_rds.0.connection_url", connURL),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql_rds.0.max_open_connections", "2"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql_rds.0.max_idle_connections", "0"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql_rds.0.max_connection_lifetime", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_rds.0.connection_url", connURL),
+					resource.TestCheckResourceAttr(resourceName, "mysql_rds.0.max_open_connections", "2"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_rds.0.max_idle_connections", "0"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_rds.0.max_connection_lifetime", "0"),
 				),
 			},
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfig_mysql_aurora(name, backend, connURL),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.#", "1"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.0", "FOOBAR"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql_aurora.0.connection_url", connURL),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql_aurora.0.max_open_connections", "2"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql_aurora.0.max_idle_connections", "0"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql_aurora.0.max_connection_lifetime", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_aurora.0.connection_url", connURL),
+					resource.TestCheckResourceAttr(resourceName, "mysql_aurora.0.max_open_connections", "2"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_aurora.0.max_idle_connections", "0"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_aurora.0.max_connection_lifetime", "0"),
 				),
 			},
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfig_mysql_legacy(name, backend, connURL),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.#", "1"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.0", "FOOBAR"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql_legacy.0.connection_url", connURL),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql_legacy.0.max_open_connections", "2"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql_legacy.0.max_idle_connections", "0"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql_legacy.0.max_connection_lifetime", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_legacy.0.connection_url", connURL),
+					resource.TestCheckResourceAttr(resourceName, "mysql_legacy.0.max_open_connections", "2"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_legacy.0.max_idle_connections", "0"),
+					resource.TestCheckResourceAttr(resourceName, "mysql_legacy.0.max_connection_lifetime", "0"),
 				),
 			},
 		},
@@ -406,6 +464,7 @@ func TestAccDatabaseSecretBackendConnection_mysql(t *testing.T) {
 
 func TestAccDatabaseSecretBackendConnectionUpdate_mysql(t *testing.T) {
 	MaybeSkipDBTests(t, dbBackendMySQL)
+	resourceName := "vault_database_secret_backend_connection.test"
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "MYSQL_URL")
@@ -422,37 +481,37 @@ func TestAccDatabaseSecretBackendConnectionUpdate_mysql(t *testing.T) {
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfigUpdate_mysql(name, backend, connURL, password, 0),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.#", "1"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.0", "FOOBAR"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.connection_url", connURL),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.max_open_connections", "2"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.max_connection_lifetime", "0"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.%", "1"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.password", password),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
+					resource.TestCheckResourceAttr(resourceName, "mysql.0.connection_url", connURL),
+					resource.TestCheckResourceAttr(resourceName, "mysql.0.max_open_connections", "2"),
+					resource.TestCheckResourceAttr(resourceName, "mysql.0.max_connection_lifetime", "0"),
+					resource.TestCheckResourceAttr(resourceName, "data.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "data.password", password),
 				),
 			},
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfigUpdate_mysql(name, backend, connURL, password, 10),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.#", "1"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.0", "FOOBAR"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.connection_url", connURL),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.max_open_connections", "2"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.max_connection_lifetime", "10"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.%", "1"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.password", password),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
+					resource.TestCheckResourceAttr(resourceName, "mysql.0.connection_url", connURL),
+					resource.TestCheckResourceAttr(resourceName, "mysql.0.max_open_connections", "2"),
+					resource.TestCheckResourceAttr(resourceName, "mysql.0.max_connection_lifetime", "10"),
+					resource.TestCheckResourceAttr(resourceName, "data.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "data.password", password),
 				),
 			},
 		},
@@ -461,6 +520,7 @@ func TestAccDatabaseSecretBackendConnectionUpdate_mysql(t *testing.T) {
 
 func TestAccDatabaseSecretBackendConnectionTemplatedUpdateExcludePassword_mysql(t *testing.T) {
 	MaybeSkipDBTests(t, dbBackendMySQL)
+	resourceName := "vault_database_secret_backend_connection.test"
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t,
@@ -497,17 +557,17 @@ func TestAccDatabaseSecretBackendConnectionTemplatedUpdateExcludePassword_mysql(
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfigTemplated_mysql(name, backend, testConnURL, testUsername, testPassword, 0),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.connection_url", testConnURL),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.max_connection_lifetime", "0"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.%", "2"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.username", testUsername),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.password", testPassword),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
+					resource.TestCheckResourceAttr(resourceName, "mysql.0.connection_url", testConnURL),
+					resource.TestCheckResourceAttr(resourceName, "mysql.0.max_connection_lifetime", "0"),
+					resource.TestCheckResourceAttr(resourceName, "data.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "data.username", testUsername),
+					resource.TestCheckResourceAttr(resourceName, "data.password", testPassword),
 				),
 			},
 			{
@@ -522,17 +582,17 @@ func TestAccDatabaseSecretBackendConnectionTemplatedUpdateExcludePassword_mysql(
 					log.Printf("rotate-root: %v", resp)
 				},
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.connection_url", testConnURL),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.max_connection_lifetime", "10"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.%", "2"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.username", testUsername),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.password", testPassword),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
+					resource.TestCheckResourceAttr(resourceName, "mysql.0.connection_url", testConnURL),
+					resource.TestCheckResourceAttr(resourceName, "mysql.0.max_connection_lifetime", "10"),
+					resource.TestCheckResourceAttr(resourceName, "data.%", "2"),
+					resource.TestCheckResourceAttr(resourceName, "data.username", testUsername),
+					resource.TestCheckResourceAttr(resourceName, "data.password", testPassword),
 				),
 			},
 		},
@@ -541,6 +601,7 @@ func TestAccDatabaseSecretBackendConnectionTemplatedUpdateExcludePassword_mysql(
 
 func TestAccDatabaseSecretBackendConnection_mysql_tls(t *testing.T) {
 	MaybeSkipDBTests(t, dbBackendMySQL)
+	resourceName := "vault_database_secret_backend_connection.test"
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "MYSQL_CA", "MYSQL_URL", "MYSQL_CERTIFICATE_KEY")
@@ -557,22 +618,22 @@ func TestAccDatabaseSecretBackendConnection_mysql_tls(t *testing.T) {
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfig_mysql_tls(name, backend, connURL, password, tlsCA, tlsCertificateKey),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.#", "1"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.0", "FOOBAR"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.connection_url", connURL),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.max_open_connections", "2"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.max_idle_connections", "0"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.max_connection_lifetime", "0"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.%", "1"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "data.password", password),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.tlsCA", tlsCA+"\n"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "mysql.0.tls_certificate_key", tlsCertificateKey+"\n"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
+					resource.TestCheckResourceAttr(resourceName, "mysql.0.connection_url", connURL),
+					resource.TestCheckResourceAttr(resourceName, "mysql.0.max_open_connections", "2"),
+					resource.TestCheckResourceAttr(resourceName, "mysql.0.max_idle_connections", "0"),
+					resource.TestCheckResourceAttr(resourceName, "mysql.0.max_connection_lifetime", "0"),
+					resource.TestCheckResourceAttr(resourceName, "data.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "data.password", password),
+					resource.TestCheckResourceAttr(resourceName, "mysql.0.tls_ca", tlsCA+"\n"),
+					resource.TestCheckResourceAttr(resourceName, "mysql.0.tls_certificate_key", tlsCertificateKey+"\n"),
 				),
 			},
 		},
@@ -581,6 +642,7 @@ func TestAccDatabaseSecretBackendConnection_mysql_tls(t *testing.T) {
 
 func TestAccDatabaseSecretBackendConnection_postgresql(t *testing.T) {
 	MaybeSkipDBTests(t, dbBackendPostgres)
+	resourceName := "vault_database_secret_backend_connection.test"
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "POSTGRES_URL")
@@ -597,19 +659,19 @@ func TestAccDatabaseSecretBackendConnection_postgresql(t *testing.T) {
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfig_postgresql(name, backend, connURL, userTempl),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.#", "1"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "root_rotation_statements.0", "FOOBAR"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "postgresql.0.connection_url", connURL),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "postgresql.0.max_open_connections", "2"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "postgresql.0.max_idle_connections", "0"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "postgresql.0.max_connection_lifetime", "0"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "postgresql.0.username_template", userTempl),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
+					resource.TestCheckResourceAttr(resourceName, "postgresql.0.connection_url", connURL),
+					resource.TestCheckResourceAttr(resourceName, "postgresql.0.max_open_connections", "2"),
+					resource.TestCheckResourceAttr(resourceName, "postgresql.0.max_idle_connections", "0"),
+					resource.TestCheckResourceAttr(resourceName, "postgresql.0.max_connection_lifetime", "0"),
+					resource.TestCheckResourceAttr(resourceName, "postgresql.0.username_template", userTempl),
 				),
 			},
 		},
@@ -618,6 +680,7 @@ func TestAccDatabaseSecretBackendConnection_postgresql(t *testing.T) {
 
 func TestAccDatabaseSecretBackendConnection_elasticsearch(t *testing.T) {
 	MaybeSkipDBTests(t, dbBackendElasticSearch)
+	resourceName := "vault_database_secret_backend_connection.test"
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "ELASTIC_URL")
@@ -636,13 +699,13 @@ func TestAccDatabaseSecretBackendConnection_elasticsearch(t *testing.T) {
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfig_elasticsearch(name, backend, connURL, username, password),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "elasticsearch.0.url", connURL),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
+					resource.TestCheckResourceAttr(resourceName, "elasticsearch.0.url", connURL),
 				),
 			},
 		},
@@ -651,6 +714,7 @@ func TestAccDatabaseSecretBackendConnection_elasticsearch(t *testing.T) {
 
 func TestAccDatabaseSecretBackendConnection_snowflake(t *testing.T) {
 	MaybeSkipDBTests(t, dbBackendSnowflake)
+	resourceName := "vault_database_secret_backend_connection.test"
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "SNOWFLAKE_URL")
@@ -671,16 +735,16 @@ func TestAccDatabaseSecretBackendConnection_snowflake(t *testing.T) {
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "name", name),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "verify_connection", "true"),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "snowflake.0.connection_url", connURL),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "snowflake.0.username", username),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "snowflake.0.password", password),
-					resource.TestCheckResourceAttr("vault_database_secret_backend_connection.test", "snowflake.0.username_template", userTempl),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
+					resource.TestCheckResourceAttr(resourceName, "snowflake.0.connection_url", connURL),
+					resource.TestCheckResourceAttr(resourceName, "snowflake.0.username", username),
+					resource.TestCheckResourceAttr(resourceName, "snowflake.0.password", password),
+					resource.TestCheckResourceAttr(resourceName, "snowflake.0.username_template", userTempl),
 				),
 			},
 		},
@@ -782,6 +846,29 @@ resource "vault_database_secret_backend_connection" "test" {
     password = "%s"
     tls = false
     protocol_version = 5
+  }
+}
+`, path, name, host, username, password)
+}
+
+func testAccDatabaseSecretBackendConnectionConfig_couchbase(name, path, host, username, password string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "db" {
+  path = "%s"
+  type = "database"
+}
+
+resource "vault_database_secret_backend_connection" "test" {
+  backend                  = vault_mount.db.path
+  name                     = "%s"
+  allowed_roles            = ["dev", "prod"]
+  root_rotation_statements = ["FOOBAR"]
+
+  couchbase {
+    hosts    = ["%s"]
+    username = "%s"
+    password = "%s"
+	bucket_name = "beer-sample"
   }
 }
 `, path, name, host, username, password)

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -153,10 +153,10 @@ func TestAccDatabaseSecretBackendConnection_cassandraProtocol(t *testing.T) {
 func TestAccDatabaseSecretBackendConnection_couchbase(t *testing.T) {
 	MaybeSkipDBTests(t, dbBackendCouchbase)
 
-	values := testutil.SkipTestEnvUnset(t, "COUCHBASE_HOST")
+	values := testutil.SkipTestEnvUnset(t, "COUCHBASE_HOST", "COUCHBASE_USERNAME", "COUCHBASE_PASSWORD")
 	host := values[0]
-	username := os.Getenv("COUCHBASE_USERNAME")
-	password := os.Getenv("COUCHBASE_PASSWORD")
+	username := values[1]
+	password := values[2]
 	backend := acctest.RandomWithPrefix("tf-test-db")
 	name := acctest.RandomWithPrefix("db")
 	resourceName := "vault_database_secret_backend_connection.test"

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -151,12 +151,10 @@ func TestAccDatabaseSecretBackendConnection_cassandraProtocol(t *testing.T) {
 }
 
 func TestAccDatabaseSecretBackendConnection_couchbase(t *testing.T) {
-	MaybeSkipDBTests(t, dbBackendInfluxDB)
+	MaybeSkipDBTests(t, dbBackendCouchbase)
 
-	host := os.Getenv("COUCHBASE_HOST")
-	if host == "" {
-		t.Skip("COUCHBASE_HOST not set")
-	}
+	values := testutil.SkipTestEnvUnset(t, "COUCHBASE_HOST")
+	host := values[0]
 	username := os.Getenv("COUCHBASE_USERNAME")
 	password := os.Getenv("COUCHBASE_PASSWORD")
 	backend := acctest.RandomWithPrefix("tf-test-db")

--- a/website/docs/r/database_secret_backend_connection.md
+++ b/website/docs/r/database_secret_backend_connection.md
@@ -115,7 +115,7 @@ Exactly one of the nested blocks of configuration options must be supplied.
 
 ### Couchbase Configuration Options
 
-* `hosts` - (Required) A list of Couchbase hosts to connect to. Must use couchbases:// scheme if `tls` is `true`.
+* `hosts` - (Required) A set of Couchbase URIs to connect to. Must use `couchbases://` scheme if `tls` is `true`.
 
 * `username` - (Required) Specifies the username for Vault to use.
 

--- a/website/docs/r/database_secret_backend_connection.md
+++ b/website/docs/r/database_secret_backend_connection.md
@@ -57,6 +57,8 @@ The following arguments are supported:
 
 * `cassandra` - (Optional) A nested block containing configuration options for Cassandra connections.
 
+* `couchbase` - (Optional) A nested block containing configuration options for Couchbase connections.
+
 * `mongodb` - (Optional) A nested block containing configuration options for MongoDB connections.
 
 * `mongodbatlas` - (Optional) A nested block containing configuration options for MongoDB Atlas connections.
@@ -111,6 +113,25 @@ Exactly one of the nested blocks of configuration options must be supplied.
 * `connect_timeout` - (Optional) The number of seconds to use as a connection
   timeout.
 
+### Couchbase Configuration Options
+
+* `hosts` - (Required) A list of Couchbase hosts to connect to. Must use couchbases:// scheme if `tls` is `true`.
+
+* `username` - (Required) Specifies the username for Vault to use.
+
+* `password` - (Required) Specifies the password corresponding to the given username.
+
+* `tls` - (Optional) Whether to use TLS when connecting to Couchbase.
+
+* `insecure_tls` - (Optional) Whether to skip verification of the server
+  certificate when using TLS.
+
+* `base64_pem` - (Optional) Required if `tls` is `true`. Specifies the certificate authority of the Couchbase server, as a PEM certificate that has been base64 encoded.
+
+* `bucket_name` - (Optional) Required for Couchbase versions prior to 6.5.0. This is only used to verify vault's connection to the server.
+
+* `username_template` - (Optional) Template describing how dynamic usernames are generated.
+
 ### InfluxDB Configuration Options
 
 * `host` - (Required) The host to connect to.
@@ -137,7 +158,6 @@ Exactly one of the nested blocks of configuration options must be supplied.
 * `connect_timeout` - (Optional) The number of seconds to use as a connection
   timeout.
 
-
 ### MongoDB Configuration Options
 
 * `connection_url` - (Required) A URL containing connection information. See
@@ -149,7 +169,6 @@ Exactly one of the nested blocks of configuration options must be supplied.
 See the [Vault
   docs](https://www.vaultproject.io/docs/concepts/username-templating)
 
-
 ### MongoDB Atlas Configuration Options
 
 * `public_key` - (Required) The Public Programmatic API Key used to authenticate with the MongoDB Atlas API.
@@ -157,7 +176,6 @@ See the [Vault
 * `private_key` - (Required) The Private Programmatic API Key used to connect with MongoDB Atlas API.
 
 * `project_id` - (Required) The Project ID the Database User should be created within.
-
 
 ### SAP HanaDB Configuration Options
 
@@ -194,7 +212,7 @@ See the [Vault
 * `username_template` - (Optional) For Vault v1.7+. The template to use for username generation.
 See the [Vault
   docs](https://www.vaultproject.io/docs/concepts/username-templating)
- 
+
 * `contained_db` - (Optional bool: false) For Vault v1.9+. Set to true when the target is a
   Contained Database, e.g. AzureSQL.
   See the [Vault


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resouce_database_secret_backend_connection - add support for `couchbase` db backend
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
--- PASS: TestAccDatabaseSecretBackendConnection_couchbase (35.06s)
--- PASS: TestAccDatabaseSecretBackendConnection_influxdb (31.74s)
```
