### PR TITLE
Add support for configuring a DB secret's plugin_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 BUGS:
 * `resource/kubernetes_auth_backend_config`: Ensure `disable_iss_validation` is honored in all cases ([#1315](https://github.com/hashicorp/terraform-provider-vault/pull/1315))
 
+IMPROVEMENTS:
+* `resource/database_secret_backend_connection`: Add support for configuring the secret engine's `plugin_name` ([#1320](https://github.com/hashicorp/terraform-provider-vault/pull/1320))
+
 ## 3.2.1 (January 20, 2022)
 BUGS:
 * `resource/rabbitmq_secret_backend_role`: Add nil check when reading RabbitMQ role from Vault ([#1312](https://github.com/hashicorp/terraform-provider-vault/pull/1312))

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -65,15 +65,7 @@ var (
 		dbBackendSnowflake:     {name: dbBackendSnowflake},
 		dbBackendRedshift:      {name: dbBackendRedshift},
 	}
-	// dbEngines key values, initialized in init()
-	dbBackendTypes []string
 )
-
-func init() {
-	for k := range dbEngines {
-		dbBackendTypes = append(dbBackendTypes, k)
-	}
-}
 
 type dbEngine struct {
 	name string
@@ -88,6 +80,11 @@ func (i *dbEngine) getPluginName(d *schema.ResourceData) string {
 }
 
 func databaseSecretBackendConnectionResource() *schema.Resource {
+	dbBackendTypes := []string{}
+	for k := range dbEngines {
+		dbBackendTypes = append(dbBackendTypes, k)
+	}
+
 	return &schema.Resource{
 		Create: databaseSecretBackendConnectionCreate,
 		Read:   databaseSecretBackendConnectionRead,

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -1296,6 +1296,24 @@ func Test_dbEngine_getPluginName(t *testing.T) {
 			want: "foo-database-plugin",
 		},
 		{
+			name: "default-underscored",
+			fields: fields{
+				name: "foo_qux_baz",
+			},
+			args: args{
+				schema.TestResourceDataRaw(
+					t,
+					map[string]*schema.Schema{
+						"plugin_name": {
+							Type:     schema.TypeString,
+							Required: false,
+						},
+					},
+					map[string]interface{}{}),
+			},
+			want: "foo-qux-baz-database-plugin",
+		},
+		{
 			name: "set",
 			fields: fields{
 				name: "foo",

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -29,15 +29,14 @@ const testDefaultDatabaseSecretBackendResource = "vault_database_secret_backend_
 // copy/build a db plugin and install it with a unique name, then register it in vault.
 
 func TestAccDatabaseSecretBackendConnection_import(t *testing.T) {
-	MaybeSkipDBTests(t, dbBackendPostgres)
+	MaybeSkipDBTests(t, dbEnginePostgres)
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "POSTGRES_URL")
 	connURL := values[0]
 
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	// should match dbEngine.getPluginName()'s default return value
-	pluginName := fmt.Sprintf("%s-database-plugin", dbBackendPostgres)
+	pluginName := dbEnginePostgres.DefaultPluginName()
 	name := acctest.RandomWithPrefix("db")
 
 	userTempl := "{{.DisplayName}}"
@@ -73,7 +72,7 @@ func TestAccDatabaseSecretBackendConnection_import(t *testing.T) {
 }
 
 func TestAccDatabaseSecretBackendConnection_cassandra(t *testing.T) {
-	MaybeSkipDBTests(t, dbBackendCassandra)
+	MaybeSkipDBTests(t, dbEngineCassandra)
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "CASSANDRA_HOST")
@@ -82,7 +81,7 @@ func TestAccDatabaseSecretBackendConnection_cassandra(t *testing.T) {
 	username := os.Getenv("CASSANDRA_USERNAME")
 	password := os.Getenv("CASSANDRA_PASSWORD")
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	pluginName := fmt.Sprintf("%s-database-plugin", dbBackendCassandra)
+	pluginName := dbEngineCassandra.DefaultPluginName()
 	name := acctest.RandomWithPrefix("db")
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
@@ -116,7 +115,7 @@ func TestAccDatabaseSecretBackendConnection_cassandra(t *testing.T) {
 }
 
 func TestAccDatabaseSecretBackendConnection_cassandraProtocol(t *testing.T) {
-	MaybeSkipDBTests(t, dbBackendCassandra)
+	MaybeSkipDBTests(t, dbEngineCassandra)
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "CASSANDRA_HOST")
@@ -125,8 +124,7 @@ func TestAccDatabaseSecretBackendConnection_cassandraProtocol(t *testing.T) {
 	username := os.Getenv("CASSANDRA_USERNAME")
 	password := os.Getenv("CASSANDRA_PASSWORD")
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	// should match dbEngine.getPluginName()'s default return value
-	pluginName := fmt.Sprintf("%s-database-plugin", dbBackendCassandra)
+	pluginName := dbEngineCassandra.DefaultPluginName()
 	name := acctest.RandomWithPrefix("db")
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
@@ -160,7 +158,7 @@ func TestAccDatabaseSecretBackendConnection_cassandraProtocol(t *testing.T) {
 }
 
 func TestAccDatabaseSecretBackendConnection_couchbase(t *testing.T) {
-	MaybeSkipDBTests(t, dbBackendCouchbase)
+	MaybeSkipDBTests(t, dbEngineCouchbase)
 
 	values := testutil.SkipTestEnvUnset(t, "COUCHBASE_HOST_1", "COUCHBASE_HOST_2", "COUCHBASE_USERNAME", "COUCHBASE_PASSWORD")
 	host1 := values[0]
@@ -168,8 +166,7 @@ func TestAccDatabaseSecretBackendConnection_couchbase(t *testing.T) {
 	username := values[2]
 	password := values[3]
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	// should match dbEngine.getPluginName()'s default return value
-	pluginName := fmt.Sprintf("%s-database-plugin", dbBackendCouchbase)
+	pluginName := dbEngineCouchbase.DefaultPluginName()
 	name := acctest.RandomWithPrefix("db")
 	resourceName := testDefaultDatabaseSecretBackendResource
 	resource.Test(t, resource.TestCase{
@@ -207,7 +204,7 @@ func TestAccDatabaseSecretBackendConnection_couchbase(t *testing.T) {
 }
 
 func TestAccDatabaseSecretBackendConnection_influxdb(t *testing.T) {
-	MaybeSkipDBTests(t, dbBackendInfluxDB)
+	MaybeSkipDBTests(t, dbEngineInfluxDB)
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "INFLUXDB_HOST")
@@ -216,8 +213,7 @@ func TestAccDatabaseSecretBackendConnection_influxdb(t *testing.T) {
 	username := os.Getenv("INFLUXDB_USERNAME")
 	password := os.Getenv("INFLUXDB_PASSWORD")
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	// should match dbEngine.getPluginName()'s default return value
-	pluginName := fmt.Sprintf("%s-database-plugin", dbBackendInfluxDB)
+	pluginName := dbEngineInfluxDB.DefaultPluginName()
 	name := acctest.RandomWithPrefix("db")
 	resourceName := testDefaultDatabaseSecretBackendResource
 	resource.Test(t, resource.TestCase{
@@ -250,7 +246,7 @@ func TestAccDatabaseSecretBackendConnection_influxdb(t *testing.T) {
 }
 
 func TestAccDatabaseSecretBackendConnection_mongodbatlas(t *testing.T) {
-	MaybeSkipDBTests(t, dbBackendMongoDBAtlas)
+	MaybeSkipDBTests(t, dbEngineMongoDBAtlas)
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "MONGODB_ATLAS_PUBLIC_KEY")
@@ -259,8 +255,7 @@ func TestAccDatabaseSecretBackendConnection_mongodbatlas(t *testing.T) {
 	privateKey := os.Getenv("MONGODB_ATLAS_PRIVATE_KEY")
 	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	// should match dbEngine.getPluginName()'s default return value
-	pluginName := fmt.Sprintf("%s-database-plugin", dbBackendMongoDBAtlas)
+	pluginName := dbEngineMongoDBAtlas.DefaultPluginName()
 	name := acctest.RandomWithPrefix("db")
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
@@ -286,15 +281,14 @@ func TestAccDatabaseSecretBackendConnection_mongodbatlas(t *testing.T) {
 }
 
 func TestAccDatabaseSecretBackendConnection_mongodb(t *testing.T) {
-	MaybeSkipDBTests(t, dbBackendMongoDB)
+	MaybeSkipDBTests(t, dbEngineMongoDB)
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "MONGODB_URL")
 	connURL := values[0]
 
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	// should match dbEngine.getPluginName()'s default return value
-	pluginName := fmt.Sprintf("%s-database-plugin", dbBackendMongoDB)
+	pluginName := dbEngineMongoDB.DefaultPluginName()
 	name := acctest.RandomWithPrefix("db")
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
@@ -318,15 +312,14 @@ func TestAccDatabaseSecretBackendConnection_mongodb(t *testing.T) {
 }
 
 func TestAccDatabaseSecretBackendConnection_mssql(t *testing.T) {
-	MaybeSkipDBTests(t, dbBackendMSSQL)
+	MaybeSkipDBTests(t, dbEngineMSSQL)
 
 	cleanupFunc, connURL := mssqlhelper.PrepareMSSQLTestContainer(t)
 
 	t.Cleanup(cleanupFunc)
 
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	// should match dbEngine.getPluginName()'s default return value
-	pluginName := fmt.Sprintf("%s-database-plugin", dbBackendMSSQL)
+	pluginName := dbEngineMSSQL.DefaultPluginName()
 	name := acctest.RandomWithPrefix("db")
 
 	resource.Test(t, resource.TestCase{
@@ -372,15 +365,14 @@ func TestAccDatabaseSecretBackendConnection_mssql(t *testing.T) {
 }
 
 func TestAccDatabaseSecretBackendConnection_mysql(t *testing.T) {
-	MaybeSkipDBTests(t, dbBackendMySQL)
+	MaybeSkipDBTests(t, dbEngineMySQL)
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "MYSQL_URL")
 	connURL := values[0]
 
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	// should match dbEngine.getPluginName()'s default return value
-	pluginName := fmt.Sprintf("%s-database-plugin", dbBackendMySQL)
+	pluginName := dbEngineMySQL.DefaultPluginName()
 	name := acctest.RandomWithPrefix("db")
 	password := acctest.RandomWithPrefix("password")
 	resource.Test(t, resource.TestCase{
@@ -466,15 +458,14 @@ func testComposeCheckFuncCommonDatabaseSecretBackend(name, backend, pluginName s
 }
 
 func TestAccDatabaseSecretBackendConnectionUpdate_mysql(t *testing.T) {
-	MaybeSkipDBTests(t, dbBackendMySQL)
+	MaybeSkipDBTests(t, dbEngineMySQL)
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "MYSQL_URL")
 	connURL := values[0]
 
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	// should match dbEngine.getPluginName()'s default return value
-	pluginName := fmt.Sprintf("%s-database-plugin", dbBackendMySQL)
+	pluginName := dbEngineMySQL.DefaultPluginName()
 	name := acctest.RandomWithPrefix("db")
 	password := acctest.RandomWithPrefix("password")
 	resource.Test(t, resource.TestCase{
@@ -519,7 +510,7 @@ func TestAccDatabaseSecretBackendConnectionUpdate_mysql(t *testing.T) {
 }
 
 func TestAccDatabaseSecretBackendConnectionTemplatedUpdateExcludePassword_mysql(t *testing.T) {
-	MaybeSkipDBTests(t, dbBackendMySQL)
+	MaybeSkipDBTests(t, dbEngineMySQL)
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t,
@@ -538,8 +529,7 @@ func TestAccDatabaseSecretBackendConnectionTemplatedUpdateExcludePassword_mysql(
 	}
 
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	// should match dbEngine.getPluginName()'s default return value
-	pluginName := fmt.Sprintf("%s-database-plugin", dbBackendMySQL)
+	pluginName := dbEngineMySQL.DefaultPluginName()
 	name := acctest.RandomWithPrefix("db")
 	testUsername := acctest.RandomWithPrefix("username")
 	testPassword := acctest.RandomWithPrefix("password")
@@ -597,15 +587,14 @@ func TestAccDatabaseSecretBackendConnectionTemplatedUpdateExcludePassword_mysql(
 }
 
 func TestAccDatabaseSecretBackendConnection_mysql_tls(t *testing.T) {
-	MaybeSkipDBTests(t, dbBackendMySQL)
+	MaybeSkipDBTests(t, dbEngineMySQL)
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "MYSQL_CA", "MYSQL_URL", "MYSQL_CERTIFICATE_KEY")
 	tlsCA, connURL, tlsCertificateKey := values[0], values[1], values[2]
 
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	// should match dbEngine.getPluginName()'s default return value
-	pluginName := fmt.Sprintf("%s-database-plugin", dbBackendMySQL)
+	pluginName := dbEngineMySQL.DefaultPluginName()
 	name := acctest.RandomWithPrefix("db")
 	password := acctest.RandomWithPrefix("password")
 	resource.Test(t, resource.TestCase{
@@ -637,15 +626,14 @@ func TestAccDatabaseSecretBackendConnection_mysql_tls(t *testing.T) {
 }
 
 func TestAccDatabaseSecretBackendConnection_postgresql(t *testing.T) {
-	MaybeSkipDBTests(t, dbBackendPostgres)
+	MaybeSkipDBTests(t, dbEnginePostgres)
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "POSTGRES_URL")
 	connURL := values[0]
 
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	// should match dbEngine.getPluginName()'s default return value
-	pluginName := fmt.Sprintf("%s-database-plugin", dbBackendPostgres)
+	pluginName := dbEnginePostgres.DefaultPluginName()
 	name := acctest.RandomWithPrefix("db")
 	userTempl := "{{.DisplayName}}"
 	resource.Test(t, resource.TestCase{
@@ -674,7 +662,7 @@ func TestAccDatabaseSecretBackendConnection_postgresql(t *testing.T) {
 }
 
 func TestAccDatabaseSecretBackendConnection_elasticsearch(t *testing.T) {
-	MaybeSkipDBTests(t, dbBackendElasticSearch)
+	MaybeSkipDBTests(t, dbEngineElasticSearch)
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "ELASTIC_URL")
@@ -683,8 +671,7 @@ func TestAccDatabaseSecretBackendConnection_elasticsearch(t *testing.T) {
 	username := os.Getenv("ELASTIC_USERNAME")
 	password := os.Getenv("ELASTIC_PASSWORD")
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	// should match dbEngine.getPluginName()'s default return value
-	pluginName := fmt.Sprintf("%s-database-plugin", dbBackendElasticSearch)
+	pluginName := dbEngineElasticSearch.DefaultPluginName()
 	name := acctest.RandomWithPrefix("db")
 
 	resource.Test(t, resource.TestCase{
@@ -707,7 +694,7 @@ func TestAccDatabaseSecretBackendConnection_elasticsearch(t *testing.T) {
 }
 
 func TestAccDatabaseSecretBackendConnection_snowflake(t *testing.T) {
-	MaybeSkipDBTests(t, dbBackendSnowflake)
+	MaybeSkipDBTests(t, dbEngineSnowflake)
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "SNOWFLAKE_URL")
@@ -716,8 +703,7 @@ func TestAccDatabaseSecretBackendConnection_snowflake(t *testing.T) {
 	username := os.Getenv("SNOWFLAKE_USERNAME")
 	password := os.Getenv("SNOWFLAKE_PASSWORD")
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	// should match dbEngine.getPluginName()'s default return value
-	pluginName := fmt.Sprintf("%s-database-plugin", dbBackendSnowflake)
+	pluginName := dbEngineSnowflake.DefaultPluginName()
 	name := acctest.RandomWithPrefix("db")
 	userTempl := "{{.DisplayName}}"
 
@@ -745,15 +731,14 @@ func TestAccDatabaseSecretBackendConnection_snowflake(t *testing.T) {
 }
 
 func TestAccDatabaseSecretBackendConnection_redshift(t *testing.T) {
-	MaybeSkipDBTests(t, dbBackendRedshift)
+	MaybeSkipDBTests(t, dbEngineRedshift)
 
 	url := os.Getenv("REDSHIFT_URL")
 	if url == "" {
 		t.Skip("REDSHIFT_URL not set")
 	}
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	// should match dbEngine.getPluginName()'s default return value
-	pluginName := fmt.Sprintf("%s-database-plugin", dbBackendRedshift)
+	pluginName := dbEngineRedshift.DefaultPluginName()
 	name := acctest.RandomWithPrefix("db")
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
@@ -1247,34 +1232,40 @@ func deleteMySQLUser(t *testing.T, db *sql.DB, username string) {
 	}
 }
 
-func MaybeSkipDBTests(t *testing.T, engine string) {
+func MaybeSkipDBTests(t *testing.T, engine *dbEngine) {
 	// require TF_ACC to be set
 	testutil.SkipTestAcc(t)
 
 	envVars := []string{"SKIP_DB_TESTS"}
-	if _, ok := dbEngines[engine]; ok {
-		envVars = append(envVars, envVars[0]+"_"+strings.ToUpper(engine))
+	for _, e := range dbEngines {
+		if e == engine {
+			envVars = append(envVars, envVars[0]+"_"+strings.ToUpper(engine.name))
+			break
+		}
 	}
 	testutil.SkipTestEnvSet(t, envVars...)
 }
 
-func Test_dbEngine_getPluginName(t *testing.T) {
+func Test_dbEngine_GetPluginName(t *testing.T) {
 	type fields struct {
-		name string
+		name              string
+		defaultPluginName string
 	}
 	type args struct {
 		d *schema.ResourceData
 	}
 	tests := []struct {
-		name   string
-		fields fields
-		args   args
-		want   string
+		name    string
+		fields  fields
+		args    args
+		want    string
+		wantErr bool
 	}{
 		{
 			name: "default",
 			fields: fields{
-				name: "foo",
+				name:              "foo",
+				defaultPluginName: "foo-database-plugin",
 			},
 			args: args{
 				schema.TestResourceDataRaw(
@@ -1288,24 +1279,6 @@ func Test_dbEngine_getPluginName(t *testing.T) {
 					map[string]interface{}{}),
 			},
 			want: "foo-database-plugin",
-		},
-		{
-			name: "default-underscored",
-			fields: fields{
-				name: "foo_qux_baz",
-			},
-			args: args{
-				schema.TestResourceDataRaw(
-					t,
-					map[string]*schema.Schema{
-						"plugin_name": {
-							Type:     schema.TypeString,
-							Required: false,
-						},
-					},
-					map[string]interface{}{}),
-			},
-			want: "foo-qux-baz-database-plugin",
 		},
 		{
 			name: "set",
@@ -1327,14 +1300,42 @@ func Test_dbEngine_getPluginName(t *testing.T) {
 			},
 			want: "baz-qux",
 		},
+		{
+			name: "fail",
+			fields: fields{
+				name: "fail",
+			},
+			args: args{
+				schema.TestResourceDataRaw(
+					t,
+					map[string]*schema.Schema{
+						"plugin_name": {
+							Type:     schema.TypeString,
+							Required: false,
+						},
+					},
+					map[string]interface{}{},
+				),
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			i := &dbEngine{
-				name: tt.fields.name,
+				name:              tt.fields.name,
+				defaultPluginName: tt.fields.defaultPluginName,
 			}
-			if got := i.getPluginName(tt.args.d); got != tt.want {
-				t.Errorf("getPluginName() expected %v, actual %v", tt.want, got)
+
+			got, err := i.GetPluginName(tt.args.d)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetPluginName() error = %v, wantErr %v", err, tt.wantErr)
+
+				return
+			}
+
+			if got != tt.want {
+				t.Errorf("GetPluginName() expected %v, actual %v", tt.want, got)
 			}
 		})
 	}
@@ -1373,9 +1374,7 @@ func Test_getDBEngine(t *testing.T) {
 						},
 					}),
 			},
-			want: &dbEngine{
-				name: dbBackendMSSQL,
-			},
+			want:    dbEngineMSSQL,
 			wantErr: false,
 		},
 		{

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -325,7 +325,7 @@ func TestAccDatabaseSecretBackendConnection_mssql(t *testing.T) {
 	backend := acctest.RandomWithPrefix("tf-test-db")
 	name := acctest.RandomWithPrefix("db")
 
-	// should match dbEngineInfo.getPluginName()'s default return value
+	// should match dbEngine.getPluginName()'s default return value
 	pluginName := fmt.Sprintf("%s-database-plugin", dbBackendMSSQL)
 
 	resource.Test(t, resource.TestCase{
@@ -1264,7 +1264,7 @@ func MaybeSkipDBTests(t *testing.T, engine string) {
 	testutil.SkipTestEnvSet(t, envVars...)
 }
 
-func Test_dbEngineInfo_getPluginName(t *testing.T) {
+func Test_dbEngine_getPluginName(t *testing.T) {
 	type fields struct {
 		name string
 	}
@@ -1318,7 +1318,7 @@ func Test_dbEngineInfo_getPluginName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			i := &dbEngineInfo{
+			i := &dbEngine{
 				name: tt.fields.name,
 			}
 			if got := i.getPluginName(tt.args.d); got != tt.want {
@@ -1328,14 +1328,14 @@ func Test_dbEngineInfo_getPluginName(t *testing.T) {
 	}
 }
 
-func Test_getDBEngineInfo(t *testing.T) {
+func Test_getDBEngine(t *testing.T) {
 	type args struct {
 		d *schema.ResourceData
 	}
 	tests := []struct {
 		name        string
 		args        args
-		want        *dbEngineInfo
+		want        *dbEngine
 		wantErr     bool
 		expectedErr error
 	}{
@@ -1361,7 +1361,7 @@ func Test_getDBEngineInfo(t *testing.T) {
 						},
 					}),
 			},
-			want: &dbEngineInfo{
+			want: &dbEngine{
 				name: dbBackendMSSQL,
 			},
 			wantErr: false,
@@ -1394,18 +1394,18 @@ func Test_getDBEngineInfo(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := getDBEngineInfo(tt.args.d)
+			got, err := getDBEngine(tt.args.d)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("getDBEngineInfo() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("getDBEngine() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
 			if tt.wantErr && tt.expectedErr != nil {
 				if !reflect.DeepEqual(err, tt.expectedErr) {
-					t.Fatalf("getDBEngineInfo() expected err %v, actual %v", tt.expectedErr, err)
+					t.Fatalf("getDBEngine() expected err %v, actual %v", tt.expectedErr, err)
 				}
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getDBEngineInfo() expected %v, actual %v", tt.want, got)
+				t.Errorf("getDBEngine() expected %v, actual %v", tt.want, got)
 			}
 		})
 	}

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -1255,11 +1255,8 @@ func MaybeSkipDBTests(t *testing.T, engine string) {
 	testutil.SkipTestAcc(t)
 
 	envVars := []string{"SKIP_DB_TESTS"}
-	for _, e := range dbBackendTypes {
-		if e == engine {
-			envVars = append(envVars, envVars[0]+"_"+strings.ToUpper(engine))
-			break
-		}
+	if _, ok := dbEngines[engine]; ok {
+		envVars = append(envVars, envVars[0]+"_"+strings.ToUpper(engine))
 	}
 	testutil.SkipTestEnvSet(t, envVars...)
 }

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -984,6 +984,7 @@ resource "vault_database_secret_backend_connection" "test" {
 %s
 }
 `, path, pluginName, name, fmt.Sprintf(config, connURL))
+
 	return result
 }
 

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -337,7 +337,6 @@ func TestAccDatabaseSecretBackendConnection_mssql(t *testing.T) {
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfig_mssql(name, backend, connURL, pluginName, false),
 				Check: testComposeCheckFuncCommonDatabaseSecretBackend(name, backend, pluginName,
-					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "plugin_name", pluginName),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "allowed_roles.#", "2"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "allowed_roles.0", "dev"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "allowed_roles.1", "prod"),

--- a/website/docs/r/database_secret_backend_connection.md
+++ b/website/docs/r/database_secret_backend_connection.md
@@ -45,6 +45,8 @@ The following arguments are supported:
 
 * `backend` - (Required) The unique name of the Vault mount to configure.
 
+* `plugin_name` - (Optional) Specifies the name of the plugin to use.
+
 * `verify_connection` - (Optional) Whether the connection should be verified on
   initial configuration or not.
 


### PR DESCRIPTION
This PR adds support for setting the `plugin_name` in the `vault_database_secret_backend_connection` resource. Previously all related resources could only be provisioned using a well known default value from Vault.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1288 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
make testacc TESTARGS='-v -test.run TestAccDatabaseSecretBackendConnection_mssql'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -v -test.run TestAccDatabaseSecretBackendConnection_mssql -timeout 20m ./...

[...]

=== RUN   TestAccDatabaseSecretBackendConnection_mssql
--- PASS: TestAccDatabaseSecretBackendConnection_mssql (17.70s)

```
