### PR TITLE
Correct spelling for allowed_organizational_units attribute

### DIFF
--- a/vault/resource_cert_auth_backend_role.go
+++ b/vault/resource_cert_auth_backend_role.go
@@ -67,8 +67,19 @@ func certAuthBackendRoleResource() *schema.Resource {
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
 			},
-			Optional: true,
-			Computed: true,
+			Optional:      true,
+			Computed:      true,
+			ConflictsWith: []string{"allowed_organizational_units"},
+			Deprecated:    "use allowed_organizational_units instead",
+		},
+		"allowed_organizational_units": {
+			Type: schema.TypeSet,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+			Optional:      true,
+			Computed:      true,
+			ConflictsWith: []string{"allowed_organization_units"},
 		},
 		"required_extensions": {
 			Type: schema.TypeSet,
@@ -143,6 +154,8 @@ func certAuthResourceWrite(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("allowed_organization_units"); ok {
 		data["allowed_organization_units"] = v.(*schema.Set).List()
+	} else if v, ok := d.GetOk("allowed_organizational_units"); ok {
+		data["allowed_organizational_units"] = v.(*schema.Set).List()
 	}
 
 	if v, ok := d.GetOk("required_extensions"); ok {
@@ -192,6 +205,8 @@ func certAuthResourceUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("allowed_organization_units"); ok {
 		data["allowed_organization_units"] = v.(*schema.Set).List()
+	} else if v, ok := d.GetOk("allowed_organizational_units"); ok {
+		data["allowed_organizational_units"] = v.(*schema.Set).List()
 	}
 
 	if v, ok := d.GetOk("required_extensions"); ok {
@@ -285,6 +300,17 @@ func certAuthResourceRead(d *schema.ResourceData, meta interface{}) error {
 				schema.HashString, resp.Data["allowed_organization_units"].([]interface{})))
 	} else {
 		d.Set("allowed_organization_units",
+			schema.NewSet(
+				schema.HashString, []interface{}{}))
+	}
+
+	// Vault sometimes returns these as null instead of an empty list.
+	if resp.Data["allowed_organizational_units"] != nil {
+		d.Set("allowed_organizational_units",
+			schema.NewSet(
+				schema.HashString, resp.Data["allowed_organizational_units"].([]interface{})))
+	} else {
+		d.Set("allowed_organizational_units",
 			schema.NewSet(
 				schema.HashString, []interface{}{}))
 	}

--- a/vault/resource_cert_auth_backend_role_test.go
+++ b/vault/resource_cert_auth_backend_role_test.go
@@ -177,19 +177,20 @@ func testCertAuthBackendCheck_attrs(backend, name string) resource.TestCheckFunc
 		}
 
 		attrs := map[string]string{
-			"name":                       "display_name",
-			"allowed_names":              "allowed_names",
-			"allowed_dns_sans":           "allowed_dns_sans",
-			"allowed_email_sans":         "allowed_email_sans",
-			"allowed_uri_sans":           "allowed_uri_sans",
-			"allowed_organization_units": "allowed_organization_units",
-			"required_extensions":        "required_extensions",
-			"token_period":               "token_period",
-			"token_policies":             "token_policies",
-			"certificate":                "certificate",
-			"token_ttl":                  "token_ttl",
-			"token_max_ttl":              "token_max_ttl",
-			"token_bound_cidrs":          "token_bound_cidrs",
+			"name":                         "display_name",
+			"allowed_names":                "allowed_names",
+			"allowed_dns_sans":             "allowed_dns_sans",
+			"allowed_email_sans":           "allowed_email_sans",
+			"allowed_uri_sans":             "allowed_uri_sans",
+			"allowed_organization_units":   "allowed_organization_units",
+			"allowed_organizational_units": "allowed_organizational_units",
+			"required_extensions":          "required_extensions",
+			"token_period":                 "token_period",
+			"token_policies":               "token_policies",
+			"certificate":                  "certificate",
+			"token_ttl":                    "token_ttl",
+			"token_max_ttl":                "token_max_ttl",
+			"token_bound_cidrs":            "token_bound_cidrs",
 		}
 
 		for stateAttr, apiAttr := range attrs {

--- a/website/docs/r/cert_auth_backend_role.html.md
+++ b/website/docs/r/cert_auth_backend_role.html.md
@@ -47,7 +47,9 @@ The following arguments are supported:
 
 * `allowed_uri_sans` - (Optional) Allowed URIs for authenticated client certificates
 
-* `allowed_organization_units` - (Optional) Allowed organization units for authenticated client certificates
+* `allowed_organization_units` - (**Deprecated**) Allowed organization units for authenticated client certificates
+
+* `allowed_organizational_units` - (Optional) Allowed organizational units for authenticated client certificates
 
 * `required_extensions` - (Optional) TLS extensions required on client certificates
 


### PR DESCRIPTION
The `allowed_organization_units` attribute on a `cert_auth_backend_role` resource in Terraform is labelled incorrectly. It should be [what the Vault API expects](https://www.vaultproject.io/api/auth/cert#allowed_organizational_units): `allowed_organizational_units`. This prevents this attribute from being applied via terraform.

This PR deprecates `allowed_organization_units` for the new, correct spelling `allowed_organizational_units`

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #397 #507 #786

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUGS:

resource/cert_auth_backend_role: Correct spelling for allowed_organizational_units attribute (https://github.com/hashicorp/terraform-provider-vault/pull/1372)
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -run=TestAccXXX -timeout 30m ./...
?   	github.com/hashicorp/terraform-provider-vault	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/generate	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/codegen	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/generated	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode	14.458s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode	6.265s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet	11.990s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role	9.445s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template	14.287s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation	2.711s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/helper	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/schema	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/testutil	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/util	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/vault	14.076s [no tests to run]
```
