### PR TITLE
r/aws_secret_backend - add support for `username_template`

### DIFF
--- a/vault/resource_aws_secret_backend.go
+++ b/vault/resource_aws_secret_backend.go
@@ -85,6 +85,12 @@ func awsSecretBackendResource() *schema.Resource {
 				Optional:    true,
 				Description: "Specifies a custom HTTP STS endpoint to use.",
 			},
+			"username_template": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "Template describing how dynamic usernames are generated.",
+			},
 		},
 	}
 }
@@ -101,6 +107,7 @@ func awsSecretBackendCreate(d *schema.ResourceData, meta interface{}) error {
 	region := d.Get("region").(string)
 	iamEndpoint := d.Get("iam_endpoint").(string)
 	stsEndpoint := d.Get("sts_endpoint").(string)
+	usernameTemplate := d.Get("username_template").(string)
 
 	d.Partial(true)
 	log.Printf("[DEBUG] Mounting AWS backend at %q", path)
@@ -131,6 +138,9 @@ func awsSecretBackendCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 	if stsEndpoint != "" {
 		data["sts_endpoint"] = stsEndpoint
+	}
+	if usernameTemplate != "" {
+		data["username_template"] = usernameTemplate
 	}
 	_, err = client.Logical().Write(path+"/config/root", data)
 	if err != nil {
@@ -202,6 +212,9 @@ func awsSecretBackendRead(d *schema.ResourceData, meta interface{}) error {
 		if v, ok := resp.Data["sts_endpoint"].(string); ok {
 			d.Set("sts_endpoint", v)
 		}
+		if v, ok := resp.Data["username_template"].(string); ok {
+			d.Set("username_template", v)
+		}
 	}
 
 	d.Set("path", path)
@@ -238,6 +251,8 @@ func awsSecretBackendUpdate(d *schema.ResourceData, meta interface{}) error {
 		region := d.Get("region").(string)
 		iamEndpoint := d.Get("iam_endpoint").(string)
 		stsEndpoint := d.Get("sts_endpoint").(string)
+		usernameTemplate := d.Get("username_template").(string)
+
 		if region != "" {
 			data["region"] = region
 		}
@@ -246,6 +261,9 @@ func awsSecretBackendUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 		if stsEndpoint != "" {
 			data["sts_endpoint"] = stsEndpoint
+		}
+		if usernameTemplate != "" {
+			data["username_template"] = usernameTemplate
 		}
 		_, err := client.Logical().Write(path+"/config/root", data)
 		if err != nil {

--- a/vault/resource_aws_secret_backend_test.go
+++ b/vault/resource_aws_secret_backend_test.go
@@ -168,12 +168,12 @@ resource "vault_aws_secret_backend" "test" {
 func testAccAWSSecretBackendConfig_userTemplate(path, accessKey, secretKey, templ string) string {
 	return fmt.Sprintf(`
 resource "vault_aws_secret_backend" "test" {
-  path = %[1]q
+  path = "%[1]s"
   description = "test description"
   default_lease_ttl_seconds = 3600
   max_lease_ttl_seconds = 86400
-  access_key = %[2]q
-  secret_key = %[3]q
-  username_template = %[4]q
+  access_key = "%[2]s"
+  secret_key = "%[3]s"
+  username_template = "%[4]s"
 }`, path, accessKey, secretKey, templ)
 }

--- a/vault/resource_aws_secret_backend_test.go
+++ b/vault/resource_aws_secret_backend_test.go
@@ -168,12 +168,12 @@ resource "vault_aws_secret_backend" "test" {
 func testAccAWSSecretBackendConfig_userTemplate(path, accessKey, secretKey, templ string) string {
 	return fmt.Sprintf(`
 resource "vault_aws_secret_backend" "test" {
-  path = "%[1]s"
+  path = "%s"
   description = "test description"
   default_lease_ttl_seconds = 3600
   max_lease_ttl_seconds = 86400
-  access_key = "%[2]s"
-  secret_key = "%[3]s"
-  username_template = "%[4]s"
+  access_key = "%s"
+  secret_key = "%s"
+  username_template = "%s"
 }`, path, accessKey, secretKey, templ)
 }

--- a/vault/resource_aws_secret_backend_test.go
+++ b/vault/resource_aws_secret_backend_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestAccAWSSecretBackend_basic(t *testing.T) {
 	path := acctest.RandomWithPrefix("tf-test-aws")
+	resourceName := "vault_aws_secret_backend.test"
 	accessKey, secretKey := testutil.GetTestAWSCreds(t)
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
@@ -24,75 +25,79 @@ func TestAccAWSSecretBackend_basic(t *testing.T) {
 			{
 				Config: testAccAWSSecretBackendConfig_basic(path, accessKey, secretKey),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "path", path),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "description", "test description"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "default_lease_ttl_seconds", "3600"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "max_lease_ttl_seconds", "86400"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "access_key", accessKey),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "secret_key", secretKey),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "region", "us-east-1"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "iam_endpoint", ""),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "sts_endpoint", ""),
+					resource.TestCheckResourceAttr(resourceName, "path", path),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
+					resource.TestCheckResourceAttr(resourceName, "default_lease_ttl_seconds", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "max_lease_ttl_seconds", "86400"),
+					resource.TestCheckResourceAttr(resourceName, "access_key", accessKey),
+					resource.TestCheckResourceAttr(resourceName, "secret_key", secretKey),
+					resource.TestCheckResourceAttr(resourceName, "region", "us-east-1"),
+					resource.TestCheckResourceAttr(resourceName, "iam_endpoint", ""),
+					resource.TestCheckResourceAttr(resourceName, "sts_endpoint", ""),
+					resource.TestCheckResourceAttrSet(resourceName, "username_template"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// the API can't serve these fields, so ignore them
+				ImportStateVerifyIgnore: []string{"secret_key"},
 			},
 			{
 				Config: testAccAWSSecretBackendConfig_updated(path, accessKey, secretKey),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "path", path),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "description", "test description"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "default_lease_ttl_seconds", "1800"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "max_lease_ttl_seconds", "43200"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "access_key", accessKey),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "secret_key", secretKey),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "region", "us-west-1"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "iam_endpoint", "https://iam.amazonaws.com"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "sts_endpoint", "https://sts.us-west-1.amazonaws.com"),
+					resource.TestCheckResourceAttr(resourceName, "path", path),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
+					resource.TestCheckResourceAttr(resourceName, "default_lease_ttl_seconds", "1800"),
+					resource.TestCheckResourceAttr(resourceName, "max_lease_ttl_seconds", "43200"),
+					resource.TestCheckResourceAttr(resourceName, "access_key", accessKey),
+					resource.TestCheckResourceAttr(resourceName, "secret_key", secretKey),
+					resource.TestCheckResourceAttr(resourceName, "region", "us-west-1"),
+					resource.TestCheckResourceAttr(resourceName, "iam_endpoint", "https://iam.amazonaws.com"),
+					resource.TestCheckResourceAttr(resourceName, "sts_endpoint", "https://sts.us-west-1.amazonaws.com"),
 				),
 			},
 			{
 				Config: testAccAWSSecretBackendConfig_noCreds(path),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "path", path),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "description", "test description"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "default_lease_ttl_seconds", "1800"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "max_lease_ttl_seconds", "43200"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "access_key", ""),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "secret_key", ""),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "region", "us-west-1"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "iam_endpoint", ""),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "sts_endpoint", ""),
