### PR TITLE
Ensure all callers of readEntity() properly handle errEntityNotFound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## 3.3.1 (Unreleased)
 BUGS:
 * `resource/identity_group`: Report an error upon duplicate resource creation failure. Document group name caveats. ([#1352](https://github.com/hashicorp/terraform-provider-vault/pull/1352))
-* `resource/pki_secret_backend_root_sign_intermediate`: Fix panic when reading `ca_chain` from Vault ([#1357](https://github.com/hashicorp/terraform-provider-vault/issues/1357)
+* `resource/pki_secret_backend_root_sign_intermediate`: Fix panic when reading `ca_chain` from Vault ([#1357](https://github.com/hashicorp/terraform-provider-vault/issues/1357))
 * `resource/raft_snapshot_agent_config`: Properly handle nil response on read ([#1360](https://github.com/hashicorp/terraform-provider-vault/pull/1360))
+* `resource/identity_*`: Ensure non-existent entities are handled properly ([#1361](https://github.com/hashicorp/terraform-provider-vault/pull/1361))
 
 ## 3.3.0 (February 17, 2022)
 FEATURES:

--- a/vault/resource_identity_entity.go
+++ b/vault/resource_identity_entity.go
@@ -170,20 +170,20 @@ func identityEntityRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*api.Client)
 	id := d.Id()
 
+	log.Printf("[DEBUG] Read IdentityEntity %s", id)
 	resp, err := readIdentityEntity(client, id, d.IsNewResource())
 	if err != nil {
 		// We need to check if the secret_id has expired
-		if resp == nil && util.IsExpiredTokenErr(err) {
+		if util.IsExpiredTokenErr(err) {
 			return nil
 		}
-		return fmt.Errorf("error reading IdentityEntity %q: %s", id, err)
-	}
 
-	log.Printf("[DEBUG] Read IdentityEntity %s", id)
-	if resp == nil {
-		log.Printf("[WARN] IdentityEntity %q not found, removing from state", id)
-		d.SetId("")
-		return nil
+		if isIdentityNotFoundError(err) {
+			log.Printf("[WARN] IdentityEntity %q not found, removing from state", id)
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("error reading IdentityEntity %q: %w", id, err)
 	}
 
 	for _, k := range []string{"name", "metadata", "disabled", "policies"} {

--- a/vault/resource_identity_entity_policies.go
+++ b/vault/resource_identity_entity_policies.go
@@ -97,15 +97,15 @@ func identityEntityPoliciesRead(d *schema.ResourceData, meta interface{}) error 
 	client := meta.(*api.Client)
 	id := d.Id()
 
+	log.Printf("[DEBUG] Read IdentityEntityPolicies %s", id)
 	resp, err := readIdentityEntity(client, id, d.IsNewResource())
 	if err != nil {
+		if isIdentityNotFoundError(err) {
+			log.Printf("[WARN] IdentityEntityPolicies %q not found, removing from state", id)
+			d.SetId("")
+			return nil
+		}
 		return err
-	}
-	log.Printf("[DEBUG] Read IdentityEntityPolicies %s", id)
-	if resp == nil {
-		log.Printf("[WARN] IdentityEntityPolicies %q not found, removing from state", id)
-		d.SetId("")
-		return nil
 	}
 
 	d.Set("entity_id", id)
@@ -149,6 +149,9 @@ func identityEntityPoliciesDelete(d *schema.ResourceData, meta interface{}) erro
 	} else {
 		apiPolicies, err := readIdentityEntityPolicies(client, id)
 		if err != nil {
+			if isIdentityNotFoundError(err) {
+				return nil
+			}
 			return err
 		}
 		for _, policy := range d.Get("policies").(*schema.Set).List() {

--- a/vault/resource_identity_group.go
+++ b/vault/resource_identity_group.go
@@ -230,19 +230,20 @@ func identityGroupRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*api.Client)
 	id := d.Id()
 
+	log.Printf("[DEBUG] Read IdentityGroup %s", id)
 	resp, err := readIdentityGroup(client, id, d.IsNewResource())
 	if err != nil {
 		// We need to check if the secret_id has expired
 		if util.IsExpiredTokenErr(err) {
 			return nil
 		}
+
+		if isIdentityNotFoundError(err) {
+			log.Printf("[WARN] IdentityGroup %q not found, removing from state", id)
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("error reading IdentityGroup %q: %s", id, err)
-	}
-	log.Printf("[DEBUG] Read IdentityGroup %s", id)
-	if resp == nil {
-		log.Printf("[WARN] IdentityGroup %q not found, removing from state", id)
-		d.SetId("")
-		return nil
 	}
 
 	readFields := []string{"name", "type", "metadata", "member_entity_ids", "member_group_ids", "policies"}
@@ -318,9 +319,6 @@ func readIdentityGroupMemberEntityIds(client *api.Client, groupID string, retry 
 	resp, err := readIdentityGroup(client, groupID, retry)
 	if err != nil {
 		return nil, err
-	}
-	if resp == nil {
-		return nil, fmt.Errorf("error IdentityGroup %s does not exist", groupID)
 	}
 
 	if v, ok := resp.Data["member_entity_ids"]; ok && v != nil {

--- a/vault/resource_identity_group_policies.go
+++ b/vault/resource_identity_group_policies.go
@@ -97,19 +97,23 @@ func identityGroupPoliciesRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*api.Client)
 	id := d.Id()
 
+	log.Printf("[DEBUG] Read IdentityGroupPolicies %s", id)
 	resp, err := readIdentityGroup(client, id, d.IsNewResource())
 	if err != nil {
+		if isIdentityNotFoundError(err) {
+			log.Printf("[WARN] IdentityGroupPolicies %q not found, removing from state", id)
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
-	log.Printf("[DEBUG] Read IdentityGroupPolicies %s", id)
-	if resp == nil {
-		log.Printf("[WARN] IdentityGroupPolicies %q not found, removing from state", id)
-		d.SetId("")
-		return nil
-	}
 
-	d.Set("group_id", id)
-	d.Set("group_name", resp.Data["name"])
+	if err := d.Set("group_id", id); err != nil {
+		return err
+	}
+	if err := d.Set("group_name", resp.Data["name"]); err != nil {
+		return err
+	}
 
 	if d.Get("exclusive").(bool) {
 		if err = d.Set("policies", resp.Data["policies"]); err != nil {


### PR DESCRIPTION
In #1263 we added better support Vault CCC. This change also brought in a regression related to the handling of entity existence and read and delete methods. This PR should fix that regression.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-v -test.run TestAccIdentity'                                                                                                                                          
ok      github.com/hashicorp/terraform-provider-vault/util      0.435s [no tests to run]
=== RUN   TestAccIdentityEntityAlias
--- PASS: TestAccIdentityEntityAlias (3.38s)
=== RUN   TestAccIdentityEntityAlias_Update
--- PASS: TestAccIdentityEntityAlias_Update (3.24s)
=== RUN   TestAccIdentityEntityAlias_Metadata
--- PASS: TestAccIdentityEntityAlias_Metadata (3.18s)
=== RUN   TestAccIdentityEntityPoliciesExclusive
--- PASS: TestAccIdentityEntityPoliciesExclusive (3.01s)
=== RUN   TestAccIdentityEntityPoliciesNonExclusive
--- PASS: TestAccIdentityEntityPoliciesNonExclusive (3.12s)
=== RUN   TestAccIdentityEntity
--- PASS: TestAccIdentityEntity (1.66s)
=== RUN   TestAccIdentityEntityUpdate
--- PASS: TestAccIdentityEntityUpdate (2.91s)
=== RUN   TestAccIdentityEntityUpdateRemoveValues
--- PASS: TestAccIdentityEntityUpdateRemoveValues (2.93s)
=== RUN   TestAccIdentityEntityUpdateRemovePolicies
--- PASS: TestAccIdentityEntityUpdateRemovePolicies (2.93s)
=== RUN   TestAccIdentityGroupAlias
--- PASS: TestAccIdentityGroupAlias (1.79s)
=== RUN   TestAccIdentityGroupAliasUpdate
--- PASS: TestAccIdentityGroupAliasUpdate (3.22s)
=== RUN   TestAccIdentityGroupMemberEntityIdsExclusiveEmpty
--- PASS: TestAccIdentityGroupMemberEntityIdsExclusiveEmpty (4.38s)
=== RUN   TestAccIdentityGroupMemberEntityIdsExclusive
    resource_identity_group_member_entity_ids_test.go:53: &{{{{0 0} 0 0 0 0} [] {0xc000d38340} false false false false map[] map[] []  [] false 0xc000bce420 false 0 0 testing.tRunner 0xc0007024e0 1 [17887630 17877282 17887295 17882525 30633835 17013223 17214849] TestAccIdentityGroupMemberEntityIdsExclusive {13870639439441694416 35791417733 0x2d1ed00} 0 0xc000671b60 0xc000c4a230 [] {0 0}  <nil> 0} false false 0xc000928780}
--- SKIP: TestAccIdentityGroupMemberEntityIdsExclusive (0.00s)
=== RUN   TestAccIdentityGroupMemberEntityIdsNonExclusiveEmpty
--- PASS: TestAccIdentityGroupMemberEntityIdsNonExclusiveEmpty (4.57s)
=== RUN   TestAccIdentityGroupMemberEntityIdsNonExclusive
    resource_identity_group_member_entity_ids_test.go:123: &{{{{0 0} 0 0 0 0} [] {0xc001a14340} false false false false map[] map[] []  [] false 0xc000bce420 false 0 0 testing.tRunner 0xc0007024e0 1 [17887630 17877282 17887295 17882525 30633835 17013223 17214849] TestAccIdentityGroupMemberEntityIdsNonExclusive {13870639444311307712 40365941116 0x2d1ed00} 0 0xc0014283c0 0xc000dbc070 [] {0 0}  <nil> 0} false false 0xc000928780}
--- SKIP: TestAccIdentityGroupMemberEntityIdsNonExclusive (0.00s)
=== RUN   TestAccIdentityGroupPoliciesExclusive
--- PASS: TestAccIdentityGroupPoliciesExclusive (3.03s)
=== RUN   TestAccIdentityGroupPoliciesNonExclusive
--- PASS: TestAccIdentityGroupPoliciesNonExclusive (3.13s)
=== RUN   TestAccIdentityGroup
--- PASS: TestAccIdentityGroup (1.74s)
=== RUN   TestAccIdentityGroupUpdate
--- PASS: TestAccIdentityGroupUpdate (7.06s)
=== RUN   TestAccIdentityGroupExternal
--- PASS: TestAccIdentityGroupExternal (1.68s)
=== RUN   TestAccIdentityGroup_DuplicateCreate
--- PASS: TestAccIdentityGroup_DuplicateCreate (0.98s)
=== RUN   TestAccIdentityOidcKeyAllowedClientId
--- PASS: TestAccIdentityOidcKeyAllowedClientId (4.96s)
=== RUN   TestAccIdentityOidcKey
--- PASS: TestAccIdentityOidcKey (3.12s)
=== RUN   TestAccIdentityOidcKeyUpdate
--- PASS: TestAccIdentityOidcKeyUpdate (5.32s)
=== RUN   TestAccIdentityOidcRole
--- PASS: TestAccIdentityOidcRole (2.52s)
=== RUN   TestAccIdentityOidcRoleWithClientId
--- PASS: TestAccIdentityOidcRoleWithClientId (2.65s)
=== RUN   TestAccIdentityOidcRoleUpdate
--- PASS: TestAccIdentityOidcRoleUpdate (4.66s)
=== RUN   TestAccIdentityOidc
--- PASS: TestAccIdentityOidc (2.94s)

...
```
