### PR TITLE
Fix type assert panic in setCAChain()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 3.4.0 (Unreleased)
+## 3.3.1 (Unreleased)
 BUGS:
 * `resource/identity_group`: Report an error upon duplicate resource creation failure. Document group name caveats. ([#1352](https://github.com/hashicorp/terraform-provider-vault/pull/1352))
+* `resource/pki_secret_backend_root_sign_intermediate`: Fix panic when reading `ca_chain` from Vault ([#1357](https://github.com/hashicorp/terraform-provider-vault/issues/1357)
 
 ## 3.3.0 (February 17, 2022)
 FEATURES:

--- a/vault/resource_pki_secret_backend_root_sign_intermediate.go
+++ b/vault/resource_pki_secret_backend_root_sign_intermediate.go
@@ -303,7 +303,14 @@ func setCAChain(d *schema.ResourceData, resp *api.Secret) error {
 	field := "ca_chain"
 	var caChain []string
 	if v, ok := resp.Data[field]; ok && v != nil {
-		caChain = v.([]string)
+		switch v := v.(type) {
+		case []interface{}:
+			for _, v := range v {
+				caChain = append(caChain, v.(string))
+			}
+		default:
+			return fmt.Errorf("response contains an unexpected type %T for %q", v, field)
+		}
 	}
 
 	// provide the CAChain from the issuing_ca and the intermediate CA certificate


### PR DESCRIPTION
Ensure that the provider does not panic when handling the `ca_chain`.

Add extensive unit tests for `setCAChain()`.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1357 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-v -test.run Test_setCAChain'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -v -test.run Test_setCAChain -timeout 30m ./...

ok      github.com/hashicorp/terraform-provider-vault/util      0.674s [no tests to run]
=== RUN   Test_setCAChain
=== RUN   Test_setCAChain/empty-ca-chain
=== RUN   Test_setCAChain/absent-ca-chain
=== RUN   Test_setCAChain/populated-ca-chain
=== RUN   Test_setCAChain/invalid-ca-chain-type
=== RUN   Test_setCAChain/missing-intermediate-cert
=== RUN   Test_setCAChain/missing-issuing-ca
--- PASS: Test_setCAChain (0.00s)
    --- PASS: Test_setCAChain/empty-ca-chain (0.00s)
    --- PASS: Test_setCAChain/absent-ca-chain (0.00s)
    --- PASS: Test_setCAChain/populated-ca-chain (0.00s)
    --- PASS: Test_setCAChain/invalid-ca-chain-type (0.00s)
    --- PASS: Test_setCAChain/missing-intermediate-cert (0.00s)
    --- PASS: Test_setCAChain/missing-issuing-ca (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     2.932s

[...]

$ make testacc TESTARGS='-v -test.run TestPkiSecretBackendRootSignIntermediate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -v -test.run TestPkiSecretBackendRootSignIntermediate -timeout 30m ./...

ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
=== RUN   TestPkiSecretBackendRootSignIntermediate_basic_default
--- PASS: TestPkiSecretBackendRootSignIntermediate_basic_default (5.03s)
=== RUN   TestPkiSecretBackendRootSignIntermediate_basic_pem
--- PASS: TestPkiSecretBackendRootSignIntermediate_basic_pem (2.45s)
=== RUN   TestPkiSecretBackendRootSignIntermediate_basic_der
--- PASS: TestPkiSecretBackendRootSignIntermediate_basic_der (3.19s)
=== RUN   TestPkiSecretBackendRootSignIntermediate_basic_pem_bundle
--- PASS: TestPkiSecretBackendRootSignIntermediate_basic_pem_bundle (3.41s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     14.564s

```
