### PR TITLE
Add support for settng use_microsoft_graph_api in r/azure_secret_backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ IMPROVEMENTS:
 * `resource/pki_secret_backend_root_sign_intermediate`: Update schema for `ca_chain` from string to a list of   
   `issuing_ca` and `certificate`, add new `certificate_bundle` attribute that provides the concatenation of the   
   intermediate and issuing CA certificates (PEM encoded) ([#1330](https://github.com/hashicorp/terraform-provider-vault/pull/1330))
+* `resource/azure_secret_backend`: Add support for setting `use_microsoft_graph_api` ([#1335](https://github.com/hashicorp/terraform-provider-vault/pull/1335))
 
 ## 3.2.1 (January 20, 2022)
 BUGS:

--- a/vault/resource_azure_secret_backend.go
+++ b/vault/resource_azure_secret_backend.go
@@ -224,7 +224,6 @@ func azureSecretBackendPath(path string) string {
 
 func azureSecretBackendRequestData(d *schema.ResourceData) map[string]interface{} {
 	fields := []string{
-		"description",
 		"client_id",
 		"environment",
 		"tenant_id",

--- a/vault/resource_azure_secret_backend.go
+++ b/vault/resource_azure_secret_backend.go
@@ -142,23 +142,20 @@ func azureSecretBackendRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error reading from Vault: %s", err)
 	}
 
-	if v, ok := resp.Data["client_id"].(string); ok {
-		d.Set("client_id", v)
-	}
-	if v, ok := resp.Data["subscription_id"].(string); ok {
-		d.Set("subscription_id", v)
-	}
-	if v, ok := resp.Data["tenant_id"].(string); ok {
-		d.Set("tenant_id", v)
-	}
-	if v, ok := resp.Data["environment"].(string); ok && v != "" {
-		d.Set("environment", v)
-	} else {
-		d.Set("environment", "AzurePublicCloud")
+	for _, k := range []string{"client_id", "subscription_id", "tenant_id", "use_microsoft_graph_api"} {
+		if v, ok := resp.Data[k]; ok {
+			if err := d.Set(k, v); err != nil {
+				return err
+			}
+		}
 	}
 
-	if v, ok := resp.Data["use_microsoft_graph_api"]; ok {
-		if err := d.Set("use_microsoft_graph_api", v); err != nil {
+	if v, ok := resp.Data["environment"]; ok && v.(string) != "" {
+		if err := d.Set("environment", v); err != nil {
+			return err
+		}
+	} else {
+		if err := d.Set("environment", "AzurePublicCloud"); err != nil {
 			return err
 		}
 	}

--- a/vault/resource_azure_secret_backend_test.go
+++ b/vault/resource_azure_secret_backend_test.go
@@ -29,6 +29,7 @@ func TestAzureSecretBackend(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_azure_secret_backend.test", "client_id", "11111111-2222-3333-4444-333333333333"),
 					resource.TestCheckResourceAttr("vault_azure_secret_backend.test", "client_secret", "12345678901234567890"),
 					resource.TestCheckResourceAttr("vault_azure_secret_backend.test", "environment", "AzurePublicCloud"),
+					resource.TestCheckResourceAttr("vault_azure_secret_backend.test", "use_microsoft_graph_api", "false"),
 				),
 			},
 			{
@@ -40,6 +41,7 @@ func TestAzureSecretBackend(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_azure_secret_backend.test", "client_id", "22222222-3333-4444-5555-444444444444"),
 					resource.TestCheckResourceAttr("vault_azure_secret_backend.test", "client_secret", "098765432109876543214"),
 					resource.TestCheckResourceAttr("vault_azure_secret_backend.test", "environment", "AzurePublicCloud"),
+					resource.TestCheckResourceAttr("vault_azure_secret_backend.test", "use_microsoft_graph_api", "true"),
 				),
 			},
 		},
@@ -90,5 +92,6 @@ func testAzureSecretBackend_updated(path string) string {
 	 client_id = "22222222-3333-4444-5555-444444444444"
 	 client_secret = "098765432109876543214"
 	 environment = "AzurePublicCloud"
+	 use_microsoft_graph_api = true
 	}`, path)
 }

--- a/vault/resource_azure_secret_backend_test.go
+++ b/vault/resource_azure_secret_backend_test.go
@@ -44,6 +44,18 @@ func TestAzureSecretBackend(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_azure_secret_backend.test", "use_microsoft_graph_api", "true"),
 				),
 			},
+			{
+				Config: testAzureSecretBackend_updateSubscriptionID(path),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_azure_secret_backend.test", "path", path),
+					resource.TestCheckResourceAttr("vault_azure_secret_backend.test", "subscription_id", "11111112-2221-3332-4443-111111111110"),
+					resource.TestCheckResourceAttr("vault_azure_secret_backend.test", "tenant_id", "22222222-3333-4444-5555-333333333333"),
+					resource.TestCheckResourceAttr("vault_azure_secret_backend.test", "client_id", "22222222-3333-4444-5555-444444444444"),
+					resource.TestCheckResourceAttr("vault_azure_secret_backend.test", "client_secret", "098765432109876543214"),
+					resource.TestCheckResourceAttr("vault_azure_secret_backend.test", "environment", "AzurePublicCloud"),
+					resource.TestCheckResourceAttr("vault_azure_secret_backend.test", "use_microsoft_graph_api", "true"),
+				),
+			},
 		},
 	})
 }
@@ -88,6 +100,19 @@ func testAzureSecretBackend_updated(path string) string {
 	resource "vault_azure_secret_backend" "test" {
 	 path = "%s"
 	 subscription_id = "11111111-2222-3333-4444-111111111111"
+	 tenant_id = "22222222-3333-4444-5555-333333333333"
+	 client_id = "22222222-3333-4444-5555-444444444444"
+	 client_secret = "098765432109876543214"
+	 environment = "AzurePublicCloud"
+	 use_microsoft_graph_api = true
+	}`, path)
+}
+
+func testAzureSecretBackend_updateSubscriptionID(path string) string {
+	return fmt.Sprintf(`
+	resource "vault_azure_secret_backend" "test" {
+	 path = "%s"
+	 subscription_id = "11111112-2221-3332-4443-111111111110"
 	 tenant_id = "22222222-3333-4444-5555-333333333333"
 	 client_id = "22222222-3333-4444-5555-444444444444"
 	 client_secret = "098765432109876543214"

--- a/website/docs/r/azure_secret_backend.html.md
+++ b/website/docs/r/azure_secret_backend.html.md
@@ -57,6 +57,7 @@ The following arguments are supported:
 
 - `use_microsoft_graph_api` (`bool: <optional>`) - Use the Microsoft Graph API introduced in `vault-1.9`. 
    Should be set to true for `vault-1.10+`
+
 - `tenant_id` (`string: <required>`) - The tenant id for the Azure Active Directory.
 
 - `client_id` (`string:""`) - The OAuth2 client id to connect to Azure.

--- a/website/docs/r/azure_secret_backend.html.md
+++ b/website/docs/r/azure_secret_backend.html.md
@@ -19,15 +19,33 @@ artifacts accordingly. See
 [the main provider documentation](../index.html)
 for more details.
 
-## Example Usage
+~> It is highly recommended that one transition to the Microsoft Graph API.
+See [use_microsoft_graph_api ](https://www.vaultproject.io/api-docs/secret/azure#use_microsoft_graph_api)
+for more information. The example below demonstrates how to do this. 
+
+## Example Usage: *vault-1.9 and above*
 
 ```hcl
 resource "vault_azure_secret_backend" "azure" {
-  subscription_id = "11111111-2222-3333-4444-111111111111"
-  tenant_id       = "11111111-2222-3333-4444-222222222222"
-  client_id       = "11111111-2222-3333-4444-333333333333"
-  client_secret   = "12345678901234567890"
-  environment     = "AzurePublicCloud"
+  use_microsoft_graph_api = true
+  subscription_id         = "11111111-2222-3333-4444-111111111111"
+  tenant_id               = "11111111-2222-3333-4444-222222222222"
+  client_id               = "11111111-2222-3333-4444-333333333333"
+  client_secret           = "12345678901234567890"
+  environment             = "AzurePublicCloud"
+}
+```
+
+## Example Usage: *vault-1.8 and below*
+
+```hcl
+resource "vault_azure_secret_backend" "azure" {
+  use_microsoft_graph_api = false
+  subscription_id         = "11111111-2222-3333-4444-111111111111"
+  tenant_id               = "11111111-2222-3333-4444-222222222222"
+  client_id               = "11111111-2222-3333-4444-333333333333"
+  client_secret           = "12345678901234567890"
+  environment             = "AzurePublicCloud"
 }
 ```
 
@@ -36,10 +54,17 @@ resource "vault_azure_secret_backend" "azure" {
 The following arguments are supported:
 
 - `subscription_id` (`string: <required>`) - The subscription id for the Azure Active Directory.
+
+- `use_microsoft_graph_api` (`bool: <optional>`) - Use the Microsoft Graph API introduced in `vault-1.9`. 
+   Should be set to true for `vault-1.10+`
 - `tenant_id` (`string: <required>`) - The tenant id for the Azure Active Directory.
+
 - `client_id` (`string:""`) - The OAuth2 client id to connect to Azure.
+
 - `client_secret` (`string:""`) - The OAuth2 client secret to connect to Azure.
+
 - `environment` (`string:""`) - The Azure environment.
+
 - `path` (`string: <optional>`) - The unique path this backend should be mounted at. Defaults to `azure`.
 
 ## Attributes Reference


### PR DESCRIPTION
Add support for setting `use_microsoft_graph_api` in `r/azure_secret_backend`

- Factor out common request data from `create` and `update` functions
- Extend test coverage

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1304 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-count=1 -test.run ^TestAzureSecretBackend$$'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -count=1 -test.run ^TestAzureSecretBackend$ -timeout 30m ./...
ok      github.com/hashicorp/terraform-provider-vault/util      0.320s [no tests to run]

[...]

=== RUN   TestAzureSecretBackend
--- PASS: TestAzureSecretBackend (4.24s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     5.935s
```
