### PR TITLE
Fixing #1387 vault_azure_access_credentials crash

### DIFF
--- a/vault/data_source_azure_access_credentials.go
+++ b/vault/data_source_azure_access_credentials.go
@@ -206,9 +206,8 @@ func azureAccessCredentialsDataSourceRead(d *schema.ResourceData, meta interface
 
 	data, err := getConfigData()
 
-	//Will attempt to read the environment from the Azure Secrets config in Vault, unless it doesn't have permission of it has been explicitly overridden.
 	if err != nil || data["environment"] != "public" {
-		log.Printf("[DEBUG] Unable to query Azure Environment from Vault Configuration, using local definition.")
+		log.Printf("[DEBUG] Unable to query Azure Environment from Vault backend.")
 		if v, ok := data["environment"]; ok {
 			environment = v.(string)
 			switch environment {

--- a/vault/data_source_azure_access_credentials.go
+++ b/vault/data_source_azure_access_credentials.go
@@ -101,7 +101,7 @@ func azureAccessCredentialsDataSource() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "public",
-				Description: "The Cloud Environment which should be used. Possible values are public, usgovernment, and china. Defaults to public. ",
+				Description: "The Cloud Environment which should be used. Possible values are public, usgovernment, and china. Defaults to the environment configured in the Vault `backend`, otherwise public.",
 			},
 		},
 	}

--- a/website/docs/d/azure_access_credentials.html.md
+++ b/website/docs/d/azure_access_credentials.html.md
@@ -86,6 +86,8 @@ to 300.
 
 * `tenant_id` - (Optional) The tenant ID to use during credential validation.
    Defaults to the tenant ID configured in the Vault `backend`.
+   
+* `environment` - (Optional) The Cloud Environment which should be used. Possible values are public, usgovernment, and china. Defaults to the environment configured in the Vault `backend`, otherwise public.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Adds a fix for #1387 to allow both subscription_id and tenant_id to be specified. In the event the token doesn't have permission to read the config on the vault backend, it also allows for an environment to be defined in the data source and override the default public cloud option. Values for non-public have been replicated from the Azure Terraform Provider to provide consistency. 

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #1387 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
