### PR TITLE
Fix panic when tenant_id and subscription are specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.4.1 (Unreleased)
+BUGS:
+* `data/azure_access_credentials`: Fix panic when `tenant_id` and `subscription_id` are specified together; add new `environment` override field
+  ([#1391](https://github.com/terraform-providers/terraform-provider-vault/pull/1391)).
+
 ## 3.4.0 (March 24, 2022)
 FEATURES:
 * `data/azure_access_credentials` Add `subscription_id` and `tenant_id` fields to used during credential validation ([#1384](https://github.com/terraform-providers/terraform-provider-vault/pull/1384)).

--- a/website/docs/d/azure_access_credentials.html.md
+++ b/website/docs/d/azure_access_credentials.html.md
@@ -87,6 +87,10 @@ to 300.
 * `tenant_id` - (Optional) The tenant ID to use during credential validation.
    Defaults to the tenant ID configured in the Vault `backend`.
 
+* `environment` - (Optional) The Azure environment to use during credential validation.
+  Defaults to the environment configured in the Vault backend.
+  Some possible values: `AzurePublicCloud`, `AzureGovernmentCloud`
+
 ## Attributes Reference
 
 In addition to the arguments above, the following attributes are exported:


### PR DESCRIPTION
Add environment field to the schema. This can override whatever
environment is set in the Vault backend.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1387 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
