### PR TITLE
Git ignore scratch directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ website/vendor
 # Binaries
 terraform-provider-vault
 /cmd/coverage/coverage
+
+# Scratch directory for miscellaneous files/examples/etc.
+scratch


### PR DESCRIPTION
Sometimes it's nice to be able to keep files that you don't want to track in the repo. You can now use the `scratch` directory for that.