### PR TITLE
No longer skip vault "next" tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
             export MONGODB_URL="mongodb://root:mongodb@127.0.0.1:27017/admin?ssl=false"
             export MSSQL_URL="sqlserver://sa:yourStrong1000Password@127.0.0.1:1433"
             # This will be removed after VAULT-4324 is fixed
-            make testacc TESTARGS='-v' SKIP_MSSQL_MULTI_CI=true SKIP_RAFT_TESTS=true SKIP_VAULT_NEXT_TESTS=true
+            make testacc TESTARGS='-v' SKIP_MSSQL_MULTI_CI=true SKIP_RAFT_TESTS=true
       - run:
           name: "Run Build"
           command: |

--- a/vault/resource_consul_secret_backend_role_test.go
+++ b/vault/resource_consul_secret_backend_role_test.go
@@ -2,7 +2,6 @@ package vault
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -26,6 +25,10 @@ func TestConsulSecretBackendRole(t *testing.T) {
 		resource.TestCheckResourceAttr(resourcePath, "ttl", "0"),
 		resource.TestCheckResourceAttr(resourcePath, "policies.#", "1"),
 		resource.TestCheckResourceAttr(resourcePath, "policies.0", "foo"),
+		resource.TestCheckResourceAttr(resourcePath, "consul_roles.#", "1"),
+		resource.TestCheckResourceAttr(resourcePath, "consul_roles.0", "role-0"),
+		resource.TestCheckResourceAttr(resourcePath, "consul_namespace", "consul-ns-0"),
+		resource.TestCheckResourceAttr(resourcePath, "partition", "partition-0"),
 	}
 
 	updateTestCheckFuncs := []resource.TestCheckFunc{
@@ -38,26 +41,14 @@ func TestConsulSecretBackendRole(t *testing.T) {
 		resource.TestCheckResourceAttr(resourcePath, "policies.#", "2"),
 		resource.TestCheckResourceAttr(resourcePath, "policies.0", "foo"),
 		resource.TestCheckResourceAttr(resourcePath, "policies.1", "bar"),
+		resource.TestCheckResourceAttr(resourcePath, "consul_roles.#", "3"),
+		resource.TestCheckResourceAttr(resourcePath, "consul_roles.0", "role-0"),
+		resource.TestCheckResourceAttr(resourcePath, "consul_roles.1", "role-1"),
+		resource.TestCheckResourceAttr(resourcePath, "consul_roles.2", "role-2"),
+		resource.TestCheckResourceAttr(resourcePath, "consul_namespace", "consul-ns-1"),
+		resource.TestCheckResourceAttr(resourcePath, "partition", "partition-1"),
 	}
 
-	var withRoles bool
-	if v := os.Getenv(testutil.EnvVarSkipVaultNext); v == "" {
-		withRoles = true
-		createTestCheckFuncs = append(createTestCheckFuncs,
-			resource.TestCheckResourceAttr(resourcePath, "consul_roles.#", "1"),
-			resource.TestCheckResourceAttr(resourcePath, "consul_roles.0", "role-0"),
-			resource.TestCheckResourceAttr(resourcePath, "consul_namespace", "consul-ns-0"),
-			resource.TestCheckResourceAttr(resourcePath, "partition", "partition-0"),
-		)
-		updateTestCheckFuncs = append(updateTestCheckFuncs,
-			resource.TestCheckResourceAttr(resourcePath, "consul_roles.#", "3"),
-			resource.TestCheckResourceAttr(resourcePath, "consul_roles.0", "role-0"),
-			resource.TestCheckResourceAttr(resourcePath, "consul_roles.1", "role-1"),
-			resource.TestCheckResourceAttr(resourcePath, "consul_roles.2", "role-2"),
-			resource.TestCheckResourceAttr(resourcePath, "consul_namespace", "consul-ns-1"),
-			resource.TestCheckResourceAttr(resourcePath, "partition", "partition-1"),
-		)
-	}
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
@@ -68,7 +59,7 @@ func TestConsulSecretBackendRole(t *testing.T) {
 				ExpectError: regexp.MustCompile(`policies or consul_roles must be set`),
 			},
 			{
-				Config: testConsulSecretBackendRole_initialConfig(backend, name, token, true, withRoles),
+				Config: testConsulSecretBackendRole_initialConfig(backend, name, token, true, true),
 				Check:  resource.ComposeTestCheckFunc(createTestCheckFuncs...),
 			},
 			{
@@ -76,7 +67,7 @@ func TestConsulSecretBackendRole(t *testing.T) {
 				ExpectError: regexp.MustCompile(`policies or consul_roles must be set`),
 			},
 			{
-				Config: testConsulSecretBackendRole_updateConfig(backend, name, token, true, withRoles),
+				Config: testConsulSecretBackendRole_updateConfig(backend, name, token, true, true),
 				Check:  resource.ComposeTestCheckFunc(updateTestCheckFuncs...),
 			},
 		},

--- a/vault/resource_github_auth_backend_test.go
+++ b/vault/resource_github_auth_backend_test.go
@@ -21,8 +21,6 @@ const testGHOrg = "hashicorp"
 
 func TestAccGithubAuthBackend_basic(t *testing.T) {
 	testutil.SkipTestAcc(t)
-	// TODO: remove once we can test against the vault-1.10 dev builds
-	testutil.SkipTestEnvSet(t, testutil.EnvVarSkipVaultNext)
 
 	orgMeta := testutil.GetGHOrgResponse(t, testGHOrg)
 
@@ -68,8 +66,6 @@ func TestAccGithubAuthBackend_basic(t *testing.T) {
 
 func TestAccGithubAuthBackend_tuning(t *testing.T) {
 	testutil.SkipTestAcc(t)
-	// TODO: remove once we can test against the vault-1.10 dev builds
-	testutil.SkipTestEnvSet(t, testutil.EnvVarSkipVaultNext)
 
 	orgMeta := testutil.GetGHOrgResponse(t, testGHOrg)
 
@@ -139,8 +135,6 @@ func TestAccGithubAuthBackend_tuning(t *testing.T) {
 
 func TestAccGithubAuthBackend_description(t *testing.T) {
 	testutil.SkipTestAcc(t)
-	// TODO: remove once we can test against the vault-1.10 dev builds
-	testutil.SkipTestEnvSet(t, testutil.EnvVarSkipVaultNext)
 
 	orgMeta := testutil.GetGHOrgResponse(t, testGHOrg)
 

--- a/vault/resource_transit_secret_backend_key_test.go
+++ b/vault/resource_transit_secret_backend_key_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestTransitSecretBackendKey_basic(t *testing.T) {
-	testutil.SkipTestEnvSet(t, testutil.EnvVarSkipVaultNext)
-
 	backend := acctest.RandomWithPrefix("transit")
 	name := acctest.RandomWithPrefix("key")
 	resourceName := "vault_transit_secret_backend_key.test"
@@ -92,8 +90,6 @@ func TestTransitSecretBackendKey_basic(t *testing.T) {
 }
 
 func TestTransitSecretBackendKey_rsa4096(t *testing.T) {
-	testutil.SkipTestEnvSet(t, testutil.EnvVarSkipVaultNext)
-
 	backend := acctest.RandomWithPrefix("transit")
 	name := acctest.RandomWithPrefix("key")
 	resourceName := "vault_transit_secret_backend_key.test"


### PR DESCRIPTION
Since we are now testing against vault-1.10+, we no longer need to skip the related acceptance tests.