### PR TITLE
Add cross-referencing link to Learn tutorials

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -495,6 +495,12 @@ default
 vault_team_policy
 ```
 
+## Tutorials 
+
+Refer to the [Codify Management of Vault Enterprise Using
+Terraform](https://learn.hashicorp.com/tutorials/vault/codify-mgmt-enterprise)
+tutorial for more example.
+
 
 [namespaces]: https://www.vaultproject.io/docs/enterprise/namespaces#vault-enterprise-namespaces
 [aliasing]: https://www.terraform.io/docs/configuration/providers.html#alias-multiple-provider-configurations

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -497,9 +497,7 @@ vault_team_policy
 
 ## Tutorials 
 
-Refer to the [Codify Management of Vault Enterprise Using
-Terraform](https://learn.hashicorp.com/tutorials/vault/codify-mgmt-enterprise)
-tutorial for additional examples using Vault namespaces.
+Refer to the [Codify Management of Vault Enterprise Using Terraform](https://learn.hashicorp.com/tutorials/vault/codify-mgmt-enterprise) tutorial for additional examples using Vault namespaces.
 
 
 [namespaces]: https://www.vaultproject.io/docs/enterprise/namespaces#vault-enterprise-namespaces

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -499,7 +499,7 @@ vault_team_policy
 
 Refer to the [Codify Management of Vault Enterprise Using
 Terraform](https://learn.hashicorp.com/tutorials/vault/codify-mgmt-enterprise)
-tutorial for more example.
+tutorial for additional examples using Vault namespaces.
 
 
 [namespaces]: https://www.vaultproject.io/docs/enterprise/namespaces#vault-enterprise-namespaces

--- a/website/docs/r/auth_backend.html.md
+++ b/website/docs/r/auth_backend.html.md
@@ -82,7 +82,6 @@ $ terraform import vault_auth_backend.example github
 
 Refer to the following tutorials for additional usage examples:
 
-- [Codify Management of Vault Enterprise Using
-Terraform](https://learn.hashicorp.com/tutorials/vault/codify-mgmt-enterprise)
+- [Codify Management of Vault Enterprise Using Terraform](https://learn.hashicorp.com/tutorials/vault/codify-mgmt-enterprise)
 
 - [Codify Management of Vault Using Terraform](https://learn.hashicorp.com/tutorials/vault/codify-mgmt-oss)

--- a/website/docs/r/auth_backend.html.md
+++ b/website/docs/r/auth_backend.html.md
@@ -77,3 +77,12 @@ Auth methods can be imported using the `path`, e.g.
 ```
 $ terraform import vault_auth_backend.example github
 ```
+
+## Tutorials 
+
+Refer to the following tutorials for additional usage examples:
+
+- [Codify Management of Vault Enterprise Using
+Terraform](https://learn.hashicorp.com/tutorials/vault/codify-mgmt-enterprise)
+
+- [Codify Management of Vault Using Terraform](https://learn.hashicorp.com/tutorials/vault/codify-mgmt-oss)

--- a/website/docs/r/policy.html.md
+++ b/website/docs/r/policy.html.md
@@ -47,7 +47,6 @@ $ terraform import vault_policy.example dev-team
 
 Refer to the following tutorials for additional usage examples:
 
-- [Codify Management of Vault Enterprise Using
-Terraform](https://learn.hashicorp.com/tutorials/vault/codify-mgmt-enterprise)
+- [Codify Management of Vault Enterprise Using Terraform](https://learn.hashicorp.com/tutorials/vault/codify-mgmt-enterprise)
 
 - [Codify Management of Vault Using Terraform](https://learn.hashicorp.com/tutorials/vault/codify-mgmt-oss)

--- a/website/docs/r/policy.html.md
+++ b/website/docs/r/policy.html.md
@@ -42,3 +42,12 @@ Policies can be imported using the `name`, e.g.
 ```
 $ terraform import vault_policy.example dev-team
 ```
+
+## Tutorials 
+
+Refer to the following tutorials for additional usage examples:
+
+- [Codify Management of Vault Enterprise Using
+Terraform](https://learn.hashicorp.com/tutorials/vault/codify-mgmt-enterprise)
+
+- [Codify Management of Vault Using Terraform](https://learn.hashicorp.com/tutorials/vault/codify-mgmt-oss)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

It was reported that users don't easily find the tutorials which demonstrates the use of Vault provider. 

This PR adds cross referencing links to the [Vault Learn](https://learn.hashicorp.com/vault) tutorials to provide additional guidance. 

<br />

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
