### PR TITLE
Add ability to configure for the kv-v2 mounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 3.3.0 (Unreleased)
+FEATURES:
+* **New Resource**: `resource/kv_v2_config`: Add support to configure kv-v2 secret mount ([#1311](https://github.com/hashicorp/terraform-provider-vault/pull/1311))
+
 BUGS:
 * `resource/kubernetes_auth_backend_config`: Ensure `disable_iss_validation` is honored in all cases ([#1315](https://github.com/hashicorp/terraform-provider-vault/pull/1315))
 

--- a/vault/data_source_kv_v2_config.go
+++ b/vault/data_source_kv_v2_config.go
@@ -1,0 +1,38 @@
+package vault
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func kvV2ConfigDataSource() *schema.Resource {
+	return &schema.Resource{
+		Read: kvV2ConfigDataSourceRead,
+		Schema: map[string]*schema.Schema{
+			"path": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The kv-v2 backend mount point.",
+			},
+			"max_versions": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The number of versions to keep per key.",
+			},
+			"cas_required": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: " If true all keys will require the cas parameter to be set on all write requests.",
+			},
+			"delete_version_after": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "If set, specifies the length of time before a version is deleted. Accepts Go duration format string.",
+			},
+		},
+	}
+}
+
+func kvV2ConfigDataSourceRead(d *schema.ResourceData, meta interface{}) error {
+	targetPath := d.Get("path").(string)
+	return kvV2ConfigReadByPath(d, meta, targetPath)
+}

--- a/vault/data_source_kv_v2_config_test.go
+++ b/vault/data_source_kv_v2_config_test.go
@@ -1,0 +1,105 @@
+package vault
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/hashicorp/terraform-provider-vault/testutil"
+)
+
+func TestAccKvV2ConfigDataSource_basic(t *testing.T) {
+	backend := acctest.RandomWithPrefix("kv-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckKvV2ConfigDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKvV2Config_basic(backend, 4),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_kv_v2_config.kv-config",
+						"path", backend),
+					resource.TestCheckResourceAttr("vault_kv_v2_config.kv-config",
+						"max_versions", fmt.Sprint(4)),
+					resource.TestCheckResourceAttr("vault_kv_v2_config.kv-config",
+						"cas_required", fmt.Sprintf("%t", false)),
+					resource.TestCheckResourceAttr("vault_kv_v2_config.kv-config",
+						"delete_version_after", "0s"),
+				),
+			},
+			{
+				Config: testAccKvV2ConfigDataSource_basic(backend, 4),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.vault_kv_v2_config.kv-config",
+						"path", backend),
+					resource.TestCheckResourceAttr("data.vault_kv_v2_config.kv-config",
+						"max_versions", fmt.Sprint(4)),
+					resource.TestCheckResourceAttr("data.vault_kv_v2_config.kv-config",
+						"cas_required", fmt.Sprintf("%t", false)),
+					resource.TestCheckResourceAttr("data.vault_kv_v2_config.kv-config",
+						"delete_version_after", "0s"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccKvV2ConfigDataSource_full(t *testing.T) {
+	backend := acctest.RandomWithPrefix("kv-test")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckKvV2ConfigDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKvV2Config_full(backend, 2, true, "1h5m3s"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_kv_v2_config.kv-config",
+						"path", backend),
+					resource.TestCheckResourceAttr("vault_kv_v2_config.kv-config",
+						"max_versions", fmt.Sprint(2)),
+					resource.TestCheckResourceAttr("vault_kv_v2_config.kv-config",
+						"cas_required", fmt.Sprintf("%t", true)),
+					resource.TestCheckResourceAttr("vault_kv_v2_config.kv-config",
+						"delete_version_after", "1h5m3s"),
+				),
+			},
+			{
+				Config: testAccKvV2ConfigDataSource_full(backend, 2, true, "1h5m3s"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.vault_kv_v2_config.kv-config",
+						"path", backend),
+					resource.TestCheckResourceAttr("data.vault_kv_v2_config.kv-config",
+						"max_versions", fmt.Sprint(2)),
+					resource.TestCheckResourceAttr("data.vault_kv_v2_config.kv-config",
+						"cas_required", fmt.Sprintf("%t", true)),
+					resource.TestCheckResourceAttr("data.vault_kv_v2_config.kv-config",
+						"delete_version_after", "1h5m3s"),
+				),
+			},
+		},
+	})
+}
+
+func testAccKvV2ConfigDataSource_basic(path string, max_versions int) string {
+	return fmt.Sprintf(`
+%s
+
+data "vault_kv_v2_config" "kv-config" {
+  path = %q
+}`, testAccKvV2Config_basic(path, max_versions), path)
+}
+
+func testAccKvV2ConfigDataSource_full(path string, max_versions int, cas_required bool, delete_version_after string) string {
+	return fmt.Sprintf(`
+%s
+
+data "vault_kv_v2_config" "kv-config" {
+  path = %q
+}`, testAccKvV2Config_full(path, max_versions, cas_required, delete_version_after), path)
+}

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -284,6 +284,10 @@ var (
 			Resource:      authBackendDataSource(),
 			PathInventory: []string{"/sys/auth"},
 		},
