### PR TITLE
Jira Sync: transition to "Re-Triage" on issue reopen.

### DIFF
--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -69,4 +69,4 @@ jobs:
       uses: atlassian/gajira-transition@v2.0.1
       with:
         issue: ${{ steps.search.outputs.issue }}
-        transition: "Pending Triage"
+        transition: "Re-Triage"


### PR DESCRIPTION
The Jira Sync job is failing whenever a GH issue is reopened. The Jira rules expect a transition to `Re-Triage` rather than `Pending Triage`

See https://github.com/hashicorp/terraform-provider-vault/actions/runs/2054158516 for an example of the job failing.