### PR TITLE
New data resources: pki_access_credentials and consul_access_credentials

### DIFF
--- a/vault/data_source_consul_access_credentials.go
+++ b/vault/data_source_consul_access_credentials.go
@@ -1,0 +1,66 @@
+package vault
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/vault/api"
+)
+
+func consulAccessCredentialsDataSource() *schema.Resource {
+	return &schema.Resource{
+		// FIXME: Is it a faux pas to simply reuse an existing resource's Create?
+		Read: consulAccessCredentialsDataSourceRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of an existing role against which to create this Consul credential",
+			},
+			"backend": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The path of the Consul Secret Backend the role belongs to.",
+			},
+			"token": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The secret token.",
+			},
+			"accessor": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The consul accessor token.",
+			},
+		},
+	}
+}
+
+func consulAccessCredentialsDataSourceRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	backend := d.Get("backend").(string)
+	name := d.Get("name").(string)
+
+	path := fmt.Sprintf("%s/creds/%s", backend, name)
+
+	data := map[string]interface{}{}
+
+	log.Printf("[DEBUG] Requesting token from %s on Consul secret backend %q", name, backend)
+	secret, err := client.Logical().Write(path, data)
+	if err != nil {
+		return fmt.Errorf("error creating token from %s on Consul secret backend %q: %s", name, backend, err)
+	}
+	log.Printf("[DEBUG] Created token from %s on Consul secret backend %q: %s", name, backend, secret.LeaseID)
+	secretToken := secret.Data["token"].(string)
+	accessorToken := secret.Data["accessor"].(string)
+
+	d.SetId(secret.LeaseID)
+	d.Set("token", secretToken)
+	d.Set("accessor", accessorToken)
+
+	return nil
+}

--- a/vault/data_source_consul_access_credentials.go
+++ b/vault/data_source_consul_access_credentials.go
@@ -13,6 +13,7 @@ func consulAccessCredentialsDataSource() *schema.Resource {
 		// FIXME: Is it a faux pas to simply reuse an existing resource's Create?
 		Read: consulAccessCredentialsDataSourceRead,
 		Schema: map[string]*schema.Schema{
+			// FIXME: Should this be name or role? The data sources seem to be inconsistent regarding preference
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -35,6 +36,7 @@ func consulAccessCredentialsDataSource() *schema.Resource {
 				Computed:    true,
 				Description: "The consul accessor token.",
 			},
+			// FIXME: AWS access credential has lease information, do we need to do the same?
 		},
 	}
 }

--- a/vault/data_source_consul_access_credentials_test.go
+++ b/vault/data_source_consul_access_credentials_test.go
@@ -1,0 +1,41 @@
+package vault
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/hashicorp/terraform-provider-vault/testutil"
+)
+
+func TestAccDataSourceConsul_basic(t *testing.T) {
+	path := acctest.RandomWithPrefix("tf-test-consul")
+	accessor := "592fca4f-3ce9-4a00-8730-9a2fac6afabd"
+	token := "026a0c16-87cd-4c2d-b3f3-fb539f592b7e"
+	resource.Test(t, resource.TestCase{
+		Providers:    testProviders,
+		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		CheckDestroy: testAccConsulSecretBackendCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceConsul_initialConfig(path, token, accessor),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.vault_consul_access_credential.test", "path", path),
+					resource.TestCheckResourceAttr("data.vault_consul_access_credential.test", "token", token),
+					resource.TestCheckResourceAttr("data.vault_consul_access_credential.test", "accessor", accessor),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceConsul_initialConfig(path, token, accessor string) string {
+	return fmt.Sprintf(`
+data "vault_consul_access_credential" "test" {
+  path = "%s"
+  token = "%s"
+  accessor = "%s"
+}`, path, token, accessor)
+}

--- a/vault/data_source_pki_access_credentials.go
+++ b/vault/data_source_pki_access_credentials.go
@@ -15,6 +15,8 @@ func pkiAccessCredentialsDataSource() *schema.Resource {
 				Required:    true,
 				Description: "PKI backend to read credentials from.",
 			},
+			// FIXME: Should this be name or role? The data sources seem to be inconsistent regarding preference
+			// Using name does make it easy to invoke the pkiSecretBackednCertCreate function...
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -127,6 +129,7 @@ func pkiAccessCredentialsDataSource() *schema.Resource {
 				Computed:    true,
 				Description: "The certificate expiration.",
 			},
+			// FIXME: AWS access credential has lease information, do we need to do the same?
 		},
 	}
 }

