### PR TITLE
Add support for Okta, TOTP and PingID MFA methods

### DIFF
--- a/vault/provider.go
+++ b/vault/provider.go
@@ -549,6 +549,21 @@ var (
 			PathInventory:  []string{"/sys/mfa/method/duo/{name}"},
 			EnterpriseOnly: true,
 		},
+		"vault_mfa_okta": {
+			Resource:       mfaOktaResource(),
+			PathInventory:  []string{"/sys/mfa/method/okta/{name}"},
+			EnterpriseOnly: true,
+		},
+		"vault_mfa_totp": {
+			Resource:       mfaTOTPResource(),
+			PathInventory:  []string{"/sys/mfa/method/totp/{name}"},
+			EnterpriseOnly: true,
+		},
+		"vault_mfa_pingid": {
+			Resource:       mfaPingIDResource(),
+			PathInventory:  []string{"/sys/mfa/method/totp/{name}"},
+			EnterpriseOnly: true,
+		},
 		"vault_mount": {
 			Resource:      MountResource(),
 			PathInventory: []string{"/sys/mounts/{path}"},

--- a/vault/resource_mfa_okta.go
+++ b/vault/resource_mfa_okta.go
@@ -27,9 +27,10 @@ func mfaOktaResource() *schema.Resource {
 				ValidateFunc: validateNoTrailingSlash,
 			},
 			"mount_accessor": {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "The mount to tie this method to for use in automatic mappings. The mapping will use the Name field of Aliases associated with this mount as the username in the mapping.",
+				Type:     schema.TypeString,
+				Required: true,
+				Description: "The mount to tie this method to for use in automatic mappings. " +
+					"The mapping will use the Name field of Aliases associated with this mount as the username in the mapping.",
 			},
 			"username_format": {
 				Type:        schema.TypeString,
@@ -70,16 +71,16 @@ func mfaOktaPath(name string) string {
 func mfaOktaRequestData(d *schema.ResourceData) map[string]interface{} {
 	data := map[string]interface{}{}
 
-	nonBooleanAPIFields := []string{
-		"name", "mount_accessor", "username_format",
-		"org_name", "api_token", "base_url",
-	}
-
 	if v, ok := d.GetOkExists("primary_email"); ok {
-		data["primary_email"] = v.(string)
+		data["primary_email"] = v.(bool)
 	}
 
-	for _, k := range nonBooleanAPIFields {
+	fields := []string{
+		"name", "api_token", "mount_accessor",
+		"username_format", "org_name", "base_url",
+	}
+
+	for _, k := range fields {
 		if v, ok := d.GetOk(k); ok {
 			data[k] = v
 		}

--- a/vault/resource_mfa_okta.go
+++ b/vault/resource_mfa_okta.go
@@ -58,7 +58,7 @@ func mfaOktaResource() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Computed:    true,
-				Description: "If set, the username will only match the primary email for the account.",
+				Description: "If set to true, the username will only match the primary email for the account.",
 			},
 		},
 	}

--- a/vault/resource_mfa_okta.go
+++ b/vault/resource_mfa_okta.go
@@ -1,0 +1,143 @@
+package vault
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/vault/api"
+)
+
+func mfaOktaResource() *schema.Resource {
+	return &schema.Resource{
+		Create: mfaOktaWrite,
+		Update: mfaOktaWrite,
+		Delete: mfaOktaDelete,
+		Read:   mfaOktaRead,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  "Name of the MFA method.",
+				ValidateFunc: validateNoTrailingSlash,
+			},
+			"mount_accessor": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The mount to tie this method to for use in automatic mappings. The mapping will use the Name field of Aliases associated with this mount as the username in the mapping.",
+			},
+			"username_format": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A format string for mapping Identity names to MFA method names. Values to substitute should be placed in `{{}}`.",
+			},
+			"org_name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the organization to be used in the Okta API.",
+			},
+			"api_token": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Sensitive:   true,
+				Description: "Okta API key.",
+			},
+			"base_url": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "If set, will be used as the base domain for API requests.",
+			},
+			"primary_email": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: "If set, the username will only match the primary email for the account.",
+			},
+		},
+	}
+}
+
+func mfaOktaPath(name string) string {
+	return "sys/mfa/method/okta/" + strings.Trim(name, "/")
+}
+
+func mfaOktaRequestData(d *schema.ResourceData) map[string]interface{} {
+	data := map[string]interface{}{}
+
+	nonBooleanAPIFields := []string{
+		"name", "mount_accessor", "username_format",
+		"org_name", "api_token", "base_url",
+	}
+
+	if v, ok := d.GetOkExists("primary_email"); ok {
+		data["primary_email"] = v.(string)
+	}
+
+	for _, k := range nonBooleanAPIFields {
+		if v, ok := d.GetOk(k); ok {
+			data[k] = v
+		}
+	}
+
+	return data
+}
+
+func mfaOktaWrite(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	name := d.Get("name").(string)
+	path := mfaOktaPath(name)
+
+	log.Printf("[DEBUG] Creating mfaOkta %s in Vault", name)
+	_, err := client.Logical().Write(path, mfaOktaRequestData(d))
+	if err != nil {
+		return fmt.Errorf("error writing to Vault at %s, err=%w", path, err)
+	}
+
+	d.SetId(path)
+
+	return mfaOktaRead(d, meta)
+}
+
+func mfaOktaRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	path := d.Id()
+
+	log.Printf("[DEBUG] Reading MFA Okta config %q", path)
+	resp, err := client.Logical().Read(path)
+	if err != nil {
+		return fmt.Errorf("error reading from Vault at %s, err=%w", path, err)
+	}
+
+	fields := []string{
+		"name", "mount_accessor", "username_format",
+		"org_name", "base_url", "primary_email",
+	}
+
+	for _, k := range fields {
+		if err := d.Set(k, resp.Data[k]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func mfaOktaDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	path := d.Id()
+
+	log.Printf("[DEBUG] Deleting mfaOkta %s from Vault", path)
+
+	_, err := client.Logical().Delete(path)
+	if err != nil {
+		return fmt.Errorf("error deleting from Vault at %s, err=%w", path, err)
+	}
+
+	return nil
+}

--- a/vault/resource_mfa_okta_test.go
+++ b/vault/resource_mfa_okta_test.go
@@ -1,0 +1,50 @@
+package vault
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/hashicorp/terraform-provider-vault/testutil"
+)
+
+func TestMFAOktaBasic(t *testing.T) {
+	mfaOktaPath := acctest.RandomWithPrefix("mfa-okta")
+	resourceName := "vault_mfa_okta.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testutil.TestEntPreCheck(t) },
+		Providers: testProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testMFAOktaConfig(mfaOktaPath),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", mfaOktaPath),
+					resource.TestCheckResourceAttr(resourceName, "username_format", "user@example.com"),
+					resource.TestCheckResourceAttr(resourceName, "org_name", "hashicorp"),
+				),
+			},
+		},
+	})
+}
+
+func testMFAOktaConfig(path string) string {
+	userPassPath := acctest.RandomWithPrefix("userpass")
+
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "userpass" {
+  type = "userpass"
+  path = %q
+}
+
+resource "vault_mfa_okta" "test" {
+  name                  = %q
+  mount_accessor        = vault_auth_backend.userpass.accessor
+  username_format       = "user@example.com"
+  org_name				= "hashicorp"
+  api_token				= "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+}
+`, userPassPath, path)
+}

--- a/vault/resource_mfa_okta_test.go
+++ b/vault/resource_mfa_okta_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestMFAOktaBasic(t *testing.T) {
-	mfaOktaPath := acctest.RandomWithPrefix("mfa-okta")
+	path := acctest.RandomWithPrefix("mfa-okta")
 	resourceName := "vault_mfa_okta.test"
 
 	resource.Test(t, resource.TestCase{
@@ -19,20 +19,24 @@ func TestMFAOktaBasic(t *testing.T) {
 		Providers: testProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testMFAOktaConfig(mfaOktaPath),
+				Config: testMFAOktaConfig(path),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", mfaOktaPath),
+					resource.TestCheckResourceAttr(resourceName, "name", path),
 					resource.TestCheckResourceAttr(resourceName, "username_format", "user@example.com"),
 					resource.TestCheckResourceAttr(resourceName, "org_name", "hashicorp"),
 				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"api_token"},
 			},
 		},
 	})
 }
 
 func testMFAOktaConfig(path string) string {
-	userPassPath := acctest.RandomWithPrefix("userpass")
-
 	return fmt.Sprintf(`
 resource "vault_auth_backend" "userpass" {
   type = "userpass"
@@ -46,5 +50,5 @@ resource "vault_mfa_okta" "test" {
   org_name				= "hashicorp"
   api_token				= "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
 }
-`, userPassPath, path)
+`, acctest.RandomWithPrefix("userpass"), path)
 }

--- a/vault/resource_mfa_okta_test.go
+++ b/vault/resource_mfa_okta_test.go
@@ -24,6 +24,7 @@ func TestMFAOktaBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", path),
 					resource.TestCheckResourceAttr(resourceName, "username_format", "user@example.com"),
 					resource.TestCheckResourceAttr(resourceName, "org_name", "hashicorp"),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
 				),
 			},
 			{

--- a/vault/resource_mfa_pingid.go
+++ b/vault/resource_mfa_pingid.go
@@ -135,11 +135,22 @@ func mfaPingIDRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error reading from Vault at %s, err=%w", path, err)
 	}
 
