### PR TITLE
Add `auto_rotate_interval` to Transit Key backend

### DIFF
--- a/vault/resource_transit_secret_backend_key.go
+++ b/vault/resource_transit_secret_backend_key.go
@@ -77,6 +77,7 @@ func transitSecretBackendKeyResource() *schema.Resource {
 			"auto_rotate_interval": {
 				Type:        schema.TypeInt,
 				Optional:    true,
+				Computed:    true,
 				Description: "Amount of time the key should live before being automatically rotated. A value of 0 disables automatic rotation for the key.",
 			},
 			"type": {

--- a/vault/resource_transit_secret_backend_key.go
+++ b/vault/resource_transit_secret_backend_key.go
@@ -75,7 +75,7 @@ func transitSecretBackendKeyResource() *schema.Resource {
 				Default:     false,
 			},
 			"auto_rotate_interval": {
-				Type:        schema.TypeString,
+				Type:        schema.TypeInt,
 				Optional:    true,
 				Description: "Amount of time the key should live before being automatically rotated. A value of 0 disables automatic rotation for the key.",
 			},
@@ -195,14 +195,14 @@ func transitSecretBackendKeyCreate(d *schema.ResourceData, meta interface{}) err
 		"deletion_allowed":       d.Get("deletion_allowed").(bool),
 		"exportable":             d.Get("exportable").(bool),
 		"allow_plaintext_backup": d.Get("allow_plaintext_backup").(bool),
-		"auto_rotate_interval":   d.Get("auto_rotate_interval").(string),
+		"auto_rotate_interval":   d.Get("auto_rotate_interval").(int),
 	}
 
 	data := map[string]interface{}{
 		"convergent_encryption": d.Get("convergent_encryption").(bool),
 		"derived":               d.Get("derived").(bool),
 		"type":                  d.Get("type").(string),
-		"auto_rotate_interval":  d.Get("auto_rotate_interval").(string),
+		"auto_rotate_interval":  d.Get("auto_rotate_interval").(int),
 	}
 
 	log.Printf("[DEBUG] Creating encryption key %s on transit secret backend %q", name, backend)
@@ -295,24 +295,43 @@ func transitSecretBackendKeyRead(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	d.Set("keys", keys)
-	d.Set("backend", backend)
-	d.Set("name", name)
-	d.Set("allow_plaintext_backup", secret.Data["allow_plaintext_backup"].(bool))
-	d.Set("auto_rotate_interval", secret.Data["auto_rotate_interval"].(string))
-	d.Set("convergent_encryption", convergentEncryption)
-	d.Set("deletion_allowed", secret.Data["deletion_allowed"].(bool))
-	d.Set("derived", secret.Data["derived"].(bool))
-	d.Set("exportable", secret.Data["exportable"].(bool))
-	d.Set("latest_version", latestVersion)
-	d.Set("min_available_version", minAvailableVersion)
-	d.Set("min_decryption_version", minDecryptionVersion)
-	d.Set("min_encryption_version", minEncryptionVersion)
-	d.Set("supports_decryption", secret.Data["supports_decryption"].(bool))
-	d.Set("supports_derivation", secret.Data["supports_derivation"].(bool))
-	d.Set("supports_encryption", secret.Data["supports_encryption"].(bool))
-	d.Set("supports_signing", secret.Data["supports_signing"].(bool))
-	d.Set("type", secret.Data["type"].(string))
+	if err := d.Set("keys", keys); err != nil {
+		return err
+	}
+	if err := d.Set("backend", backend); err != nil {
+		return err
+	}
+	if err := d.Set("name", name); err != nil {
+		return err
+	}
+	if err := d.Set("latest_version", latestVersion); err != nil {
+		return err
+	}
+	if err := d.Set("min_available_version", minAvailableVersion); err != nil {
+		return err
+	}
+	if err := d.Set("min_decryption_version", minDecryptionVersion); err != nil {
+		return err
+	}
+	if err := d.Set("min_encryption_version", minEncryptionVersion); err != nil {
+		return err
+	}
+	if err := d.Set("convergent_encryption", convergentEncryption); err != nil {
+		return err
+	}
+
+	fields := []string{
+		"allow_plaintext_backup", "auto_rotate_interval",
+		"deletion_allowed", "derived", "exportable",
+		"supports_decryption", "supports_derivation",
+		"supports_encryption", "supports_signing", "type",
+	}
+
+	for _, k := range fields {
+		if err := d.Set(k, secret.Data[k]); err != nil {
+			return err
+		}
+	}
 
 	return nil
 }

--- a/vault/resource_transit_secret_backend_key.go
+++ b/vault/resource_transit_secret_backend_key.go
@@ -74,6 +74,11 @@ func transitSecretBackendKeyResource() *schema.Resource {
 				Description: "If set, enables taking backup of named key in the plaintext format. Once set, this cannot be disabled.",
 				Default:     false,
 			},
+			"auto_rotate_interval": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Amount of time the key should live before being automatically rotated. A value of 0 disables automatic rotation for the key.",
+			},
 			"type": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -190,12 +195,14 @@ func transitSecretBackendKeyCreate(d *schema.ResourceData, meta interface{}) err
 		"deletion_allowed":       d.Get("deletion_allowed").(bool),
 		"exportable":             d.Get("exportable").(bool),
 		"allow_plaintext_backup": d.Get("allow_plaintext_backup").(bool),