--- a/vault/data_source_pki_access_credentials.go
+++ b/vault/data_source_pki_access_credentials.go
@@ -1,0 +1,132 @@
+package vault
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func pkiAccessCredentialsDataSource() *schema.Resource {
+	return &schema.Resource{
+		// FIXME: Is it a faux pas to simply reuse an existing resource's Create?
+		Read: pkiSecretBackendCertCreate,
+		Schema: map[string]*schema.Schema{
+			"backend": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "PKI backend to read credentials from.",
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Name of the role to create the certificate against.",
+			},
+			"common_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "CN of the certificate to create.",
+				ForceNew:    true,
+			},
+			"alt_names": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "List of alternative names.",
+				ForceNew:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"ip_sans": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "List of alternative IPs.",
+				ForceNew:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"uri_sans": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "List of alternative URIs.",
+				ForceNew:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"other_sans": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "List of other SANs.",
+				ForceNew:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"ttl": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    false,
+				Description: "Time to live.",
+			},
+			"format": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "The format of data.",
+				ForceNew:     true,
+				Default:      "pem",
+				ValidateFunc: validation.StringInSlice([]string{"pem", "der", "pem_bundle"}, false),
+			},
+			"private_key_format": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "The private key format.",
+				ForceNew:     true,
+				Default:      "der",
+				ValidateFunc: validation.StringInSlice([]string{"der", "pkcs8"}, false),
+			},
+			"exclude_cn_from_sans": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Flag to exclude CN from SANs.",
+				ForceNew:    true,
+			},
+			"certificate": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The certicate.",
+			},
+			"issuing_ca": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The issuing CA.",
+			},
+			"ca_chain": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The CA chain.",
+			},
+			"private_key": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The private key.",
+				Sensitive:   true,
+			},
+			"private_key_type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The private key type.",
+			},
+			"serial_number": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The serial number.",
+			},
+			"expiration": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "The certificate expiration.",
+			},
+		},
+	}
+}

