### PR TITLE
Changed token argument to optional

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -98,7 +98,7 @@ variables in order to keep credential information out of the configuration.
   `VAULT_ADDR` in the Terraform process environment will be set to the
   value of the `address` argument from this provider. By default, this is false.
 
-* `token` - (Required) Vault token that will be used by Terraform to
+* `token` - (Optional) Vault token that will be used by Terraform to
   authenticate. May be set via the `VAULT_TOKEN` environment variable.
   If none is otherwise supplied, Terraform will attempt to read it from
   `~/.vault-token` (where the vault command stores its current token).
@@ -106,7 +106,9 @@ variables in order to keep credential information out of the configuration.
   with a short TTL to limit the exposure of any requested secrets, unless
   `skip_child_token` is set to `true` (see below). Note that
   the given token must have the update capability on the auth/token/create
-  path in Vault in order to create child tokens.
+  path in Vault in order to create child tokens.  A token is required for
+  the provider.  A token can explicitly set via token argument, alternatively 
+  a token can be implicitly set via an auth_login block.
 
 * `token_name` - (Optional) Token name, that will be used by Terraform when
   creating the child token (`display_name`). This is useful to provide a reference of the


### PR DESCRIPTION
The token argument is not a required argument.  A token is required but a token can be acquired via auth_login or explicitly set with the token argument.  Corrected docs to reflect this option.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
