### PR TITLE
Use dbEngine instances in place of constants.

### DIFF
--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -122,7 +122,10 @@ type dbEngine struct {
 	defaultPluginName string
 }
 
-func (i *dbEngine) getPluginName(d *schema.ResourceData) (string, error) {
+// GetPluginName from the schema.ResourceData if it is configured,
+// otherwise return the default plugin name.
+// Return an error if no plugin name can be found.
+func (i *dbEngine) GetPluginName(d *schema.ResourceData) (string, error) {
 	if val, ok := d.GetOk("plugin_name"); ok {
 		return val.(string), nil
 	}
@@ -136,6 +139,16 @@ func (i *dbEngine) getPluginName(d *schema.ResourceData) (string, error) {
 
 func (i *dbEngine) String() string {
 	return i.name
+}
+
+// Name of the Vault DB secrets engine.
+func (i *dbEngine) Name() string {
+	return i.name
+}
+
+// DefaultPluginName for this dbEngine.
+func (i *dbEngine) DefaultPluginName() string {
+	return i.defaultPluginName
 }
 
 func databaseSecretBackendConnectionResource() *schema.Resource {
@@ -221,7 +234,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 					},
 				},
 				MaxItems:      1,
-				ConflictsWith: util.CalculateConflictsWith(dbEngineElasticSearch.name, dbEngineTypes),
+				ConflictsWith: util.CalculateConflictsWith(dbEngineElasticSearch.Name(), dbEngineTypes),
 			},
 
 			dbEngineCassandra.name: {
@@ -296,7 +309,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 					},
 				},
 				MaxItems:      1,
-				ConflictsWith: util.CalculateConflictsWith(dbEngineCassandra.name, dbEngineTypes),
+				ConflictsWith: util.CalculateConflictsWith(dbEngineCassandra.Name(), dbEngineTypes),
 			},
 
 			dbEngineCouchbase.name: {
@@ -355,7 +368,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 					},
 				},
 				MaxItems:      1,
-				ConflictsWith: util.CalculateConflictsWith(dbEngineCouchbase.name, dbEngineTypes),
+				ConflictsWith: util.CalculateConflictsWith(dbEngineCouchbase.Name(), dbEngineTypes),
 			},
 
 			dbEngineInfluxDB.name: {
@@ -426,7 +439,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 					},
 				},
 				MaxItems:      1,
-				ConflictsWith: util.CalculateConflictsWith(dbEngineInfluxDB.name, dbEngineTypes),
+				ConflictsWith: util.CalculateConflictsWith(dbEngineInfluxDB.Name(), dbEngineTypes),
 			},
 
 			dbEngineMongoDB.name: {
@@ -435,7 +448,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				Description:   "Connection parameters for the mongodb-database-plugin plugin.",
 				Elem:          connectionStringResource(&connectionStringConfig{}),
 				MaxItems:      1,
-				ConflictsWith: util.CalculateConflictsWith(dbEngineMongoDB.name, dbEngineTypes),
+				ConflictsWith: util.CalculateConflictsWith(dbEngineMongoDB.Name(), dbEngineTypes),
 			},
 
 			dbEngineMongoDBAtlas.name: {
@@ -463,7 +476,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 					},
 				},
 				MaxItems:      1,
-				ConflictsWith: util.CalculateConflictsWith(dbEngineMongoDBAtlas.name, dbEngineTypes),
+				ConflictsWith: util.CalculateConflictsWith(dbEngineMongoDBAtlas.Name(), dbEngineTypes),
 			},
 
 			dbEngineHana.name: {
@@ -474,7 +487,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 					excludeUsernameTemplate: true,
 				}),
 				MaxItems:      1,
