### PR TITLE
Change Behaviour of Provider Configuration to Only Use auth_login when No Token is Provided

### DIFF
--- a/vault/provider_test.go
+++ b/vault/provider_test.go
@@ -118,7 +118,11 @@ func TestAccAuthLoginProviderConfigure(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testResourceApproleConfig_basic(),
-				Check:  testResourceApproleLoginCheckAttrs(t),
+				Check:  testResourceApproleLoginCheckAttrs(t, false),
+			},
+			{
+				Config: testResourceApproleConfig_basic(),
+				Check:  testResourceApproleLoginCheckAttrs(t, true),
 			},
 		},
 	})
@@ -233,7 +237,7 @@ resource "vault_approle_auth_backend_role_secret_id" "admin" {
 `
 }
 
-func testResourceApproleLoginCheckAttrs(t *testing.T) resource.TestCheckFunc {
+func testResourceApproleLoginCheckAttrs(t *testing.T, useAuthLogin bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		resourceState := s.Modules[0].Resources["vault_approle_auth_backend_role_secret_id.admin"]
 		if resourceState == nil {
@@ -273,6 +277,17 @@ func testResourceApproleLoginCheckAttrs(t *testing.T) resource.TestCheckFunc {
 		}
 		approleProviderData := approleProviderResource.TestResourceData()
 		approleProviderData.Set(consts.FieldAuthLoginDefault, authLoginData)
+
+		if useAuthLogin {
+			provider.GetTokenFunc = func(d *schema.ResourceData) (string, error) {
+				return "", nil
+			}
+		} else {
+			provider.GetTokenFunc = func(d *schema.ResourceData) (string, error) {
+				return os.Getenv("VAULT_TOKEN"), nil
+			}
+		}
+
 		_, err := provider.NewProviderMeta(approleProviderData)
 		if err != nil {
 			t.Fatal(err)
@@ -463,7 +478,7 @@ func TestAccProviderToken(t *testing.T) {
 			}
 
 			// Get and check the p token.
-			token, err := provider.GetToken(d)
+			token, err := provider.GetTokenFunc(d)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -786,7 +801,7 @@ func TestAccProviderVaultAddrEnv(t *testing.T) {
 			}
 
 			// Get and check the provider token.
-			token, err := provider.GetToken(d)
+			token, err := provider.GetTokenFunc(d)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -147,9 +147,11 @@ variables in order to keep credential information out of the configuration.
 
 * `auth_login` - (Optional) A configuration block, described below, that
   attempts to authenticate using the `auth/<method>/login` path to
-  acquire a token which Terraform will use. Terraform still issues itself
-  a limited child token using auth/token/create in order to enforce a short
-  TTL and limit exposure. *[See usage details below.](#generic)*
+  acquire a token which Terraform will use, unless a token was found in the
+  `VAULT_TOKEN` environment variable, the `~/.vault-token` file, or using the
+  token helper. Terraform still issues itself a limited child token using
+  `auth/token/create` in order to enforce a short TTL and limit exposure.
+  *[See usage details below.](#generic)*
 
 * `client_auth` - (Optional) A configuration block, described below, that
   provides credentials used by Terraform to authenticate with the Vault


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Closes #1157

I believe this PR would offer a viable solution to the problem raised in Issue #1157, by allowing a Terraform configuration to contain an **auth_login** block in the **vault** provider configuration, but the provider would use a Vault Token found in the environment instead of using the **auth_login** block.

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):

```release-note
provider: Change behaviour to only use auth_login block when no Vault Token is present in the environment
```

Output from acceptance testing:

```
$ TESTARGS="--run AuthLoginProviderConfigure" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v --run AuthLoginProviderConfigure -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/codegen   0.390s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode--- 1.610s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode--- 1.144s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet--- 0.820s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role------- 1.907s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template--- 1.380s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      0.511s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
?       github.com/hashicorp/terraform-provider-vault/testutil  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/util      0.602s [no tests to run]
=== RUN   TestAccAuthLoginProviderConfigure
--- PASS: TestAccAuthLoginProviderConfigure (24.29s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     26.415s
```
