### PR TITLE
Fix: properly detect the db plugin name on import

### DIFF
--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -1284,7 +1284,7 @@ func validateDBPluginName(s string) error {
 	}
 
 	return fmt.Errorf("unsupported database plugin name %q, must begin with one of: %s", s,
-		strings.Join(pluginPrefixes, ","))
+		strings.Join(pluginPrefixes, ", "))
 }
 
 func getSortedPluginPrefixes() []string {

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -374,7 +374,7 @@ func TestAccDatabaseSecretBackendConnection_mssql(t *testing.T) {
 				ResourceName:            testDefaultDatabaseSecretBackendResource,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"verify_connection", "mssql.0.password"},
+				ImportStateVerifyIgnore: []string{"verify_connection", "mssql.0.password", "mssql.0.connection_url"},
 			},
 		},
 	})
@@ -1609,7 +1609,7 @@ func Test_getDBEngineFromResp(t *testing.T) {
 			},
 		},
 		{
-			name: "variant",
+			name: "unsupported",
 			engines: []*dbEngine{
 				{
 					name:              "foo",

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -1625,6 +1625,38 @@ func Test_getDBEngineFromResp(t *testing.T) {
 			expectErr: fmt.Errorf("no supported database engines found for plugin %q", "bar-custom"),
 		},
 		{
+			name: "invalid-empty-prefix",
+			engines: []*dbEngine{
+				{
+					name: "foo",
+				},
+			},
+			r: &api.Secret{
+				Data: map[string]interface{}{
+					"plugin_name": "bar-custom",
+				},
+			},
+			want: nil,
+			expectErr: fmt.Errorf(
+				"empty plugin prefix, no default plugin name set for dbEngine %q", "foo"),
+		},
+		{
+			name: "invalid-empty-plugin-name",
+			engines: []*dbEngine{
+				{
+					name:              "foo",
+					defaultPluginName: "foo" + dbPluginSuffix,
+				},
+			},
+			r: &api.Secret{
+				Data: map[string]interface{}{
+					"plugin_name": "",
+				},
+			},
+			want:      nil,
+			expectErr: fmt.Errorf(`invalid response data, "plugin_name" is empty`),
+		},
+		{
 			name: "invalid-data",
 			r: &api.Secret{
 				Data: map[string]interface{}{},

--- a/website/docs/r/database_secret_backend_connection.md
+++ b/website/docs/r/database_secret_backend_connection.md
@@ -45,7 +45,9 @@ The following arguments are supported:
 
 * `backend` - (Required) The unique name of the Vault mount to configure.
 
-* `plugin_name` - (Optional) Specifies the name of the plugin to use.
+* `plugin_name` - (Optional) Specifies the name of the plugin to use. All values must be prefixed
+ to match the corresponding database engine directive.
+ For example the `plugin_name` for the `mysql_aurora` engine must begin with `mysql-aurora`. Note the hyphenation.
 
 * `verify_connection` - (Optional) Whether the connection should be verified on
   initial configuration or not.


### PR DESCRIPTION
- Previously the import of database_secret_backend_connection resource
  instance would fail because there was no way to determine what the
  corresponding dbEngine should be.

Fixes:
- ensure that the plugin_name field conforms to a know set of database
  plugin prefixes.
- add methods for getting the dbEngine by database plugin prefix.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #1288 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-v -test.run TestAccDatabaseSecretBackendConnection_mssql'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -v -test.run TestAccDatabaseSecretBackendConnection_mssql -timeout 30m ./...


=== RUN   TestAccDatabaseSecretBackendConnection_mssql
--- PASS: TestAccDatabaseSecretBackendConnection_mssql (11.80s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     12.606s

...
```
