### PR TITLE
Add missing read handler for Redshift DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.3.0 (Unreleased)
 BUGS:
 * `resource/kubernetes_auth_backend_config`: Ensure `disable_iss_validation` is honored in all cases ([#1315](https://github.com/hashicorp/terraform-provider-vault/pull/1315))
+* `resource/database_secret_backend_connection`: Add error handling for unrecognized plugins on read (()[])
 
 IMPROVEMENTS:
 * `resource/token_auth_backend_role`: Add `allowed_policies_glob` and `disallowed_polices_glob` ([#1316](https://github.com/hashicorp/terraform-provider-vault/pull/1316))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 3.3.0 (Unreleased)
 BUGS:
 * `resource/kubernetes_auth_backend_config`: Ensure `disable_iss_validation` is honored in all cases ([#1315](https://github.com/hashicorp/terraform-provider-vault/pull/1315))
-* `resource/database_secret_backend_connection`: Add error handling for unrecognized plugins on read (()[])
+* `resource/database_secret_backend_connection`: Add error handling for unrecognized plugins on read ([#1325](https://github.com/hashicorp/terraform-provider-vault/pull/1325))
 
 IMPROVEMENTS:
 * `resource/token_auth_backend_role`: Add `allowed_policies_glob` and `disallowed_polices_glob` ([#1316](https://github.com/hashicorp/terraform-provider-vault/pull/1316))

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -1329,7 +1329,7 @@ func databaseSecretBackendConnectionRead(d *schema.ResourceData, meta interface{
 	case dbEngineRedshift:
 		d.Set("redshift", getConnectionDetailsFromResponse(d, "redshift.0.", resp))
 	default:
-		return fmt.Errorf("unsupported database plugin: %s", resp.Data["plugin_name"].(string))
+		return fmt.Errorf("no response handler for dbEngine: %s", db.Name())
 	}
 
 	if err != nil {

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -1249,7 +1249,7 @@ func databaseSecretBackendConnectionRead(d *schema.ResourceData, meta interface{
 	case "redshift-database-plugin":
 		d.Set("redshift", getConnectionDetailsFromResponse(d, "redshift.0.", resp))
 	default:
-		return fmt.Errorf("unrecognized database plugin")
+		return fmt.Errorf("unsupported database plugin: %s", resp.Data["plugin_name"].(string))
 	}
 
 	if err != nil {

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -1329,7 +1329,7 @@ func databaseSecretBackendConnectionRead(d *schema.ResourceData, meta interface{
 	case dbEngineRedshift:
 		d.Set("redshift", getConnectionDetailsFromResponse(d, "redshift.0.", resp))
 	default:
-		return fmt.Errorf("no response handler for dbEngine: %s", db.Name())
+		return fmt.Errorf("no response handler for dbEngine: %s", db)
 	}
 
 	if err != nil {

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -1246,6 +1246,10 @@ func databaseSecretBackendConnectionRead(d *schema.ResourceData, meta interface{
 		d.Set("elasticsearch", getElasticsearchConnectionDetailsFromResponse(d, "elasticsearch.0.", resp))
 	case "snowflake-database-plugin":
 		d.Set("snowflake", getSnowflakeConnectionDetailsFromResponse(d, "snowflake.0.", resp))
+	case "redshift-database-plugin":
+		d.Set("redshift", getConnectionDetailsFromResponse(d, "redshift.0.", resp))
+	default:
+		return fmt.Errorf("unrecognized database plugin")
 	}
 
 	if err != nil {

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -1326,7 +1326,7 @@ func databaseSecretBackendConnectionRead(d *schema.ResourceData, meta interface{
 		d.Set("elasticsearch", getElasticsearchConnectionDetailsFromResponse(d, "elasticsearch.0.", resp))
 	case dbEngineSnowflake:
 		d.Set("snowflake", getSnowflakeConnectionDetailsFromResponse(d, "snowflake.0.", resp))
-	case "redshift-database-plugin":
+	case dbEngineRedshift:
 		d.Set("redshift", getConnectionDetailsFromResponse(d, "redshift.0.", resp))
 	default:
 		return fmt.Errorf("unsupported database plugin: %s", resp.Data["plugin_name"].(string))

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -1200,7 +1200,7 @@ resource "vault_database_secret_backend_connection" "test" {
 }
 
 func testAccDatabaseSecretBackendConnectionConfig_redshift(name, path, connURL string, isUpdate bool) string {
-	ret := fmt.Sprintf(`
+	config := fmt.Sprintf(`
 resource "vault_mount" "db" {
   path = "%s"
   type = "database"
@@ -1208,9 +1208,9 @@ resource "vault_mount" "db" {
 `, path)
 
 	if !isUpdate {
-		ret += fmt.Sprintf(`
+		config += fmt.Sprintf(`
 resource "vault_database_secret_backend_connection" "test" {
-  backend = "${vault_mount.db.path}"
+  backend = vault_mount.db.path
   name = "%s"
   allowed_roles = ["dev", "prod"]
   root_rotation_statements = ["FOOBAR"]
@@ -1219,9 +1219,9 @@ resource "vault_database_secret_backend_connection" "test" {
   }
 }`, name, connURL)
 	} else {
-		ret += fmt.Sprintf(`
+		config += fmt.Sprintf(`
 resource "vault_database_secret_backend_connection" "test" {
-  backend = "${vault_mount.db.path}"
+  backend = vault_mount.db.path
   name = "%s"
   allowed_roles = ["dev", "prod", "engineering"]
   root_rotation_statements = ["FOOBAR", "BAZQUX"]
@@ -1232,7 +1232,7 @@ resource "vault_database_secret_backend_connection" "test" {
 }`, name, connURL)
 	}
 
-	return ret
+	return config
 }
 
 func newMySQLConnection(t *testing.T, connURL string, username string, password string) *sql.DB {


### PR DESCRIPTION
This PR adds a missing case for reading data for the Redshift plugin. It also adds a default case for unrecognized plugins in `databaseSecretBackendConnectionRead`.

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note: bug
`resource/database_secret_backend_connection`: Add error handling for unrecognized plugins on read
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccDatabaseSecretBackendConnection_postgresql'
=== RUN   TestAccDatabaseSecretBackendConnection_postgresql
--- PASS: TestAccDatabaseSecretBackendConnection_postgresql (1.66s)
PASS

$ make testacc TESTARGS='-run=TestAccDatabaseSecretBackendConnection_redshift'
=== RUN   TestAccDatabaseSecretBackendConnection_redshift
--- PASS: TestAccDatabaseSecretBackendConnection_redshift (4.21s)
PASS
```
