### PR TITLE
Support for custom metadata field in Kubernetes auth backend config

### DIFF
--- a/testdata/openapi.json
+++ b/testdata/openapi.json
@@ -7805,6 +7805,14 @@
                       "name": "Disable use of local CA and service account JWT"
                     }
                   },
+                  "enable_custom_metadata_from_annotations": {
+                    "type": "boolean",
+                    "description": "Enable reading and parsing Kubernetes annotations from service account for policy templating",
+                    "default": false,
+                    "x-vault-displayAttrs": {
+                      "name": "Enable reading and parsing Kubernetes annotations from service account"
+                    }
+                  },
                   "issuer": {
                     "type": "string",
                     "description": "Optional JWT issuer. If no issuer is specified, then this plugin will use kubernetes.io/serviceaccount as the default issuer. (Deprecated, will be removed in a future release)",

--- a/vault/data_source_kubernetes_auth_backend_config.go
+++ b/vault/data_source_kubernetes_auth_backend_config.go
@@ -61,6 +61,12 @@ func kubernetesAuthBackendConfigDataSource() *schema.Resource {
 				Optional:    true,
 				Description: "Optional disable defaulting to the local CA cert and service account JWT when running in a Kubernetes pod.",
 			},
+			"enable_custom_metadata_from_annotations": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Optional:    true,
+				Description: "Optional enable reading and parsing Kubernetes annotations from service account for policy templating.",
+			},
 		},
 	}
 }
@@ -96,6 +102,7 @@ func kubernetesAuthBackendConfigDataSourceRead(d *schema.ResourceData, meta inte
 	d.Set("issuer", resp.Data["issuer"])
 	d.Set("disable_iss_validation", resp.Data["disable_iss_validation"])
 	d.Set("disable_local_ca_jwt", resp.Data["disable_local_ca_jwt"])
+	d.Set("enable_custom_metadata_from_annotations", resp.Data["enable_custom_metadata_from_annotations"])
 
 	return nil
 }

--- a/vault/data_source_kubernetes_auth_backend_config_test.go
+++ b/vault/data_source_kubernetes_auth_backend_config_test.go
@@ -58,6 +58,7 @@ func TestAccKubernetesAuthBackendConfigDataSource_full(t *testing.T) {
 	issuer := "kubernetes/serviceaccount"
 	disableIssValidation := true
 	disableLocalCaJwt := true
+	enableCustomMetadata := true
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
@@ -65,7 +66,7 @@ func TestAccKubernetesAuthBackendConfigDataSource_full(t *testing.T) {
 		CheckDestroy: testAccCheckKubernetesAuthBackendConfigDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, jwt, issuer, disableIssValidation, disableLocalCaJwt),
+				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, jwt, issuer, disableIssValidation, disableLocalCaJwt, enableCustomMetadata),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"backend", backend),
@@ -85,10 +86,12 @@ func TestAccKubernetesAuthBackendConfigDataSource_full(t *testing.T) {
 						"disable_iss_validation", strconv.FormatBool(disableIssValidation)),
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"disable_local_ca_jwt", strconv.FormatBool(disableLocalCaJwt)),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"enable_custom_metadata_from_annotations", strconv.FormatBool(enableCustomMetadata)),
 				),
 			},
 			{
-				Config: testAccKubernetesAuthBackendConfigDataSourceConfig_full(backend, jwt, issuer, disableIssValidation, disableLocalCaJwt),
+				Config: testAccKubernetesAuthBackendConfigDataSourceConfig_full(backend, jwt, issuer, disableIssValidation, disableLocalCaJwt, enableCustomMetadata),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_config.config",
 						"backend", backend),
@@ -108,6 +111,8 @@ func TestAccKubernetesAuthBackendConfigDataSource_full(t *testing.T) {
 						"disable_iss_validation", strconv.FormatBool(disableIssValidation)),
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"disable_local_ca_jwt", strconv.FormatBool(disableLocalCaJwt)),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"enable_custom_metadata_from_annotations", strconv.FormatBool(enableCustomMetadata)),
 				),
 			},
 		},
@@ -123,11 +128,11 @@ data "vault_kubernetes_auth_backend_config" "config" {
 }`, testAccKubernetesAuthBackendConfigConfig_basic(backend, jwt), backend)
 }
 
-func testAccKubernetesAuthBackendConfigDataSourceConfig_full(backend, jwt string, issuer string, disableIssValidation bool, disableLocalCaJwt bool) string {
+func testAccKubernetesAuthBackendConfigDataSourceConfig_full(backend, jwt string, issuer string, disableIssValidation bool, disableLocalCaJwt bool, enableCustomMetadata bool) string {
 	return fmt.Sprintf(`
 %s
 
 data "vault_kubernetes_auth_backend_config" "config" {
   backend = "%s"
-}`, testAccKubernetesAuthBackendConfigConfig_full(backend, jwt, issuer, disableIssValidation, disableLocalCaJwt), backend)
+}`, testAccKubernetesAuthBackendConfigConfig_full(backend, jwt, issuer, disableIssValidation, disableLocalCaJwt, enableCustomMetadata), backend)
 }