+		"auto_rotate_interval":   d.Get("auto_rotate_interval").(string),
 	}
 
 	data := map[string]interface{}{
 		"convergent_encryption": d.Get("convergent_encryption").(bool),
 		"derived":               d.Get("derived").(bool),
 		"type":                  d.Get("type").(string),
+		"auto_rotate_interval":  d.Get("auto_rotate_interval").(string),
 	}
 
 	log.Printf("[DEBUG] Creating encryption key %s on transit secret backend %q", name, backend)
@@ -292,6 +299,7 @@ func transitSecretBackendKeyRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("backend", backend)
 	d.Set("name", name)
 	d.Set("allow_plaintext_backup", secret.Data["allow_plaintext_backup"].(bool))
+	d.Set("auto_rotate_interval", secret.Data["auto_rotate_interval"].(string))
 	d.Set("convergent_encryption", convergentEncryption)
 	d.Set("deletion_allowed", secret.Data["deletion_allowed"].(bool))
 	d.Set("derived", secret.Data["derived"].(bool))
@@ -321,6 +329,7 @@ func transitSecretBackendKeyUpdate(d *schema.ResourceData, meta interface{}) err
 		"deletion_allowed":       d.Get("deletion_allowed"),
 		"exportable":             d.Get("exportable"),
 		"allow_plaintext_backup": d.Get("allow_plaintext_backup"),
+		"auto_rotate_interval":   d.Get("auto_rotate_interval"),
 	}
 
 	_, err := client.Logical().Write(path+"/config", data)

--- a/vault/resource_transit_secret_backend_key_test.go
+++ b/vault/resource_transit_secret_backend_key_test.go
@@ -27,7 +27,7 @@ func TestTransitSecretBackendKey_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "backend", backend),
 					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "name", name),
 					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "deletion_allowed", "true"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "auto_rotate_interval", "1h0m0s"),
+					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "auto_rotate_interval", "3600"),
 					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "convergent_encryption", "false"),
 					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "derived", "false"),
 					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "exportable", "false"),
@@ -46,7 +46,7 @@ func TestTransitSecretBackendKey_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "backend", backend),
 					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "name", name),
 					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "deletion_allowed", "true"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "auto_rotate_interval", "24h0m0s"),
+					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "auto_rotate_interval", "7200"),
 					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "convergent_encryption", "false"),
 					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "derived", "false"),
 					resource.TestCheckResourceAttrSet("vault_transit_secret_backend_key.test", "keys.#"),
@@ -95,6 +95,7 @@ func TestTransitSecretBackendKey_rsa4096(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "supports_derivation", "false"),
 					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "supports_encryption", "true"),
 					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "supports_signing", "true"),
+					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "auto_rotate_interval", "0"),
 				),
 			},
 			{
@@ -112,6 +113,7 @@ func TestTransitSecretBackendKey_rsa4096(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "supports_derivation", "false"),
 					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "supports_encryption", "true"),
 					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "supports_signing", "true"),
+					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "auto_rotate_interval", "0"),
 					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "min_decryption_version", "1"),
 					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "min_encryption_version", "1"),
 					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "deletion_allowed", "true"),
