### PR TITLE
Update transit secret key to support auto_rotate_period

### DIFF
--- a/website/docs/r/transit_secret_backend_key.html.md
+++ b/website/docs/r/transit_secret_backend_key.html.md
@@ -53,7 +53,7 @@ The following arguments are supported:
 
 * `min_encryption_version` - (Optional) Minimum key version to use for encryption
 
-* `auto_rotate_interval` - (Optional) Amount of time the key should live before being automatically rotated.
+* `auto_rotate_period` - (Optional) Amount of time the key should live before being automatically rotated.
   A value of 0 disables automatic rotation for the key.
 
 ## Attributes Reference
@@ -78,6 +78,9 @@ The following arguments are supported:
 * `supports_signing` - Whether or not the key supports signing, based on key type.
 
 
+## Deprecations
+
+* `auto_rotate_interval` - Replaced by `auto_rotate_period`.
 
 ## Import
 


### PR DESCRIPTION
The provider originally shipped with support for the
`auto_rotate_interval field`, this was subsequently changed in the GA
release of Vault to be `auto_rotate_period`. This fix deprecates the
former and adds the latter.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-v -test.run TestTransit*'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -v -test.run TestTransit* -timeout 30m ./...

[...]

ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
=== RUN   TestTransitSecretBackendKey_basic
--- PASS: TestTransitSecretBackendKey_basic (4.94s)
=== RUN   TestTransitSecretBackendKey_rsa4096
--- PASS: TestTransitSecretBackendKey_rsa4096 (8.62s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     14.425s
...
```