--- a/vault/resource_kubernetes_auth_backend_config.go
+++ b/vault/resource_kubernetes_auth_backend_config.go
@@ -76,6 +76,12 @@ func kubernetesAuthBackendConfigResource() *schema.Resource {
 				Optional:    true,
 				Description: "Optional disable defaulting to the local CA cert and service account JWT when running in a Kubernetes pod.",
 			},
+			"enable_custom_metadata_from_annotations": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Optional:    true,
+				Description: "Optional enable reading and parsing Kubernetes annotations from service account for policy templating",
+			},
 		},
 	}
 }
@@ -121,6 +127,10 @@ func kubernetesAuthBackendConfigCreate(d *schema.ResourceData, meta interface{})
 
 	if v, ok := d.GetOk("disable_local_ca_jwt"); ok {
 		data["disable_local_ca_jwt"] = v
+	}
+
+	if v, ok := d.GetOk("enable_custom_metadata_from_annotations"); ok {
+		data["enable_custom_metadata_from_annotations"] = v
 	}
 	_, err := client.Logical().Write(path, data)
 	if err != nil {
@@ -175,6 +185,7 @@ func kubernetesAuthBackendConfigRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("issuer", resp.Data["issuer"])
 	d.Set("disable_iss_validation", resp.Data["disable_iss_validation"])
 	d.Set("disable_local_ca_jwt", resp.Data["disable_local_ca_jwt"])
+	d.Set("enable_custom_metadata_from_annotations", resp.Data["enable_custom_metadata_from_annotations"])
 
 	iPemKeys := resp.Data["pem_keys"].([]interface{})
 	pemKeys := make([]string, 0, len(iPemKeys))
@@ -223,6 +234,10 @@ func kubernetesAuthBackendConfigUpdate(d *schema.ResourceData, meta interface{})
 
 	if v, ok := d.GetOk("disable_local_ca_jwt"); ok {
 		data["disable_local_ca_jwt"] = v
+	}
+
+	if v, ok := d.GetOk("enable_custom_metadata_from_annotations"); ok {
+		data["enable_custom_metadata_from_annotations"] = v
 	}
 
 	_, err := client.Logical().Write(path, data)

--- a/vault/resource_kubernetes_auth_backend_config_test.go
+++ b/vault/resource_kubernetes_auth_backend_config_test.go
@@ -71,6 +71,7 @@ func TestAccKubernetesAuthBackendConfig_import(t *testing.T) {
 	issuer := "kubernetes/serviceaccount"
 	disableIssValidation := false
 	disableLocalCaJwt := false
+	enableCustomMetadata := true
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
@@ -78,7 +79,7 @@ func TestAccKubernetesAuthBackendConfig_import(t *testing.T) {
 		CheckDestroy: testAccCheckKubernetesAuthBackendConfigDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, jwt, issuer, disableIssValidation, disableLocalCaJwt),
+				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, jwt, issuer, disableIssValidation, disableLocalCaJwt, enableCustomMetadata),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"backend", backend),
@@ -98,6 +99,8 @@ func TestAccKubernetesAuthBackendConfig_import(t *testing.T) {
 						"disable_iss_validation", strconv.FormatBool(disableIssValidation)),
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"disable_local_ca_jwt", strconv.FormatBool(disableLocalCaJwt)),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"enable_custom_metadata_from_annotations", strconv.FormatBool(enableCustomMetadata)),
 				),
 			},
 			{
@@ -221,6 +224,7 @@ func TestAccKubernetesAuthBackendConfig_full(t *testing.T) {
 	issuer := "api"
 	disableIssValidation := true
 	disableLocalCaJwt := true
+	enableCustomMetadata := true
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
@@ -228,7 +232,7 @@ func TestAccKubernetesAuthBackendConfig_full(t *testing.T) {
 		CheckDestroy: testAccCheckKubernetesAuthBackendConfigDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, jwt, issuer, disableIssValidation, disableLocalCaJwt),
+				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, jwt, issuer, disableIssValidation, disableLocalCaJwt, enableCustomMetadata),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"backend", backend),
@@ -248,6 +252,8 @@ func TestAccKubernetesAuthBackendConfig_full(t *testing.T) {
 						"disable_iss_validation", strconv.FormatBool(disableIssValidation)),
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"disable_local_ca_jwt", strconv.FormatBool(disableLocalCaJwt)),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"enable_custom_metadata_from_annotations", strconv.FormatBool(enableCustomMetadata)),
 				),
 			},
 		},
