### PR TITLE
Add organization_id field to github_auth_backend (vault-1.10+)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,7 @@ jobs:
             export MSSQL_URL="sqlserver://sa:yourStrong1000Password@127.0.0.1:1433"
             # This will be removed after VAULT-4324 is fixed
             export SKIP_RAFT_TESTS='true'
+            export SKIP_VAULT_NEXT_TESTS='true'
             make testacc TESTARGS='-v'
       - run:
           name: "Run Build"

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Azure/go-autorest/autorest v0.11.21
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.8
 	github.com/aws/aws-sdk-go v1.41.8
+	github.com/cli/go-gh v0.0.1
 	github.com/containerd/containerd v1.5.9 // indirect
 	github.com/denisenkom/go-mssqldb v0.11.0
 	github.com/go-sql-driver/mysql v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/Azure/go-autorest/autorest v0.11.21
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.8
 	github.com/aws/aws-sdk-go v1.41.8
-	github.com/cli/go-gh v0.0.1
 	github.com/containerd/containerd v1.5.9 // indirect
 	github.com/denisenkom/go-mssqldb v0.11.0
 	github.com/go-sql-driver/mysql v1.6.0
@@ -25,5 +24,6 @@ require (
 	github.com/hashicorp/vault/sdk v0.3.1-0.20211214161113-fcc5f22bea02
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/opencontainers/runc v1.0.3 // indirect
+	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 // indirect
 	golang.org/x/oauth2 v0.0.0-20211005180243-6b3c2da341f1
 )

--- a/go.sum
+++ b/go.sum
@@ -112,8 +112,6 @@ github.com/DataDog/datadog-go v2.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3
 github.com/DataDog/datadog-go v3.2.0+incompatible h1:qSG2N4FghB1He/r2mFrWKCaL7dXCilEuNEeAn20fdD4=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/Jeffail/gabs v1.1.1/go.mod h1:6xMvQMK4k33lb7GUUpaAPh6nKMmemQeg5d4gn7/bOXc=
-github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
-github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RPBiVg=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
@@ -286,12 +284,6 @@ github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible h1:C29Ae4G5GtYyY
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3 h1:TJH+oke8D16535+jHExHj4nQvzlZrj7ug5D7I/orNUA=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
-github.com/cli/go-gh v0.0.1 h1:Fm1hwNUsxmGzlHymCj6ELb/qTkgH6k0o+9aJ97PUmeA=
-github.com/cli/go-gh v0.0.1/go.mod h1:J1eNgrPJYAUy7TwPKj7GW1ibqI+WCiMndtyzrCyZIiQ=
-github.com/cli/safeexec v1.0.0 h1:0VngyaIyqACHdcMNWfo6+KdUYnqEr2Sg+bSP1pdF+dI=
-github.com/cli/safeexec v1.0.0/go.mod h1:Z/D4tTN8Vs5gXYHDCbaM1S/anmEDnJb1iW0+EJ5zx3Q=
-github.com/cli/shurcooL-graphql v0.0.1 h1:/9J3t9O6p1B8zdBBtQighq5g7DQRItBwuwGh3SocsKM=
-github.com/cli/shurcooL-graphql v0.0.1/go.mod h1:U7gCSuMZP/Qy7kbqkk5PrqXEeDgtfG5K+W+u8weorps=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudfoundry-community/go-cfclient v0.0.0-20210823134051-721f0e559306/go.mod h1:0FdHblxw7g3M2PPICOw9i8YZOHP9dZTHbJUtoxL7Z/E=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
@@ -956,8 +948,6 @@ github.com/hashicorp/vic v1.5.1-0.20190403131502-bbfe86ec9443/go.mod h1:bEpDU35n
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/henvic/httpretty v0.0.6 h1:JdzGzKZBajBfnvlMALXXMVQWxWMF/ofTy8C3/OSUTxs=
-github.com/henvic/httpretty v0.0.6/go.mod h1:X38wLjWXHkXT7r2+uK8LjCMne9rsuNaBLJ+5cU2/Pmo=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.3.2 h1:L18LIDzqlW6xN2rEkpdV8+oL/IXWJ1APd+vsdYy4Wdw=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=

