### PR TITLE
Update vhosts syntax

### DIFF
--- a/website/docs/r/rabbitmq_secret_backend_role.html.md
+++ b/website/docs/r/rabbitmq_secret_backend_role.html.md
@@ -32,7 +32,12 @@ resource "vault_rabbitmq_secret_backend_role" "role" {
   name    = "deploy"
 
   tags = "tag1,tag2"
-  vhosts = "{\"/\": {\"configure\":\".*\", \"write\":\".*\", \"read\": \".*\"}}"
+  vhost {
+    host      = "/"
+    configure = ".*"
+    write     = ".*"
+    read      = ".*"
+  }
 }
 ```
 
@@ -48,7 +53,7 @@ Must be unique within the backend.
 
 * `tags` - (Optional) Specifies a comma-separated RabbitMQ management tags.
 
-* `vhosts` - (Optional) Specifies a map of virtual hosts to permissions.
+* `vhost` - (Optional) Specifies a map of virtual hosts to permissions.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Adding some corrections to the documentation in order to stick with the latest syntax used. Currently it was outdated and up on terraform apply it was failing with error that vhosts not expected.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Closes #778 
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