@@ -267,7 +273,7 @@ func TestAccKubernetesAuthBackendConfig_fullUpdate(t *testing.T) {
 		CheckDestroy: testAccCheckKubernetesAuthBackendConfigDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, oldJWT, oldIssuer, false, false),
+				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, oldJWT, oldIssuer, false, false, false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"backend", backend),
@@ -289,10 +295,12 @@ func TestAccKubernetesAuthBackendConfig_fullUpdate(t *testing.T) {
 						"disable_iss_validation", strconv.FormatBool(false)),
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"disable_local_ca_jwt", strconv.FormatBool(false)),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"enable_custom_metadata_from_annotations", strconv.FormatBool(false)),
 				),
 			},
 			{
-				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, newJWT, newIssuer, true, true),
+				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, newJWT, newIssuer, true, true, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"backend", backend),
@@ -312,11 +320,13 @@ func TestAccKubernetesAuthBackendConfig_fullUpdate(t *testing.T) {
 						"disable_iss_validation", strconv.FormatBool(true)),
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"disable_local_ca_jwt", strconv.FormatBool(true)),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"enable_custom_metadata_from_annotations", strconv.FormatBool(true)),
 				),
 			},
 			{
 				// ensure we can set disable_iss_validation to false
-				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, newJWT, newIssuer, false, true),
+				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, newJWT, newIssuer, false, true, true),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"backend", backend),
@@ -336,6 +346,8 @@ func TestAccKubernetesAuthBackendConfig_fullUpdate(t *testing.T) {
 						"disable_iss_validation", strconv.FormatBool(false)),
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"disable_local_ca_jwt", strconv.FormatBool(true)),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"enable_custom_metadata_from_annotations", strconv.FormatBool(true)),
 				),
 			},
 		},
@@ -357,7 +369,7 @@ resource "vault_kubernetes_auth_backend_config" "config" {
 }`, backend, kubernetesCAcert, jwt)
 }
 
-func testAccKubernetesAuthBackendConfigConfig_full(backend, jwt string, issuer string, disableIssValidation bool, disableLocalCaJwt bool) string {
+func testAccKubernetesAuthBackendConfigConfig_full(backend, jwt string, issuer string, disableIssValidation bool, disableLocalCaJwt bool, enableCustomMetadata bool) string {
 	return fmt.Sprintf(`
 resource "vault_auth_backend" "kubernetes" {
   type = "kubernetes"
@@ -373,5 +385,6 @@ resource "vault_kubernetes_auth_backend_config" "config" {
   issuer = %q
   disable_iss_validation = %t
   disable_local_ca_jwt = %t
-}`, backend, kubernetesCAcert, jwt, kubernetesPEMfile, issuer, disableIssValidation, disableLocalCaJwt)
+  enable_custom_metadata_from_annotations = %t
+}`, backend, kubernetesCAcert, jwt, kubernetesPEMfile, issuer, disableIssValidation, disableLocalCaJwt, enableCustomMetadata)
 }

--- a/website/docs/r/kubernetes_auth_backend_config.md
+++ b/website/docs/r/kubernetes_auth_backend_config.md
@@ -47,6 +47,8 @@ The following arguments are supported:
 
 * `disable_local_ca_jwt` - (Optional) Disable defaulting to the local CA cert and service account JWT when running in a Kubernetes pod. Requires Vault `v1.5.4+` or Vault auth kubernetes plugin `v0.7.1+`
 
+* `enable_custom_metadata_from_annotations` - (Optional) Enable reading and parsing Kubernetes annotations from service account for policy templating, annotations must have prefix `vault.hashicorp.com/auth-metadata/` to be read.
+
 
 ## Attributes Reference
 


### PR DESCRIPTION
This change accompanies https://github.com/monzo/vault-plugin-auth-kubernetes/pull/1, which adds a new config flag `enable_custom_metadata_from_annotations` to the Kubernetes auth plugin. If enabled this will cause the auth plugin to read service account annotations in Kubernetes prefixed with `vault.hashicorp.com/auth-metadata/` as auth metadata in Vault.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* `resource/vault_kubernetes_auth_backend_config`: Add `enable_custom_metadata_from_annotations` config parameter to k8s auth backend (PR link TODO)
* `data/vault_kubernetes_auth_backend_config`: Add `enable_custom_metadata_from_annotations` config parameter to k8s auth backend (PR link TODO)

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
TODO
...
```
