### PR TITLE
Add optional role_session_name to data.vault_aws_access_credentials

### DIFF
--- a/vault/data_source_aws_access_credentials.go
+++ b/vault/data_source_aws_access_credentials.go
@@ -120,6 +120,11 @@ func awsAccessCredentialsDataSource() *schema.Resource {
 				Optional:    true,
 				Description: "User specified Time-To-Live for the STS token. Uses the Role defined default_sts_ttl when not specified",
 			},
+			"role_session_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The role session name to attach to the assumed role ARN.",
+			},
 		},
 	}
 }
@@ -140,6 +145,10 @@ func awsAccessCredentialsDataSourceRead(d *schema.ResourceData, meta interface{}
 
 	if v, ok := d.GetOk("ttl"); ok {
 		data["ttl"] = []string{v.(string)}
+	}
+
+	if v, ok := d.GetOk("role_session_name"); ok {
+		data["role_session_name"] = []string{v.(string)}
 	}
 
 	log.Printf("[DEBUG] Reading %q from Vault with data %#v", path, data)

--- a/vault/data_source_aws_access_credentials_test.go
+++ b/vault/data_source_aws_access_credentials_test.go
@@ -126,6 +126,69 @@ func TestAccDataSourceAWSAccessCredentials_sts(t *testing.T) {
 	}
 }
 
+func TestAccDataSourceAWSAccessCredentials_sts_role_session_name(t *testing.T) {
+	mountPath := acctest.RandomWithPrefix("tf-test-aws")
+	accessKey, secretKey := testutil.GetTestAWSCreds(t)
+	region := testutil.GetTestAWSRegion(t)
+	role_session_name := "test_session_name"
+
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testutil.TestAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAWSAccessCredentialsConfig_sts_basic(mountPath, accessKey, secretKey, region),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "access_key"),
+					resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "secret_key"),
+					resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "security_token"),
+					resource.TestCheckResourceAttr("data.vault_aws_access_credentials.test", "type", "sts"),
+					resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "lease_id"),
+					testAccDataSourceAWSAccessCredentialsCheck_tokenWorks(region),
+				),
+			},
+			{
+				Config: testAccDataSourceAWSAccessCredentialsConfig_sts_role_session_name(mountPath, accessKey, secretKey, region, role_session_name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "access_key"),
+					resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "secret_key"),
+					resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "security_token"),
+					resource.TestCheckResourceAttr("data.vault_aws_access_credentials.test", "type", "sts"),
+					resource.TestCheckResourceAttr("data.vault_aws_access_credentials.test", "role_session_name", role_session_name),
+					resource.TestCheckResourceAttrSet("data.vault_aws_access_credentials.test", "lease_id"),
+					testAccDataSourceAWSAccessCredentialsCheck_tokenWorks(region),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAWSAccessCredentialsConfig_sts_role_session_name(mountPath, accessKey, secretKey, region, role_session_name string) string {
+	return fmt.Sprintf(`
+resource "vault_aws_secret_backend" "aws" {
+	path = "%s"
+	description = "Obtain AWS credentials."
+	access_key = "%s"
+	secret_key = "%s"
+	region = "%s"
+}
+
+resource "vault_aws_secret_backend_role" "role" {
+	backend = vault_aws_secret_backend.aws.path
+	name = "test"
+	credential_type = "federation_token"
+	policy_document = "{\"Version\": \"2012-10-17\", \"Statement\": [{\"Effect\": \"Allow\", \"Action\": \"iam:*\", \"Resource\": \"*\"}]}"
+}
+
+data "vault_aws_access_credentials" "test" {
+	backend = vault_aws_secret_backend.aws.path
+	role = vault_aws_secret_backend_role.role.name
+	type = "sts"
+	role_session_name = "%s"
+	region = vault_aws_secret_backend.aws.region
+}`, mountPath, accessKey, secretKey, region, role_session_name)
+}
+
 func TestAccDataSourceAWSAccessCredentials_sts_ttl(t *testing.T) {
 	mountPath := acctest.RandomWithPrefix("tf-test-aws")
 	accessKey, secretKey := testutil.GetTestAWSCreds(t)

--- a/website/docs/d/aws_access_credentials.html.md
+++ b/website/docs/d/aws_access_credentials.html.md
@@ -75,6 +75,9 @@ in addition to the keys.
 from the configured role. If the role does not have multiple ARNs, this does
 not need to be specified.
 
+* `role_session_name` - (Optional) The role session name to attach to the assumed role ARN. role_session_name is limited to 64 characters; if exceeded, the `role_session_name` in the assumed role ARN will be truncated to 64 characters. If `role_session_name` is not provided, then it will be generated dynamically by default.
+
+
 * `ttl` - (Optional) Specifies the TTL for the use of the STS token. This
 is specified as a string with a duration suffix. Valid only when
 `credential_type` is `assumed_role` or `federation_token`


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1108

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

IMPROVEMENTS:
* `data/vault_aws_access_credentials` : Support custom role session name ([#1108]
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
