### PR TITLE
Ensure `disable_iss_validation` is honored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.0 (Unreleased)
+BUGS:
+* `resource/kubernetes_auth_backend_config`: Ensure `disable_iss_validation` is honored in all cases ([#1315](https://github.com/hashicorp/terraform-provider-vault/pull/1315))
+
 ## 3.2.1 (January 20, 2022)
 BUGS:
 * `resource/rabbitmq_secret_backend_role`: Add nil check when reading RabbitMQ role from Vault ([#1312](https://github.com/hashicorp/terraform-provider-vault/pull/1312))

--- a/vault/resource_kubernetes_auth_backend_config.go
+++ b/vault/resource_kubernetes_auth_backend_config.go
@@ -217,7 +217,7 @@ func kubernetesAuthBackendConfigUpdate(d *schema.ResourceData, meta interface{})
 		data["issuer"] = v.(string)
 	}
 
-	if v, ok := d.GetOk("disable_iss_validation"); ok {
+	if v, ok := d.GetOkExists("disable_iss_validation"); ok {
 		data["disable_iss_validation"] = v
 	}
 

--- a/vault/resource_kubernetes_auth_backend_config_test.go
+++ b/vault/resource_kubernetes_auth_backend_config_test.go
@@ -260,10 +260,6 @@ func TestAccKubernetesAuthBackendConfig_fullUpdate(t *testing.T) {
 	newJWT := kubernetesAnotherJWT
 	oldIssuer := "kubernetes/serviceaccount"
 	newIssuer := "api"
-	oldDisableIssValidation := false
-	newDisableIssValidation := true
-	oldDisableLocalCaJwt := false
-	newDisableLocalCaJwt := true
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
@@ -271,7 +267,7 @@ func TestAccKubernetesAuthBackendConfig_fullUpdate(t *testing.T) {
 		CheckDestroy: testAccCheckKubernetesAuthBackendConfigDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, oldJWT, oldIssuer, oldDisableIssValidation, oldDisableLocalCaJwt),
+				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, oldJWT, oldIssuer, false, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"backend", backend),
@@ -290,13 +286,13 @@ func TestAccKubernetesAuthBackendConfig_fullUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"issuer", oldIssuer),
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
-						"disable_iss_validation", strconv.FormatBool(oldDisableIssValidation)),
+						"disable_iss_validation", strconv.FormatBool(false)),
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
-						"disable_local_ca_jwt", strconv.FormatBool(oldDisableLocalCaJwt)),
+						"disable_local_ca_jwt", strconv.FormatBool(false)),
 				),
 			},
 			{
-				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, newJWT, newIssuer, newDisableIssValidation, newDisableLocalCaJwt),
+				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, newJWT, newIssuer, true, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"backend", backend),
@@ -313,9 +309,33 @@ func TestAccKubernetesAuthBackendConfig_fullUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"issuer", newIssuer),
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
-						"disable_iss_validation", strconv.FormatBool(newDisableIssValidation)),
+						"disable_iss_validation", strconv.FormatBool(true)),
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
-						"disable_local_ca_jwt", strconv.FormatBool(newDisableLocalCaJwt)),
+						"disable_local_ca_jwt", strconv.FormatBool(true)),
+				),
+			},
+			{
+				// ensure we can set disable_iss_validation to false
+				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, newJWT, newIssuer, false, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"backend", backend),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"kubernetes_host", "http://example.com:443"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"kubernetes_ca_cert", kubernetesCAcert),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"token_reviewer_jwt", newJWT),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"pem_keys.#", "1"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"pem_keys.0", kubernetesPEMfile),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"issuer", newIssuer),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"disable_iss_validation", strconv.FormatBool(false)),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"disable_local_ca_jwt", strconv.FormatBool(true)),
 				),
 			},
 		},


### PR DESCRIPTION
Previously we were using `GetOk()` on a boolean schema field for
`disable_iss_validation` which prevented the provider from provisioning
Vault's Kubernetes auth backend properly.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1313 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-v -test.run TestAccKubernetesAuthBackendConfig'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -v -test.run TestAccKubernetesAuthBackendConfig -timeout 20m ./...

ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
=== RUN   TestAccKubernetesAuthBackendConfigDataSource_basic
--- PASS: TestAccKubernetesAuthBackendConfigDataSource_basic (3.29s)
=== RUN   TestAccKubernetesAuthBackendConfigDataSource_full
--- PASS: TestAccKubernetesAuthBackendConfigDataSource_full (3.01s)
=== RUN   TestAccKubernetesAuthBackendConfig_import
--- PASS: TestAccKubernetesAuthBackendConfig_import (3.94s)
=== RUN   TestAccKubernetesAuthBackendConfig_basic
--- PASS: TestAccKubernetesAuthBackendConfig_basic (1.71s)
=== RUN   TestAccKubernetesAuthBackendConfig_update
--- PASS: TestAccKubernetesAuthBackendConfig_update (3.00s)
=== RUN   TestAccKubernetesAuthBackendConfig_full
--- PASS: TestAccKubernetesAuthBackendConfig_full (1.71s)
=== RUN   TestAccKubernetesAuthBackendConfig_fullUpdate
--- PASS: TestAccKubernetesAuthBackendConfig_fullUpdate (4.30s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     21.770s
...
```