-				ConflictsWith: util.CalculateConflictsWith(dbEngineHana.name, dbEngineTypes),
+				ConflictsWith: util.CalculateConflictsWith(dbEngineHana.Name(), dbEngineTypes),
 			},
 
 			dbEngineMSSQL.name: {
@@ -483,7 +496,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				Description:   "Connection parameters for the mssql-database-plugin plugin.",
 				Elem:          mssqlConnectionStringResource(),
 				MaxItems:      1,
-				ConflictsWith: util.CalculateConflictsWith(dbEngineMSSQL.name, dbEngineTypes),
+				ConflictsWith: util.CalculateConflictsWith(dbEngineMSSQL.Name(), dbEngineTypes),
 			},
 
 			dbEngineMySQL.name: {
@@ -492,7 +505,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				Description:   "Connection parameters for the mysql-database-plugin plugin.",
 				Elem:          mysqlConnectionStringResource(),
 				MaxItems:      1,
-				ConflictsWith: util.CalculateConflictsWith(dbEngineMySQL.name, dbEngineTypes),
+				ConflictsWith: util.CalculateConflictsWith(dbEngineMySQL.Name(), dbEngineTypes),
 			},
 			dbEngineMySQLRDS.name: {
 				Type:          schema.TypeList,
@@ -500,7 +513,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				Description:   "Connection parameters for the mysql-rds-database-plugin plugin.",
 				Elem:          connectionStringResource(&connectionStringConfig{}),
 				MaxItems:      1,
-				ConflictsWith: util.CalculateConflictsWith(dbEngineMySQLRDS.name, dbEngineTypes),
+				ConflictsWith: util.CalculateConflictsWith(dbEngineMySQLRDS.Name(), dbEngineTypes),
 			},
 			dbEngineMySQLAurora.name: {
 				Type:          schema.TypeList,
@@ -508,7 +521,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				Description:   "Connection parameters for the mysql-aurora-database-plugin plugin.",
 				Elem:          connectionStringResource(&connectionStringConfig{}),
 				MaxItems:      1,
-				ConflictsWith: util.CalculateConflictsWith(dbEngineMySQLAurora.name, dbEngineTypes),
+				ConflictsWith: util.CalculateConflictsWith(dbEngineMySQLAurora.Name(), dbEngineTypes),
 			},
 			dbEngineMySQLLegacy.name: {
 				Type:          schema.TypeList,
@@ -516,7 +529,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				Description:   "Connection parameters for the mysql-legacy-database-plugin plugin.",
 				Elem:          connectionStringResource(&connectionStringConfig{}),
 				MaxItems:      1,
-				ConflictsWith: util.CalculateConflictsWith(dbEngineMySQLLegacy.name, dbEngineTypes),
+				ConflictsWith: util.CalculateConflictsWith(dbEngineMySQLLegacy.Name(), dbEngineTypes),
 			},
 
 			dbEnginePostgres.name: {
@@ -525,7 +538,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				Description:   "Connection parameters for the postgresql-database-plugin plugin.",
 				Elem:          connectionStringResource(&connectionStringConfig{}),
 				MaxItems:      1,
-				ConflictsWith: util.CalculateConflictsWith(dbEnginePostgres.name, dbEngineTypes),
+				ConflictsWith: util.CalculateConflictsWith(dbEnginePostgres.Name(), dbEngineTypes),
 			},
 
 			dbEngineOracle.name: {
@@ -534,7 +547,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				Description:   "Connection parameters for the oracle-database-plugin plugin.",
 				Elem:          connectionStringResource(&connectionStringConfig{}),
 				MaxItems:      1,
-				ConflictsWith: util.CalculateConflictsWith(dbEngineOracle.name, dbEngineTypes),
+				ConflictsWith: util.CalculateConflictsWith(dbEngineOracle.Name(), dbEngineTypes),
 			},
 
 			dbEngineRedshift.name: {
@@ -543,7 +556,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				Description:   "Connection parameters for the redshift-database-plugin plugin.",
 				Elem:          connectionStringResource(&connectionStringConfig{includeUserPass: true}),
 				MaxItems:      1,
-				ConflictsWith: util.CalculateConflictsWith(dbEngineRedshift.name, dbEngineTypes),
+				ConflictsWith: util.CalculateConflictsWith(dbEngineRedshift.Name(), dbEngineTypes),
 			},
 
 			dbEngineSnowflake.name: {
@@ -552,7 +565,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				Description:   "Connection parameters for the snowflake-database-plugin plugin.",
 				Elem:          connectionStringResource(&connectionStringConfig{includeUserPass: true}),
 				MaxItems:      1,
-				ConflictsWith: util.CalculateConflictsWith(dbEngineSnowflake.name, dbEngineTypes),
+				ConflictsWith: util.CalculateConflictsWith(dbEngineSnowflake.Name(), dbEngineTypes),
 			},
 
 			"backend": {
@@ -662,7 +675,7 @@ func getDatabaseAPIData(d *schema.ResourceData) (map[string]interface{}, error) 
 		return nil, err
 	}
 
-	pluginName, err := db.getPluginName(d)
+	pluginName, err := db.GetPluginName(d)
 	if err != nil {
 		return nil, err
 	}

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -224,7 +224,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				ConflictsWith: util.CalculateConflictsWith(dbEngineElasticSearch.name, dbEngineTypes),
 			},
 