+					resource.TestCheckResourceAttr(resourceName, "path", path),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
+					resource.TestCheckResourceAttr(resourceName, "default_lease_ttl_seconds", "1800"),
+					resource.TestCheckResourceAttr(resourceName, "max_lease_ttl_seconds", "43200"),
+					resource.TestCheckResourceAttr(resourceName, "access_key", ""),
+					resource.TestCheckResourceAttr(resourceName, "secret_key", ""),
+					resource.TestCheckResourceAttr(resourceName, "region", "us-west-1"),
+					resource.TestCheckResourceAttr(resourceName, "iam_endpoint", ""),
+					resource.TestCheckResourceAttr(resourceName, "sts_endpoint", ""),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAWSSecretBackend_import(t *testing.T) {
+func TestAccAWSSecretBackend_usernameTempl(t *testing.T) {
 	path := acctest.RandomWithPrefix("tf-test-aws")
+	resourceName := "vault_aws_secret_backend.test"
 	accessKey, secretKey := testutil.GetTestAWSCreds(t)
+	templ := fmt.Sprintf(`{{ printf "vault-%%s-%%s-%%s" (printf "%%s-%%s" (.DisplayName) (.PolicyName) | truncate 42) (unix_time) (random 20) | truncate 64 }}`)
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
+		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		CheckDestroy: testAccAWSSecretBackendCheckDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSecretBackendConfig_basic(path, accessKey, secretKey),
+				Config: testAccAWSSecretBackendConfig_userTemplate(path, accessKey, secretKey, templ),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "path", path),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "description", "test description"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "default_lease_ttl_seconds", "3600"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "max_lease_ttl_seconds", "86400"),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "access_key", accessKey),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "secret_key", secretKey),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend.test", "region", "us-east-1"),
+					resource.TestCheckResourceAttr(resourceName, "username_template", templ),
 				),
 			},
 			{
-				ResourceName:      "vault_aws_secret_backend.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				// the API can't serve these fields, so ignore them
-				ImportStateVerifyIgnore: []string{"access_key", "secret_key", "region"},
+				ImportStateVerifyIgnore: []string{"secret_key"},
 			},
 		},
 	})
