### PR TITLE
Fix persistent diff for kubernetes_ca_cert in k8s-auth-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 BUGS:
 * `resource/kubernetes_auth_backend_config`: Ensure `disable_iss_validation` is honored in all cases ([#1315](https://github.com/hashicorp/terraform-provider-vault/pull/1315))
 * `resource/database_secret_backend_connection`: Add error handling for unrecognized plugins on read ([#1325](https://github.com/hashicorp/terraform-provider-vault/pull/1325))
+* `resource/kubernetes_auth_backend_config`: Prevent persistent diff for `kubernetes_ca_cert` when it is loaded by the backend ([#1337](https://github.com/hashicorp/terraform-provider-vault/pull/1337))
 
 IMPROVEMENTS:
 * `resource/token_auth_backend_role`: Add `allowed_policies_glob` and `disallowed_polices_glob` ([#1316](https://github.com/hashicorp/terraform-provider-vault/pull/1316))

--- a/vault/data_source_kubernetes_auth_backend_config_test.go
+++ b/vault/data_source_kubernetes_auth_backend_config_test.go
@@ -21,7 +21,7 @@ func TestAccKubernetesAuthBackendConfigDataSource_basic(t *testing.T) {
 		CheckDestroy: testAccCheckKubernetesAuthBackendConfigDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesAuthBackendConfigConfig_basic(backend, jwt),
+				Config: testAccKubernetesAuthBackendConfigConfig_basic(backend, jwt, kubernetesCAcert),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"backend", backend),
@@ -120,7 +120,7 @@ func testAccKubernetesAuthBackendConfigDataSourceConfig_basic(backend, jwt strin
 
 data "vault_kubernetes_auth_backend_config" "config" {
   backend = %q
-}`, testAccKubernetesAuthBackendConfigConfig_basic(backend, jwt), backend)
+}`, testAccKubernetesAuthBackendConfigConfig_basic(backend, jwt, kubernetesCAcert), backend)
 }
 
 func testAccKubernetesAuthBackendConfigDataSourceConfig_full(backend, jwt string, issuer string, disableIssValidation bool, disableLocalCaJwt bool) string {

--- a/vault/resource_kubernetes_auth_backend_config.go
+++ b/vault/resource_kubernetes_auth_backend_config.go
@@ -33,7 +33,7 @@ func kubernetesAuthBackendConfigResource() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "PEM encoded CA cert for use by the TLS client used to talk with the Kubernetes API.",
 				Optional:    true,
-				Default:     "",
+				Computed:    true,
 			},
 			"token_reviewer_jwt": {
 				Type:        schema.TypeString,
@@ -131,7 +131,10 @@ func kubernetesAuthBackendConfigCreate(d *schema.ResourceData, meta interface{})
 	// NOTE: Since reading the auth/<backend>/config does
 	// not return the `token_reviewer_jwt`,
 	// set it from data after successfully storing it in Vault.
-	d.Set("token_reviewer_jwt", data["token_reviewer_jwt"])
+	if err := d.Set("token_reviewer_jwt", data["token_reviewer_jwt"]); err != nil {
+		return err
+	}
+
 	log.Printf("[DEBUG] Wrote Kubernetes auth backend config %q", path)
 
 	return kubernetesAuthBackendConfigRead(d, meta)
@@ -162,6 +165,7 @@ func kubernetesAuthBackendConfigRead(d *schema.ResourceData, meta interface{}) e
 	if err != nil {
 		return fmt.Errorf("error reading Kubernetes auth backend config %q: %s", path, err)
 	}
+
 	log.Printf("[DEBUG] Read Kubernetes auth backend config %q", path)
 	if resp == nil {
 		log.Printf("[WARN] Kubernetes auth backend config %q not found, removing from state", path)
@@ -169,21 +173,25 @@ func kubernetesAuthBackendConfigRead(d *schema.ResourceData, meta interface{}) e
 		return nil
 	}
 
-	d.Set("backend", backend)
-	d.Set("kubernetes_host", resp.Data["kubernetes_host"])
-	d.Set("kubernetes_ca_cert", resp.Data["kubernetes_ca_cert"])
-	d.Set("issuer", resp.Data["issuer"])
-	d.Set("disable_iss_validation", resp.Data["disable_iss_validation"])
-	d.Set("disable_local_ca_jwt", resp.Data["disable_local_ca_jwt"])
-
-	iPemKeys := resp.Data["pem_keys"].([]interface{})
-	pemKeys := make([]string, 0, len(iPemKeys))
-
-	for _, iPemKey := range iPemKeys {
-		pemKeys = append(pemKeys, iPemKey.(string))
+	if err := d.Set("backend", backend); err != nil {
+		return err
 	}
 
-	d.Set("pem_keys", pemKeys)
+	params := []string{
+		"kubernetes_host",
+		"kubernetes_ca_cert",
+		"issuer",
+		"disable_iss_validation",
+		"disable_local_ca_jwt",
+		"pem_keys",
+	}
+
+	for _, k := range params {
+		v := resp.Data[k]
+		if err := d.Set(k, v); err != nil {
+			return err
+		}
+	}
 
 	return nil
 }

--- a/vault/resource_kubernetes_auth_backend_config_test.go
+++ b/vault/resource_kubernetes_auth_backend_config_test.go
@@ -108,7 +108,7 @@ func TestAccKubernetesAuthBackendConfig_import(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"backend", "token_reviewer_jwt"},
 			},
 			{
-				Config: testAccKubernetesAuthBackendConfigConfig_basic(backend, jwt),
+				Config: testAccKubernetesAuthBackendConfigConfig_basic(backend, jwt, kubernetesCAcert),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"backend", backend),
@@ -141,7 +141,7 @@ func TestAccKubernetesAuthBackendConfig_basic(t *testing.T) {
 		CheckDestroy: testAccCheckKubernetesAuthBackendConfigDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesAuthBackendConfigConfig_basic(backend, jwt),
+				Config: testAccKubernetesAuthBackendConfigConfig_basic(backend, jwt, kubernetesCAcert),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"backend", backend),
@@ -186,7 +186,7 @@ func TestAccKubernetesAuthBackendConfig_update(t *testing.T) {
 		CheckDestroy: testAccCheckKubernetesAuthBackendConfigDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccKubernetesAuthBackendConfigConfig_basic(backend, oldJWT),
+				Config: testAccKubernetesAuthBackendConfigConfig_basic(backend, oldJWT, kubernetesCAcert),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"backend", backend),
@@ -199,7 +199,7 @@ func TestAccKubernetesAuthBackendConfig_update(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccKubernetesAuthBackendConfigConfig_basic(backend, newJWT),
+				Config: testAccKubernetesAuthBackendConfigConfig_basic(backend, newJWT, kubernetesCAcert),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"backend", backend),
@@ -342,8 +342,58 @@ func TestAccKubernetesAuthBackendConfig_fullUpdate(t *testing.T) {
 	})
 }
 
-func testAccKubernetesAuthBackendConfigConfig_basic(backend, jwt string) string {
-	return fmt.Sprintf(`
+func TestAccKubernetesAuthBackendConfig_localCA(t *testing.T) {
+	backend := acctest.RandomWithPrefix("kubernetes")
+	jwt := kubernetesJWT
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckKubernetesAuthBackendConfigDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKubernetesAuthBackendConfigConfig_basic(backend, jwt, ""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"backend", backend),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"kubernetes_host", "http://example.com:443"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"kubernetes_ca_cert", ""),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"token_reviewer_jwt", jwt),
+				),
+			},
+			{
+				PreConfig: func() {
+					client := testProvider.Meta().(*api.Client)
+					path := kubernetesAuthBackendConfigPath(backend)
+					if _, err := client.Logical().Write(path, map[string]interface{}{
+						"kubernetes_ca_cert": kubernetesCAcert,
+						"kubernetes_host":    "http://example.com:443",
+						"token_reviewer_jwt": jwt,
+					}); err != nil {
+						t.Fatal(err)
+					}
+				},
+				Config: testAccKubernetesAuthBackendConfigConfig_basic(backend, jwt, ""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"backend", backend),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"kubernetes_host", "http://example.com:443"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"kubernetes_ca_cert", kubernetesCAcert),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						"token_reviewer_jwt", jwt),
+				),
+			},
+		},
+	})
+}
+
+func testAccKubernetesAuthBackendConfigConfig_basic(backend, jwt, ca string) string {
+	config := fmt.Sprintf(`
 resource "vault_auth_backend" "kubernetes" {
   type = "kubernetes"
   path = "%s"
@@ -352,13 +402,20 @@ resource "vault_auth_backend" "kubernetes" {
 resource "vault_kubernetes_auth_backend_config" "config" {
   backend = vault_auth_backend.kubernetes.path
   kubernetes_host = "http://example.com:443"
-  kubernetes_ca_cert = %q
   token_reviewer_jwt = %q
-}`, backend, kubernetesCAcert, jwt)
+`, backend, jwt)
+
+	if ca != "" {
+		config += fmt.Sprintf(`
+  kubernetes_ca_cert = %q
+`, ca)
+	}
+
+	return config + "}"
 }
 
 func testAccKubernetesAuthBackendConfigConfig_full(backend, jwt string, issuer string, disableIssValidation bool, disableLocalCaJwt bool) string {
-	return fmt.Sprintf(`
+	config := fmt.Sprintf(`
 resource "vault_auth_backend" "kubernetes" {
   type = "kubernetes"
   path = "%s"
@@ -374,4 +431,6 @@ resource "vault_kubernetes_auth_backend_config" "config" {
   disable_iss_validation = %t
   disable_local_ca_jwt = %t
 }`, backend, kubernetesCAcert, jwt, kubernetesPEMfile, issuer, disableIssValidation, disableLocalCaJwt)
+
+	return config
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #904 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-v -test.run TestAccKubernetesAuth'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -v -test.run TestAccKubernetesAuth -timeout 30m ./...

[...]

ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
=== RUN   TestAccKubernetesAuthBackendConfigDataSource_basic
--- PASS: TestAccKubernetesAuthBackendConfigDataSource_basic (3.32s)
=== RUN   TestAccKubernetesAuthBackendConfigDataSource_full
--- PASS: TestAccKubernetesAuthBackendConfigDataSource_full (3.05s)
=== RUN   TestAccKubernetesAuthBackendRoleDataSource_basic
--- PASS: TestAccKubernetesAuthBackendRoleDataSource_basic (1.82s)
=== RUN   TestAccKubernetesAuthBackendRoleDataSource_full
--- PASS: TestAccKubernetesAuthBackendRoleDataSource_full (1.79s)
=== RUN   TestAccKubernetesAuthBackendConfig_import
--- PASS: TestAccKubernetesAuthBackendConfig_import (13.00s)
=== RUN   TestAccKubernetesAuthBackendConfig_basic
--- PASS: TestAccKubernetesAuthBackendConfig_basic (1.75s)
=== RUN   TestAccKubernetesAuthBackendConfig_update
--- PASS: TestAccKubernetesAuthBackendConfig_update (3.05s)
=== RUN   TestAccKubernetesAuthBackendConfig_full
--- PASS: TestAccKubernetesAuthBackendConfig_full (1.74s)
=== RUN   TestAccKubernetesAuthBackendConfig_fullUpdate
--- PASS: TestAccKubernetesAuthBackendConfig_fullUpdate (4.38s)
=== RUN   TestAccKubernetesAuthBackendConfig_localCA
--- PASS: TestAccKubernetesAuthBackendConfig_localCA (3.00s)
=== RUN   TestAccKubernetesAuthBackendRole_import
--- PASS: TestAccKubernetesAuthBackendRole_import (2.16s)
=== RUN   TestAccKubernetesAuthBackendRole_basic
--- PASS: TestAccKubernetesAuthBackendRole_basic (1.72s)
=== RUN   TestAccKubernetesAuthBackendRole_update
--- PASS: TestAccKubernetesAuthBackendRole_update (3.10s)
=== RUN   TestAccKubernetesAuthBackendRole_full
--- PASS: TestAccKubernetesAuthBackendRole_full (1.71s)
=== RUN   TestAccKubernetesAuthBackendRole_fullUpdate
--- PASS: TestAccKubernetesAuthBackendRole_fullUpdate (6.91s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     56.008s

...
```
