### PR TITLE
[wip] add tune block to ldap_auth_backend resource

### DIFF
--- a/vault/resource_ldap_auth_backend.go
+++ b/vault/resource_ldap_auth_backend.go
@@ -146,6 +146,8 @@ func ldapAuthBackendResource() *schema.Resource {
 			Computed:  true,
 			Sensitive: true,
 		},
+
+		"tune": authMountTuneSchema(),
 	}
 
 	addTokenFields(fields, &addTokenFieldsConfig{})
@@ -285,7 +287,23 @@ func ldapAuthBackendUpdate(d *schema.ResourceData, meta interface{}) error {
 		d.SetId("")
 		return fmt.Errorf("error writing ldap config %q: %s", path, err)
 	}
+
 	log.Printf("[DEBUG] Wrote LDAP config %q", path)
+
+	if d.HasChange("tune") {
+		log.Printf("[INFO] LDAP Auth '%q' tune configuration changed", d.Id())
+		if raw, ok := d.GetOk("tune"); ok {
+			backendType := d.Get("type")
+			log.Printf("[DEBUG] Writing %s auth tune to '%q'", backendType, path)
+
+			err := authMountTune(client, path, raw)
+			if err != nil {
+				return nil
+			}
+
+			log.Printf("[INFO] Written %s auth tune to %q", backendType, path)
+		}
+	}
 
 	return ldapAuthBackendRead(d, meta)
 }
@@ -310,17 +328,17 @@ func ldapAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("accessor", authMount.Accessor)
 	d.Set("local", authMount.Local)
 
-	path = ldapAuthBackendConfigPath(path)
+	configPath := ldapAuthBackendConfigPath(path)
 
-	log.Printf("[DEBUG] Reading LDAP auth backend config %q", path)
-	resp, err := client.Logical().Read(path)
+	log.Printf("[DEBUG] Reading LDAP auth backend config %q", configPath)
+	resp, err := client.Logical().Read(configPath)
 	if err != nil {
-		return fmt.Errorf("error reading ldap auth backend config %q: %s", path, err)
+		return fmt.Errorf("error reading ldap auth backend config %q: %s", configPath, err)
 	}
-	log.Printf("[DEBUG] Read LDAP auth backend config %q", path)
+	log.Printf("[DEBUG] Read LDAP auth backend config %q", configPath)
 
 	if resp == nil {
-		log.Printf("[WARN] LDAP auth backend config %q not found, removing from state", path)
+		log.Printf("[WARN] LDAP auth backend config %q not found, removing from state", configPath)
 		d.SetId("")
 		return nil
 	}
@@ -349,6 +367,18 @@ func ldapAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 
 	// `bindpass`, `client_tls_cert` and `client_tls_key` cannot be read out from the API
 	// So... if they drift, they drift.
+
+	log.Printf("[DEBUG] Reading ldap auth tune from %q", path+"/tune")
+	rawTune, err := authMountTuneGet(client, "auth/"+path)
+	if err != nil {
+		return fmt.Errorf("error reading tune information from Vault: %s", err)
+	}
+
+	log.Printf("[CUSTOM] %+v", rawTune)
+	if err := d.Set("tune", []map[string]interface{}{rawTune}); err != nil {
+		log.Printf("[ERROR] Error when setting tune config from path %q to state: %s", path+"/tune", err)
+		return err
+	}
 
 	return nil
 }

--- a/website/docs/r/ldap_auth_backend.html.md
+++ b/website/docs/r/ldap_auth_backend.html.md
@@ -73,6 +73,36 @@ The following arguments are supported:
 
 * `local` - (Optional) Specifies if the auth method is local only.
 
+* tune - (Optional) Extra configuration block. Structure is documented below.
+
+The `tune` block is used to tune the auth backend:
+
+* `default_lease_ttl` - (Optional) Specifies the default time-to-live.
+  If set, this overrides the global default.
+  Must be a valid [duration string](https://golang.org/pkg/time/#ParseDuration)
+
+* `max_lease_ttl` - (Optional) Specifies the maximum time-to-live.
+  If set, this overrides the global default.
+  Must be a valid [duration string](https://golang.org/pkg/time/#ParseDuration)
+
+* `audit_non_hmac_response_keys` - (Optional) Specifies the list of keys that will
+  not be HMAC'd by audit devices in the response data object.
+
+* `audit_non_hmac_request_keys` - (Optional) Specifies the list of keys that will
+  not be HMAC'd by audit devices in the request data object.
+
+* `listing_visibility` - (Optional) Specifies whether to show this mount in
+  the UI-specific listing endpoint. Valid values are "unauth" or "hidden".
+
+* `passthrough_request_headers` - (Optional) List of headers to whitelist and
+  pass from the request to the backend.
+
+* `allowed_response_headers` - (Optional) List of headers to whitelist and allowing
+  a plugin to include them in the response.
+
+* `token_type` - (Optional) Specifies the type of tokens that should be returned by
+  the mount. Valid values are "default-service", "default-batch", "service", "batch".
+
 ### Common Token Arguments
 
 These arguments are common across several Authentication Token resources since Vault 1.2.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->
This PR adds the `tune` field to the `ldap_auth_backend` resource. Before that, it was not possible to change the `listing_visibility` of a ldap mount. 

```release-note
IMPROVEMENTS:

resource/ldap_auth_backend: add tune block to resource
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