--- a/vault/data_source_pki_access_credentials_test.go
+++ b/vault/data_source_pki_access_credentials_test.go
@@ -1,0 +1,119 @@
+package vault
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/hashicorp/terraform-provider-vault/testutil"
+)
+
+func TestAccDataSourcePkiSecretBackendCert_basic(t *testing.T) {
+	rootPath := "pki-root-" + strconv.Itoa(acctest.RandInt())
+	intermediatePath := "pki-intermediate-" + strconv.Itoa(acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testProviders,
+		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		CheckDestroy: testPkiSecretBackendCertDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testPkiSecretBackendCertConfig_basic(rootPath, intermediatePath),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.vault_pki_secret_backend_cert.test", "backend", intermediatePath),
+					resource.TestCheckResourceAttr("data.vault_pki_secret_backend_cert.test", "common_name", "cert.test.my.domain"),
+					resource.TestCheckResourceAttr("data.vault_pki_secret_backend_cert.test", "ttl", "720h"),
+					resource.TestCheckResourceAttr("data.vault_pki_secret_backend_cert.test", "uri_sans.#", "1"),
+					resource.TestCheckResourceAttr("data.vault_pki_secret_backend_cert.test", "uri_sans.0", "spiffe://test.my.domain"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourcePkiSecretBackendCertConfig_basic(rootPath string, intermediatePath string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "test-root" {
+  path = "%s"
+  type = "pki"
+  description = "test root"
+  default_lease_ttl_seconds = "8640000"
+  max_lease_ttl_seconds = "8640000"
+}
+
+resource "vault_mount" "test-intermediate" {
+  depends_on = [ "vault_mount.test-root" ]
+  path = "%s"
+  type = "pki"
+  description = "test intermediate"
+  default_lease_ttl_seconds = "86400"
+  max_lease_ttl_seconds = "86400"
+}
+
+resource "vault_pki_secret_backend_root_cert" "test" {
+  depends_on = [ "vault_mount.test-intermediate" ]
+  backend = vault_mount.test-root.path
+  type = "internal"
+  common_name = "my.domain"
+  ttl = "86400"
+  format = "pem"
+  private_key_format = "der"
+  key_type = "rsa"
+  key_bits = 4096
+  ou = "test"
+  organization = "test"
+  country = "test"
+  locality = "test"
+  province = "test"
+}
+
+resource "vault_pki_secret_backend_intermediate_cert_request" "test" {
+  depends_on = [ "vault_pki_secret_backend_root_cert.test" ]
+  backend = vault_mount.test-intermediate.path
+  type = "internal"
+  common_name = "test.my.domain"
+}
+
+resource "vault_pki_secret_backend_root_sign_intermediate" "test" {
+  depends_on = [ "vault_pki_secret_backend_intermediate_cert_request.test" ]
+  backend = vault_mount.test-root.path
+  csr = vault_pki_secret_backend_intermediate_cert_request.test.csr
+  common_name = "test.my.domain"
+  permitted_dns_domains = [".test.my.domain"]
+  ou = "test"
+  organization = "test"
+  country = "test"
+  locality = "test"
+  province = "test"
+}
+
+resource "vault_pki_secret_backend_intermediate_set_signed" "test" {
+  depends_on = [ "vault_pki_secret_backend_root_sign_intermediate.test" ]
+  backend = vault_mount.test-intermediate.path
+  certificate = vault_pki_secret_backend_root_sign_intermediate.test.certificate
+}
+
+resource "vault_pki_secret_backend_role" "test" {
+  depends_on = [ "vault_pki_secret_backend_intermediate_set_signed.test" ]
+  backend = vault_mount.test-intermediate.path
+  name = "test"
+  allowed_domains  = ["test.my.domain"]
+  allow_subdomains = true
+  allowed_uri_sans = ["spiffe://test.my.domain"]
+  max_ttl = "3600"
+  key_usage = ["DigitalSignature", "KeyAgreement", "KeyEncipherment"]
+}
+
+data "vault_pki_secret_backend_cert" "test" {
+  depends_on = [ "vault_pki_secret_backend_role.test" ]
+  backend = vault_mount.test-intermediate.path
+  name = vault_pki_secret_backend_role.test.name
+  common_name = "cert.test.my.domain"
+  uri_sans = ["spiffe://test.my.domain"]
+  ttl = "720h"
+  min_seconds_remaining = 60
+}`, rootPath, intermediatePath)
+}

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -276,6 +276,14 @@ var (
 			Resource:      genericSecretDataSource(),
 			PathInventory: []string{"/secret/data/{path}"},
 		},
+		"vault_pki_access_credentials": {
+			Resource:      pkiAccessCredentialsDataSource(),
+			PathInventory: []string{"/pki/issue/{name}"},
+		},
+		"vault_consul_access_credentials": {
+			Resource:      consulAccessCredentialsDataSource(),
+			PathInventory: []string{"/consul/creds/{name}"},
+		},
 		"vault_policy_document": {
 			Resource:      policyDocumentDataSource(),
 			PathInventory: []string{"/sys/policy/{name}"},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1332

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`data/pki_access_credentials`: New data source to issue PKI credentials
`data/consul_access_credentials`: New data source to issue Consul tokens
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run="(TestAccDataSourceConsul_basic|TestAccDataSourcePkiSecretBackendCert_basic)"'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -run="(TestAccDataSourceConsul_basic|TestAccDataSourcePkiSecretBackendCert_basic)" -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/codegen   (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
?       github.com/hashicorp/terraform-provider-vault/testutil  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
=== RUN   TestAccDataSourceConsul_basic
    data_source_consul_access_credentials_test.go:16: Step 1/1 error: Error running apply: exit status 1
        
        Error: error creating token from test on Consul secret backend "tf-test-consul-4061879306666987093": Error making API request.
        
        URL: PUT http://localhost:8200/v1/tf-test-consul-4061879306666987093/creds/test
        Code: 405. Errors:
        
        * 1 error occurred:
                * unsupported operation
        
        
        
          with data.vault_consul_access_credentials.test,
          on terraform_plugin_test.tf line 18, in data "vault_consul_access_credentials" "test":
          18: data "vault_consul_access_credentials" "test" {
        
--- FAIL: TestAccDataSourceConsul_basic (2.74s)
=== RUN   TestAccDataSourcePkiSecretBackendCert_basic
--- PASS: TestAccDataSourcePkiSecretBackendCert_basic (6.54s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-vault/vault     9.320s
FAIL
make: *** [GNUmakefile:15: testacc] Error 1
```

### TODOs

- [ ] Pass integration test of consul
- [x] Pass integration test of vault
- [x] Clear FIXMEs