@@ -158,4 +163,17 @@ resource "vault_aws_secret_backend" "test" {
   max_lease_ttl_seconds = 43200
   region = "us-west-1"
 }`, path)
+}
+
+func testAccAWSSecretBackendConfig_userTemplate(path, accessKey, secretKey, templ string) string {
+	return fmt.Sprintf(`
+resource "vault_aws_secret_backend" "test" {
+  path = %[1]q
+  description = "test description"
+  default_lease_ttl_seconds = 3600
+  max_lease_ttl_seconds = 86400
+  access_key = %[2]q
+  secret_key = %[3]q
+  username_template = %[4]q
+}`, path, accessKey, secretKey, templ)
 }

--- a/website/docs/r/aws_secret_backend.html.md
+++ b/website/docs/r/aws_secret_backend.html.md
@@ -67,6 +67,17 @@ for credentials issued by this backend.
 
 * `sts_endpoint` - (Optional) Specifies a custom HTTP STS endpoint to use.
 
+* `username_template` - (Optional)  Template describing how dynamic usernames are generated. The username template is used to generate both IAM usernames (capped at 64 characters) and STS usernames (capped at 32 characters). If no template is provided the field defaults to the template:
+
+```sh
+{{ if (eq .Type "STS") }}
+    {{ printf "vault-%s-%s" (unix_time) (random 20) | truncate 32 }}
+{{ else }}
+    {{ printf "vault-%s-%s-%s" (printf "%s-%s" (.DisplayName) (.PolicyName) | truncate 42) (unix_time) (random 20) | truncate 64 }}
+{{ end }}
+
+```
+
 ## Attributes Reference
 
 No additional attributes are exported by this resource.

--- a/website/docs/r/aws_secret_backend.html.md
+++ b/website/docs/r/aws_secret_backend.html.md
@@ -69,7 +69,7 @@ for credentials issued by this backend.
 
 * `username_template` - (Optional)  Template describing how dynamic usernames are generated. The username template is used to generate both IAM usernames (capped at 64 characters) and STS usernames (capped at 32 characters). If no template is provided the field defaults to the template:
 
-```sh
+```
 {{ if (eq .Type "STS") }}
     {{ printf "vault-%s-%s" (unix_time) (random 20) | truncate 32 }}
 {{ else }}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1180

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
aws_secret_backend - add support for `username_template`
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSSecretBackend_'
--- PASS: TestAccAWSSecretBackend_basic (40.29s)
--- PASS: TestAccAWSSecretBackend_usernameTempl (19.98s)
```
