### PR TITLE
add allowed_policies_glob and disallowed_polices_glob to auth token role backend

### DIFF
--- a/vault/resource_token_auth_backend_role.go
+++ b/vault/resource_token_auth_backend_role.go
@@ -51,7 +51,7 @@ func tokenAuthBackendRoleResource() *schema.Resource {
 				Type: schema.TypeString,
 			},
 			DefaultFunc: tokenAuthBackendRoleEmptyStringSet,
-			Description: "List of allowed policies with glob match for given role.",
+			Description: "Set of allowed policies with glob match for given role.",
 		},
 		"disallowed_policies": {
 			Type:     schema.TypeSet,

--- a/vault/resource_token_auth_backend_role.go
+++ b/vault/resource_token_auth_backend_role.go
@@ -169,7 +169,11 @@ func tokenAuthBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("role_name", roleName)
 
-	for _, k := range []string{"allowed_policies", "allowed_policies_glob", "disallowed_policies", "disallowed_policies_glob", "orphan", "path_suffix", "renewable"} {
+	params := []string{
+		"allowed_policies", "allowed_policies_glob", "disallowed_policies",
+		"disallowed_policies_glob", "orphan", "path_suffix", "renewable",
+	}
+	for _, k := range params {
 		if err := d.Set(k, resp.Data[k]); err != nil {
 			return fmt.Errorf("error reading %s for Token auth backend role %q: %q", k, path, err)
 		}

--- a/vault/resource_token_auth_backend_role.go
+++ b/vault/resource_token_auth_backend_role.go
@@ -69,7 +69,7 @@ func tokenAuthBackendRoleResource() *schema.Resource {
 				Type: schema.TypeString,
 			},
 			DefaultFunc: tokenAuthBackendRoleEmptyStringSet,
-			Description: "List of disallowed policies with glob match for given role.",
+			Description: "Set of disallowed policies with glob match for given role.",
 		},
 		"orphan": {
 			Type:        schema.TypeBool,

--- a/vault/resource_token_auth_backend_role.go
+++ b/vault/resource_token_auth_backend_role.go
@@ -44,6 +44,15 @@ func tokenAuthBackendRoleResource() *schema.Resource {
 			DefaultFunc: tokenAuthBackendRoleEmptyStringSet,
 			Description: "List of allowed policies for given role.",
 		},
+		"allowed_policies_glob": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+			DefaultFunc: tokenAuthBackendRoleEmptyStringSet,
+			Description: "List of allowed policies with glob match for given role.",
+		},
 		"disallowed_policies": {
 			Type:     schema.TypeSet,
 			Optional: true,
@@ -52,6 +61,15 @@ func tokenAuthBackendRoleResource() *schema.Resource {
 			},
 			DefaultFunc: tokenAuthBackendRoleEmptyStringSet,
 			Description: "List of disallowed policies for given role.",
+		},
+		"disallowed_policies_glob": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+			DefaultFunc: tokenAuthBackendRoleEmptyStringSet,
+			Description: "List of disallowed policies with glob match for given role.",
 		},
 		"orphan": {
 			Type:        schema.TypeBool,
@@ -93,7 +111,9 @@ func tokenAuthBackendRoleUpdateFields(d *schema.ResourceData, data map[string]in
 	setTokenFields(d, data, tokenAuthBackendRoleTokenConfig())
 
 	data["allowed_policies"] = d.Get("allowed_policies").(*schema.Set).List()
+	data["allowed_policies_glob"] = d.Get("allowed_policies_glob").(*schema.Set).List()
 	data["disallowed_policies"] = d.Get("disallowed_policies").(*schema.Set).List()
+	data["disallowed_policies_glob"] = d.Get("disallowed_policies_glob").(*schema.Set).List()
 	data["orphan"] = d.Get("orphan").(bool)
 	data["renewable"] = d.Get("renewable").(bool)
 	data["path_suffix"] = d.Get("path_suffix").(string)
@@ -149,7 +169,7 @@ func tokenAuthBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("role_name", roleName)
 
-	for _, k := range []string{"allowed_policies", "disallowed_policies", "orphan", "path_suffix", "renewable"} {
+	for _, k := range []string{"allowed_policies", "allowed_policies_glob", "disallowed_policies", "disallowed_policies_glob", "orphan", "path_suffix", "renewable"} {
 		if err := d.Set(k, resp.Data[k]); err != nil {
 			return fmt.Errorf("error reading %s for Token auth backend role %q: %q", k, path, err)
 		}

--- a/vault/resource_token_auth_backend_role_test.go
+++ b/vault/resource_token_auth_backend_role_test.go
@@ -72,8 +72,13 @@ func TestAccTokenAuthBackendRoleUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_token_auth_backend_role.role", "allowed_policies.#", "2"),
 					resource.TestCheckResourceAttr("vault_token_auth_backend_role.role", "allowed_policies.0", "dev"),
 					resource.TestCheckResourceAttr("vault_token_auth_backend_role.role", "allowed_policies.1", "test"),
+					resource.TestCheckResourceAttr("vault_token_auth_backend_role.role", "allowed_policies_glob.#", "2"),
+					resource.TestCheckResourceAttr("vault_token_auth_backend_role.role", "allowed_policies_glob.0", "dev/*"),
+					resource.TestCheckResourceAttr("vault_token_auth_backend_role.role", "allowed_policies_glob.1", "test/*"),
 					resource.TestCheckResourceAttr("vault_token_auth_backend_role.role", "disallowed_policies.#", "1"),
 					resource.TestCheckResourceAttr("vault_token_auth_backend_role.role", "disallowed_policies.0", "default"),
+					resource.TestCheckResourceAttr("vault_token_auth_backend_role.role", "disallowed_policies_glob.#", "1"),
+					resource.TestCheckResourceAttr("vault_token_auth_backend_role.role", "disallowed_policies_glob.0", "def*"),
 					resource.TestCheckResourceAttr("vault_token_auth_backend_role.role", "orphan", "true"),
 					resource.TestCheckResourceAttr("vault_token_auth_backend_role.role", "token_period", "86400"),
 					resource.TestCheckResourceAttr("vault_token_auth_backend_role.role", "renewable", "false"),
@@ -93,8 +98,13 @@ func TestAccTokenAuthBackendRoleUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_token_auth_backend_role.role", "allowed_policies.#", "2"),
 					resource.TestCheckResourceAttr("vault_token_auth_backend_role.role", "allowed_policies.0", "dev"),
 					resource.TestCheckResourceAttr("vault_token_auth_backend_role.role", "allowed_policies.1", "test"),
+					resource.TestCheckResourceAttr("vault_token_auth_backend_role.role", "allowed_policies_glob.#", "2"),
+					resource.TestCheckResourceAttr("vault_token_auth_backend_role.role", "allowed_policies_glob.0", "dev/*"),
+					resource.TestCheckResourceAttr("vault_token_auth_backend_role.role", "allowed_policies_glob.1", "test/*"),
 					resource.TestCheckResourceAttr("vault_token_auth_backend_role.role", "disallowed_policies.#", "1"),
 					resource.TestCheckResourceAttr("vault_token_auth_backend_role.role", "disallowed_policies.0", "default"),
+					resource.TestCheckResourceAttr("vault_token_auth_backend_role.role", "disallowed_policies_glob.#", "1"),
+					resource.TestCheckResourceAttr("vault_token_auth_backend_role.role", "disallowed_policies_glob.0", "def*"),
 					resource.TestCheckResourceAttr("vault_token_auth_backend_role.role", "orphan", "true"),
 					resource.TestCheckResourceAttr("vault_token_auth_backend_role.role", "token_period", "86400"),
 					resource.TestCheckResourceAttr("vault_token_auth_backend_role.role", "renewable", "false"),
@@ -188,16 +198,18 @@ func testAccTokenAuthBackendRoleCheck_attrs(role string) resource.TestCheckFunc 
 		}
 
 		attrs := map[string]string{
-			"role_name":              "name",
-			"allowed_policies":       "allowed_policies",
-			"disallowed_policies":    "disallowed_policies",
-			"orphan":                 "orphan",
-			"token_period":           "token_period",
-			"token_explicit_max_ttl": "token_explicit_max_ttl",
-			"path_suffix":            "path_suffix",
-			"renewable":              "renewable",
-			"token_bound_cidrs":      "token_bound_cidrs",
-			"token_type":             "token_type",
+			"role_name":                "name",
+			"allowed_policies":         "allowed_policies",
+			"allowed_policies_glob":    "allowed_policies_glob",
+			"disallowed_policies":      "disallowed_policies",
+			"disallowed_policies_glob": "disallowed_policies_glob",
+			"orphan":                   "orphan",
+			"token_period":             "token_period",
+			"token_explicit_max_ttl":   "token_explicit_max_ttl",
+			"path_suffix":              "path_suffix",
+			"renewable":                "renewable",
+			"token_bound_cidrs":        "token_bound_cidrs",
+			"token_type":               "token_type",
 		}
 
 		for stateAttr, apiAttr := range attrs {
@@ -281,7 +293,9 @@ func testAccTokenAuthBackendRoleConfigUpdate(role string) string {
 resource "vault_token_auth_backend_role" "role" {
   role_name = "%s"
   allowed_policies = ["dev", "test"]
+  allowed_policies_glob = ["dev/*", "test/*"]
   disallowed_policies = ["default"]
+  disallowed_policies_glob = ["def*"]
   orphan = true
   token_period = "86400"
   renewable = false

--- a/website/docs/r/token_auth_backend_role.html.md
+++ b/website/docs/r/token_auth_backend_role.html.md
@@ -35,7 +35,11 @@ The following arguments are supported:
 
 * `allowed_policies` (Optional) List of allowed policies for given role.
 
+* `allowed_policies_glob` (Optional) List of allowed policies with glob match for given role.
+
 * `disallowed_policies` (Optional) List of disallowed policies for given role.
+
+* `disallowed_policies_glob` (Optional) List of disallowed policies with glob match for given role.
 
 * `orphan` (Optional) If true, tokens created against this policy will be orphan tokens.
 

--- a/website/docs/r/token_auth_backend_role.html.md
+++ b/website/docs/r/token_auth_backend_role.html.md
@@ -39,7 +39,7 @@ The following arguments are supported:
 
 * `disallowed_policies` (Optional) List of disallowed policies for given role.
 
-* `disallowed_policies_glob` (Optional) List of disallowed policies with glob match for given role.
+* `disallowed_policies_glob` (Optional) Set of disallowed policies with glob match for given role.
 
 * `orphan` (Optional) If true, tokens created against this policy will be orphan tokens.
 

--- a/website/docs/r/token_auth_backend_role.html.md
+++ b/website/docs/r/token_auth_backend_role.html.md
@@ -35,7 +35,7 @@ The following arguments are supported:
 
 * `allowed_policies` (Optional) List of allowed policies for given role.
 
-* `allowed_policies_glob` (Optional) List of allowed policies with glob match for given role.
+* `allowed_policies_glob` (Optional) Set of allowed policies with glob match for given role.
 
 * `disallowed_policies` (Optional) List of disallowed policies for given role.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->


Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add support for allowed_policies_glob and disallowed_policies_glob in vault_token_auth_backend_role resource.
```

Output from acceptance testing:

```
$ TESTARGS="--run TokenAuthBackendRole" make testacc                           
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v --run TokenAuthBackendRole -timeout 20m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/codegen   (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
?       github.com/hashicorp/terraform-provider-vault/testutil  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
=== RUN   TestAccTokenAuthBackendRoleImport
--- PASS: TestAccTokenAuthBackendRoleImport (0.79s)
=== RUN   TestAccTokenAuthBackendRole
--- PASS: TestAccTokenAuthBackendRole (0.58s)
=== RUN   TestAccTokenAuthBackendRoleUpdate
--- PASS: TestAccTokenAuthBackendRoleUpdate (2.07s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     3.455s


...
```