+	if err := d.Set("mount_accessor", d.Get("mount_accessor")); err != nil {
+		return err
+	}
+
+	if err := d.Set("username_format", d.Get("username_format")); err != nil {
+		return err
+	}
+
+	if err := d.Set("settings_file_base64", d.Get("settings_file_base64")); err != nil {
+		return err
+	}
+
 	fields := []string{
 		"name", "idp_url", "admin_url",
 		"authenticator_url", "org_alias", "type",
 		"use_signature", "id", "namespace_id",
-		// "mount_accessor", "username_format", "settings_file_base64",
 	}
 
 	for _, k := range fields {

--- a/vault/resource_mfa_pingid.go
+++ b/vault/resource_mfa_pingid.go
@@ -1,0 +1,123 @@
+package vault
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/vault/api"
+)
+
+func mfaPingIDResource() *schema.Resource {
+	return &schema.Resource{
+		Create: mfaPingIDWrite,
+		Update: mfaPingIDWrite,
+		Delete: mfaPingIDDelete,
+		Read:   mfaPingIDRead,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  "Name of the MFA method.",
+				ValidateFunc: validateNoTrailingSlash,
+			},
+			"mount_accessor": {
+				Type:     schema.TypeString,
+				Required: true,
+				Description: "The mount to tie this method to for use in automatic mappings. " +
+					"The mapping will use the Name field of Aliases associated with this mount as the username in the mapping.",
+			},
+			"username_format": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "A format string for mapping Identity names to MFA method names. Values to substitute should be placed in `{{}}`.",
+			},
+			"settings_file_base64": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "A base64-encoded third-party settings file retrieved from PingID's configuration page.",
+			},
+		},
+	}
+}
+
+func mfaPingIDPath(name string) string {
+	return "sys/mfa/method/pingid/" + strings.Trim(name, "/")
+}
+
+func mfaPingIDRequestData(d *schema.ResourceData) map[string]interface{} {
+	data := map[string]interface{}{}
+
+	// Read does not return any API Fields listed in docs
+	// TODO confirm expected behavior
+	fields := []string{
+		"name", "mount_accessor", "settings_file_base64",
+	}
+
+	for _, k := range fields {
+		if v, ok := d.GetOk(k); ok {
+			data[k] = v
+		}
+	}
+
+	return data
+}
+
+func mfaPingIDWrite(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	name := d.Get("name").(string)
+	path := mfaPingIDPath(name)
+
+	log.Printf("[DEBUG] Creating mfaPingID %s in Vault", name)
+	_, err := client.Logical().Write(path, mfaPingIDRequestData(d))
+	if err != nil {
+		return fmt.Errorf("error writing to Vault at %s, err=%w", path, err)
+	}
+
+	d.SetId(path)
+
+	return mfaPingIDRead(d, meta)
+}
+
+func mfaPingIDRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	path := d.Id()
+
+	log.Printf("[DEBUG] Reading MFA PingID config %q", path)
+	resp, err := client.Logical().Read(path)
+	if err != nil {
+		return fmt.Errorf("error reading from Vault at %s, err=%w", path, err)
+	}
+
+	fields := []string{
+		"name", "mount_accessor", "username_format",
+		"settings_file_base64",
+	}
+
+	for _, k := range fields {
+		if err := d.Set(k, resp.Data[k]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func mfaPingIDDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	path := d.Id()
+
+	log.Printf("[DEBUG] Deleting mfaPingID %s from Vault", path)
+
+	_, err := client.Logical().Delete(path)
+	if err != nil {
+		return fmt.Errorf("error deleting from Vault at %s, err=%w", path, err)
+	}
+
+	return nil
+}

--- a/vault/resource_mfa_pingid.go
+++ b/vault/resource_mfa_pingid.go
@@ -42,6 +42,46 @@ func mfaPingIDResource() *schema.Resource {
 				Required:    true,
 				Description: "A base64-encoded third-party settings file retrieved from PingID's configuration page.",
 			},
+			"idp_url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "IDP URL computed by Vault.",
+			},
+			"admin_url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Admin URL computed by Vault.",
+			},
+			"authenticator_url": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Authenticator URL computed by Vault.",
+			},
+			"org_alias": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Org Alias computed by Vault.",
+			},
+			"id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "ID computed by Vault.",
+			},
+			"namespace_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Namespace ID computed by Vault.",
+			},
+			"type": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Type of configuration computed by Vault.",
+			},
+			"use_signature": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "If set, enables use of PingID signature. Computed by Vault",
+			},
 		},
 	}
 }