--- a/go.sum
+++ b/go.sum
@@ -112,6 +112,8 @@ github.com/DataDog/datadog-go v2.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3
 github.com/DataDog/datadog-go v3.2.0+incompatible h1:qSG2N4FghB1He/r2mFrWKCaL7dXCilEuNEeAn20fdD4=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/Jeffail/gabs v1.1.1/go.mod h1:6xMvQMK4k33lb7GUUpaAPh6nKMmemQeg5d4gn7/bOXc=
+github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
+github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RPBiVg=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
 github.com/Masterminds/semver v1.4.2/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
@@ -284,6 +286,12 @@ github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible h1:C29Ae4G5GtYyY
 github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/circonus-labs/circonusllhist v0.1.3 h1:TJH+oke8D16535+jHExHj4nQvzlZrj7ug5D7I/orNUA=
 github.com/circonus-labs/circonusllhist v0.1.3/go.mod h1:kMXHVDlOchFAehlya5ePtbp5jckzBHf4XRpQvBOLI+I=
+github.com/cli/go-gh v0.0.1 h1:Fm1hwNUsxmGzlHymCj6ELb/qTkgH6k0o+9aJ97PUmeA=
+github.com/cli/go-gh v0.0.1/go.mod h1:J1eNgrPJYAUy7TwPKj7GW1ibqI+WCiMndtyzrCyZIiQ=
+github.com/cli/safeexec v1.0.0 h1:0VngyaIyqACHdcMNWfo6+KdUYnqEr2Sg+bSP1pdF+dI=
+github.com/cli/safeexec v1.0.0/go.mod h1:Z/D4tTN8Vs5gXYHDCbaM1S/anmEDnJb1iW0+EJ5zx3Q=
+github.com/cli/shurcooL-graphql v0.0.1 h1:/9J3t9O6p1B8zdBBtQighq5g7DQRItBwuwGh3SocsKM=
+github.com/cli/shurcooL-graphql v0.0.1/go.mod h1:U7gCSuMZP/Qy7kbqkk5PrqXEeDgtfG5K+W+u8weorps=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudfoundry-community/go-cfclient v0.0.0-20210823134051-721f0e559306/go.mod h1:0FdHblxw7g3M2PPICOw9i8YZOHP9dZTHbJUtoxL7Z/E=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
@@ -948,6 +956,8 @@ github.com/hashicorp/vic v1.5.1-0.20190403131502-bbfe86ec9443/go.mod h1:bEpDU35n
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
+github.com/henvic/httpretty v0.0.6 h1:JdzGzKZBajBfnvlMALXXMVQWxWMF/ofTy8C3/OSUTxs=
+github.com/henvic/httpretty v0.0.6/go.mod h1:X38wLjWXHkXT7r2+uK8LjCMne9rsuNaBLJ+5cU2/Pmo=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.3.2 h1:L18LIDzqlW6xN2rEkpdV8+oL/IXWJ1APd+vsdYy4Wdw=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
@@ -1662,8 +1672,9 @@ golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210825183410-e898025ed96a/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211008194852-3b03d305991f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211020060615-d418f374d309 h1:A0lJIi+hcTR6aajJH4YqKWwohY4aW9RO7oRMcdv+HKI=
 golang.org/x/net v0.0.0-20211020060615-d418f374d309/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 h1:CIJ76btIcR3eFI5EgSo6k1qKw9KJexJuRLI9G7Hp5wE=
+golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190130055435-99b60b757ec1/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -206,9 +206,7 @@ func GetGHOrgResponse(t *testing.T, org string) *GHOrgResponse {
 		return v
 	}
 
