### PR TITLE
Add audit non HMAC'd request/response keys to mount resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ IMPROVEMENTS:
 * `resource/database_secret_backend_connection`: Add support for configuring Redshift databases ([#1279](https://github.com/hashicorp/terraform-provider-vault/pull/1279))
 * `resource/pki_secret_backend_intermediate_cert_request`: Add support for the `ed25519` key_type ([#1278](https://github.com/hashicorp/terraform-provider-vault/pull/1278))
 * `resource/rabbitmq_secret_backend_role`: Add support for `vhost_topics` ([#1246](https://github.com/hashicorp/terraform-provider-vault/pull/1246))
+* `resource/vault_mount`: Add support for `audit_non_hmac_request_keys` and `audit_non_hmac_response_keys` ([#1297](https://github.com/hashicorp/terraform-provider-vault/pull/1297))
 
 ## 3.1.1 (December 22, 2021)
 BUGS:

--- a/vault/resource_mount.go
+++ b/vault/resource_mount.go
@@ -60,6 +60,20 @@ func MountResource() *schema.Resource {
 				Description: "Maximum possible lease duration for tokens and secrets in seconds",
 			},
 
+			"audit_non_hmac_request_keys": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Specifies the list of keys that will not be HMAC'd by audit devices in the request data object.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+
+			"audit_non_hmac_response_keys": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Specifies the list of keys that will not be HMAC'd by audit devices in the response data object.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+
 			"accessor": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -111,8 +125,10 @@ func mountWrite(d *schema.ResourceData, meta interface{}) error {
 		Type:        d.Get("type").(string),
 		Description: d.Get("description").(string),
 		Config: api.MountConfigInput{
-			DefaultLeaseTTL: fmt.Sprintf("%ds", d.Get("default_lease_ttl_seconds")),
-			MaxLeaseTTL:     fmt.Sprintf("%ds", d.Get("max_lease_ttl_seconds")),
+			DefaultLeaseTTL:          fmt.Sprintf("%ds", d.Get("default_lease_ttl_seconds")),
+			MaxLeaseTTL:              fmt.Sprintf("%ds", d.Get("max_lease_ttl_seconds")),
+			AuditNonHMACRequestKeys:  expandStringSliceWithEmpty(d.Get("audit_non_hmac_request_keys").([]interface{}), false),
+			AuditNonHMACResponseKeys: expandStringSliceWithEmpty(d.Get("audit_non_hmac_response_keys").([]interface{}), false),
 		},
 		Local:                 d.Get("local").(bool),
 		Options:               opts(d),
@@ -140,6 +156,14 @@ func mountUpdate(d *schema.ResourceData, meta interface{}) error {
 		DefaultLeaseTTL: fmt.Sprintf("%ds", d.Get("default_lease_ttl_seconds")),
 		MaxLeaseTTL:     fmt.Sprintf("%ds", d.Get("max_lease_ttl_seconds")),
 		Options:         opts(d),
+	}
+
+	if d.HasChange("audit_non_hmac_request_keys") {
+		config.AuditNonHMACRequestKeys = expandStringSliceWithEmpty(d.Get("audit_non_hmac_request_keys").([]interface{}), false)
+	}
+
+	if d.HasChange("audit_non_hmac_response_keys") {
+		config.AuditNonHMACResponseKeys = expandStringSliceWithEmpty(d.Get("audit_non_hmac_response_keys").([]interface{}), false)
 	}
 
 	if d.HasChange("description") {
@@ -228,6 +252,8 @@ func mountRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("description", mount.Description)
 	d.Set("default_lease_ttl_seconds", mount.Config.DefaultLeaseTTL)
 	d.Set("max_lease_ttl_seconds", mount.Config.MaxLeaseTTL)
+	d.Set("audit_non_hmac_request_keys", mount.Config.AuditNonHMACRequestKeys)
+	d.Set("audit_non_hmac_response_keys", mount.Config.AuditNonHMACResponseKeys)
 	d.Set("accessor", mount.Accessor)
 	d.Set("local", mount.Local)
 	d.Set("options", mount.Options)

--- a/vault/resource_mount.go
+++ b/vault/resource_mount.go
@@ -127,8 +127,8 @@ func mountWrite(d *schema.ResourceData, meta interface{}) error {
 		Config: api.MountConfigInput{
 			DefaultLeaseTTL:          fmt.Sprintf("%ds", d.Get("default_lease_ttl_seconds")),
 			MaxLeaseTTL:              fmt.Sprintf("%ds", d.Get("max_lease_ttl_seconds")),
-			AuditNonHMACRequestKeys:  expandStringSliceWithEmpty(d.Get("audit_non_hmac_request_keys").([]interface{}), false),
-			AuditNonHMACResponseKeys: expandStringSliceWithEmpty(d.Get("audit_non_hmac_response_keys").([]interface{}), false),
+			AuditNonHMACRequestKeys:  expandStringSlice(d.Get("audit_non_hmac_request_keys").([]interface{})),
+			AuditNonHMACResponseKeys: expandStringSlice(d.Get("audit_non_hmac_response_keys").([]interface{})),
 		},
 		Local:                 d.Get("local").(bool),
 		Options:               opts(d),
@@ -159,11 +159,11 @@ func mountUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("audit_non_hmac_request_keys") {
-		config.AuditNonHMACRequestKeys = expandStringSliceWithEmpty(d.Get("audit_non_hmac_request_keys").([]interface{}), false)
+		config.AuditNonHMACRequestKeys = expandStringSlice(d.Get("audit_non_hmac_request_keys").([]interface{}))
 	}
 
 	if d.HasChange("audit_non_hmac_response_keys") {
-		config.AuditNonHMACResponseKeys = expandStringSliceWithEmpty(d.Get("audit_non_hmac_response_keys").([]interface{}), false)
+		config.AuditNonHMACResponseKeys = expandStringSlice(d.Get("audit_non_hmac_response_keys").([]interface{}))
 	}
 
 	if d.HasChange("description") {

--- a/vault/resource_mount_test.go
+++ b/vault/resource_mount_test.go
@@ -603,48 +603,6 @@ resource "vault_mount" "test" {
 
 `
 
-func testResourceMount_UpdateAuditNonHMACRequestKeys(s *terraform.State) error {
-	resourceState := s.Modules[0].Resources["vault_mount.test"]
-	instanceState := resourceState.Primary
-
-	path := instanceState.ID
-
-	if path != instanceState.Attributes["path"] {
-		return fmt.Errorf("id doesn't match path")
-	}
-
-	if path != "remountingExample" {
-		return fmt.Errorf("unexpected path value")
-	}
-
-	mount, err := findMount(path)
-	if err != nil {
-		return fmt.Errorf("error reading back mount: %s", err)
-	}
-
-	expectedRequestKeys := []string{
-		instanceState.Attributes["audit_non_hmac_request_keys.0"],
-		instanceState.Attributes["audit_non_hmac_request_keys.1"],
-	}
-	if !reflect.DeepEqual(expectedRequestKeys, mount.Config.AuditNonHMACRequestKeys) {
-		return fmt.Errorf("expected audit_non_hmac_request_keys %#v, actual %#v",
-			expectedRequestKeys,
-			mount.Config.AuditNonHMACRequestKeys)
-	}
-
-	expectedResponseKeys := []string{
-		instanceState.Attributes["audit_non_hmac_response_keys.0"],
-		instanceState.Attributes["audit_non_hmac_response_keys.1"],
-	}
-	if !reflect.DeepEqual(expectedResponseKeys, mount.Config.AuditNonHMACResponseKeys) {
-		return fmt.Errorf("expected audit_non_hmac_response_keys %#v, actual %#v",
-			expectedResponseKeys,
-			mount.Config.AuditNonHMACResponseKeys)
-	}
-
-	return nil
-}
-
 func testResourceMount_CheckExternalEntropyAccess(expectedPath string, expectedExternalEntropyAccess bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		resourceState := s.Modules[0].Resources["vault_mount.test"]

--- a/vault/resource_mount_test.go
+++ b/vault/resource_mount_test.go
@@ -113,7 +113,9 @@ func TestResourceMount_SealWrap(t *testing.T) {
 
 // Test Audit non-HMAC fields
 func TestResourceMount_AuditNonHMACRequestKeys(t *testing.T) {
+	resourcePath := "vault_mount.test"
 	path := "example-" + acctest.RandString(10)
+
 	expectReqKeysNew := []string{"test1request", "test2request"}
 	expectRespKeysNew := []string{"test1response", "test2response"}
 	expectReqKeysUpdate := []string{"test3request", "test4request"}
@@ -125,26 +127,26 @@ func TestResourceMount_AuditNonHMACRequestKeys(t *testing.T) {
 			{
 				Config: testResourceMount_AuditNonHMACRequestKeysConfig(path, expectReqKeysNew, expectRespKeysNew),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_mount.test", "path", path),
-					resource.TestCheckResourceAttr("vault_mount.test", "audit_non_hmac_request_keys.#", "2"),
-					resource.TestCheckResourceAttr("vault_mount.test", "audit_non_hmac_request_keys.0", "test1request"),
-					resource.TestCheckResourceAttr("vault_mount.test", "audit_non_hmac_request_keys.1", "test2request"),
-					resource.TestCheckResourceAttr("vault_mount.test", "audit_non_hmac_response_keys.#", "2"),
-					resource.TestCheckResourceAttr("vault_mount.test", "audit_non_hmac_response_keys.0", "test1response"),
-					resource.TestCheckResourceAttr("vault_mount.test", "audit_non_hmac_response_keys.1", "test2response"),
+					resource.TestCheckResourceAttr(resourcePath, "path", path),
+					resource.TestCheckResourceAttr(resourcePath, "audit_non_hmac_request_keys.#", "2"),
+					resource.TestCheckResourceAttr(resourcePath, "audit_non_hmac_request_keys.0", expectReqKeysNew[0]),
+					resource.TestCheckResourceAttr(resourcePath, "audit_non_hmac_request_keys.1", expectReqKeysNew[1]),
+					resource.TestCheckResourceAttr(resourcePath, "audit_non_hmac_response_keys.#", "2"),
+					resource.TestCheckResourceAttr(resourcePath, "audit_non_hmac_response_keys.0", expectRespKeysNew[0]),
+					resource.TestCheckResourceAttr(resourcePath, "audit_non_hmac_response_keys.1", expectRespKeysNew[1]),
 					testResourceMount_CheckAuditNonHMACRequestKeys(path, expectReqKeysNew, expectRespKeysNew),
 				),
 			},
 			{
 				Config: testResourceMount_AuditNonHMACRequestKeysConfig(path, expectReqKeysUpdate, expectRespKeysUpdate),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_mount.test", "path", path),
-					resource.TestCheckResourceAttr("vault_mount.test", "audit_non_hmac_request_keys.#", "2"),
-					resource.TestCheckResourceAttr("vault_mount.test", "audit_non_hmac_request_keys.0", "test3request"),
-					resource.TestCheckResourceAttr("vault_mount.test", "audit_non_hmac_request_keys.1", "test4request"),
-					resource.TestCheckResourceAttr("vault_mount.test", "audit_non_hmac_response_keys.#", "2"),
-					resource.TestCheckResourceAttr("vault_mount.test", "audit_non_hmac_response_keys.0", "test3response"),
-					resource.TestCheckResourceAttr("vault_mount.test", "audit_non_hmac_response_keys.1", "test4response"),
+					resource.TestCheckResourceAttr(resourcePath, "path", path),
+					resource.TestCheckResourceAttr(resourcePath, "audit_non_hmac_request_keys.#", "2"),
+					resource.TestCheckResourceAttr(resourcePath, "audit_non_hmac_request_keys.0", expectReqKeysUpdate[0]),
+					resource.TestCheckResourceAttr(resourcePath, "audit_non_hmac_request_keys.1", expectReqKeysUpdate[1]),
+					resource.TestCheckResourceAttr(resourcePath, "audit_non_hmac_response_keys.#", "2"),
+					resource.TestCheckResourceAttr(resourcePath, "audit_non_hmac_response_keys.0", expectRespKeysUpdate[0]),
+					resource.TestCheckResourceAttr(resourcePath, "audit_non_hmac_response_keys.1", expectRespKeysUpdate[1]),
 					testResourceMount_CheckAuditNonHMACRequestKeys(path, expectReqKeysUpdate, expectRespKeysUpdate),
 				),
 			},

--- a/website/docs/r/mount.html.md
+++ b/website/docs/r/mount.html.md
@@ -64,6 +64,10 @@ The following arguments are supported:
 
 * `max_lease_ttl_seconds` - (Optional) Maximum possible lease duration for tokens and secrets in seconds
 
+* `audit_non_hmac_response_keys` - (Optional) Specifies the list of keys that will not be HMAC'd by audit devices in the response data object.
+
+* `audit_non_hmac_request_keys` - (Optional) Specifies the list of keys that will not be HMAC'd by audit devices in the request data object.
+
 * `local` - (Optional) Boolean flag that can be explicitly set to true to enforce local mount in HA environment
 
 * `options` - (Optional) Specifies mount type specific options that are passed to the backend


### PR DESCRIPTION
This PR continues the work done in #1194 

Output from acceptance testing:

```
make testacc TESTARGS='-v -test.run TestResourceMount'                                             
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -v -test.run TestResourceMount -timeout 20m ./...

[...]

=== RUN   TestResourceMount
--- PASS: TestResourceMount (7.74s)
=== RUN   TestResourceMount_Local
--- PASS: TestResourceMount_Local (16.50s)
=== RUN   TestResourceMount_SealWrap
--- PASS: TestResourceMount_SealWrap (7.44s)
=== RUN   TestResourceMount_AuditNonHMACRequestKeys
--- PASS: TestResourceMount_AuditNonHMACRequestKeys (2.92s)
=== RUN   TestResourceMount_KVV2
--- PASS: TestResourceMount_KVV2 (2.44s)
=== RUN   TestResourceMount_ExternalEntropyAccess
--- PASS: TestResourceMount_ExternalEntropyAccess (11.26s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     50.999s

```
