### PR TITLE
Improve generic secrets data doc

### DIFF
--- a/website/docs/d/generic_secret.html.md
+++ b/website/docs/d/generic_secret.html.md
@@ -25,6 +25,8 @@ for more details.
 
 ## Example Usage
 
+### Generic secret
+
 ```hcl
 data "vault_generic_secret" "rundeck_auth" {
   path = "secret/rundeck_auth"
@@ -37,6 +39,24 @@ data "vault_generic_secret" "rundeck_auth" {
 provider "rundeck" {
   url        = "http://rundeck.example.com/"
   auth_token = data.vault_generic_secret.rundeck_auth.data["auth_token"]
+}
+```
+
+### KV 
+
+For this example, consider `example` as a path for a KV engine.
+
+```hcl
+data "vault_generic_secret" "example_creds" {
+  path = "example/creds"
+}
+
+data "template_file" "example_template" {
+  template = file("./example.tmpl")
+  vars = {
+    username = data.vault_generic_secret.example_creds.data["username"]
+    password = data.vault_generic_secret.example_creds.data["password"]
+  }
 }
 ```
 


### PR DESCRIPTION
While trying to use this data resource, I've struggled a little to understand how to use it for KV secrets engine. After a bit of reading and unsuccesful attempts, I've noticed that other users are getting confused by the docs (#470).

This PR improves the documentation by adding a new example for KV engine.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #470

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
