### PR TITLE
Add support for Consul namespaces and partitions

### DIFF
--- a/vault/resource_consul_secret_backend_role.go
+++ b/vault/resource_consul_secret_backend_role.go
@@ -59,7 +59,7 @@ func consulSecretBackendRoleResource() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				Description: "Then Consul namespace that the token will be " +
+				Description: "The Consul namespace that the token will be " +
 					"created in. Applicable for Vault 1.10+ and Consul 1.7+",
 			},
 			"partition": {

--- a/vault/resource_consul_secret_backend_role_test.go
+++ b/vault/resource_consul_secret_backend_role_test.go
@@ -46,12 +46,16 @@ func TestConsulSecretBackendRole(t *testing.T) {
 		createTestCheckFuncs = append(createTestCheckFuncs,
 			resource.TestCheckResourceAttr(resourcePath, "consul_roles.#", "1"),
 			resource.TestCheckResourceAttr(resourcePath, "consul_roles.0", "role-0"),
+			resource.TestCheckResourceAttr(resourcePath, "consul_namespace", "consul-ns-0"),
+			resource.TestCheckResourceAttr(resourcePath, "partition", "partition-0"),
 		)
 		updateTestCheckFuncs = append(updateTestCheckFuncs,
 			resource.TestCheckResourceAttr(resourcePath, "consul_roles.#", "3"),
 			resource.TestCheckResourceAttr(resourcePath, "consul_roles.0", "role-0"),
 			resource.TestCheckResourceAttr(resourcePath, "consul_roles.1", "role-1"),
 			resource.TestCheckResourceAttr(resourcePath, "consul_roles.2", "role-2"),
+			resource.TestCheckResourceAttr(resourcePath, "consul_namespace", "consul-ns-1"),
+			resource.TestCheckResourceAttr(resourcePath, "partition", "partition-1"),
 		)
 	}
 	resource.Test(t, resource.TestCase{
@@ -111,6 +115,8 @@ resource "vault_consul_secret_backend" "test" {
 resource "vault_consul_secret_backend_role" "test" {
   backend = vault_consul_secret_backend.test.path
   name = "%s"
+  consul_namespace = "consul-ns-0"
+  partition = "partition-0"
 `, backend, token, name)
 
 	if withPolicies {
@@ -148,6 +154,8 @@ resource "vault_consul_secret_backend" "test" {
 resource "vault_consul_secret_backend_role" "test" {
   backend = vault_consul_secret_backend.test.path
   name = "%s"
+  consul_namespace = "consul-ns-1"
+  partition = "partition-1"
   ttl = 120
   max_ttl = 240
   local = true

--- a/website/docs/r/consul_secret_backend_role.html.md
+++ b/website/docs/r/consul_secret_backend_role.html.md
@@ -39,7 +39,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the Consul secrets engine role to create.
  
-* `consul_namespace` - (Optional) Then Consul namespace that the token will be created in.
+* `consul_namespace` - (Optional) The Consul namespace that the token will be created in.
    Applicable for Vault 1.10+ and Consul 1.7+",
 
 * `partition` - (Optional) The admin partition that the token will be created in.

--- a/website/docs/r/consul_secret_backend_role.html.md
+++ b/website/docs/r/consul_secret_backend_role.html.md
@@ -38,10 +38,17 @@ The following arguments are supported:
 * `backend` - (Optional) The unique name of an existing Consul secrets backend mount. Must not begin or end with a `/`. One of `path` or `backend` is required.
 
 * `name` - (Required) The name of the Consul secrets engine role to create.
+ 
+* `consul_namespace` - (Optional) Then Consul namespace that the token will be created in.
+   Applicable for Vault 1.10+ and Consul 1.7+",
+
+* `partition` - (Optional) The admin partition that the token will be created in.
+   Applicable for Vault 1.10+ and Consul 1.11+",
 
 * `policies` - (Required when `consul_roles` is unset) The list of Consul ACL policies to associate with these roles.
- 
-* `consul_roles` - (Required when `policies` is unset) Set of Consul roles to attach to the token. Applicable for Vault 1.10+ with Consul 1.5+.
+
+* `consul_roles` - (Required when `policies` is unset) Set of Consul roles to attach to the token.
+   Applicable for Vault 1.10+ with Consul 1.5+.
 
 * `max_ttl` - (Optional) Maximum TTL for leases associated with this role, in seconds.
 


### PR DESCRIPTION
Update the `consul_secret_backend_role` resource to support Consul namespaces and partitions.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
$ make testacc TESTARGS='-v -test.run TestConsul'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -v -test.run TestConsul -timeout 30m ./...

ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
=== RUN   TestConsulSecretBackendRole
--- PASS: TestConsulSecretBackendRole (4.70s)
=== RUN   TestConsulSecretBackendRoleNameFromPath
--- PASS: TestConsulSecretBackendRoleNameFromPath (0.00s)
=== RUN   TestConsulSecretBackendRoleBackendFromPath
--- PASS: TestConsulSecretBackendRoleBackendFromPath (0.00s)
=== RUN   TestConsulSecretBackend
--- PASS: TestConsulSecretBackend (6.73s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     13.954s

...
```
