### PR TITLE
Update `organization` field to failing GitHub tests

### DIFF
--- a/vault/resource_github_team_test.go
+++ b/vault/resource_github_team_test.go
@@ -120,8 +120,7 @@ func testAccGithubTeamConfig_basic(backend string, team string, policies []strin
 	return fmt.Sprintf(`
 resource "vault_github_auth_backend" "gh" {
 	path = "%s"
-  	organization = "vault"
-	organization_id = 2999
+	organization = "hashicorp"
 }
 
 resource "vault_github_team" "team" {

--- a/vault/resource_github_team_test.go
+++ b/vault/resource_github_team_test.go
@@ -121,6 +121,7 @@ func testAccGithubTeamConfig_basic(backend string, team string, policies []strin
 resource "vault_github_auth_backend" "gh" {
 	path = "%s"
   	organization = "vault"
+	organization_id = 2999
 }
 
 resource "vault_github_team" "team" {

--- a/vault/resource_github_user_test.go
+++ b/vault/resource_github_user_test.go
@@ -104,6 +104,7 @@ func testAccGithubUserConfig_basic(backend string, user string, policies []strin
 resource "vault_github_auth_backend" "gh" {
 	path = "%s"
   	organization = "vault"
+	organization_id = 2999
 }
 
 resource "vault_github_user" "user" {

--- a/vault/resource_github_user_test.go
+++ b/vault/resource_github_user_test.go
@@ -103,8 +103,7 @@ func testAccGithubUserConfig_basic(backend string, user string, policies []strin
 	return fmt.Sprintf(`
 resource "vault_github_auth_backend" "gh" {
 	path = "%s"
-  	organization = "vault"
-	organization_id = 2999
+	organization = "hashicorp"
 }
 
 resource "vault_github_user" "user" {


### PR DESCRIPTION
Updates the field in order to fix regression.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccGithubTeam_basic'
=== RUN   TestAccGithubTeam_basic
--- PASS: TestAccGithubTeam_basic (2.99s)
PASS

$ make testacc TESTARGS='-run=TestAccGithubUser_basic'
=== RUN   TestAccGithubUser_basic
--- PASS: TestAccGithubUser_basic (2.99s)
PASS
```