@@ -95,8 +135,10 @@ func mfaPingIDRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	fields := []string{
-		"name", "mount_accessor", "username_format",
-		"settings_file_base64",
+		"name", "idp_url", "admin_url",
+		"authenticator_url", "org_alias", "type",
+		"use_signature", "id", "namespace_id",
+		// "mount_accessor", "username_format", "settings_file_base64",
 	}
 
 	for _, k := range fields {

--- a/vault/resource_mfa_pingid.go
+++ b/vault/resource_mfa_pingid.go
@@ -97,6 +97,7 @@ func mfaPingIDRequestData(d *schema.ResourceData) map[string]interface{} {
 	// TODO confirm expected behavior
 	fields := []string{
 		"name", "mount_accessor", "settings_file_base64",
+		"username_format",
 	}
 
 	for _, k := range fields {

--- a/vault/resource_mfa_pingid_test.go
+++ b/vault/resource_mfa_pingid_test.go
@@ -24,6 +24,7 @@ func TestMFAPingIDBasic(t *testing.T) {
 				Config: testMFAPingIDConfig(mfaPingIDPath, settingsFile),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", mfaPingIDPath),
+					resource.TestCheckResourceAttr(resourceName, "username_format", "user@example.com"),
 					resource.TestCheckResourceAttr(resourceName, "type", "pingid"),
 					resource.TestCheckResourceAttr(resourceName, "use_signature", "true"),
 					resource.TestCheckResourceAttr(resourceName, "namespace_id", ""),

--- a/vault/resource_mfa_pingid_test.go
+++ b/vault/resource_mfa_pingid_test.go
@@ -24,6 +24,9 @@ func TestMFAPingIDBasic(t *testing.T) {
 				Config: testMFAPingIDConfig(mfaPingIDPath, settingsFile),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", mfaPingIDPath),
+					resource.TestCheckResourceAttr(resourceName, "type", "pingid"),
+					resource.TestCheckResourceAttr(resourceName, "use_signature", "true"),
+					resource.TestCheckResourceAttr(resourceName, "namespace_id", ""),
 				),
 			},
 		},

--- a/vault/resource_mfa_pingid_test.go
+++ b/vault/resource_mfa_pingid_test.go
@@ -29,6 +29,7 @@ func TestMFAPingIDBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "use_signature", "true"),
 					resource.TestCheckResourceAttr(resourceName, "namespace_id", ""),
 					resource.TestCheckResourceAttr(resourceName, "settings_file_base64", settingsFile),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
 				),
 			},
 			{

--- a/vault/resource_mfa_pingid_test.go
+++ b/vault/resource_mfa_pingid_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestMFAPingIDBasic(t *testing.T) {
-	mfaPingIDPath := acctest.RandomWithPrefix("mfa-pingid")
+	path := acctest.RandomWithPrefix("mfa-pingid")
 	// Base64 Encoded string taken from Vault repo example
 	settingsFile := "I0F1dG8tR2VuZXJhdGVkIGZyb20gUGluZ09uZSwgZG93bmxvYWRlZCBieSBpZD1bU1NPXSBlbWFpbD1baGFtaWRAaGFzaGljb3JwLmNvbV0KI1dlZCBEZWMgMTUgMTM6MDg6NDQgTVNUIDIwMjEKdXNlX2Jhc2U2NF9rZXk9YlhrdGMyVmpjbVYwTFd0bGVRPT0KdXNlX3NpZ25hdHVyZT10cnVlCnRva2VuPWxvbC10b2tlbgppZHBfdXJsPWh0dHBzOi8vaWRweG55bDNtLnBpbmdpZGVudGl0eS5jb20vcGluZ2lkCm9yZ19hbGlhcz1sb2wtb3JnLWFsaWFzCmFkbWluX3VybD1odHRwczovL2lkcHhueWwzbS5waW5naWRlbnRpdHkuY29tL3BpbmdpZAphdXRoZW50aWNhdG9yX3VybD1odHRwczovL2F1dGhlbnRpY2F0b3IucGluZ29uZS5jb20vcGluZ2lkL3BwbQ=="
 	resourceName := "vault_mfa_pingid.test"
@@ -21,22 +21,26 @@ func TestMFAPingIDBasic(t *testing.T) {
 		Providers: testProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testMFAPingIDConfig(mfaPingIDPath, settingsFile),
+				Config: testMFAPingIDConfig(path, settingsFile),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", mfaPingIDPath),
+					resource.TestCheckResourceAttr(resourceName, "name", path),
 					resource.TestCheckResourceAttr(resourceName, "username_format", "user@example.com"),
 					resource.TestCheckResourceAttr(resourceName, "type", "pingid"),
 					resource.TestCheckResourceAttr(resourceName, "use_signature", "true"),
 					resource.TestCheckResourceAttr(resourceName, "namespace_id", ""),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"mount_accessor", "username_format", "settings_file_base64"},
+			},
 		},
 	})
 }
 
 func testMFAPingIDConfig(path, file string) string {
-	userPassPath := acctest.RandomWithPrefix("userpass")
-
 	return fmt.Sprintf(`
 resource "vault_auth_backend" "userpass" {
   type = "userpass"
@@ -49,5 +53,5 @@ resource "vault_mfa_pingid" "test" {
   username_format       = "user@example.com"
   settings_file_base64	= %q
 }
-`, userPassPath, path, file)
+`, acctest.RandomWithPrefix("userpass"), path, file)
 }

--- a/vault/resource_mfa_pingid_test.go
+++ b/vault/resource_mfa_pingid_test.go
@@ -28,6 +28,7 @@ func TestMFAPingIDBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "type", "pingid"),
 					resource.TestCheckResourceAttr(resourceName, "use_signature", "true"),
 					resource.TestCheckResourceAttr(resourceName, "namespace_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "settings_file_base64", settingsFile),
 				),
 			},
 			{

--- a/vault/resource_mfa_pingid_test.go
+++ b/vault/resource_mfa_pingid_test.go
@@ -1,0 +1,49 @@
+package vault
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/hashicorp/terraform-provider-vault/testutil"
+)
+
+func TestMFAPingIDBasic(t *testing.T) {
+	mfaPingIDPath := acctest.RandomWithPrefix("mfa-pingid")
+	// Base64 Encoded string taken from Vault repo example
+	settingsFile := "I0F1dG8tR2VuZXJhdGVkIGZyb20gUGluZ09uZSwgZG93bmxvYWRlZCBieSBpZD1bU1NPXSBlbWFpbD1baGFtaWRAaGFzaGljb3JwLmNvbV0KI1dlZCBEZWMgMTUgMTM6MDg6NDQgTVNUIDIwMjEKdXNlX2Jhc2U2NF9rZXk9YlhrdGMyVmpjbVYwTFd0bGVRPT0KdXNlX3NpZ25hdHVyZT10cnVlCnRva2VuPWxvbC10b2tlbgppZHBfdXJsPWh0dHBzOi8vaWRweG55bDNtLnBpbmdpZGVudGl0eS5jb20vcGluZ2lkCm9yZ19hbGlhcz1sb2wtb3JnLWFsaWFzCmFkbWluX3VybD1odHRwczovL2lkcHhueWwzbS5waW5naWRlbnRpdHkuY29tL3BpbmdpZAphdXRoZW50aWNhdG9yX3VybD1odHRwczovL2F1dGhlbnRpY2F0b3IucGluZ29uZS5jb20vcGluZ2lkL3BwbQ=="
+	resourceName := "vault_mfa_pingid.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testutil.TestEntPreCheck(t) },
+		Providers: testProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testMFAPingIDConfig(mfaPingIDPath, settingsFile),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", mfaPingIDPath),
+				),
+			},
+		},
+	})
+}
+
+func testMFAPingIDConfig(path, file string) string {
+	userPassPath := acctest.RandomWithPrefix("userpass")
+
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "userpass" {
+  type = "userpass"
+  path = %q
+}
+
+resource "vault_mfa_pingid" "test" {
+  name                  = %q
+  mount_accessor        = vault_auth_backend.userpass.accessor
+  username_format       = "user@example.com"
+  settings_file_base64	= %q
+}
+`, userPassPath, path, file)
+}