@@ -159,7 +161,7 @@ resource "vault_transit_secret_backend_key" "test" {
   backend = vault_mount.transit.path
   name = "%s"
   deletion_allowed = true
-  auto_rotate_interval = "1h0m0s"
+  auto_rotate_interval = 3600
 }
 `, path, name)
 }
@@ -213,7 +215,7 @@ resource "vault_transit_secret_backend_key" "test" {
   min_decryption_version = 1
   min_encryption_version = 1
   deletion_allowed       = true
-  auto_rotate_interval   = "24h0m0s"
+  auto_rotate_interval   = 7200
   exportable             = true
   allow_plaintext_backup = true
 }

--- a/vault/resource_transit_secret_backend_key_test.go
+++ b/vault/resource_transit_secret_backend_key_test.go
@@ -27,6 +27,7 @@ func TestTransitSecretBackendKey_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "backend", backend),
 					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "name", name),
 					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "deletion_allowed", "true"),
+					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "auto_rotate_interval", "1h0m0s"),
 					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "convergent_encryption", "false"),
 					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "derived", "false"),
 					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "exportable", "false"),
@@ -45,6 +46,7 @@ func TestTransitSecretBackendKey_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "backend", backend),
 					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "name", name),
 					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "deletion_allowed", "true"),
+					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "auto_rotate_interval", "24h0m0s"),
 					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "convergent_encryption", "false"),
 					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "derived", "false"),
 					resource.TestCheckResourceAttrSet("vault_transit_secret_backend_key.test", "keys.#"),
@@ -157,6 +159,7 @@ resource "vault_transit_secret_backend_key" "test" {
   backend = vault_mount.transit.path
   name = "%s"
   deletion_allowed = true
+  auto_rotate_interval = "1h0m0s"
 }
 `, path, name)
 }
@@ -210,6 +213,7 @@ resource "vault_transit_secret_backend_key" "test" {
   min_decryption_version = 1
   min_encryption_version = 1
   deletion_allowed       = true
+  auto_rotate_interval   = "24h0m0s"
   exportable             = true
   allow_plaintext_backup = true
 }

--- a/vault/resource_transit_secret_backend_key_test.go
+++ b/vault/resource_transit_secret_backend_key_test.go
@@ -14,8 +14,11 @@ import (
 )
 
 func TestTransitSecretBackendKey_basic(t *testing.T) {
+	testutil.SkipTestEnvSet(t, "SKIP_VAULT_NEXT_TESTS")
+
 	backend := acctest.RandomWithPrefix("transit")
 	name := acctest.RandomWithPrefix("key")
+	resourceName := "vault_transit_secret_backend_key.test"
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
@@ -24,43 +27,43 @@ func TestTransitSecretBackendKey_basic(t *testing.T) {
 			{
 				Config: testTransitSecretBackendKeyConfig_basic(name, backend),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "name", name),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "deletion_allowed", "true"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "auto_rotate_interval", "3600"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "convergent_encryption", "false"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "derived", "false"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "exportable", "false"),
-					resource.TestCheckResourceAttrSet("vault_transit_secret_backend_key.test", "keys.#"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "latest_version", "1"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "type", "aes256-gcm96"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "supports_decryption", "true"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "supports_derivation", "true"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "supports_encryption", "true"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "supports_signing", "false"),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "deletion_allowed", "true"),
+					resource.TestCheckResourceAttr(resourceName, "auto_rotate_interval", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "convergent_encryption", "false"),
+					resource.TestCheckResourceAttr(resourceName, "derived", "false"),
+					resource.TestCheckResourceAttr(resourceName, "exportable", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "keys.#"),
+					resource.TestCheckResourceAttr(resourceName, "latest_version", "1"),
+					resource.TestCheckResourceAttr(resourceName, "type", "aes256-gcm96"),
+					resource.TestCheckResourceAttr(resourceName, "supports_decryption", "true"),
+					resource.TestCheckResourceAttr(resourceName, "supports_derivation", "true"),
+					resource.TestCheckResourceAttr(resourceName, "supports_encryption", "true"),
+					resource.TestCheckResourceAttr(resourceName, "supports_signing", "false"),
 				),
 			},
 			{
 				Config: testTransitSecretBackendKeyConfig_updated(name, backend),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "name", name),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "deletion_allowed", "true"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "auto_rotate_interval", "7200"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "convergent_encryption", "false"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "derived", "false"),
