### PR TITLE
r/rabbitmq_secret_backend - add `password_policy` and `username_template` arguments.

### DIFF
--- a/vault/resource_rabbitmq_secret_backend.go
+++ b/vault/resource_rabbitmq_secret_backend.go
@@ -35,6 +35,7 @@ func rabbitMQSecretBackendResource() *schema.Resource {
 			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				ForceNew:    true,
 				Description: "Human-friendly description of the mount for the backend.",
 			},
 			"default_lease_ttl_seconds": {
@@ -53,17 +54,20 @@ func rabbitMQSecretBackendResource() *schema.Resource {
 			"connection_uri": {
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: "Specifies the RabbitMQ connection URI.",
 			},
 			"username": {
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Sensitive:   true,
 				Description: "Specifies the RabbitMQ management administrator username",
 			},
 			"password": {
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Sensitive:   true,
 				Description: "Specifies the RabbitMQ management administrator password",
 			},

--- a/vault/resource_rabbitmq_secret_backend.go
+++ b/vault/resource_rabbitmq_secret_backend.go
@@ -156,6 +156,10 @@ func rabbitMQSecretBackendRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("default_lease_ttl_seconds", mount.Config.DefaultLeaseTTL)
 	d.Set("max_lease_ttl_seconds", mount.Config.MaxLeaseTTL)
 
+	// access key, secret key, and region, sadly, we can't read out
+	// the API doesn't support it
+	// So... if they drift, they drift.
+
 	return nil
 }
 

--- a/vault/resource_rabbitmq_secret_backend_test.go
+++ b/vault/resource_rabbitmq_secret_backend_test.go
@@ -16,6 +16,7 @@ import (
 func TestAccRabbitMQSecretBackend_basic(t *testing.T) {
 	path := acctest.RandomWithPrefix("tf-test-rabbitmq")
 	connectionUri, username, password := testutil.GetTestRMQCreds(t)
+	resourceName := "vault_rabbitmq_secret_backend.test"
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
@@ -24,57 +25,33 @@ func TestAccRabbitMQSecretBackend_basic(t *testing.T) {
 			{
 				Config: testAccRabbitMQSecretBackendConfig_basic(path, connectionUri, username, password),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend.test", "path", path),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend.test", "description", "test description"),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend.test", "default_lease_ttl_seconds", "3600"),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend.test", "max_lease_ttl_seconds", "86400"),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend.test", "connection_uri", connectionUri),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend.test", "username", username),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend.test", "password", password),
+					resource.TestCheckResourceAttr(resourceName, "path", path),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
+					resource.TestCheckResourceAttr(resourceName, "default_lease_ttl_seconds", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "max_lease_ttl_seconds", "86400"),
+					resource.TestCheckResourceAttr(resourceName, "connection_uri", connectionUri),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "password", password),
 				),
 			},
 			{
-				Config: testAccRabbitMQSecretBackendConfig_updated(path, connectionUri, username, password),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend.test", "path", path),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend.test", "description", "test description"),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend.test", "default_lease_ttl_seconds", "1800"),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend.test", "max_lease_ttl_seconds", "43200"),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend.test", "connection_uri", connectionUri),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend.test", "username", username),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend.test", "password", password),
-				),
-			},
-		},
-	})
-}
-
-func TestAccRabbitMQSecretBackend_import(t *testing.T) {
-	path := acctest.RandomWithPrefix("tf-test-rabbitmq")
-	connectionUri, username, password := testutil.GetTestRMQCreds(t)
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testutil.TestAccPreCheck(t) },
-		Providers:    testProviders,
-		CheckDestroy: testAccRabbitMQSecretBackendCheckDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccRabbitMQSecretBackendConfig_basic(path, connectionUri, username, password),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend.test", "path", path),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend.test", "description", "test description"),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend.test", "default_lease_ttl_seconds", "3600"),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend.test", "max_lease_ttl_seconds", "86400"),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend.test", "connection_uri", connectionUri),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend.test", "username", username),
-					resource.TestCheckResourceAttr("vault_rabbitmq_secret_backend.test", "password", password),
-				),
-			},
-			{
-				ResourceName:      "vault_rabbitmq_secret_backend.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				// the API can't serve these fields, so ignore them
 				ImportStateVerifyIgnore: []string{"connection_uri", "username", "password", "verify_connection"},
+			},
+			{
+				Config: testAccRabbitMQSecretBackendConfig_updated(path, connectionUri, username, password),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "path", path),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
+					resource.TestCheckResourceAttr(resourceName, "default_lease_ttl_seconds", "1800"),
+					resource.TestCheckResourceAttr(resourceName, "max_lease_ttl_seconds", "43200"),
+					resource.TestCheckResourceAttr(resourceName, "connection_uri", connectionUri),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "password", password),
+				),
 			},
 		},
 	})

--- a/website/docs/r/rabbitmq_secret_backend.html.md
+++ b/website/docs/r/rabbitmq_secret_backend.html.md
@@ -41,10 +41,13 @@ The following arguments are supported:
 * `verify_connection` - (Optional) Specifies whether to verify connection URI, username, and password.
 Defaults to `true`.
 
+* `password_policy` - (Optional) Specifies a password policy to use when creating dynamic credentials. Defaults to generating an alphanumeric password if not set.
+
+* `username_template` - (Optional) Template describing how dynamic usernames are generated.
 
 ~> **Important** Because Vault does not support reading the configured
 credentials back from the API, Terraform cannot detect and correct drift
-on `connection_uri`, `username`, `password` or `verify_connection`. Changing the values, however, _will_
+on `connection_uri`, `username`, `password`, `verify_connection`, `username_template`, and `password_policy`. Changing the values, however, _will_
 overwrite the previously stored values.
 
 * `path` - (Optional) The unique path this backend should be mounted at. Must


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource_rabbitmq_secret_backend - add `password_policy` and `username_template` arguments.
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccRabbitmqSecretBackend_basic'
--- PASS: TestAccRabbitMQSecretBackend_basic (2.28s)
--- PASS: TestAccRabbitMQSecretBackend_template (1.23s)
```