-			"cassandra": {
+			dbEngineCassandra.name: {
 				Type:        schema.TypeList,
 				Optional:    true,
 				Description: "Connection parameters for the cassandra-database-plugin plugin.",
@@ -299,7 +299,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				ConflictsWith: util.CalculateConflictsWith(dbEngineCassandra.name, dbEngineTypes),
 			},
 
-			"couchbase": {
+			dbEngineCouchbase.name: {
 				Type:        schema.TypeList,
 				Optional:    true,
 				Description: "Connection parameters for the couchbase-database-plugin plugin.",
@@ -358,7 +358,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				ConflictsWith: util.CalculateConflictsWith(dbEngineCouchbase.name, dbEngineTypes),
 			},
 
-			"influxdb": {
+			dbEngineInfluxDB.name: {
 				Type:        schema.TypeList,
 				Optional:    true,
 				Description: "Connection parameters for the influxdb-database-plugin plugin.",
@@ -429,7 +429,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				ConflictsWith: util.CalculateConflictsWith(dbEngineInfluxDB.name, dbEngineTypes),
 			},
 
-			"mongodb": {
+			dbEngineMongoDB.name: {
 				Type:          schema.TypeList,
 				Optional:      true,
 				Description:   "Connection parameters for the mongodb-database-plugin plugin.",
@@ -438,7 +438,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				ConflictsWith: util.CalculateConflictsWith(dbEngineMongoDB.name, dbEngineTypes),
 			},
 
-			"mongodbatlas": {
+			dbEngineMongoDBAtlas.name: {
 				Type:        schema.TypeList,
 				Optional:    true,
 				Description: "Connection parameters for the mongodbatlas-database-plugin plugin.",
@@ -466,7 +466,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				ConflictsWith: util.CalculateConflictsWith(dbEngineMongoDBAtlas.name, dbEngineTypes),
 			},
 
-			"hana": {
+			dbEngineHana.name: {
 				Type:        schema.TypeList,
 				Optional:    true,
 				Description: "Connection parameters for the hana-database-plugin plugin.",
@@ -477,7 +477,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				ConflictsWith: util.CalculateConflictsWith(dbEngineHana.name, dbEngineTypes),
 			},
 
-			"mssql": {
+			dbEngineMSSQL.name: {
 				Type:          schema.TypeList,
 				Optional:      true,
 				Description:   "Connection parameters for the mssql-database-plugin plugin.",
@@ -486,7 +486,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				ConflictsWith: util.CalculateConflictsWith(dbEngineMSSQL.name, dbEngineTypes),
 			},
 
-			"mysql": {
+			dbEngineMySQL.name: {
 				Type:          schema.TypeList,
 				Optional:      true,
 				Description:   "Connection parameters for the mysql-database-plugin plugin.",
@@ -494,7 +494,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				MaxItems:      1,
 				ConflictsWith: util.CalculateConflictsWith(dbEngineMySQL.name, dbEngineTypes),
 			},
-			"mysql_rds": {
+			dbEngineMySQLRDS.name: {
 				Type:          schema.TypeList,
 				Optional:      true,
 				Description:   "Connection parameters for the mysql-rds-database-plugin plugin.",
@@ -502,7 +502,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				MaxItems:      1,
 				ConflictsWith: util.CalculateConflictsWith(dbEngineMySQLRDS.name, dbEngineTypes),
 			},
-			"mysql_aurora": {
+			dbEngineMySQLAurora.name: {
 				Type:          schema.TypeList,
 				Optional:      true,
 				Description:   "Connection parameters for the mysql-aurora-database-plugin plugin.",
@@ -510,7 +510,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				MaxItems:      1,
 				ConflictsWith: util.CalculateConflictsWith(dbEngineMySQLAurora.name, dbEngineTypes),
 			},
-			"mysql_legacy": {
+			dbEngineMySQLLegacy.name: {
 				Type:          schema.TypeList,
 				Optional:      true,
 				Description:   "Connection parameters for the mysql-legacy-database-plugin plugin.",
@@ -519,7 +519,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				ConflictsWith: util.CalculateConflictsWith(dbEngineMySQLLegacy.name, dbEngineTypes),
 			},
 
-			"postgresql": {
+			dbEnginePostgres.name: {
 				Type:          schema.TypeList,
 				Optional:      true,
 				Description:   "Connection parameters for the postgresql-database-plugin plugin.",
@@ -528,7 +528,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				ConflictsWith: util.CalculateConflictsWith(dbEnginePostgres.name, dbEngineTypes),
 			},
 
-			"oracle": {
+			dbEngineOracle.name: {
 				Type:          schema.TypeList,
 				Optional:      true,
 				Description:   "Connection parameters for the oracle-database-plugin plugin.",
@@ -537,7 +537,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				ConflictsWith: util.CalculateConflictsWith(dbEngineOracle.name, dbEngineTypes),
 			},
 
-			"redshift": {
+			dbEngineRedshift.name: {
 				Type:          schema.TypeList,
 				Optional:      true,
 				Description:   "Connection parameters for the redshift-database-plugin plugin.",
@@ -546,7 +546,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 				ConflictsWith: util.CalculateConflictsWith(dbEngineRedshift.name, dbEngineTypes),
 			},
 
-			"snowflake": {
+			dbEngineSnowflake.name: {
 				Type:          schema.TypeList,
 				Optional:      true,
 				Description:   "Connection parameters for the snowflake-database-plugin plugin.",

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -29,15 +29,14 @@ const testDefaultDatabaseSecretBackendResource = "vault_database_secret_backend_
 // copy/build a db plugin and install it with a unique name, then register it in vault.
 
 func TestAccDatabaseSecretBackendConnection_import(t *testing.T) {
-	MaybeSkipDBTests(t, dbBackendPostgres)
+	MaybeSkipDBTests(t, dbEnginePostgres)
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "POSTGRES_URL")
 	connURL := values[0]
 
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	// should match dbEngine.getPluginName()'s default return value
-	pluginName := fmt.Sprintf("%s-database-plugin", dbBackendPostgres)
+	pluginName := dbEnginePostgres.defaultPluginName
 	name := acctest.RandomWithPrefix("db")
 
 	userTempl := "{{.DisplayName}}"
@@ -73,7 +72,7 @@ func TestAccDatabaseSecretBackendConnection_import(t *testing.T) {
 }
 
 func TestAccDatabaseSecretBackendConnection_cassandra(t *testing.T) {
-	MaybeSkipDBTests(t, dbBackendCassandra)
+	MaybeSkipDBTests(t, dbEngineCassandra)
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "CASSANDRA_HOST")
@@ -82,7 +81,7 @@ func TestAccDatabaseSecretBackendConnection_cassandra(t *testing.T) {
 	username := os.Getenv("CASSANDRA_USERNAME")
 	password := os.Getenv("CASSANDRA_PASSWORD")
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	pluginName := fmt.Sprintf("%s-database-plugin", dbBackendCassandra)
+	pluginName := dbEngineCassandra.defaultPluginName
 	name := acctest.RandomWithPrefix("db")
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
@@ -116,7 +115,7 @@ func TestAccDatabaseSecretBackendConnection_cassandra(t *testing.T) {
 }
 
 func TestAccDatabaseSecretBackendConnection_cassandraProtocol(t *testing.T) {
-	MaybeSkipDBTests(t, dbBackendCassandra)
+	MaybeSkipDBTests(t, dbEngineCassandra)
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "CASSANDRA_HOST")
@@ -125,8 +124,7 @@ func TestAccDatabaseSecretBackendConnection_cassandraProtocol(t *testing.T) {
 	username := os.Getenv("CASSANDRA_USERNAME")
 	password := os.Getenv("CASSANDRA_PASSWORD")
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	// should match dbEngine.getPluginName()'s default return value
-	pluginName := fmt.Sprintf("%s-database-plugin", dbBackendCassandra)
+	pluginName := dbEngineCassandra.defaultPluginName
 	name := acctest.RandomWithPrefix("db")
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
@@ -160,7 +158,7 @@ func TestAccDatabaseSecretBackendConnection_cassandraProtocol(t *testing.T) {
 }
 
 func TestAccDatabaseSecretBackendConnection_couchbase(t *testing.T) {
-	MaybeSkipDBTests(t, dbBackendCouchbase)
+	MaybeSkipDBTests(t, dbEngineCouchbase)
 
 	values := testutil.SkipTestEnvUnset(t, "COUCHBASE_HOST_1", "COUCHBASE_HOST_2", "COUCHBASE_USERNAME", "COUCHBASE_PASSWORD")
 	host1 := values[0]
@@ -168,8 +166,7 @@ func TestAccDatabaseSecretBackendConnection_couchbase(t *testing.T) {
 	username := values[2]
 	password := values[3]
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	// should match dbEngine.getPluginName()'s default return value
-	pluginName := fmt.Sprintf("%s-database-plugin", dbBackendCouchbase)
+	pluginName := dbEngineCouchbase.defaultPluginName
 	name := acctest.RandomWithPrefix("db")
 	resourceName := testDefaultDatabaseSecretBackendResource
 	resource.Test(t, resource.TestCase{
@@ -207,7 +204,7 @@ func TestAccDatabaseSecretBackendConnection_couchbase(t *testing.T) {
 }
 
 func TestAccDatabaseSecretBackendConnection_influxdb(t *testing.T) {
-	MaybeSkipDBTests(t, dbBackendInfluxDB)
+	MaybeSkipDBTests(t, dbEngineInfluxDB)
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "INFLUXDB_HOST")
@@ -216,8 +213,7 @@ func TestAccDatabaseSecretBackendConnection_influxdb(t *testing.T) {
 	username := os.Getenv("INFLUXDB_USERNAME")
 	password := os.Getenv("INFLUXDB_PASSWORD")
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	// should match dbEngine.getPluginName()'s default return value
-	pluginName := fmt.Sprintf("%s-database-plugin", dbBackendInfluxDB)
+	pluginName := dbEngineInfluxDB.defaultPluginName
 	name := acctest.RandomWithPrefix("db")
 	resourceName := testDefaultDatabaseSecretBackendResource
 	resource.Test(t, resource.TestCase{
@@ -250,7 +246,7 @@ func TestAccDatabaseSecretBackendConnection_influxdb(t *testing.T) {
 }
 
 func TestAccDatabaseSecretBackendConnection_mongodbatlas(t *testing.T) {
-	MaybeSkipDBTests(t, dbBackendMongoDBAtlas)
+	MaybeSkipDBTests(t, dbEngineMongoDBAtlas)
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "MONGODB_ATLAS_PUBLIC_KEY")
@@ -259,8 +255,7 @@ func TestAccDatabaseSecretBackendConnection_mongodbatlas(t *testing.T) {
 	privateKey := os.Getenv("MONGODB_ATLAS_PRIVATE_KEY")
 	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	// should match dbEngine.getPluginName()'s default return value
-	pluginName := fmt.Sprintf("%s-database-plugin", dbBackendMongoDBAtlas)
+	pluginName := dbEngineMongoDBAtlas.defaultPluginName
 	name := acctest.RandomWithPrefix("db")
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
@@ -286,15 +281,14 @@ func TestAccDatabaseSecretBackendConnection_mongodbatlas(t *testing.T) {
 }
 
 func TestAccDatabaseSecretBackendConnection_mongodb(t *testing.T) {
-	MaybeSkipDBTests(t, dbBackendMongoDB)
+	MaybeSkipDBTests(t, dbEngineMongoDB)
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "MONGODB_URL")
 	connURL := values[0]
 
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	// should match dbEngine.getPluginName()'s default return value
-	pluginName := fmt.Sprintf("%s-database-plugin", dbBackendMongoDB)
+	pluginName := dbEngineMongoDB.defaultPluginName
 	name := acctest.RandomWithPrefix("db")
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
@@ -318,15 +312,14 @@ func TestAccDatabaseSecretBackendConnection_mongodb(t *testing.T) {
 }
 
 func TestAccDatabaseSecretBackendConnection_mssql(t *testing.T) {
-	MaybeSkipDBTests(t, dbBackendMSSQL)
+	MaybeSkipDBTests(t, dbEngineMSSQL)
 
 	cleanupFunc, connURL := mssqlhelper.PrepareMSSQLTestContainer(t)
 
 	t.Cleanup(cleanupFunc)
 
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	// should match dbEngine.getPluginName()'s default return value
-	pluginName := fmt.Sprintf("%s-database-plugin", dbBackendMSSQL)
+	pluginName := fmt.Sprintf("%s-database-plugin", dbEngineMSSQL.name)
 	name := acctest.RandomWithPrefix("db")
 
 	resource.Test(t, resource.TestCase{
@@ -372,15 +365,14 @@ func TestAccDatabaseSecretBackendConnection_mssql(t *testing.T) {
 }
 
 func TestAccDatabaseSecretBackendConnection_mysql(t *testing.T) {
-	MaybeSkipDBTests(t, dbBackendMySQL)
+	MaybeSkipDBTests(t, dbEngineMySQL)
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "MYSQL_URL")
 	connURL := values[0]
 
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	// should match dbEngine.getPluginName()'s default return value
-	pluginName := fmt.Sprintf("%s-database-plugin", dbBackendMySQL)
+	pluginName := fmt.Sprintf("%s-database-plugin", dbEngineMySQL.name)
 	name := acctest.RandomWithPrefix("db")
 	password := acctest.RandomWithPrefix("password")
 	resource.Test(t, resource.TestCase{
@@ -466,15 +458,14 @@ func testComposeCheckFuncCommonDatabaseSecretBackend(name, backend, pluginName s
 }
 
 func TestAccDatabaseSecretBackendConnectionUpdate_mysql(t *testing.T) {
-	MaybeSkipDBTests(t, dbBackendMySQL)
+	MaybeSkipDBTests(t, dbEngineMySQL)
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "MYSQL_URL")
 	connURL := values[0]
 
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	// should match dbEngine.getPluginName()'s default return value
-	pluginName := fmt.Sprintf("%s-database-plugin", dbBackendMySQL)
+	pluginName := fmt.Sprintf("%s-database-plugin", dbEngineMySQL.name)
 	name := acctest.RandomWithPrefix("db")
 	password := acctest.RandomWithPrefix("password")
 	resource.Test(t, resource.TestCase{
@@ -519,7 +510,7 @@ func TestAccDatabaseSecretBackendConnectionUpdate_mysql(t *testing.T) {
 }
 
 func TestAccDatabaseSecretBackendConnectionTemplatedUpdateExcludePassword_mysql(t *testing.T) {
-	MaybeSkipDBTests(t, dbBackendMySQL)
+	MaybeSkipDBTests(t, dbEngineMySQL)
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t,
@@ -538,8 +529,7 @@ func TestAccDatabaseSecretBackendConnectionTemplatedUpdateExcludePassword_mysql(
 	}
 
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	// should match dbEngine.getPluginName()'s default return value
-	pluginName := fmt.Sprintf("%s-database-plugin", dbBackendMySQL)
+	pluginName := fmt.Sprintf("%s-database-plugin", dbEngineMySQL.name)
 	name := acctest.RandomWithPrefix("db")
 	testUsername := acctest.RandomWithPrefix("username")
 	testPassword := acctest.RandomWithPrefix("password")
@@ -597,15 +587,14 @@ func TestAccDatabaseSecretBackendConnectionTemplatedUpdateExcludePassword_mysql(
 }
 
 func TestAccDatabaseSecretBackendConnection_mysql_tls(t *testing.T) {
-	MaybeSkipDBTests(t, dbBackendMySQL)
+	MaybeSkipDBTests(t, dbEngineMySQL)
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "MYSQL_CA", "MYSQL_URL", "MYSQL_CERTIFICATE_KEY")
 	tlsCA, connURL, tlsCertificateKey := values[0], values[1], values[2]
 
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	// should match dbEngine.getPluginName()'s default return value
-	pluginName := fmt.Sprintf("%s-database-plugin", dbBackendMySQL)
+	pluginName := dbEngineMySQL.defaultPluginName
 	name := acctest.RandomWithPrefix("db")
 	password := acctest.RandomWithPrefix("password")
 	resource.Test(t, resource.TestCase{
@@ -637,15 +626,14 @@ func TestAccDatabaseSecretBackendConnection_mysql_tls(t *testing.T) {
 }
 
 func TestAccDatabaseSecretBackendConnection_postgresql(t *testing.T) {
-	MaybeSkipDBTests(t, dbBackendPostgres)
+	MaybeSkipDBTests(t, dbEnginePostgres)
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "POSTGRES_URL")
 	connURL := values[0]
 
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	// should match dbEngine.getPluginName()'s default return value
-	pluginName := fmt.Sprintf("%s-database-plugin", dbBackendPostgres)
+	pluginName := dbEnginePostgres.defaultPluginName
 	name := acctest.RandomWithPrefix("db")
 	userTempl := "{{.DisplayName}}"
 	resource.Test(t, resource.TestCase{
@@ -674,7 +662,7 @@ func TestAccDatabaseSecretBackendConnection_postgresql(t *testing.T) {
 }
 
 func TestAccDatabaseSecretBackendConnection_elasticsearch(t *testing.T) {
-	MaybeSkipDBTests(t, dbBackendElasticSearch)
+	MaybeSkipDBTests(t, dbEngineElasticSearch)
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "ELASTIC_URL")
@@ -683,8 +671,7 @@ func TestAccDatabaseSecretBackendConnection_elasticsearch(t *testing.T) {
 	username := os.Getenv("ELASTIC_USERNAME")
 	password := os.Getenv("ELASTIC_PASSWORD")
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	// should match dbEngine.getPluginName()'s default return value
-	pluginName := fmt.Sprintf("%s-database-plugin", dbBackendElasticSearch)
+	pluginName := dbEngineElasticSearch.defaultPluginName
 	name := acctest.RandomWithPrefix("db")
 
 	resource.Test(t, resource.TestCase{
@@ -707,7 +694,7 @@ func TestAccDatabaseSecretBackendConnection_elasticsearch(t *testing.T) {
 }
 
 func TestAccDatabaseSecretBackendConnection_snowflake(t *testing.T) {
-	MaybeSkipDBTests(t, dbBackendSnowflake)
+	MaybeSkipDBTests(t, dbEngineSnowflake)
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
 	values := testutil.SkipTestEnvUnset(t, "SNOWFLAKE_URL")
@@ -716,8 +703,7 @@ func TestAccDatabaseSecretBackendConnection_snowflake(t *testing.T) {
 	username := os.Getenv("SNOWFLAKE_USERNAME")
 	password := os.Getenv("SNOWFLAKE_PASSWORD")
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	// should match dbEngine.getPluginName()'s default return value
-	pluginName := fmt.Sprintf("%s-database-plugin", dbBackendSnowflake)
+	pluginName := dbEngineSnowflake.defaultPluginName
 	name := acctest.RandomWithPrefix("db")
 	userTempl := "{{.DisplayName}}"
 
@@ -745,15 +731,14 @@ func TestAccDatabaseSecretBackendConnection_snowflake(t *testing.T) {
 }
 
 func TestAccDatabaseSecretBackendConnection_redshift(t *testing.T) {
-	MaybeSkipDBTests(t, dbBackendRedshift)
+	MaybeSkipDBTests(t, dbEngineRedshift)
 
 	url := os.Getenv("REDSHIFT_URL")
 	if url == "" {
 		t.Skip("REDSHIFT_URL not set")
 	}
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	// should match dbEngine.getPluginName()'s default return value
-	pluginName := fmt.Sprintf("%s-database-plugin", dbBackendRedshift)
+	pluginName := dbEngineRedshift.defaultPluginName
 	name := acctest.RandomWithPrefix("db")
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
@@ -1247,34 +1232,40 @@ func deleteMySQLUser(t *testing.T, db *sql.DB, username string) {
 	}
 }
 
-func MaybeSkipDBTests(t *testing.T, engine string) {
+func MaybeSkipDBTests(t *testing.T, engine *dbEngine) {
 	// require TF_ACC to be set
 	testutil.SkipTestAcc(t)
 
 	envVars := []string{"SKIP_DB_TESTS"}
-	if _, ok := dbEngines[engine]; ok {
-		envVars = append(envVars, envVars[0]+"_"+strings.ToUpper(engine))
+	for _, e := range dbEngines {
+		if e == engine {
+			envVars = append(envVars, envVars[0]+"_"+strings.ToUpper(engine.name))
+			break
+		}
 	}
 	testutil.SkipTestEnvSet(t, envVars...)
 }
 
 func Test_dbEngine_getPluginName(t *testing.T) {
 	type fields struct {
-		name string
+		name              string
+		defaultPluginName string
 	}
 	type args struct {
 		d *schema.ResourceData
 	}
 	tests := []struct {
-		name   string
-		fields fields
-		args   args
-		want   string
+		name    string
+		fields  fields
+		args    args
+		want    string
+		wantErr bool
 	}{
 		{
 			name: "default",
 			fields: fields{
-				name: "foo",
+				name:              "foo",
+				defaultPluginName: "foo-database-plugin",
 			},
 			args: args{
 				schema.TestResourceDataRaw(
@@ -1288,24 +1279,6 @@ func Test_dbEngine_getPluginName(t *testing.T) {
 					map[string]interface{}{}),
 			},
 			want: "foo-database-plugin",
-		},
-		{
-			name: "default-underscored",
-			fields: fields{
-				name: "foo_qux_baz",
-			},
-			args: args{
-				schema.TestResourceDataRaw(
-					t,
-					map[string]*schema.Schema{
-						"plugin_name": {
-							Type:     schema.TypeString,
-							Required: false,
-						},
-					},
-					map[string]interface{}{}),
-			},
-			want: "foo-qux-baz-database-plugin",
 		},
 		{
 			name: "set",
@@ -1327,13 +1300,41 @@ func Test_dbEngine_getPluginName(t *testing.T) {
 			},
 			want: "baz-qux",
 		},
+		{
+			name: "fail",
+			fields: fields{
+				name: "fail",
+			},
+			args: args{
+				schema.TestResourceDataRaw(
+					t,
+					map[string]*schema.Schema{
+						"plugin_name": {
+							Type:     schema.TypeString,
+							Required: false,
+						},
+					},
+					map[string]interface{}{},
+				),
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			i := &dbEngine{
-				name: tt.fields.name,
+				name:              tt.fields.name,
+				defaultPluginName: tt.fields.defaultPluginName,
 			}
-			if got := i.getPluginName(tt.args.d); got != tt.want {
+
+			got, err := i.getPluginName(tt.args.d)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getPluginName() error = %v, wantErr %v", err, tt.wantErr)
+
+				return
+			}
+
+			if got != tt.want {
 				t.Errorf("getPluginName() expected %v, actual %v", tt.want, got)
 			}
 		})
@@ -1373,9 +1374,7 @@ func Test_getDBEngine(t *testing.T) {
 						},
 					}),
 			},
-			want: &dbEngine{
-				name: dbBackendMSSQL,
-			},
+			want:    dbEngineMSSQL,
 			wantErr: false,
 		},
 		{

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -36,7 +36,7 @@ func TestAccDatabaseSecretBackendConnection_import(t *testing.T) {
 	connURL := values[0]
 
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	pluginName := dbEnginePostgres.defaultPluginName
+	pluginName := dbEnginePostgres.DefaultPluginName()
 	name := acctest.RandomWithPrefix("db")
 
 	userTempl := "{{.DisplayName}}"
@@ -81,7 +81,7 @@ func TestAccDatabaseSecretBackendConnection_cassandra(t *testing.T) {
 	username := os.Getenv("CASSANDRA_USERNAME")
 	password := os.Getenv("CASSANDRA_PASSWORD")
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	pluginName := dbEngineCassandra.defaultPluginName
+	pluginName := dbEngineCassandra.DefaultPluginName()
 	name := acctest.RandomWithPrefix("db")
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
@@ -124,7 +124,7 @@ func TestAccDatabaseSecretBackendConnection_cassandraProtocol(t *testing.T) {
 	username := os.Getenv("CASSANDRA_USERNAME")
 	password := os.Getenv("CASSANDRA_PASSWORD")
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	pluginName := dbEngineCassandra.defaultPluginName
+	pluginName := dbEngineCassandra.DefaultPluginName()
 	name := acctest.RandomWithPrefix("db")
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
@@ -166,7 +166,7 @@ func TestAccDatabaseSecretBackendConnection_couchbase(t *testing.T) {
 	username := values[2]
 	password := values[3]
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	pluginName := dbEngineCouchbase.defaultPluginName
+	pluginName := dbEngineCouchbase.DefaultPluginName()
 	name := acctest.RandomWithPrefix("db")
 	resourceName := testDefaultDatabaseSecretBackendResource
 	resource.Test(t, resource.TestCase{
@@ -213,7 +213,7 @@ func TestAccDatabaseSecretBackendConnection_influxdb(t *testing.T) {
 	username := os.Getenv("INFLUXDB_USERNAME")
 	password := os.Getenv("INFLUXDB_PASSWORD")
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	pluginName := dbEngineInfluxDB.defaultPluginName
+	pluginName := dbEngineInfluxDB.DefaultPluginName()
 	name := acctest.RandomWithPrefix("db")
 	resourceName := testDefaultDatabaseSecretBackendResource
 	resource.Test(t, resource.TestCase{
@@ -255,7 +255,7 @@ func TestAccDatabaseSecretBackendConnection_mongodbatlas(t *testing.T) {
 	privateKey := os.Getenv("MONGODB_ATLAS_PRIVATE_KEY")
 	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	pluginName := dbEngineMongoDBAtlas.defaultPluginName
+	pluginName := dbEngineMongoDBAtlas.DefaultPluginName()
 	name := acctest.RandomWithPrefix("db")
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
@@ -288,7 +288,7 @@ func TestAccDatabaseSecretBackendConnection_mongodb(t *testing.T) {
 	connURL := values[0]
 
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	pluginName := dbEngineMongoDB.defaultPluginName
+	pluginName := dbEngineMongoDB.DefaultPluginName()
 	name := acctest.RandomWithPrefix("db")
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
@@ -319,7 +319,7 @@ func TestAccDatabaseSecretBackendConnection_mssql(t *testing.T) {
 	t.Cleanup(cleanupFunc)
 
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	pluginName := fmt.Sprintf("%s-database-plugin", dbEngineMSSQL.name)
+	pluginName := dbEngineMSSQL.DefaultPluginName()
 	name := acctest.RandomWithPrefix("db")
 
 	resource.Test(t, resource.TestCase{
@@ -372,7 +372,7 @@ func TestAccDatabaseSecretBackendConnection_mysql(t *testing.T) {
 	connURL := values[0]
 
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	pluginName := fmt.Sprintf("%s-database-plugin", dbEngineMySQL.name)
+	pluginName := dbEngineMySQL.DefaultPluginName()
 	name := acctest.RandomWithPrefix("db")
 	password := acctest.RandomWithPrefix("password")
 	resource.Test(t, resource.TestCase{
@@ -465,7 +465,7 @@ func TestAccDatabaseSecretBackendConnectionUpdate_mysql(t *testing.T) {
 	connURL := values[0]
 
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	pluginName := fmt.Sprintf("%s-database-plugin", dbEngineMySQL.name)
+	pluginName := dbEngineMySQL.DefaultPluginName()
 	name := acctest.RandomWithPrefix("db")
 	password := acctest.RandomWithPrefix("password")
 	resource.Test(t, resource.TestCase{
@@ -529,7 +529,7 @@ func TestAccDatabaseSecretBackendConnectionTemplatedUpdateExcludePassword_mysql(
 	}
 
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	pluginName := fmt.Sprintf("%s-database-plugin", dbEngineMySQL.name)
+	pluginName := dbEngineMySQL.DefaultPluginName()
 	name := acctest.RandomWithPrefix("db")
 	testUsername := acctest.RandomWithPrefix("username")
 	testPassword := acctest.RandomWithPrefix("password")
@@ -594,7 +594,7 @@ func TestAccDatabaseSecretBackendConnection_mysql_tls(t *testing.T) {
 	tlsCA, connURL, tlsCertificateKey := values[0], values[1], values[2]
 
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	pluginName := dbEngineMySQL.defaultPluginName
+	pluginName := dbEngineMySQL.DefaultPluginName()
 	name := acctest.RandomWithPrefix("db")
 	password := acctest.RandomWithPrefix("password")
 	resource.Test(t, resource.TestCase{
@@ -633,7 +633,7 @@ func TestAccDatabaseSecretBackendConnection_postgresql(t *testing.T) {
 	connURL := values[0]
 
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	pluginName := dbEnginePostgres.defaultPluginName
+	pluginName := dbEnginePostgres.DefaultPluginName()
 	name := acctest.RandomWithPrefix("db")
 	userTempl := "{{.DisplayName}}"
 	resource.Test(t, resource.TestCase{
@@ -671,7 +671,7 @@ func TestAccDatabaseSecretBackendConnection_elasticsearch(t *testing.T) {
 	username := os.Getenv("ELASTIC_USERNAME")
 	password := os.Getenv("ELASTIC_PASSWORD")
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	pluginName := dbEngineElasticSearch.defaultPluginName
+	pluginName := dbEngineElasticSearch.DefaultPluginName()
 	name := acctest.RandomWithPrefix("db")
 
 	resource.Test(t, resource.TestCase{
@@ -703,7 +703,7 @@ func TestAccDatabaseSecretBackendConnection_snowflake(t *testing.T) {
 	username := os.Getenv("SNOWFLAKE_USERNAME")
 	password := os.Getenv("SNOWFLAKE_PASSWORD")
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	pluginName := dbEngineSnowflake.defaultPluginName
+	pluginName := dbEngineSnowflake.DefaultPluginName()
 	name := acctest.RandomWithPrefix("db")
 	userTempl := "{{.DisplayName}}"
 
@@ -738,7 +738,7 @@ func TestAccDatabaseSecretBackendConnection_redshift(t *testing.T) {
 		t.Skip("REDSHIFT_URL not set")
 	}
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	pluginName := dbEngineRedshift.defaultPluginName
+	pluginName := dbEngineRedshift.DefaultPluginName()
 	name := acctest.RandomWithPrefix("db")
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
@@ -1246,7 +1246,7 @@ func MaybeSkipDBTests(t *testing.T, engine *dbEngine) {
 	testutil.SkipTestEnvSet(t, envVars...)
 }
 
-func Test_dbEngine_getPluginName(t *testing.T) {
+func Test_dbEngine_GetPluginName(t *testing.T) {
 	type fields struct {
 		name              string
 		defaultPluginName string
@@ -1327,15 +1327,15 @@ func Test_dbEngine_getPluginName(t *testing.T) {
 				defaultPluginName: tt.fields.defaultPluginName,
 			}
 
-			got, err := i.getPluginName(tt.args.d)
+			got, err := i.GetPluginName(tt.args.d)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("getPluginName() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("GetPluginName() error = %v, wantErr %v", err, tt.wantErr)
 
 				return
 			}
 
 			if got != tt.want {
-				t.Errorf("getPluginName() expected %v, actual %v", tt.want, got)
+				t.Errorf("GetPluginName() expected %v, actual %v", tt.want, got)
 			}
 		})
 	}


### PR DESCRIPTION
- replace the use of map for looking up dbEngine instances by name with
  a slice
- factor out dbBackend* constants to dbEngine instances.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