-					resource.TestCheckResourceAttrSet("vault_transit_secret_backend_key.test", "keys.#"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "latest_version", "1"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "type", "aes256-gcm96"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "supports_decryption", "true"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "supports_derivation", "true"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "supports_encryption", "true"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "supports_signing", "false"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "min_decryption_version", "1"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "min_encryption_version", "1"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "deletion_allowed", "true"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "exportable", "true"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "allow_plaintext_backup", "true"),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "deletion_allowed", "true"),
+					resource.TestCheckResourceAttr(resourceName, "auto_rotate_interval", "7200"),
+					resource.TestCheckResourceAttr(resourceName, "convergent_encryption", "false"),
+					resource.TestCheckResourceAttr(resourceName, "derived", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "keys.#"),
+					resource.TestCheckResourceAttr(resourceName, "latest_version", "1"),
+					resource.TestCheckResourceAttr(resourceName, "type", "aes256-gcm96"),
+					resource.TestCheckResourceAttr(resourceName, "supports_decryption", "true"),
+					resource.TestCheckResourceAttr(resourceName, "supports_derivation", "true"),
+					resource.TestCheckResourceAttr(resourceName, "supports_encryption", "true"),
+					resource.TestCheckResourceAttr(resourceName, "supports_signing", "false"),
+					resource.TestCheckResourceAttr(resourceName, "min_decryption_version", "1"),
+					resource.TestCheckResourceAttr(resourceName, "min_encryption_version", "1"),
+					resource.TestCheckResourceAttr(resourceName, "deletion_allowed", "true"),
+					resource.TestCheckResourceAttr(resourceName, "exportable", "true"),
+					resource.TestCheckResourceAttr(resourceName, "allow_plaintext_backup", "true"),
 				),
 			},
 			{
@@ -72,8 +75,11 @@ func TestTransitSecretBackendKey_basic(t *testing.T) {
 }
 
 func TestTransitSecretBackendKey_rsa4096(t *testing.T) {
+	testutil.SkipTestEnvSet(t, "SKIP_VAULT_NEXT_TESTS")
+
 	backend := acctest.RandomWithPrefix("transit")
 	name := acctest.RandomWithPrefix("key")
+	resourceName := "vault_transit_secret_backend_key.test"
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
@@ -82,43 +88,43 @@ func TestTransitSecretBackendKey_rsa4096(t *testing.T) {
 			{
 				Config: testTransitSecretBackendKeyConfig_rsa4096(name, backend),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "name", name),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "deletion_allowed", "true"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "convergent_encryption", "false"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "derived", "false"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "exportable", "false"),
-					resource.TestCheckResourceAttrSet("vault_transit_secret_backend_key.test", "keys.#"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "latest_version", "1"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "type", "rsa-4096"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "supports_decryption", "true"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "supports_derivation", "false"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "supports_encryption", "true"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "supports_signing", "true"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "auto_rotate_interval", "0"),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "deletion_allowed", "true"),
+					resource.TestCheckResourceAttr(resourceName, "convergent_encryption", "false"),
+					resource.TestCheckResourceAttr(resourceName, "derived", "false"),
+					resource.TestCheckResourceAttr(resourceName, "exportable", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "keys.#"),
+					resource.TestCheckResourceAttr(resourceName, "latest_version", "1"),
+					resource.TestCheckResourceAttr(resourceName, "type", "rsa-4096"),
+					resource.TestCheckResourceAttr(resourceName, "supports_decryption", "true"),
+					resource.TestCheckResourceAttr(resourceName, "supports_derivation", "false"),
+					resource.TestCheckResourceAttr(resourceName, "supports_encryption", "true"),
+					resource.TestCheckResourceAttr(resourceName, "supports_signing", "true"),
+					resource.TestCheckResourceAttr(resourceName, "auto_rotate_interval", "0"),
 				),
 			},
 			{
 				Config: testTransitSecretBackendKeyConfig_rsa4096updated(name, backend),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "name", name),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "deletion_allowed", "true"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "convergent_encryption", "false"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "derived", "false"),
