### PR TITLE
Add nil check to resolve panic when reading RabbitMQ role from Vault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.1 (Unreleased)
+BUGS:
+* `resource/rabbitmq_secret_backend_role`: Add nil check to resolve panic when reading RabbitMQ role from Vault
+
 ## 3.2.0 (January 19, 2022)
 BUGS:
 * `resource/aws_secret_backend_role`: Ensure all updated fields are applied ([#1277](https://github.com/hashicorp/terraform-provider-vault/pull/1277))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.2.1 (Unreleased)
 BUGS:
-* `resource/rabbitmq_secret_backend_role`: Add nil check to resolve panic when reading RabbitMQ role from Vault
+* `resource/rabbitmq_secret_backend_role`: Add nil check when reading RabbitMQ role from Vault ([#1312](https://github.com/hashicorp/terraform-provider-vault/pull/1312))
 
 ## 3.2.0 (January 19, 2022)
 BUGS:

--- a/vault/resource_rabbitmq_secret_backend_role.go
+++ b/vault/resource_rabbitmq_secret_backend_role.go
@@ -168,12 +168,19 @@ func rabbitMQSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("backend", strings.Join(pathPieces[:len(pathPieces)-2], "/"))
 	d.Set("name", pathPieces[len(pathPieces)-1])
 
-	if err := d.Set("vhost", flattenRabbitMQSecretBackendRoleVhost(secret.Data["vhosts"].(map[string]interface{}))); err != nil {
-		return fmt.Errorf("Error setting vhosts in state: %w", err)
+	vhosts := secret.Data["vhosts"]
+	vhostTopics := secret.Data["vhost_topics"]
+
+	if vhosts != nil {
+		if err := d.Set("vhost", flattenRabbitMQSecretBackendRoleVhost(secret.Data["vhosts"].(map[string]interface{}))); err != nil {
+			return fmt.Errorf("error setting vhosts in state: %w", err)
+		}
 	}
 
-	if err := d.Set("vhost_topic", flattenRabbitMQSecretBackendRoleVhostTopics(secret.Data["vhost_topics"].(map[string]interface{}))); err != nil {
-		return fmt.Errorf("Error setting vhosts topics in state: %w", err)
+	if vhostTopics != nil {
+		if err := d.Set("vhost_topic", flattenRabbitMQSecretBackendRoleVhostTopics(secret.Data["vhost_topics"].(map[string]interface{}))); err != nil {
+			return fmt.Errorf("Error setting vhosts topics in state: %w", err)
+		}
 	}
 
 	return nil

--- a/vault/resource_rabbitmq_secret_backend_role.go
+++ b/vault/resource_rabbitmq_secret_backend_role.go
@@ -168,18 +168,15 @@ func rabbitMQSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("backend", strings.Join(pathPieces[:len(pathPieces)-2], "/"))
 	d.Set("name", pathPieces[len(pathPieces)-1])
 
-	vhosts := secret.Data["vhosts"]
-	vhostTopics := secret.Data["vhost_topics"]
-
-	if vhosts != nil {
-		if err := d.Set("vhost", flattenRabbitMQSecretBackendRoleVhost(secret.Data["vhosts"].(map[string]interface{}))); err != nil {
+	if vhosts, ok := secret.Data["vhosts"]; ok && vhosts != nil {
+		if err := d.Set("vhost", flattenRabbitMQSecretBackendRoleVhost(vhosts.(map[string]interface{}))); err != nil {
 			return fmt.Errorf("error setting vhosts in state: %w", err)
 		}
 	}
 
-	if vhostTopics != nil {
-		if err := d.Set("vhost_topic", flattenRabbitMQSecretBackendRoleVhostTopics(secret.Data["vhost_topics"].(map[string]interface{}))); err != nil {
-			return fmt.Errorf("Error setting vhosts topics in state: %w", err)
+	if vhostTopics, ok := secret.Data["vhost_topics"]; ok && vhostTopics != nil {
+		if err := d.Set("vhost_topic", flattenRabbitMQSecretBackendRoleVhostTopics(vhostTopics.(map[string]interface{}))); err != nil {
+			return fmt.Errorf("error setting vhosts topics in state: %w", err)
 		}
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #1309

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note: bug
`resource/rabbitmq_secret_backend_role`: Add nil check when reading RabbitMQ role from Vault
```

Output from acceptance testing:

```
$  make testacc TESTARGS='-v -run TestAccRabbitMQSecretBackendRole'
=== RUN   TestAccRabbitMQSecretBackendRole_basic
--- PASS: TestAccRabbitMQSecretBackendRole_basic (3.32s)
=== RUN   TestAccRabbitMQSecretBackendRole_nested
--- PASS: TestAccRabbitMQSecretBackendRole_nested (3.28s)
=== RUN   TestAccRabbitMQSecretBackendRole_topic
--- PASS: TestAccRabbitMQSecretBackendRole_topic (3.35s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     10.350s
```
