### PR TITLE
Add support for Consul roles

### DIFF
--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -16,6 +16,10 @@ import (
 	"github.com/mitchellh/go-homedir"
 )
 
+const (
+	EnvVarSkipVaultNext = "SKIP_VAULT_NEXT_TESTS"
+)
+
 func TestAccPreCheck(t *testing.T) {
 	FatalTestEnvUnset(t, "VAULT_ADDR", "VAULT_TOKEN")
 }

--- a/vault/resource_consul_secret_backend_role.go
+++ b/vault/resource_consul_secret_backend_role.go
@@ -47,7 +47,7 @@ func consulSecretBackendRoleResource() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
-			"roles": {
+			"consul_roles": {
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: `Set of Consul roles to attach to the token. Applicable for Vault 1.10+ with Consul 1.5+`,
@@ -123,8 +123,7 @@ func consulSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) erro
 	if v, ok := d.GetOkExists("local"); ok {
 		data["local"] = v
 	}
-	// to be consistent with the `policies` field name, we map `roles` to `consul_roles`
-	if v, ok := d.GetOkExists("roles"); ok {
+	if v, ok := d.GetOkExists("consul_roles"); ok {
 		data["consul_roles"] = v.(*schema.Set).List()
 	}
 
@@ -190,7 +189,7 @@ func consulSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error
 		"ttl":          "ttl",
 		"token_type":   "token_type",
 		"local":        "local",
-		"consul_roles": "roles",
+		"consul_roles": "consul_roles",
 	}
 
 	for k, v := range params {

--- a/vault/resource_consul_secret_backend_role_test.go
+++ b/vault/resource_consul_secret_backend_role_test.go
@@ -41,14 +41,14 @@ func TestConsulSecretBackendRole(t *testing.T) {
 
 	if v := os.Getenv(testutil.EnvVarSkipVaultNext); v == "" {
 		createTestCheckFuncs = append(createTestCheckFuncs,
-			resource.TestCheckResourceAttr(resourcePath, "roles.#", "1"),
-			resource.TestCheckResourceAttr(resourcePath, "roles.0", "role-0"),
+			resource.TestCheckResourceAttr(resourcePath, "consul_roles.#", "1"),
+			resource.TestCheckResourceAttr(resourcePath, "consul_roles.0", "role-0"),
 		)
 		updateTestCheckFuncs = append(updateTestCheckFuncs,
-			resource.TestCheckResourceAttr(resourcePath, "roles.#", "3"),
-			resource.TestCheckResourceAttr(resourcePath, "roles.0", "role-0"),
-			resource.TestCheckResourceAttr(resourcePath, "roles.1", "role-1"),
-			resource.TestCheckResourceAttr(resourcePath, "roles.2", "role-2"),
+			resource.TestCheckResourceAttr(resourcePath, "consul_roles.#", "3"),
+			resource.TestCheckResourceAttr(resourcePath, "consul_roles.0", "role-0"),
+			resource.TestCheckResourceAttr(resourcePath, "consul_roles.1", "role-1"),
+			resource.TestCheckResourceAttr(resourcePath, "consul_roles.2", "role-2"),
 		)
 	}
 	resource.Test(t, resource.TestCase{
@@ -105,7 +105,7 @@ resource "vault_consul_secret_backend_role" "test" {
     "foo"
   ]
 
-  roles = [
+  consul_roles = [
     "role-0",
     # canary to ensure roles is a Set
     "role-0",
@@ -137,7 +137,7 @@ resource "vault_consul_secret_backend_role" "test" {
     "foo",
     "bar",
   ]
-  roles = [
+  consul_roles = [
     "role-0",
     "role-1",
     "role-2",

--- a/vault/resource_github_auth_backend_test.go
+++ b/vault/resource_github_auth_backend_test.go
@@ -22,7 +22,7 @@ const testGHOrg = "hashicorp"
 func TestAccGithubAuthBackend_basic(t *testing.T) {
 	testutil.SkipTestAcc(t)
 	// TODO: remove once we can test against the vault-1.10 dev builds
-	testutil.SkipTestEnvSet(t, "SKIP_VAULT_NEXT_TESTS")
+	testutil.SkipTestEnvSet(t, testutil.EnvVarSkipVaultNext)
 
 	orgMeta := testutil.GetGHOrgResponse(t, testGHOrg)
 
@@ -69,7 +69,7 @@ func TestAccGithubAuthBackend_basic(t *testing.T) {
 func TestAccGithubAuthBackend_tuning(t *testing.T) {
 	testutil.SkipTestAcc(t)
 	// TODO: remove once we can test against the vault-1.10 dev builds
-	testutil.SkipTestEnvSet(t, "SKIP_VAULT_NEXT_TESTS")
+	testutil.SkipTestEnvSet(t, testutil.EnvVarSkipVaultNext)
 
 	orgMeta := testutil.GetGHOrgResponse(t, testGHOrg)
 
@@ -140,7 +140,7 @@ func TestAccGithubAuthBackend_tuning(t *testing.T) {
 func TestAccGithubAuthBackend_description(t *testing.T) {
 	testutil.SkipTestAcc(t)
 	// TODO: remove once we can test against the vault-1.10 dev builds
-	testutil.SkipTestEnvSet(t, "SKIP_VAULT_NEXT_TESTS")
+	testutil.SkipTestEnvSet(t, testutil.EnvVarSkipVaultNext)
 
 	orgMeta := testutil.GetGHOrgResponse(t, testGHOrg)
 

--- a/vault/resource_transit_secret_backend_key_test.go
+++ b/vault/resource_transit_secret_backend_key_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestTransitSecretBackendKey_basic(t *testing.T) {
-	testutil.SkipTestEnvSet(t, "SKIP_VAULT_NEXT_TESTS")
+	testutil.SkipTestEnvSet(t, testutil.EnvVarSkipVaultNext)
 
 	backend := acctest.RandomWithPrefix("transit")
 	name := acctest.RandomWithPrefix("key")
@@ -75,7 +75,7 @@ func TestTransitSecretBackendKey_basic(t *testing.T) {
 }
 
 func TestTransitSecretBackendKey_rsa4096(t *testing.T) {
-	testutil.SkipTestEnvSet(t, "SKIP_VAULT_NEXT_TESTS")
+	testutil.SkipTestEnvSet(t, testutil.EnvVarSkipVaultNext)
 
 	backend := acctest.RandomWithPrefix("transit")
 	name := acctest.RandomWithPrefix("key")
@@ -132,7 +132,7 @@ func TestTransitSecretBackendKey_rsa4096(t *testing.T) {
 }
 
 func TestTransitSecretBackendKey_import(t *testing.T) {
-	testutil.SkipTestEnvSet(t, "SKIP_VAULT_NEXT_TESTS")
+	testutil.SkipTestEnvSet(t, testutil.EnvVarSkipVaultNext)
 
 	backend := acctest.RandomWithPrefix("transit")
 	name := acctest.RandomWithPrefix("key")

--- a/website/docs/r/consul_secret_backend_role.html.md
+++ b/website/docs/r/consul_secret_backend_role.html.md
@@ -40,6 +40,8 @@ The following arguments are supported:
 * `name` - (Required) The name of the Consul secrets engine role to create.
 
 * `policies` - (Required) The list of Consul ACL policies to associate with these roles.
+ 
+* `roles` - (Optional) Set of Consul roles to attach to the token. Applicable for Vault 1.10+ with Consul 1.5+.
 
 * `max_ttl` - (Optional) Maximum TTL for leases associated with this role, in seconds.
 

--- a/website/docs/r/consul_secret_backend_role.html.md
+++ b/website/docs/r/consul_secret_backend_role.html.md
@@ -41,7 +41,7 @@ The following arguments are supported:
 
 * `policies` - (Required) The list of Consul ACL policies to associate with these roles.
  
-* `roles` - (Optional) Set of Consul roles to attach to the token. Applicable for Vault 1.10+ with Consul 1.5+.
+* `consul_roles` - (Optional) Set of Consul roles to attach to the token. Applicable for Vault 1.10+ with Consul 1.5+.
 
 * `max_ttl` - (Optional) Maximum TTL for leases associated with this role, in seconds.
 

--- a/website/docs/r/consul_secret_backend_role.html.md
+++ b/website/docs/r/consul_secret_backend_role.html.md
@@ -39,9 +39,9 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the Consul secrets engine role to create.
 
-* `policies` - (Required) The list of Consul ACL policies to associate with these roles.
+* `policies` - (Required when `consul_roles` is unset) The list of Consul ACL policies to associate with these roles.
  
-* `consul_roles` - (Optional) Set of Consul roles to attach to the token. Applicable for Vault 1.10+ with Consul 1.5+.
+* `consul_roles` - (Required when `policies` is unset) Set of Consul roles to attach to the token. Applicable for Vault 1.10+ with Consul 1.5+.
 
 * `max_ttl` - (Optional) Maximum TTL for leases associated with this role, in seconds.
 


### PR DESCRIPTION
Update the `consul_secret_backend_role` resource to support Consul roles.


Output from acceptance testing:

```
$ make testacc TESTARGS='-v -test.run TestConsul'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -v -test.run TestConsul -timeout 30m ./...
=== RUN   TestConsulSecretBackendRole
--- PASS: TestConsulSecretBackendRole (3.37s)
=== RUN   TestConsulSecretBackendRoleNameFromPath
--- PASS: TestConsulSecretBackendRoleNameFromPath (0.00s)
=== RUN   TestConsulSecretBackendRoleBackendFromPath
--- PASS: TestConsulSecretBackendRoleBackendFromPath (0.00s)
=== RUN   TestConsulSecretBackend
--- PASS: TestConsulSecretBackend (6.77s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     13.025s
```