-					resource.TestCheckResourceAttrSet("vault_transit_secret_backend_key.test", "keys.#"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "latest_version", "1"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "type", "rsa-4096"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "supports_decryption", "true"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "supports_derivation", "false"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "supports_encryption", "true"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "supports_signing", "true"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "auto_rotate_interval", "0"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "min_decryption_version", "1"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "min_encryption_version", "1"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "deletion_allowed", "true"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "exportable", "true"),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "allow_plaintext_backup", "true"),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "deletion_allowed", "true"),
+					resource.TestCheckResourceAttr(resourceName, "convergent_encryption", "false"),
+					resource.TestCheckResourceAttr(resourceName, "derived", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "keys.#"),
+					resource.TestCheckResourceAttr(resourceName, "latest_version", "1"),
+					resource.TestCheckResourceAttr(resourceName, "type", "rsa-4096"),
+					resource.TestCheckResourceAttr(resourceName, "supports_decryption", "true"),
+					resource.TestCheckResourceAttr(resourceName, "supports_derivation", "false"),
+					resource.TestCheckResourceAttr(resourceName, "supports_encryption", "true"),
+					resource.TestCheckResourceAttr(resourceName, "supports_signing", "true"),
+					resource.TestCheckResourceAttr(resourceName, "auto_rotate_interval", "0"),
+					resource.TestCheckResourceAttr(resourceName, "min_decryption_version", "1"),
+					resource.TestCheckResourceAttr(resourceName, "min_encryption_version", "1"),
+					resource.TestCheckResourceAttr(resourceName, "deletion_allowed", "true"),
+					resource.TestCheckResourceAttr(resourceName, "exportable", "true"),
+					resource.TestCheckResourceAttr(resourceName, "allow_plaintext_backup", "true"),
 				),
 			},
 		},
@@ -128,6 +134,7 @@ func TestTransitSecretBackendKey_rsa4096(t *testing.T) {
 func TestTransitSecretBackendKey_import(t *testing.T) {
 	backend := acctest.RandomWithPrefix("transit")
 	name := acctest.RandomWithPrefix("key")
+	resourceName := "vault_transit_secret_backend_key.test"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
@@ -136,13 +143,13 @@ func TestTransitSecretBackendKey_import(t *testing.T) {
 			{
 				Config: testTransitSecretBackendKeyConfig_basic(name, backend),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_transit_secret_backend_key.test", "name", name),
-					resource.TestCheckResourceAttrSet("vault_transit_secret_backend_key.test", "keys.#"),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttrSet(resourceName, "keys.#"),
 				),
 			},
 			{
-				ResourceName:      "vault_transit_secret_backend_key.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},

--- a/vault/resource_transit_secret_backend_key_test.go
+++ b/vault/resource_transit_secret_backend_key_test.go
@@ -132,6 +132,8 @@ func TestTransitSecretBackendKey_rsa4096(t *testing.T) {
 }
 
 func TestTransitSecretBackendKey_import(t *testing.T) {
+	testutil.SkipTestEnvSet(t, "SKIP_VAULT_NEXT_TESTS")
+
 	backend := acctest.RandomWithPrefix("transit")
 	name := acctest.RandomWithPrefix("key")
 	resourceName := "vault_transit_secret_backend_key.test"

--- a/website/docs/r/transit_secret_backend_key.html.md
+++ b/website/docs/r/transit_secret_backend_key.html.md
@@ -53,6 +53,8 @@ The following arguments are supported:
 
 * `min_encryption_version` - (Optional) Minimum key version to use for encryption
 
+* `auto_rotate_interval` - (Optional) Amount of time the key should live before being automatically rotated. A value of 0 disables automatic rotation for the key
+
 ## Attributes Reference
 
 * `keys` - List of key versions in the keyring. This attribute is zero-indexed and will contain a map of values depending on the `type` of the encryption key.

--- a/website/docs/r/transit_secret_backend_key.html.md
+++ b/website/docs/r/transit_secret_backend_key.html.md
@@ -53,7 +53,8 @@ The following arguments are supported:
 
 * `min_encryption_version` - (Optional) Minimum key version to use for encryption
 
-* `auto_rotate_interval` - (Optional) Amount of time the key should live before being automatically rotated. A value of 0 disables automatic rotation for the key
+* `auto_rotate_interval` - (Optional) Amount of time the key should live before being automatically rotated.
+  A value of 0 disables automatic rotation for the key.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR adds an `auto_rotate_interval` field to the Transit Secret Backend Key resource. 
Corresponding Vault PR: https://github.com/hashicorp/vault/pull/13691

Output from Acceptance Tests:
```
$ make testacc TESTARGS='-v -run TestTransitSecretBackendKey'
=== RUN   TestTransitSecretBackendKey_basic
--- PASS: TestTransitSecretBackendKey_basic (4.71s)
=== RUN   TestTransitSecretBackendKey_rsa4096
--- PASS: TestTransitSecretBackendKey_rsa4096 (5.53s)
=== RUN   TestTransitSecretBackendKey_import
--- PASS: TestTransitSecretBackendKey_import (2.13s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     13.264s
```