--- a/vault/resource_mfa_totp.go
+++ b/vault/resource_mfa_totp.go
@@ -1,0 +1,152 @@
+package vault
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/vault/api"
+)
+
+func mfaTOTPResource() *schema.Resource {
+	return &schema.Resource{
+		Create: mfaTOTPWrite,
+		Update: mfaTOTPWrite,
+		Delete: mfaTOTPDelete,
+		Read:   mfaTOTPRead,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				Description:  "Name of the MFA method.",
+				ValidateFunc: validateNoTrailingSlash,
+			},
+			"issuer": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name of the key's issuing organization.",
+			},
+			"period": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: "The length of time used to generate a counter for the TOTP token calculation.",
+			},
+			"key_size": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: "Specifies the size in bytes of the generated key.",
+			},
+			"qr_size": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: "The pixel size of the generated square QR code.",
+			},
+			"algorithm": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				Description: "Specifies the hashing algorithm used to generate the TOTP code. " +
+					"Options include 'SHA1', 'SHA256' and 'SHA512'.",
+			},
+			"digits": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+				Description: "The number of digits in the generated TOTP token. " +
+					"This value can either be 6 or 8.",
+			},
+			"skew": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+				Description: "The number of delay periods that are allowed when validating a TOTP token. " +
+					"This value can either be 0 or 1.",
+			},
+		},
+	}
+}
+
+func mfaTOTPPath(name string) string {
+	return "sys/mfa/method/totp/" + strings.Trim(name, "/")
+}
+
+func mfaTOTPRequestData(d *schema.ResourceData) map[string]interface{} {
+	data := map[string]interface{}{}
+
+	fields := []string{
+		"name", "issuer", "period",
+		"key_size", "qr_size", "algorithm",
+		"digits", "skew",
+	}
+
+	for _, k := range fields {
+		if v, ok := d.GetOk(k); ok {
+			data[k] = v
+		}
+	}
+
+	return data
+}
+
+func mfaTOTPWrite(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	name := d.Get("name").(string)
+	path := mfaTOTPPath(name)
+
+	log.Printf("[DEBUG] Creating mfaTOTP %s in Vault", name)
+	_, err := client.Logical().Write(path, mfaTOTPRequestData(d))
+	if err != nil {
+		return fmt.Errorf("error writing to Vault at %s, err=%w", path, err)
+	}
+
+	d.SetId(path)
+
+	return mfaTOTPRead(d, meta)
+}
+
+func mfaTOTPRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	path := d.Id()
+
+	log.Printf("[DEBUG] Reading MFA TOTP config %q", path)
+	resp, err := client.Logical().Read(path)
+	if err != nil {
+		return fmt.Errorf("error reading from Vault at %s, err=%w", path, err)
+	}
+
+	fields := []string{
+		"name", "issuer", "period",
+		"key_size", "qr_size", "algorithm",
+		"digits", "skew",
+	}
+
+	for _, k := range fields {
+		if err := d.Set(k, resp.Data[k]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func mfaTOTPDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	path := d.Id()
+
+	log.Printf("[DEBUG] Deleting mfaTOTP %s from Vault", path)
+
+	_, err := client.Logical().Delete(path)
+	if err != nil {
+		return fmt.Errorf("error deleting from Vault at %s, err=%w", path, err)
+	}
+
+	return nil
+}

--- a/vault/resource_mfa_totp_test.go
+++ b/vault/resource_mfa_totp_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestMFATOTPBasic(t *testing.T) {
-	mfaTOTPPath := acctest.RandomWithPrefix("mfa-totp")
+	path := acctest.RandomWithPrefix("mfa-totp")
 	resourceName := "vault_mfa_totp.test"
 
 	resource.Test(t, resource.TestCase{
@@ -19,14 +19,20 @@ func TestMFATOTPBasic(t *testing.T) {
 		Providers: testProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testMFATOTPConfig(mfaTOTPPath),
+				Config: testMFATOTPConfig(path),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", mfaTOTPPath),
+					resource.TestCheckResourceAttr(resourceName, "name", path),
 					resource.TestCheckResourceAttr(resourceName, "issuer", "hashicorp"),
 					resource.TestCheckResourceAttr(resourceName, "period", "60"),
 					resource.TestCheckResourceAttr(resourceName, "algorithm", "SHA256"),
 					resource.TestCheckResourceAttr(resourceName, "digits", "8"),
+					resource.TestCheckResourceAttr(resourceName, "key_size", "20"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -35,11 +41,12 @@ func TestMFATOTPBasic(t *testing.T) {
 func testMFATOTPConfig(path string) string {
 	return fmt.Sprintf(`
 resource "vault_mfa_totp" "test" {
-  name                  = %q
-  issuer        		= "hashicorp"	 
-  period       			= 60
-  algorithm				= "SHA256"
-  digits				= 8
+  name      = "%s"
+  issuer    = "hashicorp"
+  period    = 60
+  algorithm = "SHA256"
+  digits    = 8
+  key_size  = 20
 }
 `, path)
 }

--- a/vault/resource_mfa_totp_test.go
+++ b/vault/resource_mfa_totp_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/vault/api"
 
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
@@ -14,12 +16,13 @@ func TestMFATOTPBasic(t *testing.T) {
 	path := acctest.RandomWithPrefix("mfa-totp")
 	resourceName := "vault_mfa_totp.test"
 
+	var id string
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testutil.TestEntPreCheck(t) },
 		Providers: testProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testMFATOTPConfig(path),
+				Config: testMFATOTPConfig(path, 20),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", path),
 					resource.TestCheckResourceAttr(resourceName, "issuer", "hashicorp"),
@@ -27,6 +30,32 @@ func TestMFATOTPBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "algorithm", "SHA256"),
 					resource.TestCheckResourceAttr(resourceName, "digits", "8"),
 					resource.TestCheckResourceAttr(resourceName, "key_size", "20"),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+				),
+			},
+			{
+				PreConfig: func() {
+					client := testProvider.Meta().(*api.Client)
+					resp, err := client.Logical().Read(mfaTOTPPath(path))
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					id = resp.Data["id"].(string)
+					if id == "" {
+						t.Fatal("expected ID to be set; got empty")
+					}
+				},
+				Config: testMFATOTPConfig(path, 30),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					testCheckNotResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "name", path),
+					resource.TestCheckResourceAttr(resourceName, "issuer", "hashicorp"),
+					resource.TestCheckResourceAttr(resourceName, "period", "60"),
+					resource.TestCheckResourceAttr(resourceName, "algorithm", "SHA256"),
+					resource.TestCheckResourceAttr(resourceName, "digits", "8"),
+					resource.TestCheckResourceAttr(resourceName, "key_size", "30"),
 				),
 			},
 			{
@@ -38,7 +67,17 @@ func TestMFATOTPBasic(t *testing.T) {
 	})
 }
 
-func testMFATOTPConfig(path string) string {
+func testCheckNotResourceAttr(name, key, value string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		if err := resource.TestCheckResourceAttr(name, key, value); err == nil {
+			return fmt.Errorf("expected value %s to change for key %s.%s", value, name, key)
+		}
+
+		return nil
+	}
+}
+
+func testMFATOTPConfig(path string, keySize int) string {
 	return fmt.Sprintf(`
 resource "vault_mfa_totp" "test" {
   name      = "%s"
@@ -46,7 +85,7 @@ resource "vault_mfa_totp" "test" {
   period    = 60
   algorithm = "SHA256"
   digits    = 8
-  key_size  = 20
+  key_size  = %d
 }
-`, path)
+`, path, keySize)
 }

--- a/vault/resource_mfa_totp_test.go
+++ b/vault/resource_mfa_totp_test.go
@@ -1,0 +1,45 @@
+package vault
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/hashicorp/terraform-provider-vault/testutil"
+)
+
+func TestMFATOTPBasic(t *testing.T) {
+	mfaTOTPPath := acctest.RandomWithPrefix("mfa-totp")
+	resourceName := "vault_mfa_totp.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testutil.TestEntPreCheck(t) },
+		Providers: testProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testMFATOTPConfig(mfaTOTPPath),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", mfaTOTPPath),
+					resource.TestCheckResourceAttr(resourceName, "issuer", "hashicorp"),
+					resource.TestCheckResourceAttr(resourceName, "period", "60"),
+					resource.TestCheckResourceAttr(resourceName, "algorithm", "SHA256"),
+					resource.TestCheckResourceAttr(resourceName, "digits", "8"),
+				),
+			},
+		},
+	})
+}
+
+func testMFATOTPConfig(path string) string {
+	return fmt.Sprintf(`
+resource "vault_mfa_totp" "test" {
+  name                  = %q
+  issuer        		= "hashicorp"	 
+  period       			= 60
+  algorithm				= "SHA256"
+  digits				= 8
+}
+`, path)
+}

--- a/website/docs/r/mfa_okta.html.md
+++ b/website/docs/r/mfa_okta.html.md
@@ -1,0 +1,71 @@
+---
+layout: "vault"
+page_title: "Vault: vault_mfa_okta resource"
+sidebar_current: "docs-vault-resource-mfa-okta"
+description: |-
+  Managing the MFA Okta method configuration
+---
+
+# vault\_mfa\_okta
+
+Provides a resource to manage [Okta MFA](https://www.vaultproject.io/docs/enterprise/mfa/mfa-okta).
+
+**Note** this feature is available only with Vault Enterprise.
+
+## Example Usage
+
+```hcl
+resource "vault_auth_backend" "userpass" {
+  type = "userpass"
+  path = "userpass"
+}
+
+resource "vault_mfa_okta" "my_okta" {
+  name            = "my_okta"
+  mount_accessor  = vault_auth_backend.userpass.accessor
+  username_format = "user@example.com"
+  org_name        = "hashicorp"
+  api_token       = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `name` `(string: <required>)` – Name of the MFA method.
+
+- `mount_accessor` `(string: <required>)` - The mount to tie this method to for use in automatic mappings. 
+  The mapping will use the Name field of Aliases associated with this mount as the username in the mapping.
+
+- `username_format` `(string)` - A format string for mapping Identity names to MFA method names. 
+  Values to substitute should be placed in `{{}}`. For example, `"{{alias.name}}@example.com"`. 
+  If blank, the Alias's Name field will be used as-is. Currently-supported mappings:
+    - alias.name: The name returned by the mount configured via the `mount_accessor` parameter
+    - entity.name: The name configured for the Entity
+    - alias.metadata.`<key>`: The value of the Alias's metadata parameter
+    - entity.metadata.`<key>`: The value of the Entity's metadata parameter
+
+- `org_name` `(string: <required>)` - Name of the organization to be used in the Okta API.
+
+- `api_token` `(string: <required>)` - Okta API key.
+
+- `base_url` `(string)` - If set, will be used as the base domain for API requests. Examples are `okta.com`, 
+  `oktapreview.com`, and `okta-emea.com`.
+
+- `primary_email` `(string: <required>)` - If set to true, the username will only match the 
+  primary email for the account.
+
+
+## Attributes Reference
+
+No additional attributes are exported by this resource.
+
+## Import
+
+Mounts can be imported using the `path`, e.g.
+
+```
+$ terraform import vault_mfa_okta.my_okta my_okta
+```
+

--- a/website/docs/r/mfa_pingid.html.md
+++ b/website/docs/r/mfa_pingid.html.md
@@ -1,0 +1,81 @@
+---
+layout: "vault"
+page_title: "Vault: vault_mfa_pingid resource"
+sidebar_current: "docs-vault-resource-mfa-pingid"
+description: |-
+  Managing the MFA PingID method configuration
+---
+
+# vault\_mfa\_pingid
+
+Provides a resource to manage [PingID MFA](https://www.vaultproject.io/docs/enterprise/mfa/mfa-pingid).
+
+**Note** this feature is available only with Vault Enterprise.
+
+## Example Usage
+
+```hcl
+variable "settings_file" {}
+
+resource "vault_auth_backend" "userpass" {
+  type = "userpass"
+  path = "userpass"
+}
+
+resource "vault_mfa_pingid" "my_pingid" {
+  name                 = "my_pingid"
+  mount_accessor       = vault_auth_backend.userpass.accessor
+  username_format      = "user@example.com"
+  settings_file_base64 = var.settings_file
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `name` `(string: <required>)` – Name of the MFA method.
+
+- `mount_accessor` `(string: <required>)` - The mount to tie this method to for use in automatic mappings. 
+  The mapping will use the Name field of Aliases associated with this mount as the username in the mapping.
+
+- `username_format` `(string)` - A format string for mapping Identity names to MFA method names. 
+  Values to substitute should be placed in `{{}}`. For example, `"{{alias.name}}@example.com"`. 
+  If blank, the Alias's Name field will be used as-is. Currently-supported mappings:
+    - alias.name: The name returned by the mount configured via the `mount_accessor` parameter
+    - entity.name: The name configured for the Entity
+    - alias.metadata.`<key>`: The value of the Alias's metadata parameter
+    - entity.metadata.`<key>`: The value of the Entity's metadata parameter
+
+- `settings_file_base64` `(string: <required>)` - A base64-encoded third-party settings file retrieved
+  from PingID's configuration page.
+
+## Attributes Reference
+
+In addition to the above arguments, the following attributes are exported:
+
+- `idp_url` `(string)` – IDP URL computed by Vault
+
+- `admin_url` `(string)` – Admin URL computed by Vault
+
+- `authenticator_url` `(string)` – Authenticator URL computed by Vault
+
+- `org_alias` `(string)` – Org Alias computed by Vault
+
+- `id` `(string)` – ID computed by Vault
+
+- `namespace_id` `(string)` – Namespace ID computed by Vault
+
+- `type` `(string)` – Type of configuration computed by Vault
+
+- `use_signature` `(string)` – If set to true, enables use of PingID signature. Computed by Vault
+
+
+## Import
+
+Mounts can be imported using the `path`, e.g.
+
+```
+$ terraform import vault_mfa_pingid.my_pingid my_pingid
+```
+

--- a/website/docs/r/mfa_totp.html.md
+++ b/website/docs/r/mfa_totp.html.md
@@ -1,0 +1,62 @@
+---
+layout: "vault"
+page_title: "Vault: vault_mfa_totp resource"
+sidebar_current: "docs-vault-resource-mfa-totp"
+description: |-
+  Managing the MFA TOTP method configuration
+---
+
+# vault\_mfa\_totp
+
+Provides a resource to manage [TOTP MFA](https://www.vaultproject.io/docs/enterprise/mfa/mfa-totp).
+
+**Note** this feature is available only with Vault Enterprise.
+
+## Example Usage
+
+```hcl
+resource "vault_mfa_totp" "my_totp" {
+  name      = "my_totp"
+  issuer    = "hashicorp"
+  period    = 60
+  algorithm = "SHA256"
+  digits    = 8
+  key_size  = 20
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `name` `(string: <required>)` – Name of the MFA method.
+
+- `issuer` `(string: <required>)` - The name of the key's issuing organization.
+
+- `period` `(int)` - The length of time used to generate a counter for the TOTP token calculation.
+
+- `key_size` `(int)` - Specifies the size in bytes of the generated key.
+
+- `qr_size` `(int)` - The pixel size of the generated square QR code.
+
+- `algorithm` `(string)` - Specifies the hashing algorithm used to generate the TOTP code.
+  Options include `SHA1`, `SHA256` and `SHA512`
+
+- `digits` `(int)` - The number of digits in the generated TOTP token.
+  This value can either be 6 or 8.
+
+- `skew` `(int)` - The number of delay periods that are allowed when validating a TOTP token.
+  This value can either be 0 or 1.
+
+## Attributes Reference
+
+No additional attributes are exported by this resource.
+
+## Import
+
+Mounts can be imported using the `path`, e.g.
+
+```
+$ terraform import vault_mfa_totp.my_totp my_totp
+```
+

--- a/website/vault.erb
+++ b/website/vault.erb
@@ -349,6 +349,18 @@
                             <a href="/docs/providers/vault/r/mfa_duo.html">vault_mfa_duo</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-vault-resource-mfa-okta") %>>
+                            <a href="/docs/providers/vault/r/mfa_okta.html">vault_mfa_okta</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-vault-resource-mfa-totp") %>>
+                            <a href="/docs/providers/vault/r/mfa_totp.html">vault_mfa_totp</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-vault-resource-mfa-pingid") %>>
+                            <a href="/docs/providers/vault/r/mfa_pingid.html">vault_mfa_pingid</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-vault-resource-mount") %>>
                             <a href="/docs/providers/vault/r/mount.html">vault_mount</a>
                         </li>


### PR DESCRIPTION
Adds three new resources to support Okta, TOTP and PingID `sys/mfa` methods.

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestMFAOktaBasic'
=== RUN   TestMFAOktaBasic
--- PASS: TestMFAOktaBasic (1.73s)

$ make testacc TESTARGS='-run=TestMFATOTPBasic'
=== RUN   TestMFATOTPBasic
--- PASS: TestMFATOTPBasic (1.65s)
```