+		"vault_kv_v2_config": {
+			Resource:      kvV2ConfigDataSource(),
+			PathInventory: []string{"/secret/config"},
+		},
 		"vault_transit_encrypt": {
 			Resource:      transitEncryptDataSource(),
 			PathInventory: []string{"/transit/encrypt/{name}"},
@@ -693,6 +697,10 @@ var (
 		"vault_raft_autopilot": {
 			Resource:      raftAutopilotConfigResource(),
 			PathInventory: []string{"/sys/storage/raft/autopilot/configuration"},
+		},
+		"vault_kv_v2_config": {
+			Resource:      KvV2ConfigResource(),
+			PathInventory: []string{"/secret/config"},
 		},
 	}
 )

--- a/vault/resource_kubernetes_auth_backend_role.go
+++ b/vault/resource_kubernetes_auth_backend_role.go
@@ -43,7 +43,7 @@ func kubernetesAuthBackendRoleResource() *schema.Resource {
 			Description: "Unique name of the kubernetes backend to configure.",
 			ForceNew:    true,
 			Default:     "kubernetes",
-			// standardise on no beginning or trailing slashes
+			// standardize on no beginning or trailing slashes
 			StateFunc: func(v interface{}) string {
 				return strings.Trim(v.(string), "/")
 			},

--- a/vault/resource_kv_v2_config.go
+++ b/vault/resource_kv_v2_config.go
@@ -1,0 +1,153 @@
+package vault
+
+import (
+	"fmt"
+	"log"
+	"path"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/vault/api"
+)
+
+var kvV2ConfigDefaults = map[string]interface{}{
+	"cas_required":         false,
+	"max_versions":         "0",
+	"delete_version_after": "0s",
+}
+
+func KvV2ConfigResource() *schema.Resource {
+	return &schema.Resource{
+		Create: kvV2ConfigWrite,
+		Update: kvV2ConfigWrite,
+		Delete: kvV2ConfigDelete,
+		Read:   kvV2ConfigRead,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"path": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The kv-v2 backend mount point.",
+			},
+			"max_versions": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "The number of versions to keep per key.",
+				Default:     0,
+			},
+			"cas_required": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: " If true all keys will require the cas parameter to be set on all write requests.",
+			},
+			"delete_version_after": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "If set, specifies the length of time before a version is deleted. Accepts Go duration format string.",
+				Default:     "0s",
+			},
+		},
+	}
+}
+
+func kvV2ConfigWrite(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	targetPath := d.Get("path").(string)
+	c := map[string]interface{}{
+		"max_versions":         d.Get("max_versions").(int),
+		"cas_required":         d.Get("cas_required").(bool),
+		"delete_version_after": d.Get("delete_version_after").(string),
+	}
+	err := checkKvV2Mount(client, targetPath)
+	if err != nil {
+		return err
+	}
+	apiPath := kvV2MountPathConfigPath(targetPath)
+	_, err = client.Logical().Write(apiPath, c)
+	if err != nil {
+		return fmt.Errorf("error writing kv-v2 config to Vault: %s", err)
+	}
+
+	d.SetId(targetPath)
+	if err := d.Set("path", targetPath); err != nil {
+		return fmt.Errorf("error setting state key 'path': %s", err)
+	}
+	return kvV2ConfigRead(d, meta)
+}
+
+func kvV2ConfigDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	targetPath := d.Id()
+
+	log.Printf("[DEBUG] Delete kv-v2 config for %s", targetPath)
+	_, err := client.Logical().Write(kvV2MountPathConfigPath(targetPath), kvV2ConfigDefaults)
+	if err != nil {
+		return fmt.Errorf("error resetting kv-v2 config from Vault: %s", err)
+	}
+
+	return nil
+}
+
+func kvV2ConfigRead(d *schema.ResourceData, meta interface{}) error {
+	targetPath := d.Id()
+	return kvV2ConfigReadByPath(d, meta, targetPath)
+
+}
+
+func kvV2ConfigReadByPath(d *schema.ResourceData, meta interface{}, targetPath string) error {
+	client := meta.(*api.Client)
+
+	err := checkKvV2Mount(client, targetPath)
+	if err != nil {
+		return err
+	}
+	config, err := client.Logical().Read(kvV2MountPathConfigPath(targetPath))
+	if err != nil {
+		return fmt.Errorf("error reading kv-v2 config from Vault: %s", err)
+	}
+	if config.Data == nil {
+		return fmt.Errorf("no config read from kv-v2 mount: %s", targetPath)
+	}
+
+	if val, ok := config.Data["max_versions"]; ok {
+		if err := d.Set("max_versions", val); err != nil {
+			return fmt.Errorf("error setting state key 'max_versions': %s", err)
+		}
+	}
+	if val, ok := config.Data["cas_required"]; ok {
+		if err := d.Set("cas_required", val); err != nil {
+			return fmt.Errorf("error setting state key 'cas_required': %s", err)
+		}
+	}
+	if val, ok := config.Data["delete_version_after"]; ok {
+		if err := d.Set("delete_version_after", val); err != nil {
+			return fmt.Errorf("error setting state key 'delete_version_after': %s", err)
+		}
+	}
+	if err := d.Set("path", targetPath); err != nil {
+		return fmt.Errorf("error setting state key 'path': %s", err)
+	}
+	d.SetId(targetPath)
+	return nil
+
+}
+
+func checkKvV2Mount(client *api.Client, path string) error {
+	mounts, err := client.Sys().ListMounts()
+	if err != nil {
+		return fmt.Errorf("error reading mounts from Vault: %s", err)
+	}
+	mount, ok := mounts[strings.Trim(path, "/")+"/"]
+	if !ok || mount.Options["version"] != "2" {
+		return fmt.Errorf("failed to read kv-v2 mount: %s", path)
+	}
+	return nil
+}
+
+func kvV2MountPathConfigPath(mountPath string) string {
+	return path.Join(mountPath, "config")
+}

