### PR TITLE
Restore formatter, and length for AD secrets engine.

### DIFF
--- a/vault/resource_ad_secret_backend.go
+++ b/vault/resource_ad_secret_backend.go
@@ -82,6 +82,13 @@ func adSecretBackendResource() *schema.Resource {
 			Optional:    true,
 			Description: `Use anonymous bind to discover the bind DN of a user.`,
 		},
+		"formatter": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Deprecated:  `Formatter is deprecated and password_policy should be used with Vault >= 1.5.`,
+			Description: `Text to insert the password into, ex. "customPrefix{{PASSWORD}}customSuffix".`,
+		},
 		"groupattr": {
 			Type:        schema.TypeString,
 			Optional:    true,
@@ -107,6 +114,13 @@ func adSecretBackendResource() *schema.Resource {
 			Optional:    true,
 			Computed:    true,
 			Description: `The number of seconds after a Vault rotation where, if Active Directory shows a later rotation, it should be considered out-of-band.`,
+		},
+		"length": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Computed:    true,
+			Deprecated:  `Length is deprecated and password_policy should be used with Vault >= 1.5.`,
+			Description: `The desired length of passwords that Vault generates.`,
 		},
 		"local": {
 			Type:        schema.TypeBool,
@@ -258,6 +272,9 @@ func createConfigResource(d *schema.ResourceData, meta interface{}) error {
 	if v, ok := d.GetOkExists("discoverdn"); ok {
 		data["discoverdn"] = v
 	}
+	if v, ok := d.GetOkExists("formatter"); ok {
+		data["formatter"] = v
+	}
 	if v, ok := d.GetOkExists("groupattr"); ok {
 		data["groupattr"] = v
 	}
@@ -272,6 +289,9 @@ func createConfigResource(d *schema.ResourceData, meta interface{}) error {
 	}
 	if v, ok := d.GetOkExists("last_rotation_tolerance"); ok {
 		data["last_rotation_tolerance"] = v
+	}
+	if v, ok := d.GetOkExists("length"); ok {
+		data["length"] = v
 	}
 	if v, ok := d.GetOkExists("max_ttl"); ok {
 		data["max_ttl"] = v
@@ -391,6 +411,11 @@ func readConfigResource(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("error setting state key 'discoverdn': %s", err)
 		}
 	}
+	if val, ok := resp.Data["formatter"]; ok {
+		if err := d.Set("formatter", val); err != nil {
+			return fmt.Errorf("error setting state key 'formatter': %s", err)
+		}
+	}
 	if val, ok := resp.Data["groupattr"]; ok {
 		if err := d.Set("groupattr", val); err != nil {
 			return fmt.Errorf("error setting state key 'groupattr': %s", err)
@@ -414,6 +439,11 @@ func readConfigResource(d *schema.ResourceData, meta interface{}) error {
 	if val, ok := resp.Data["last_rotation_tolerance"]; ok {
 		if err := d.Set("last_rotation_tolerance", val); err != nil {
 			return fmt.Errorf("error setting state key 'last_rotation_tolerance': %s", err)
+		}
+	}
+	if val, ok := resp.Data["length"]; ok {
+		if err := d.Set("length", val); err != nil {
+			return fmt.Errorf("error setting state key 'length': %s", err)
 		}
 	}
 	if val, ok := resp.Data["max_ttl"]; ok {
@@ -540,6 +570,9 @@ func updateConfigResource(d *schema.ResourceData, meta interface{}) error {
 	if raw, ok := d.GetOk("discoverdn"); ok {
 		data["discoverdn"] = raw
 	}
+	if raw, ok := d.GetOk("formatter"); ok {
+		data["formatter"] = raw
+	}
 	if raw, ok := d.GetOk("groupattr"); ok {
 		data["groupattr"] = raw
 	}
@@ -554,6 +587,9 @@ func updateConfigResource(d *schema.ResourceData, meta interface{}) error {
 	}
 	if raw, ok := d.GetOk("last_rotation_tolerance"); ok {
 		data["last_rotation_tolerance"] = raw
+	}
+	if raw, ok := d.GetOk("length"); ok {
+		data["length"] = raw
 	}
 	if raw, ok := d.GetOk("max_ttl"); ok {
 		data["max_ttl"] = raw

--- a/website/docs/guides/version_3_upgrade.html.markdown
+++ b/website/docs/guides/version_3_upgrade.html.markdown
@@ -72,7 +72,6 @@ state changes in the meantime.
 
 - [Data Source: `vault_kubernetes_auth_backend_role`](#data-source-vault_kubernetes_auth_backend_role)
 
-- [Resource: `vault_ad_secret_backend`](#resource-vault_ad_secret_backend)
 - [Resource: `vault_approle_auth_backend_role`](#resource-vault_approle_auth_backend_role)
 - [Resource: `vault_auth_backend`](#resource-vault_auth_backend)
 - [Resource: `vault_aws_auth_backend_role`](#resource-vault_aws_auth_backend_role)
@@ -142,17 +141,6 @@ The following deprecated fields have been removed:
 * `period` - use `token_period` instead.
 
 * `num_uses` - use `token_num_uses` instead.
-
-_Specifying any of the fields above in your config or trying to interpolate them in your config will raise an error._
-
-## Resource: `vault_ad_secret_backend`
-
-### Deprecated fields have been removed
-The following deprecated fields have been removed:
-
-* `formatter` - use `password_policy` instead.
-
-* `length` - use `password_policy` instead.
 
 _Specifying any of the fields above in your config or trying to interpolate them in your config will raise an error._
 

--- a/website/docs/r/ad_secret_backend.html.md
+++ b/website/docs/r/ad_secret_backend.html.md
@@ -64,8 +64,7 @@ defaults to true.
 
 * `discoverdn` - (Optional) Use anonymous bind to discover the bind Distinguished Name of a user.
 
-* `formatter` - (Optional) Text to insert the password into, ex. "customPrefix{{PASSWORD}}customSuffix". This
-setting is deprecated and should instead use `password_policy`.
+* `formatter` - (Optional)  **Deprecated** use `password_policy`. Text to insert the password into, ex. "customPrefix{{PASSWORD}}customSuffix".
 
 * `groupattr` - (Optional) LDAP attribute to follow on objects returned by <groupfilter> in order to enumerate
 user group membership. Examples: `cn` or `memberOf`, etc. Defaults to `cn`.
@@ -81,8 +80,7 @@ Defaults to `false`.
 * `last_rotation_tolerance` - (Optional) The number of seconds after a Vault rotation where, if Active Directory
 shows a later rotation, it should be considered out-of-band
 
-* `length` - (Optional) The desired length of passwords that Vault generates. This
-setting is deprecated and should instead use `password_policy`.
+* `length` - (Optional) **Deprecated** use `password_policy`. The desired length of passwords that Vault generates.
 
 * `local` - (Optional) Mark the secrets engine as local-only. Local engines are not replicated or removed by
 replication.Tolerance duration to use when checking the last rotation time.


### PR DESCRIPTION
Partially reverts 61935a9321c68ef7f09f3d568287d955a2311c12 #1207

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1253 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
