### PR TITLE
Arg removal not properly applied for aws_secret_backend_role

### DIFF
--- a/vault/resource_aws_secret_backend_role.go
+++ b/vault/resource_aws_secret_backend_role.go
@@ -116,16 +116,16 @@ func awsSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) error {
 	data := map[string]interface{}{
 		"credential_type": credentialType,
 	}
-	if policyDocument != "" {
+	if d.HasChange("policy_document") {
 		data["policy_document"] = policyDocument
 	}
-	if len(policyARNs) != 0 {
+	if d.HasChange("policy_arns") {
 		data["policy_arns"] = policyARNs
 	}
-	if len(roleARNs) != 0 {
+	if d.HasChange("role_arns") {
 		data["role_arns"] = roleARNs
 	}
-	if len(iamGroups) != 0 || !d.IsNewResource() {
+	if d.HasChange("iam_groups") {
 		data["iam_groups"] = iamGroups
 	}
 

--- a/vault/resource_aws_secret_backend_role_test.go
+++ b/vault/resource_aws_secret_backend_role_test.go
@@ -51,6 +51,9 @@ func TestAccAWSSecretBackendRole_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "role_arns.#", "1"),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "role_arns.0", testAccAWSSecretBackendRoleRoleArn_basic),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "policy_arns.#", "0"),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_to_arn", "name", fmt.Sprintf("%s-policy-inline-to-arn", name)),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_to_arn", "backend", backend),
+					util.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline_to_arn", "policy_document", testAccAWSSecretBackendRolePolicyInline_basic),
 				),
 			},
 			{
@@ -83,6 +86,11 @@ func TestAccAWSSecretBackendRole_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_groups", "name", fmt.Sprintf("%s-role-groups", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_groups", "backend", backend),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_groups", "iam_groups.#", "2"),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_to_arn", "name", fmt.Sprintf("%s-policy-inline-to-arn", name)),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_to_arn", "backend", backend),
+					util.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline_to_arn", "policy_document", ""),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_to_arn", "policy_arns.#", "1"),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_to_arn", "policy_arns.0", testAccAWSSecretBackendRolePolicyArn_updated),
 				),
 			},
 			{
@@ -96,15 +104,22 @@ func TestAccAWSSecretBackendRole_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "backend", backend),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "policy_arns.#", "1"),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "policy_arns.0", testAccAWSSecretBackendRolePolicyArn_basic),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arns", "iam_groups.#", "0"),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "name", fmt.Sprintf("%s-policy-inline-and-arns", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "backend", backend),
 					util.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline_and_arns", "policy_document", testAccAWSSecretBackendRolePolicyInline_basic),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "policy_arns.#", "1"),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "policy_arns.0", testAccAWSSecretBackendRolePolicyArn_basic),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_and_arns", "iam_groups.#", "0"),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "name", fmt.Sprintf("%s-role-arns", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "backend", backend),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "role_arns.0", testAccAWSSecretBackendRoleRoleArn_basic),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "policy_arns.#", "0"),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_role_arns", "iam_groups.#", "0"),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_to_arn", "name", fmt.Sprintf("%s-policy-inline-to-arn", name)),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_to_arn", "backend", backend),
+					util.TestCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline_to_arn", "policy_document", testAccAWSSecretBackendRolePolicyInline_basic),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline_to_arn", "policy_arns.#", "0"),
 				),
 			},
 		},
@@ -280,7 +295,14 @@ resource "vault_aws_secret_backend_role" "test_role_arns" {
 	credential_type = "assumed_role"
 	backend = vault_aws_secret_backend.test.path
 }
-`, path, accessKey, secretKey, name, testAccAWSSecretBackendRolePolicyInline_basic, name, testAccAWSSecretBackendRolePolicyArn_basic, name, testAccAWSSecretBackendRolePolicyInline_basic, testAccAWSSecretBackendRolePolicyArn_basic, name, testAccAWSSecretBackendRoleRoleArn_basic)
+
+resource "vault_aws_secret_backend_role" "test_policy_inline_to_arn" {
+  name = "%s-policy-inline-to-arn"
+  policy_document = %q
+  credential_type = "assumed_role"
+  backend = vault_aws_secret_backend.test.path
+}
+`, path, accessKey, secretKey, name, testAccAWSSecretBackendRolePolicyInline_basic, name, testAccAWSSecretBackendRolePolicyArn_basic, name, testAccAWSSecretBackendRolePolicyInline_basic, testAccAWSSecretBackendRolePolicyArn_basic, name, testAccAWSSecretBackendRoleRoleArn_basic, name, testAccAWSSecretBackendRolePolicyInline_basic)
 }
 
 func testAccAWSSecretBackendRoleConfig_updated(name, path, accessKey, secretKey string) string {
@@ -332,5 +354,12 @@ resource "vault_aws_secret_backend_role" "test_role_groups" {
 	iam_groups = ["group1", "group2"]
 	backend = vault_aws_secret_backend.test.path
 }
-`, path, accessKey, secretKey, name, testAccAWSSecretBackendRolePolicyInline_updated, name, testAccAWSSecretBackendRolePolicyArn_updated, name, testAccAWSSecretBackendRolePolicyInline_updated, testAccAWSSecretBackendRolePolicyArn_updated, name, testAccAWSSecretBackendRoleRoleArn_updated, name)
+
+resource "vault_aws_secret_backend_role" "test_policy_inline_to_arn" {
+  name = "%s-policy-inline-to-arn"
+  policy_arns = ["%s"]
+  credential_type = "assumed_role"
+  backend = vault_aws_secret_backend.test.path
+}
+`, path, accessKey, secretKey, name, testAccAWSSecretBackendRolePolicyInline_updated, name, testAccAWSSecretBackendRolePolicyArn_updated, name, testAccAWSSecretBackendRolePolicyInline_updated, testAccAWSSecretBackendRolePolicyArn_updated, name, testAccAWSSecretBackendRoleRoleArn_updated, name, name, testAccAWSSecretBackendRolePolicyArn_updated)
 }


### PR DESCRIPTION
When an existing argument like `policy_document` is removed for `aws_secret_backend_role`, the change won't be properly applied to Vault, as it's only checking for existing data: If there is a removal, Terraform will simply not send the data to Vault. This results in constant attempts of Terraform to remove the data without success.

This changes the checks for what data should be sent to Vault, so arguments will always be set in case their data has changed (even if it's a change to null).

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Closes #742

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
aws_secret_backend_role: Removal of arguments will be properly applied to Vault
```

Output from acceptance testing:

```
❯ AWS_ACCESS_KEY_ID=abcd AWS_ACCESS_KEY=abc AWS_SECRET_ACCESS_KEY=abd TESTARGS="-v --run TestAccAWSSecretBackendRole*" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./...) -v -v --run TestAccAWSSecretBackendRole* -timeout 20m
?   	github.com/hashicorp/terraform-provider-vault	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/generate	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/codegen	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/generated	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/helper	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/schema	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/util	(cached) [no tests to run]
=== RUN   TestAccAWSSecretBackendRole_basic
--- PASS: TestAccAWSSecretBackendRole_basic (1.87s)
=== RUN   TestAccAWSSecretBackendRole_import
--- PASS: TestAccAWSSecretBackendRole_import (1.24s)
=== RUN   TestAccAWSSecretBackendRole_nested
--- PASS: TestAccAWSSecretBackendRole_nested (1.50s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/vault	4.634s
```