--- a/vault/resource_kv_v2_config_test.go
+++ b/vault/resource_kv_v2_config_test.go
@@ -1,0 +1,160 @@
+package vault
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-vault/testutil"
+	"github.com/hashicorp/vault/api"
+)
+
+func TestAccKvV2Config_import(t *testing.T) {
+	backend := acctest.RandomWithPrefix("kv-v2-config-test")
+	cas_required := true
+	delete_version_after := "1h1m1s"
+	max_versions := 4
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckKvV2ConfigDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKvV2Config_full(backend, max_versions, cas_required, delete_version_after),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_kv_v2_config.kv-config",
+						"path", backend),
+					resource.TestCheckResourceAttr("vault_kv_v2_config.kv-config",
+						"max_versions", fmt.Sprint(max_versions)),
+					resource.TestCheckResourceAttr("vault_kv_v2_config.kv-config",
+						"cas_required", fmt.Sprintf("%t", cas_required)),
+					resource.TestCheckResourceAttr("vault_kv_v2_config.kv-config",
+						"delete_version_after", delete_version_after),
+				),
+			},
+			{
+				ResourceName:      "vault_kv_v2_config.kv-config",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+func TestAccKvV2Config_fullUpdate(t *testing.T) {
+	backend := acctest.RandomWithPrefix("kv-v2-config-test")
+	cas_required := false
+	delete_version_after := "2h2m2s"
+	max_versions := 3
+	new_max_versions := 10
+	new_delete_versions_after := "1h0m0s"
+	max_version_for_basic := 1
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckKvV2ConfigDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKvV2Config_full(backend, max_versions, cas_required, delete_version_after),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_kv_v2_config.kv-config",
+						"path", backend),
+					resource.TestCheckResourceAttr("vault_kv_v2_config.kv-config",
+						"max_versions", fmt.Sprint(max_versions)),
+					resource.TestCheckResourceAttr("vault_kv_v2_config.kv-config",
+						"cas_required", fmt.Sprintf("%t", cas_required)),
+					resource.TestCheckResourceAttr("vault_kv_v2_config.kv-config",
+						"delete_version_after", delete_version_after),
+				),
+			},
+			// change max_versions
+			{
+				Config: testAccKvV2Config_full(backend, new_max_versions, cas_required, delete_version_after),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_kv_v2_config.kv-config",
+						"path", backend),
+					resource.TestCheckResourceAttr("vault_kv_v2_config.kv-config",
+						"max_versions", fmt.Sprint(new_max_versions)),
+					resource.TestCheckResourceAttr("vault_kv_v2_config.kv-config",
+						"cas_required", fmt.Sprintf("%t", cas_required)),
+					resource.TestCheckResourceAttr("vault_kv_v2_config.kv-config",
+						"delete_version_after", delete_version_after),
+				),
+			},
+			// change cas_required,delete_version_after
+			{
+				Config: testAccKvV2Config_full(backend, new_max_versions, !cas_required, new_delete_versions_after),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_kv_v2_config.kv-config",
+						"path", backend),
+					resource.TestCheckResourceAttr("vault_kv_v2_config.kv-config",
+						"max_versions", fmt.Sprint(new_max_versions)),
+					resource.TestCheckResourceAttr("vault_kv_v2_config.kv-config",
+						"cas_required", fmt.Sprintf("%t", !cas_required)),
+					resource.TestCheckResourceAttr("vault_kv_v2_config.kv-config",
+						"delete_version_after", new_delete_versions_after),
+				),
+			},
+			{
+				Config: testAccKvV2Config_basic(backend, max_version_for_basic),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_kv_v2_config.kv-config",
+						"path", backend),
+					resource.TestCheckResourceAttr("vault_kv_v2_config.kv-config",
+						"max_versions", fmt.Sprint(max_version_for_basic)),
+					resource.TestCheckResourceAttr("vault_kv_v2_config.kv-config",
+						"cas_required", fmt.Sprintf("%t", false)),
+					resource.TestCheckResourceAttr("vault_kv_v2_config.kv-config",
+						"delete_version_after", "0s"),
+				),
+			},
+		},
+	})
+}
+func testAccKvV2Config_full(path string, max_versions int, cas_required bool, delete_version_after string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "kv" {
+  type = "kv-v2"
+  path = %q
+}
+
+resource "vault_kv_v2_config" "kv-config" {
+  path = vault_mount.kv.path
+  max_versions = %d
+  cas_required = %t
+  delete_version_after = %q
+}`, path, max_versions, cas_required, delete_version_after)
+}
+
+func testAccKvV2Config_basic(path string, max_versions int) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "kv" {
+  type = "kv-v2"
+  path = %q
+}
+
+resource "vault_kv_v2_config" "kv-config" {
+  path = vault_mount.kv.path
+  max_versions = %d
+}`, path, max_versions)
+}
+
+func testAccCheckKvV2ConfigDestroy(s *terraform.State) error {
+	client := testProvider.Meta().(*api.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "vault_kv_v2_config" {
+			continue
+		}
+		secret, err := client.Logical().Read(kvV2MountPathConfigPath(rs.Primary.ID))
+		if err != nil {
+			return fmt.Errorf("error checking for kv-v2 config %q: %s", rs.Primary.ID, err)
+		}
+		if secret != nil {
+			return fmt.Errorf("vault_kv_v2_config still exists %q", rs.Primary.ID)
+		}
+	}
+	return nil
+}

--- a/vault/resource_namespace.go
+++ b/vault/resource_namespace.go
@@ -30,7 +30,7 @@ func namespaceResource() *schema.Resource {
 			"namespace_id": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "ID of the namepsace.",
+				Description: "ID of the namespace.",
 			},
 		},
 	}


### PR DESCRIPTION
Add a new resource and datasource to configure kv-v2.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1310

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
To be updated after the next unreleased version is set in the Changelog file
```

Output from acceptance testing:

```
$ TESTARGS="--run KvV2Config" make testacc
ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
=== RUN   TestAccKvV2ConfigDataSource_basic
--- PASS: TestAccKvV2ConfigDataSource_basic (3.78s)
=== RUN   TestAccKvV2ConfigDataSource_full
--- PASS: TestAccKvV2ConfigDataSource_full (2.34s)
=== RUN   TestAccKvV2Config_import
--- PASS: TestAccKvV2Config_import (1.64s)
=== RUN   TestAccKvV2Config_fullUpdate
--- PASS: TestAccKvV2Config_fullUpdate (4.39s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     15.318s
```
