### PR TITLE
Fix nil pointer during duplicate group name creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.4.0 (Unreleased)
+BUGS:
+* `resource/identity_group`: Report an error upon duplicate resource creation failure. Document group name caveats. ([#1352](https://github.com/hashicorp/terraform-provider-vault/pull/1352))
+
 ## 3.3.0 (February 17, 2022)
 FEATURES:
 * Add KMIP support: new resources `vault_kmip_secret_backend`, `vault_kmip_secret_scope` and `vault_kmip_secret_role` ([#1339](https://github.com/hashicorp/terraform-provider-vault/pull/1339))

--- a/vault/resource_identity_group_test.go
+++ b/vault/resource_identity_group_test.go
@@ -3,6 +3,7 @@ package vault
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -109,6 +110,39 @@ func TestAccIdentityGroupExternal(t *testing.T) {
 			{
 				Config: testAccIdentityGroupConfig(group),
 				Check:  testAccIdentityGroupCheckAttrs(),
+			},
+		},
+	})
+}
+
+func TestAccIdentityGroup_DuplicateCreate(t *testing.T) {
+	// group identity names are stored in lower case,
+	// this test attempts to create two resources with different casing for the
+	// same lower case group name.
+	group := fmt.Sprintf("test_group_%d", acctest.RandInt())
+	config := fmt.Sprintf(`
+resource "vault_identity_group" "test_lower" {
+  name     = %q
+  type     = "external"
+  policies = ["default"]
+}
+
+resource "vault_identity_group" "test_upper" {
+  name     = %q
+  type     = "external"
+  policies = ["default"]
+}
+`, group, strings.ToUpper(group[0:1])+group[1:])
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckIdentityGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				ExpectError: regexp.MustCompile(
+					fmt.Sprintf(`(?i)failed to create identity group %q, reason=group already exists .+`, group)),
 			},
 		},
 	})

--- a/website/docs/r/identity_group.html.md
+++ b/website/docs/r/identity_group.html.md
@@ -42,6 +42,37 @@ resource "vault_identity_group" "group" {
 }
 ```
 
+## Caveats
+
+It's important to note that Vault identity groups names are *case-insensitive*. For example the following resources would be equivalent.
+Applying this configuration would result in the provider failing to create one of the identity groups, since the resources share the same `name`.
+
+This sort of pattern should be avoided:
+```hcl
+resource "vault_identity_group" "internal" {
+  # this duplicates the resource below
+  name     = "internal"
+  type     = "internal"
+  policies = ["dev", "test"]
+
+  metadata = {
+    version = "2"
+  }
+}
+
+resource "vault_identity_group" "Internal" {
+  # this duplicates the resource above
+  name     = "Internal"
+  type     = "internal"
+  policies = ["dev", "test"]
+
+  metadata = {
+    version = "2"
+  }
+}
+```
+
+
 ## Argument Reference
 
 The following arguments are supported:


### PR DESCRIPTION
This PR fixes a nil pointer whenever a duplicate identity group is being created within the same apply operation.

Fixes:
- don't blow up when constructing the error message
- provide a more meaningful error message
- document usage patterns that should be avoided for identity groups

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1351 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-v -test.run TestAccIdentityGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -v -test.run TestAccIdentityGroup -timeout 30m ./...

[...]

ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
=== RUN   TestAccIdentityGroupAlias
--- PASS: TestAccIdentityGroupAlias (1.83s)
=== RUN   TestAccIdentityGroupAliasUpdate
--- PASS: TestAccIdentityGroupAliasUpdate (3.20s)
=== RUN   TestAccIdentityGroupMemberEntityIdsExclusiveEmpty
--- PASS: TestAccIdentityGroupMemberEntityIdsExclusiveEmpty (4.38s)
=== RUN   TestAccIdentityGroupMemberEntityIdsExclusive
    resource_identity_group_member_entity_ids_test.go:53: &{{{{0 0} 0 0 0 0} [] {0xc000a32b60} false false false false map[] map[] []  [] false 0xc000cb2420 false 0 0 testing.tRunner 0xc000682820 1 [17887630 17877282 17887295 17882525 30629611 17013223 17214849] TestAccIdentityGroupMemberEntityIdsExclusive {13869986855062114408 9425681177 0x2d1cce0} 0 0xc000355800 0xc00010e380 [] {0 0}  <nil> 0} false false 0xc0000f7950}
--- SKIP: TestAccIdentityGroupMemberEntityIdsExclusive (0.00s)
=== RUN   TestAccIdentityGroupMemberEntityIdsNonExclusiveEmpty
--- PASS: TestAccIdentityGroupMemberEntityIdsNonExclusiveEmpty (4.49s)
=== RUN   TestAccIdentityGroupMemberEntityIdsNonExclusive
    resource_identity_group_member_entity_ids_test.go:123: &{{{{0 0} 0 0 0 0} [] {0xc000a32340} false false false false map[] map[] []  [] false 0xc000cb2420 false 0 0 testing.tRunner 0xc000682820 1 [17887630 17877282 17887295 17882525 30629611 17013223 17214849] TestAccIdentityGroupMemberEntityIdsNonExclusive {13869986859922917528 13917651242 0x2d1cce0} 0 0xc000354f60 0xc0011c80e0 [] {0 0}  <nil> 0} false false 0xc0000f7950}
--- SKIP: TestAccIdentityGroupMemberEntityIdsNonExclusive (0.00s)
=== RUN   TestAccIdentityGroupPoliciesExclusive
--- PASS: TestAccIdentityGroupPoliciesExclusive (3.02s)
=== RUN   TestAccIdentityGroupPoliciesNonExclusive
--- PASS: TestAccIdentityGroupPoliciesNonExclusive (3.09s)
=== RUN   TestAccIdentityGroup
--- PASS: TestAccIdentityGroup (1.68s)
=== RUN   TestAccIdentityGroupUpdate
--- PASS: TestAccIdentityGroupUpdate (7.07s)
=== RUN   TestAccIdentityGroupExternal
--- PASS: TestAccIdentityGroupExternal (1.67s)
=== RUN   TestAccIdentityGroup_DuplicateCreate
--- PASS: TestAccIdentityGroup_DuplicateCreate (0.97s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     32.025s


...
```