-	client := &ghRESTClient{
-		client: retryablehttp.NewClient(),
-	}
+	client := newGHRESTClient()
 
 	result := &GHOrgResponse{}
 	if err := client.get(fmt.Sprintf("orgs/%s", org), result); err != nil {
@@ -222,6 +220,14 @@ func GetGHOrgResponse(t *testing.T, org string) *GHOrgResponse {
 	ghOrgResponseCache[org] = result
 
 	return result
+}
+
+func newGHRESTClient() *ghRESTClient {
+	client := retryablehttp.NewClient()
+	client.Logger = nil
+	return &ghRESTClient{
+		client: client,
+	}
 }
 
 type ghRESTClient struct {
@@ -240,9 +246,7 @@ func (c *ghRESTClient) do(method, path string, v interface{}) error {
 	}
 
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
-	client := retryablehttp.NewClient()
-	client.Logger = nil
-	resp, err := client.Do(req)
+	resp, err := c.client.Do(req)
 	if err != nil {
 		return err
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -285,3 +285,14 @@ func SetupCCCRetryClient(client *api.Client, maxRetry int) {
 	}
 	client.SetClientTimeout(to + time.Second*30)
 }
+
+// SetResourceData from a data map.
+func SetResourceData(d *schema.ResourceData, data map[string]interface{}) error {
+	for k := range data {
+		if err := d.Set(k, data[k]); err != nil {
+			return fmt.Errorf("error setting resource data for key %q, err=%w", k, err)
+		}
+	}
+
+	return nil
+}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -2,9 +2,10 @@ package util
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"reflect"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 type testingStruct struct {

--- a/vault/auth_token.go
+++ b/vault/auth_token.go
@@ -1,10 +1,10 @@
 package vault
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
 const (
@@ -276,12 +276,7 @@ func updateTokenFields(d *schema.ResourceData, data map[string]interface{}, crea
 }
 
 func readTokenFields(d *schema.ResourceData, resp *api.Secret) error {
-	for k, v := range getCommonTokenFieldMap(resp) {
-		if err := d.Set(k, v); err != nil {
-			return fmt.Errorf("error setting state key %q: %w", k, err)
-		}
-	}
-	return nil
+	return util.SetResourceData(d, getCommonTokenFieldMap(resp))
 }
 
 func getCommonTokenFieldMap(resp *api.Secret) map[string]interface{} {

--- a/vault/resource_github_auth_backend.go
+++ b/vault/resource_github_auth_backend.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
 func githubAuthBackendResource() *schema.Resource {
@@ -25,6 +27,13 @@ func githubAuthBackendResource() *schema.Resource {
 			Type:        schema.TypeString,
 			Required:    true,
 			Description: "The organization users must be part of.",
+		},
+		"organization_id": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			Computed: true,
+			Description: "The ID of the organization users must be part of. " +
+				"Vault will attempt to fetch and set this value if it is not provided (vault-1.10+)",
 		},
 		"base_url": {
 			Type:        schema.TypeString,
@@ -96,6 +105,9 @@ func githubAuthBackendUpdate(d *schema.ResourceData, meta interface{}) error {
 	if v, ok := d.GetOk("organization"); ok {
 		data["organization"] = v.(string)
 	}
+	if v, ok := d.GetOk("organization_id"); ok {
+		data["organization_id"] = v.(int)
+	}
 	if v, ok := d.GetOk("base_url"); ok {
 		data["base_url"] = v.(string)
 	}
@@ -146,18 +158,18 @@ func githubAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading github auth mount from '%q'", path)
 	mount, err := authMountInfoGet(client, d.Id())
 	if err != nil {
-		return fmt.Errorf("error reading github auth mount from '%q': %s", path, err)
+		return fmt.Errorf("error reading github auth mount from '%q': %w", path, err)
 	}
 	log.Printf("[INFO] Read github auth mount from '%q'", path)
 
 	log.Printf("[DEBUG] Reading github auth config from '%q'", configPath)
-	dt, err := client.Logical().Read(configPath)
+	resp, err := client.Logical().Read(configPath)
 	if err != nil {
-		return fmt.Errorf("error reading github auth config from '%q': %s", configPath, err)
+		return fmt.Errorf("error reading github auth config from '%q': %w", configPath, err)
 	}
 	log.Printf("[INFO] Read github auth config from '%q'", configPath)
 
-	if dt == nil {
+	if resp == nil {
 		log.Printf("[WARN] Github auth config from '%q' not found, removing from state", configPath)
 		d.SetId("")
 		return nil
@@ -166,21 +178,24 @@ func githubAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading github auth tune from '%q/tune'", path)
 	rawTune, err := authMountTuneGet(client, path)
 	if err != nil {
-		return fmt.Errorf("error reading tune information from Vault: %s", err)
+		return fmt.Errorf("error reading tune information from Vault: %w", err)
 	}
 
-	if err := d.Set("tune", []map[string]interface{}{rawTune}); err != nil {
-		log.Printf("[ERROR] Error when setting tune config from path '%q/tune' to state: %s", path, err)
+	data := getCommonTokenFieldMap(resp)
+	data["path"] = d.Id()
+	data["organization"] = resp.Data["organization"]
+	data["base_url"] = resp.Data["base_url"]
+	data["description"] = mount.Description
+	data["accessor"] = mount.Accessor
+	data["tune"] = []map[string]interface{}{rawTune}
+
+	if orgID, ok := resp.Data["organization_id"]; ok {
+		data["organization_id"] = orgID
+	}
+
+	if err := util.SetResourceData(d, data); err != nil {
 		return err
 	}
-
-	readTokenFields(d, dt)
-
-	d.Set("path", d.Id())
-	d.Set("organization", dt.Data["organization"])
-	d.Set("base_url", dt.Data["base_url"])
-	d.Set("description", mount.Description)
-	d.Set("accessor", mount.Accessor)
 
 	return nil
 }

--- a/vault/resource_github_auth_backend_test.go
+++ b/vault/resource_github_auth_backend_test.go
@@ -3,6 +3,7 @@ package vault
 import (
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -14,34 +15,48 @@ import (
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
+// as of vault-1.10 github-auth acceptance tests should use a valid GitHub
+// organization where applicable.
+const testGHOrg = "hashicorp"
+
 func TestAccGithubAuthBackend_basic(t *testing.T) {
-	backend := acctest.RandomWithPrefix("github")
+	testutil.TestAccPreCheck(t)
+	// TODO: remove once we can test against the vault-1.10 dev builds
+	testutil.SkipTestEnvSet(t, "SKIP_VAULT_NEXT_TESTS")
+
+	orgMeta := testutil.GetGHOrgResponse(t, testGHOrg)
+
+	path := acctest.RandomWithPrefix("github")
 	resName := "vault_github_auth_backend.gh"
 	var resAuth api.AuthMount
+
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		CheckDestroy: testAccCheckGithubAuthMountDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGithubAuthBackendConfig_basic(backend),
+				Config: testAccGithubAuthBackendConfig_basic(path, testGHOrg),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAuthMountExists(resName, &resAuth),
-					resource.TestCheckResourceAttr(resName, "id", backend),
-					resource.TestCheckResourceAttr(resName, "path", backend),
-					resource.TestCheckResourceAttr(resName, "organization", "vault"),
+					resource.TestCheckResourceAttr(resName, "id", path),
+					resource.TestCheckResourceAttr(resName, "path", path),
+					resource.TestCheckResourceAttr(resName, "organization", testGHOrg),
+					// expect computed value for organization_id
+					resource.TestCheckResourceAttr(resName, "organization_id", strconv.Itoa(orgMeta.ID)),
 					resource.TestCheckResourceAttr(resName, "token_ttl", "1200"),
 					resource.TestCheckResourceAttr(resName, "token_max_ttl", "3000"),
 					resource.TestCheckResourceAttrPtr(resName, "accessor", &resAuth.Accessor),
 				),
 			},
 			{
-				Config: testAccGithubAuthBackendConfig_updated(backend),
+				Config: testAccGithubAuthBackendConfig_updated(path, "unknown", 2999),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAuthMountExists(resName, &resAuth),
-					resource.TestCheckResourceAttr(resName, "id", backend),
-					resource.TestCheckResourceAttr(resName, "path", backend),
-					resource.TestCheckResourceAttr(resName, "organization", "other_vault"),
+					resource.TestCheckResourceAttr(resName, "id", path),
+					resource.TestCheckResourceAttr(resName, "path", path),
+					resource.TestCheckResourceAttr(resName, "organization", "unknown"),
+					resource.TestCheckResourceAttr(resName, "organization_id", "2999"),
 					resource.TestCheckResourceAttr(resName, "token_ttl", "2400"),
 					resource.TestCheckResourceAttr(resName, "token_max_ttl", "6000"),
 					resource.TestCheckResourceAttrPtr(resName, "accessor", &resAuth.Accessor),
@@ -52,9 +67,16 @@ func TestAccGithubAuthBackend_basic(t *testing.T) {
 }
 
 func TestAccGithubAuthBackend_tuning(t *testing.T) {
+	testutil.TestAccPreCheck(t)
+	// TODO: remove once we can test against the vault-1.10 dev builds
+	testutil.SkipTestEnvSet(t, "SKIP_VAULT_NEXT_TESTS")
+
+	orgMeta := testutil.GetGHOrgResponse(t, testGHOrg)
+
 	backend := acctest.RandomWithPrefix("github")
 	resName := "vault_github_auth_backend.gh"
 	var resAuth api.AuthMount
+
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
@@ -66,6 +88,8 @@ func TestAccGithubAuthBackend_tuning(t *testing.T) {
 					testAccCheckAuthMountExists(resName, &resAuth),
 					resource.TestCheckResourceAttr(resName, "id", backend),
 					resource.TestCheckResourceAttr(resName, "path", backend),
+					resource.TestCheckResourceAttr(resName, "organization", testGHOrg),
+					resource.TestCheckResourceAttr(resName, "organization_id", strconv.Itoa(orgMeta.ID)),
 					resource.TestCheckResourceAttr(resName, "tune.0.default_lease_ttl", "10m"),
 					resource.TestCheckResourceAttr(resName, "tune.0.max_lease_ttl", "20m"),
 					resource.TestCheckResourceAttr(resName, "tune.0.listing_visibility", "hidden"),
@@ -90,6 +114,8 @@ func TestAccGithubAuthBackend_tuning(t *testing.T) {
 					testAccCheckAuthMountExists(resName, &resAuth),
 					resource.TestCheckResourceAttr(resName, "id", backend),
 					resource.TestCheckResourceAttr(resName, "path", backend),
+					resource.TestCheckResourceAttr(resName, "organization", testGHOrg),
+					resource.TestCheckResourceAttr(resName, "organization_id", strconv.Itoa(orgMeta.ID)),
 					resource.TestCheckResourceAttr(resName, "tune.0.default_lease_ttl", "50m"),
 					resource.TestCheckResourceAttr(resName, "tune.0.max_lease_ttl", "1h10m"),
 					resource.TestCheckResourceAttr(resName, "tune.0.listing_visibility", "unauth"),
@@ -112,7 +138,13 @@ func TestAccGithubAuthBackend_tuning(t *testing.T) {
 }
 
 func TestAccGithubAuthBackend_description(t *testing.T) {
-	backend := acctest.RandomWithPrefix("github")
+	testutil.TestAccPreCheck(t)
+	// TODO: remove once we can test against the vault-1.10 dev builds
+	testutil.SkipTestEnvSet(t, "SKIP_VAULT_NEXT_TESTS")
+
+	orgMeta := testutil.GetGHOrgResponse(t, testGHOrg)
+
+	path := acctest.RandomWithPrefix("github")
 	resName := "vault_github_auth_backend.gh"
 	var resAuth api.AuthMount
 	resource.Test(t, resource.TestCase{
@@ -121,18 +153,22 @@ func TestAccGithubAuthBackend_description(t *testing.T) {
 		CheckDestroy: testAccCheckGithubAuthMountDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGithubAuthBackendConfig_description(backend, "Github Auth Mount"),
+				Config: testAccGithubAuthBackendConfig_description(path, testGHOrg, "Github Auth Mount"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAuthMountExists(resName, &resAuth),
-					resource.TestCheckResourceAttr(resName, "path", backend),
+					resource.TestCheckResourceAttr(resName, "path", path),
+					resource.TestCheckResourceAttr(resName, "organization", testGHOrg),
+					resource.TestCheckResourceAttr(resName, "organization_id", strconv.Itoa(orgMeta.ID)),
 					resource.TestCheckResourceAttr(resName, "description", "Github Auth Mount"),
 				),
 			},
 			{
-				Config: testAccGithubAuthBackendConfig_description(backend, "Github Auth Mount Updated"),
+				Config: testAccGithubAuthBackendConfig_description(path, testGHOrg, "Github Auth Mount Updated"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAuthMountExists(resName, &resAuth),
-					resource.TestCheckResourceAttr(resName, "path", backend),
+					resource.TestCheckResourceAttr(resName, "path", path),
+					resource.TestCheckResourceAttr(resName, "organization", orgMeta.Login),
+					resource.TestCheckResourceAttr(resName, "organization_id", strconv.Itoa(orgMeta.ID)),
 					resource.TestCheckResourceAttr(resName, "description", "Github Auth Mount Updated"),
 				),
 			},
@@ -141,7 +177,7 @@ func TestAccGithubAuthBackend_description(t *testing.T) {
 }
 
 func TestAccGithubAuthBackend_importTuning(t *testing.T) {
-	backend := acctest.RandomWithPrefix("github")
+	path := acctest.RandomWithPrefix("github")
 	resName := "vault_github_auth_backend.gh"
 	var resAuth api.AuthMount
 	resource.Test(t, resource.TestCase{
@@ -149,7 +185,7 @@ func TestAccGithubAuthBackend_importTuning(t *testing.T) {
 		Providers: testProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGithubAuthBackendConfig_tuning(backend),
+				Config: testAccGithubAuthBackendConfig_tuning(path),
 				Check:  testAccCheckAuthMountExists(resName, &resAuth),
 			},
 			{
@@ -222,33 +258,34 @@ func authMountDestroyHelper(s *terraform.State, client *api.Client, resType stri
 	return fmt.Errorf("Auth mount resource still exists")
 }
 
-func testAccGithubAuthBackendConfig_basic(backend string) string {
+func testAccGithubAuthBackendConfig_basic(path, org string) string {
 	return fmt.Sprintf(`
 resource "vault_github_auth_backend" "gh" {
 	path = "%s"
-	organization = "vault"
+	organization = "%s"
 	token_ttl = 1200
 	token_max_ttl = 3000
 }
-`, backend)
+`, path, org)
 }
 
-func testAccGithubAuthBackendConfig_updated(backend string) string {
+func testAccGithubAuthBackendConfig_updated(path, org string, orgID int) string {
 	return fmt.Sprintf(`
 resource "vault_github_auth_backend" "gh" {
   	path = "%s"
-	organization = "other_vault"
+	organization = "%s"
+	organization_id = %d
 	token_ttl = 2400
 	token_max_ttl = 6000
 }
-`, backend)
+`, path, org, orgID)
 }
 
-func testAccGithubAuthBackendConfig_tuning(backend string) string {
+func testAccGithubAuthBackendConfig_tuning(path string) string {
 	return fmt.Sprintf(`
 resource "vault_github_auth_backend" "gh" {
   	path = "%s"
-  	organization = "vault"
+  	organization = "%s"
   
   	tune {
 		default_lease_ttl = "10m"
@@ -261,14 +298,14 @@ resource "vault_github_auth_backend" "gh" {
 		token_type = "batch"
 	}
 }
-`, backend)
+`, path, testGHOrg)
 }
 
-func testAccGithubAuthBackendConfig_tuningUpdated(backend string) string {
+func testAccGithubAuthBackendConfig_tuningUpdated(path string) string {
 	return fmt.Sprintf(`
 resource "vault_github_auth_backend" "gh" {
   	path = "%s"
-  	organization = "vault"
+	organization = "%s"
   
   	tune {
 		default_lease_ttl = "50m"
@@ -280,15 +317,15 @@ resource "vault_github_auth_backend" "gh" {
 		token_type = "default-batch"
 	}
 }
-`, backend)
+`, path, testGHOrg)
 }
 
-func testAccGithubAuthBackendConfig_description(backend string, description string) string {
+func testAccGithubAuthBackendConfig_description(path, org, description string) string {
 	return fmt.Sprintf(`
 resource "vault_github_auth_backend" "gh" {
 	path = "%s"
-	organization = "vault"
+	organization = "%s"
 	description = "%s"  
 }
-`, backend, description)
+`, path, org, description)
 }

--- a/vault/resource_github_auth_backend_test.go
+++ b/vault/resource_github_auth_backend_test.go
@@ -20,7 +20,7 @@ import (
 const testGHOrg = "hashicorp"
 
 func TestAccGithubAuthBackend_basic(t *testing.T) {
-	testutil.TestAccPreCheck(t)
+	testutil.SkipTestAcc(t)
 	// TODO: remove once we can test against the vault-1.10 dev builds
 	testutil.SkipTestEnvSet(t, "SKIP_VAULT_NEXT_TESTS")
 
@@ -67,7 +67,7 @@ func TestAccGithubAuthBackend_basic(t *testing.T) {
 }
 
 func TestAccGithubAuthBackend_tuning(t *testing.T) {
-	testutil.TestAccPreCheck(t)
+	testutil.SkipTestAcc(t)
 	// TODO: remove once we can test against the vault-1.10 dev builds
 	testutil.SkipTestEnvSet(t, "SKIP_VAULT_NEXT_TESTS")
 
@@ -138,7 +138,7 @@ func TestAccGithubAuthBackend_tuning(t *testing.T) {
 }
 
 func TestAccGithubAuthBackend_description(t *testing.T) {
-	testutil.TestAccPreCheck(t)
+	testutil.SkipTestAcc(t)
 	// TODO: remove once we can test against the vault-1.10 dev builds
 	testutil.SkipTestEnvSet(t, "SKIP_VAULT_NEXT_TESTS")
 

--- a/website/docs/r/github_auth_backend.html.md
+++ b/website/docs/r/github_auth_backend.html.md
@@ -29,6 +29,9 @@ The following arguments are supported:
 
 * `organization` - (Required) The organization configured users must be part of.
 
+* `organization_id` (Optional) The ID of the organization users must be part of.
+  Vault will attempt to fetch and set this value if it is not provided. (Vault 1.10+)
+
 * `base_url` - (Optional) The API endpoint to use. Useful if you
   are running GitHub Enterprise or an API-compatible authentication server.
 


### PR DESCRIPTION
Add `organization_id` field to the github_auth_backend resource
    
- Update the github_auth_backend resource to accept the
      `organization_id` field for Vault 1.10+
- Add new GitHub API helper to `testutil`


<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
make testacc TESTARGS='-v -test.run TestAccGithubAuthBackend'                        
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -v -test.run TestAccGithubAuthBackend -timeout 20m ./...

[...]

=== RUN   TestAccGithubAuthBackend_basic
--- PASS: TestAccGithubAuthBackend_basic (3.93s)
=== RUN   TestAccGithubAuthBackend_tuning
--- PASS: TestAccGithubAuthBackend_tuning (3.07s)
=== RUN   TestAccGithubAuthBackend_description
--- PASS: TestAccGithubAuthBackend_description (3.00s)
=== RUN   TestAccGithubAuthBackend_importTuning
--- PASS: TestAccGithubAuthBackend_importTuning (2.19s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     12.802s


...
```
