### PR TITLE
Fix issue where group member entities were lost

### DIFF
--- a/vault/resource_identity_group_member_entity_ids.go
+++ b/vault/resource_identity_group_member_entity_ids.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
-
-	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
 func identityGroupMemberEntityIdsResource() *schema.Resource {
@@ -26,77 +24,95 @@ func identityGroupMemberEntityIdsResource() *schema.Resource {
 				},
 				Description: "Entity IDs to be assigned as group members.",
 			},
-
 			"exclusive": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
-				Description: "Should the resource manage member entity ids exclusively? Beware of race conditions when disabling exclusive management",
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+				Description: `Should the resource manage member entity ids 
+exclusively? Beware of race conditions when disabling exclusive management`,
 			},
-
 			"group_id": {
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 				Description: "ID of the group.",
 			},
-
 			"group_name": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Name of the group.",
+				Deprecated: `The value for group_name may not always be accurate, 
+use "data.vault_identity_group.*.group_name", "vault_identity_group.*.group_name" instead`,
 			},
 		},
 	}
 }
 
 func identityGroupMemberEntityIdsUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
-	id := d.Get("group_id").(string)
-
-	log.Printf("[DEBUG] Updating IdentityGroupMemberEntityIds %q", id)
-	path := identityGroupIDPath(id)
-
+	gid := d.Get("group_id").(string)
+	path := identityGroupIDPath(gid)
 	vaultMutexKV.Lock(path)
 	defer vaultMutexKV.Unlock(path)
 
-	data := make(map[string]interface{})
-	memberEntityIds := d.Get("member_entity_ids").(*schema.Set).List()
+	client := meta.(*api.Client)
 
-	resp, err := readIdentityGroup(client, id, d.IsNewResource())
+	log.Printf("[DEBUG] Updating IdentityGroupMemberEntityIds %q", gid)
+
+	if d.HasChange("group_id") {
+		o, n := d.GetChange("group_id")
+		log.Printf("[DEBUG] Group ID has changed old=%q, new=%q", o, n)
+	}
+	data := make(map[string]interface{})
+	resp, err := readIdentityGroup(client, gid, d.IsNewResource())
 	if err != nil {
 		return err
 	}
 
-	t, ok := resp.Data["type"]
-	if ok && t != "external" {
-		if d.Get("exclusive").(bool) {
-			data["member_entity_ids"] = memberEntityIds
+	var curIDS []interface{}
+	if t, ok := resp.Data["type"]; ok && t.(string) != "external" {
+		if v, ok := resp.Data["member_entity_ids"]; ok {
+			curIDS = v.([]interface{})
+		}
+
+		if d.Get("exclusive").(bool) || len(curIDS) == 0 {
+			data["member_entity_ids"] = d.Get("member_entity_ids").(*schema.Set).List()
 		} else {
-			apiMemberEntityIds, err := readIdentityGroupMemberEntityIds(client, id, d.IsNewResource())
-			if err != nil {
-				return err
+			set := map[interface{}]bool{}
+			for _, v := range curIDS {
+				set[v] = true
 			}
-			if d.HasChange("member_entity_ids") {
-				oldMemberEntityIdsI, _ := d.GetChange("member_entity_ids")
-				oldMemberEntityIds := oldMemberEntityIdsI.(*schema.Set).List()
-				for _, memberEntityId := range oldMemberEntityIds {
-					apiMemberEntityIds = util.SliceRemoveIfPresent(apiMemberEntityIds, memberEntityId)
+
+			o, _ := d.GetChange("member_entity_ids")
+			if !d.IsNewResource() && o != nil {
+				// set.delete()
+				for _, i := range o.(*schema.Set).List() {
+					delete(set, i)
 				}
 			}
-			for _, memberEntityId := range memberEntityIds {
-				apiMemberEntityIds = util.SliceAppendIfMissing(apiMemberEntityIds, memberEntityId)
+
+			if ids, ok := d.GetOk("member_entity_ids"); ok {
+				for _, id := range ids.(*schema.Set).List() {
+					// set.add()
+					set[id] = true
+				}
 			}
-			data["member_entity_ids"] = apiMemberEntityIds
+
+			// set.keys()
+			var result []interface{}
+			for k := range set {
+				result = append(result, k)
+			}
+			data["member_entity_ids"] = result
 		}
 	}
 
 	_, err = client.Logical().Write(path, data)
 	if err != nil {
-		return fmt.Errorf("error updating IdentityGroupMemberEntityIds %q: %s", id, err)
+		return fmt.Errorf("error updating IdentityGroupMemberEntityIds %q: %s", gid, err)
 	}
-	log.Printf("[DEBUG] Updated IdentityGroupMemberEntityIds %q", id)
+	log.Printf("[DEBUG] Updated IdentityGroupMemberEntityIds %q", gid)
 
-	d.SetId(id)
+	d.SetId(gid)
 
 	return identityGroupMemberEntityIdsRead(d, meta)
 }
@@ -123,38 +139,44 @@ func identityGroupMemberEntityIdsRead(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 
+	curIDS := resp.Data["member_entity_ids"]
 	if d.Get("exclusive").(bool) {
-		respdata := resp.Data["member_entity_ids"]
-		if err = d.Set("member_entity_ids", respdata); err != nil {
-			return fmt.Errorf("error setting member entity ids for IdentityGroupMemberEntityIds %q: %s", id, err)
+		if err = d.Set("member_entity_ids", curIDS); err != nil {
+			return err
 		}
 	} else {
-		userMemberEntityIds := d.Get("member_entity_ids").(*schema.Set).List()
-		newMemberEntityIds := make([]string, 0)
-		if ids, ok := resp.Data["member_entity_ids"].([]interface{}); ok && len(ids) > 0 {
-			for _, memberEntityId := range userMemberEntityIds {
-				if found, _ := util.SliceHasElement(ids, memberEntityId); found {
-					newMemberEntityIds = append(newMemberEntityIds, memberEntityId.(string))
-				}
+		set := map[interface{}]bool{}
+		if curIDS != nil {
+			for _, v := range curIDS.([]interface{}) {
+				set[v] = true
 			}
 		}
 
-		if err = d.Set("member_entity_ids", newMemberEntityIds); err != nil {
-			return fmt.Errorf("error setting member entity ids for IdentityGroupMemberEntityIds %q: %s", id, err)
+		var result []interface{}
+		// set.intersection()
+		if i, ok := d.GetOk("member_entity_ids"); ok {
+			for _, v := range i.(*schema.Set).List() {
+				if _, ok := set[v]; ok {
+					result = append(result, v)
+				}
+			}
+		}
+		if err = d.Set("member_entity_ids", result); err != nil {
+			return err
 		}
 	}
 	return nil
 }
 
 func identityGroupMemberEntityIdsDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
 	id := d.Get("group_id").(string)
-
-	log.Printf("[DEBUG] Deleting IdentityGroupMemberEntityIds %q", id)
 	path := identityGroupIDPath(id)
-
 	vaultMutexKV.Lock(path)
 	defer vaultMutexKV.Unlock(path)
+
+	client := meta.(*api.Client)
+
+	log.Printf("[DEBUG] Deleting IdentityGroupMemberEntityIds %q", id)
 
 	data := make(map[string]interface{})
 
@@ -171,14 +193,26 @@ func identityGroupMemberEntityIdsDelete(d *schema.ResourceData, meta interface{}
 		if d.Get("exclusive").(bool) {
 			data["member_entity_ids"] = make([]string, 0)
 		} else {
-			apiMemberEntityIds, err := readIdentityGroupMemberEntityIds(client, id, false)
-			if err != nil {
-				return err
+			set := map[interface{}]bool{}
+			if v, ok := resp.Data["member_entity_ids"]; ok {
+				for _, id := range v.([]interface{}) {
+					set[id] = true
+				}
 			}
-			for _, memberEntityId := range d.Get("member_entity_ids").(*schema.Set).List() {
-				apiMemberEntityIds = util.SliceRemoveIfPresent(apiMemberEntityIds, memberEntityId)
+
+			result := []interface{}{}
+			if len(set) > 0 {
+				if v, ok := d.GetOk("member_entity_ids"); ok {
+					for _, id := range v.(*schema.Set).List() {
+						delete(set, id)
+					}
+				}
+
+				for k := range set {
+					result = append(result, k)
+				}
 			}
-			data["member_entity_ids"] = apiMemberEntityIds
+			data["member_entity_ids"] = result
 		}
 	}
 

--- a/vault/resource_identity_group_member_entity_ids_test.go
+++ b/vault/resource_identity_group_member_entity_ids_test.go
@@ -3,6 +3,7 @@ package vault
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -19,6 +20,7 @@ import (
 func TestAccIdentityGroupMemberEntityIdsExclusiveEmpty(t *testing.T) {
 	devEntity := acctest.RandomWithPrefix("dev-entity")
 
+	resourceName := "vault_identity_group_member_entity_ids.member_entity_ids"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
@@ -27,34 +29,29 @@ func TestAccIdentityGroupMemberEntityIdsExclusiveEmpty(t *testing.T) {
 			{
 				Config: testAccIdentityGroupMemberEntityIdsConfigExclusiveEmpty(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccIdentityGroupMemberEntityIdsCheckAttrs("vault_identity_group_member_entity_ids.member_entity_ids"),
+					testAccIdentityGroupMemberEntityIdsCheckAttrs(resourceName),
 				),
 			},
 			{
 				Config: testAccIdentityGroupMemberEntityIdsConfigExclusive(devEntity),
 				Check: resource.ComposeTestCheckFunc(
-					testAccIdentityGroupMemberEntityIdsCheckAttrs("vault_identity_group_member_entity_ids.member_entity_ids"),
+					testAccIdentityGroupMemberEntityIdsCheckAttrs(resourceName),
 				),
 			},
 			{
 				Config: testAccIdentityGroupMemberEntityIdsConfigExclusiveEmpty(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccIdentityGroupMemberEntityIdsCheckAttrs("vault_identity_group_member_entity_ids.member_entity_ids"),
+					testAccIdentityGroupMemberEntityIdsCheckAttrs(resourceName),
 				),
 			},
 		},
 	})
 }
 
-// TODO: disabling this test until we can fix it because this test fails very consistently with the following error:
-// testing.go:669: Step 1 error: Check failed: Check 3/3 error: vault_identity_group_member_entity_ids.member_entity_ids:
-// Attribute 'member_entity_ids.#' expected "1", got "2"
 func TestAccIdentityGroupMemberEntityIdsExclusive(t *testing.T) {
-	t.Skip(t)
-
 	devEntity := acctest.RandomWithPrefix("dev-entity")
 	testEntity := acctest.RandomWithPrefix("test-entity")
-	var devEntityTester memberEntityTester
+	resourceName := "vault_identity_group_member_entity_ids.member_entity_ids"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
@@ -63,16 +60,15 @@ func TestAccIdentityGroupMemberEntityIdsExclusive(t *testing.T) {
 			{
 				Config: testAccIdentityGroupMemberEntityIdsConfigExclusive(devEntity),
 				Check: resource.ComposeTestCheckFunc(
-					testAccIdentityGroupMemberEntityIdsCheckAttrs("vault_identity_group_member_entity_ids.member_entity_ids"),
-					devEntityTester.GetMemberEntity("vault_identity_group_member_entity_ids.member_entity_ids", 1),
+					testAccIdentityGroupMemberEntityIdsCheckAttrs(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "member_entity_ids.#", "1"),
 				),
 			},
 			{
 				Config: testAccIdentityGroupMemberEntityIdsConfigExclusiveUpdate(devEntity, testEntity),
 				Check: resource.ComposeTestCheckFunc(
-					testAccIdentityGroupMemberEntityIdsCheckAttrs("vault_identity_group_member_entity_ids.member_entity_ids"),
-					resource.TestCheckResourceAttr("vault_identity_group_member_entity_ids.member_entity_ids", "member_entity_ids.#", "2"),
-					devEntityTester.CheckMemberEntity("vault_identity_group_member_entity_ids.member_entity_ids"),
+					testAccIdentityGroupMemberEntityIdsCheckAttrs(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "member_entity_ids.#", "2"),
 				),
 			},
 		},
@@ -83,6 +79,8 @@ func TestAccIdentityGroupMemberEntityIdsNonExclusiveEmpty(t *testing.T) {
 	devEntity := acctest.RandomWithPrefix("dev-entity")
 	testEntity := acctest.RandomWithPrefix("test-entity")
 	var devEntityTester memberEntityTester
+	resourceNameDev := "vault_identity_group_member_entity_ids.dev"
+	resourceNameTest := "vault_identity_group_member_entity_ids.test"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
@@ -91,121 +89,261 @@ func TestAccIdentityGroupMemberEntityIdsNonExclusiveEmpty(t *testing.T) {
 			{
 				Config: testAccIdentityGroupMemberEntityIdsConfigNonExclusiveEmpty(devEntity),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_identity_group_member_entity_ids.dev", "member_entity_ids.#", "1"),
-					devEntityTester.GetMemberEntity("vault_identity_group_member_entity_ids.dev", 1),
-					resource.TestCheckResourceAttr("vault_identity_group_member_entity_ids.test", "member_entity_ids.#", "0"),
+					testAccIdentityGroupMemberEntityIdsCheckAttrs(resourceNameDev),
+					testAccIdentityGroupMemberEntityIdsCheckAttrs(resourceNameTest),
+					resource.TestCheckResourceAttr(resourceNameTest, "member_entity_ids.#", "0"),
+					resource.TestCheckResourceAttr(resourceNameDev, "member_entity_ids.#", "1"),
+					devEntityTester.SetMemberEntities(resourceNameDev),
 				),
 			},
 			{
 				Config: testAccIdentityGroupMemberEntityIdsConfigNonExclusive(devEntity, testEntity),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_identity_group_member_entity_ids.dev", "member_entity_ids.#", "1"),
-					devEntityTester.CheckMemberEntity("vault_identity_group_member_entity_ids.dev"),
-					resource.TestCheckResourceAttr("vault_identity_group_member_entity_ids.test", "member_entity_ids.#", "1"),
+					testAccIdentityGroupMemberEntityIdsCheckAttrs(resourceNameDev),
+					testAccIdentityGroupMemberEntityIdsCheckAttrs(resourceNameTest),
+					resource.TestCheckResourceAttr(resourceNameTest, "member_entity_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceNameDev, "member_entity_ids.#", "1"),
+					devEntityTester.CheckMemberEntities(resourceNameDev),
 				),
 			},
 			{
 				Config: testAccIdentityGroupMemberEntityIdsConfigNonExclusiveEmpty(devEntity),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_identity_group_member_entity_ids.dev", "member_entity_ids.#", "1"),
-					devEntityTester.CheckMemberEntity("vault_identity_group_member_entity_ids.dev"),
-					resource.TestCheckResourceAttr("vault_identity_group_member_entity_ids.test", "member_entity_ids.#", "0"),
+					testAccIdentityGroupMemberEntityIdsCheckAttrs(resourceNameDev),
+					testAccIdentityGroupMemberEntityIdsCheckAttrs(resourceNameTest),
+					resource.TestCheckResourceAttr(resourceNameTest, "member_entity_ids.#", "0"),
+					resource.TestCheckResourceAttr(resourceNameDev, "member_entity_ids.#", "1"),
+					devEntityTester.CheckMemberEntities(resourceNameDev),
 				),
 			},
 		},
 	})
 }
 
-// TODO: disabling this test until we can fix it because this test fails very consistently with the following error:
-// testing.go:669: Step 2 error: Check failed: unexpected member entity id 8e6a0c69-3b7b-d609-a62c-20a8ceac800b
-// in group 77065bec-940e-2d0d-ea34-60440e1a4a47
-func TestAccIdentityGroupMemberEntityIdsNonExclusive(t *testing.T) {
-	t.Skip(t)
+type identityGMETest struct {
+	name        string
+	exclusive   bool
+	entityCount int
+}
 
-	devEntity := acctest.RandomWithPrefix("dev-entity")
-	testEntity := acctest.RandomWithPrefix("test-entity")
-	fooEntity := acctest.RandomWithPrefix("foo-entity")
-	var devEntityTester memberEntityTester
-	var testEntityTester memberEntityTester
-	var fooEntityTester memberEntityTester
+func TestAccIdentityGroupMemberEntityIdsNonExclusive(t *testing.T) {
+	var tester1 memberEntityTester
+	entity1 := acctest.RandomWithPrefix("entity")
+
+	entity2 := acctest.RandomWithPrefix("entity")
+	var tester2 memberEntityTester
+
+	entity3 := acctest.RandomWithPrefix("entity")
+	var tester3 memberEntityTester
+
+	resourceNameDev := "vault_identity_group_member_entity_ids.dev"
+	resourceNameTest := "vault_identity_group_member_entity_ids.test"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
 		CheckDestroy: testAccCheckidentityGroupMemberEntityIdsDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIdentityGroupMemberEntityIdsConfigNonExclusive(devEntity, testEntity),
+				Config: testAccIdentityGroupMemberEntityIdsConfigNonExclusive(entity1, entity2),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_identity_group_member_entity_ids.dev", "member_entity_ids.#", "1"),
-					devEntityTester.GetMemberEntity("vault_identity_group_member_entity_ids.dev", 1),
-					resource.TestCheckResourceAttr("vault_identity_group_member_entity_ids.test", "member_entity_ids.#", "1"),
-					testEntityTester.GetMemberEntity("vault_identity_group_member_entity_ids.test", 1),
+					resource.TestCheckResourceAttr(resourceNameDev, "member_entity_ids.#", "1"),
+					tester1.SetMemberEntities(resourceNameDev),
+					resource.TestCheckResourceAttr(resourceNameTest, "member_entity_ids.#", "1"),
+					tester2.SetMemberEntities(resourceNameTest),
 				),
 			},
 			{
-				Config: testAccIdentityGroupMemberEntityIdsConfigNonExclusiveUpdate(devEntity, fooEntity),
+				Config: testAccIdentityGroupMemberEntityIdsConfigNonExclusiveUpdate(entity1, entity3),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_identity_group_member_entity_ids.dev", "member_entity_ids.#", "1"),
-					devEntityTester.CheckMemberEntity("vault_identity_group_member_entity_ids.dev"),
-					resource.TestCheckResourceAttr("vault_identity_group_member_entity_ids.test", "member_entity_ids.#", "1"),
-					testEntityTester.CheckNoMemberEntity("vault_identity_group_member_entity_ids.test"),
-					fooEntityTester.GetMemberEntity("vault_identity_group_member_entity_ids.test", 1),
+					resource.TestCheckResourceAttr(resourceNameDev, "member_entity_ids.#", "1"),
+					tester1.CheckMemberEntities(resourceNameDev),
+					resource.TestCheckResourceAttr(resourceNameTest, "member_entity_ids.#", "1"),
+					tester2.SetMemberEntities(resourceNameTest),
+					tester3.SetMemberEntities(resourceNameTest),
 				),
 			},
 			{
-				Config: testAccIdentityGroupMemberEntityIdsConfigNonExclusiveUpdate(devEntity, fooEntity),
-				Check:  testAccIdentityGroupMemberEntityIdsCheckLogical("vault_identity_group.group", []*memberEntityTester{&devEntityTester, &fooEntityTester}),
+				Config: testAccIdentityGroupMemberEntityIdsConfigNonExclusiveUpdate(entity1, entity3),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceNameDev, "member_entity_ids.#", "1"),
+					tester1.CheckMemberEntities(resourceNameDev),
+					resource.TestCheckResourceAttr(resourceNameTest, "member_entity_ids.#", "1"),
+					tester2.CheckMemberEntities(resourceNameTest),
+					tester3.CheckMemberEntities(resourceNameTest),
+				),
 			},
 		},
 	})
+}
+
+func TestAccIdentityGroupMemberEntityIdsDynamic(t *testing.T) {
+	tests := []*identityGMETest{
+		{
+			name:        acctest.RandomWithPrefix("entity"),
+			exclusive:   false,
+			entityCount: 0,
+		},
+		{
+			name:        acctest.RandomWithPrefix("entity"),
+			exclusive:   false,
+			entityCount: 1,
+		},
+		{
+			name:        acctest.RandomWithPrefix("entity"),
+			exclusive:   false,
+			entityCount: 2,
+		},
+		{
+			name:        acctest.RandomWithPrefix("entity"),
+			exclusive:   false,
+			entityCount: 3,
+		},
+		{
+			name:        acctest.RandomWithPrefix("entity"),
+			exclusive:   false,
+			entityCount: 4,
+		},
+	}
+
+	groupName := acctest.RandomWithPrefix("group")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckidentityGroupMemberEntityIdsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityGMEIDynamic(groupName, true, tests...),
+				Check:  testIdentityGMEIMembers(groupName, tests...),
+			},
+			{
+				// increment entities
+				PreConfig: func() {
+					for _, t := range tests {
+						t.entityCount++
+					}
+				},
+				Config: testAccIdentityGMEIDynamic(groupName, true, tests...),
+				Check:  testIdentityGMEIMembers(groupName, tests...),
+			},
+			{
+				// decrement entities
+				PreConfig: func() {
+					for _, t := range tests {
+						t.entityCount--
+					}
+				},
+				Config: testAccIdentityGMEIDynamic(groupName, true, tests...),
+				Check:  testIdentityGMEIMembers(groupName, tests...),
+			},
+			{
+				// decrement tests, simulates resource destruction
+				Config: testAccIdentityGMEIDynamic(groupName, true, tests[:len(tests)-1]...),
+				Check:  testIdentityGMEIMembers(groupName, tests[:len(tests)-1]...),
+			},
+		},
+	})
+}
+
+func testIdentityGMEIMembers(groupName string, tests ...*identityGMETest) resource.TestCheckFunc {
+	var funcs []resource.TestCheckFunc
+	for _, t := range tests {
+		r := fmt.Sprintf("vault_identity_group_member_entity_ids.%s", t.name)
+		funcs = append(funcs,
+			resource.TestCheckResourceAttr(r, "member_entity_ids.#", strconv.Itoa(t.entityCount)),
+			resource.TestCheckResourceAttr(r, "exclusive", fmt.Sprintf("%t", t.exclusive)),
+			testAccIdentityGroupMemberEntityIdsCheckAttrs(r),
+		)
+	}
+	return resource.ComposeTestCheckFunc(funcs...)
+}
+
+func testAccIdentityGMEIDynamic(groupName string, externalGroup bool, tests ...*identityGMETest) string {
+	fragments := []string{
+		fmt.Sprintf(`
+resource "vault_identity_group" "group" {
+		external_member_entity_ids = %t
+		name                       = "%s"
+	}
+`, externalGroup, groupName),
+	}
+
+	for i, t := range tests {
+		fragments = append(
+			fragments, fmt.Sprintf(
+				`
+resource "vault_identity_entity" "entity_%d"{
+  count = %d
+  name  = "%s_${count.index}"
+  metadata = {
+    version = "2"
+  }
+}
+
+resource "vault_identity_group_member_entity_ids" "%s" {
+  group_id          = vault_identity_group.group.id
+  exclusive         = %t
+  member_entity_ids = coalesce(vault_identity_entity.entity_%d.*.id)
+}
+	`, i, t.entityCount, t.name, t.name, t.exclusive, i),
+		)
+	}
+
+	config := strings.Join(fragments, "\n")
+
+	return config
 }
 
 type memberEntityTester struct {
-	EntityIDKey   string
-	EntityIDValue string
+	EntityIDS []string
 }
 
-func (tester *memberEntityTester) GetMemberEntity(resource string, index int) resource.TestCheckFunc {
+func (r *memberEntityTester) SetMemberEntities(resource string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		resourceState := s.Modules[0].Resources[resource]
-		if resourceState == nil {
-			return fmt.Errorf("resource not found in state")
+		result, err := r.getMemberEntities(s, resource)
+		if err != nil {
+			return err
 		}
+		r.EntityIDS = result
+		return nil
+	}
+}
 
-		instanceState := resourceState.Primary
-		if instanceState == nil {
-			return fmt.Errorf("resource not found in state")
-		}
+func (r *memberEntityTester) getMemberEntities(s *terraform.State, resource string) ([]string, error) {
+	var result []string
+	resourceState := s.Modules[0].Resources[resource]
+	if resourceState == nil {
+		return result, fmt.Errorf("resource not found in state")
+	}
 
-		// TestCheckResourceAttr index starts at 1
-		count := 1
-		for key, element := range instanceState.Attributes {
-			if strings.HasPrefix(key, "member_entity_ids") {
-				if count == index {
-					tester.EntityIDKey = key
-					tester.EntityIDValue = element
-					return nil
-				}
+	instanceState := resourceState.Primary
+	if instanceState == nil {
+		return result, fmt.Errorf("resource not found in state")
+	}
 
-				count++
+	count, err := strconv.Atoi(instanceState.Attributes["member_entity_ids.#"])
+	if err != nil {
+		return nil, err
+	}
+
+	for i := 0; i < count; i++ {
+		k := fmt.Sprintf("member_entity_ids.%d", i)
+		result = append(result, instanceState.Attributes[k])
+	}
+
+	return result, nil
+}
+
+func (r *memberEntityTester) CheckMemberEntities(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for i, v := range r.EntityIDS {
+			k := fmt.Sprintf("member_entity_ids.%d", i)
+			f := resource.TestCheckResourceAttr(resourceName, k, v)
+			if err := f(s); err != nil {
+				return err
 			}
 		}
-
-		return fmt.Errorf("member entity index at %d  not found", index)
-	}
-}
-
-func (tester *memberEntityTester) CheckMemberEntity(resourceString string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		f := resource.TestCheckResourceAttr(resourceString, tester.EntityIDKey, tester.EntityIDValue)
-		return f(s)
-	}
-}
-
-func (tester *memberEntityTester) CheckNoMemberEntity(resourceString string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		f := resource.TestCheckNoResourceAttr(resourceString, tester.EntityIDKey)
-		return f(s)
+		return nil
 	}
 }
 
@@ -247,149 +385,140 @@ func testAccCheckidentityGroupMemberEntityIdsDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccIdentityGroupMemberEntityIdsCheckAttrs(resource string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		resourceState := s.Modules[0].Resources[resource]
-		if resourceState == nil {
-			return fmt.Errorf("resource not found in state")
-		}
-
-		instanceState := resourceState.Primary
-		if instanceState == nil {
-			return fmt.Errorf("resource not found in state")
-		}
-
-		id := instanceState.ID
-
-		path := identityGroupIDPath(id)
-		client := testProvider.Meta().(*api.Client)
-		resp, err := client.Logical().Read(path)
-		if err != nil {
-			return fmt.Errorf("%q doesn't exist", path)
-		}
-
-		attrs := map[string]string{
-			"group_id":          "id",
-			"group_name":        "name",
-			"member_entity_ids": "member_entity_ids",
-		}
-		for stateAttr, apiAttr := range attrs {
-			if resp.Data[apiAttr] == nil && instanceState.Attributes[stateAttr] == "" {
-				continue
-			}
-			var match bool
-			switch resp.Data[apiAttr].(type) {
-			case json.Number:
-				apiData, err := resp.Data[apiAttr].(json.Number).Int64()
-				if err != nil {
-					return fmt.Errorf("expected API field %s to be an int, was %q", apiAttr, resp.Data[apiAttr])
-				}
-				stateData, err := strconv.ParseInt(instanceState.Attributes[stateAttr], 10, 64)
-				if err != nil {
-					return fmt.Errorf("expected state field %s to be an int, was %q", stateAttr, instanceState.Attributes[stateAttr])
-				}
-				match = apiData == stateData
-			case bool:
-				if _, ok := resp.Data[apiAttr]; !ok && instanceState.Attributes[stateAttr] == "" {
-					match = true
-				} else {
-					stateData, err := strconv.ParseBool(instanceState.Attributes[stateAttr])
-					if err != nil {
-						return fmt.Errorf("expected state field %s to be a bool, was %q", stateAttr, instanceState.Attributes[stateAttr])
-					}
-					match = resp.Data[apiAttr] == stateData
-				}
-			case []interface{}:
-				apiData := resp.Data[apiAttr].([]interface{})
-				length := instanceState.Attributes[stateAttr+".#"]
-				if length == "" {
-					if len(resp.Data[apiAttr].([]interface{})) != 0 {
-						return fmt.Errorf("expected state field %s to have %d entries, had 0", stateAttr, len(apiData))
-					}
-					match = true
-				} else {
-					count, err := strconv.Atoi(length)
-					if err != nil {
-						return fmt.Errorf("expected %s.# to be a number, got %q", stateAttr, instanceState.Attributes[stateAttr+".#"])
-					}
-					if count != len(apiData) {
-						return fmt.Errorf("expected %s to have %d entries in state, has %d", stateAttr, len(apiData), count)
-					}
-
-					for i := 0; i < count; i++ {
-						found := false
-						for stateKey, stateValue := range instanceState.Attributes {
-							if strings.HasPrefix(stateKey, stateAttr) {
-								if apiData[i] == stateValue {
-									found = true
-								}
-							}
-						}
-						if !found {
-							return fmt.Errorf("Expected item %d of %s (%s in state) of %q to be in state but wasn't", i, apiAttr, stateAttr, apiData[i])
-						}
-					}
-					match = true
-				}
-			default:
-				match = resp.Data[apiAttr] == instanceState.Attributes[stateAttr]
-			}
-			if !match {
-				return fmt.Errorf("expected %s (%s in state) of %q to be %q, got %q", apiAttr, stateAttr, path, instanceState.Attributes[stateAttr], resp.Data[apiAttr])
-			}
-		}
-		return nil
-	}
+// vaultStateTest
+type vaultStateTest struct {
+	// rs fully qualified resource name
+	rs        string
+	stateAttr string
+	vaultAttr string
+	// isSubset check when checking equality of []interface{} state value
+	isSubset bool
 }
 
-func testAccIdentityGroupMemberEntityIdsCheckLogical(resource string, member_entity_ids []*memberEntityTester) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		resourceState := s.Modules[0].Resources[resource]
-		if resourceState == nil {
+func assertVaultState(tfs *terraform.State, path string, stateTests ...*vaultStateTest) error {
+	client := testProvider.Meta().(*api.Client)
+	resp, err := client.Logical().Read(path)
+	if err != nil {
+		return fmt.Errorf("%q doesn't exist", path)
+	}
+
+	for _, st := range stateTests {
+		rs := tfs.Modules[0].Resources[st.rs]
+		if rs == nil || (rs != nil && rs.Primary == nil) {
 			return fmt.Errorf("resource not found in state")
 		}
+		attrs := rs.Primary.Attributes
 
-		instanceState := resourceState.Primary
-		if instanceState == nil {
-			return fmt.Errorf("resource not found in state")
+		s := attrs[st.stateAttr]
+		v := resp.Data[st.vaultAttr]
+		if v == nil && s == "" {
+			continue
 		}
 
-		id := instanceState.ID
+		errFmt := fmt.Sprintf("expected %s (%%s in state) of %q to be %%#v, got %%#v",
+			st.vaultAttr, path)
 
-		path := identityGroupIDPath(id)
-		client := testProvider.Meta().(*api.Client)
-		resp, err := client.Logical().Read(path)
-		if err != nil {
-			return fmt.Errorf("%q doesn't exist", path)
-		}
-
-		if resp.Data["member_entity_ids"] == nil && member_entity_ids == nil {
-			return nil
-		}
-
-		apiMemberEntityIds := resp.Data["member_entity_ids"].([]interface{})
-
-		if len(apiMemberEntityIds) != len(member_entity_ids) {
-			return fmt.Errorf("expected group %s to have %d member_entity_ids, has %d", id, len(member_entity_ids), len(apiMemberEntityIds))
-		}
-
-		for _, apiMemberEntityIdI := range apiMemberEntityIds {
-			apiMemberEntityId := apiMemberEntityIdI.(string)
-
-			found := false
-			for _, memberEntityId := range member_entity_ids {
-				if apiMemberEntityId == memberEntityId.EntityIDValue {
-					found = true
-					break
+		switch v := v.(type) {
+		case json.Number:
+			actual, err := v.Int64()
+			if err != nil {
+				return fmt.Errorf("expected API field %s to be an int, was %T", st.vaultAttr, v)
+			}
+			expected, err := strconv.ParseInt(s, 10, 64)
+			if err != nil {
+				return fmt.Errorf("expected state field %s to be a %T, was %T", st.stateAttr, v, s)
+			}
+			if actual != expected {
+				return fmt.Errorf(errFmt, st.stateAttr, expected, actual)
+			}
+		case bool:
+			actual := v
+			if s != "" {
+				expected, err := strconv.ParseBool(s)
+				if err != nil {
+					return fmt.Errorf("expected state field %s to be a %T, was %T", st.stateAttr, v, s)
+				}
+				if actual != expected {
+					return fmt.Errorf(errFmt, st.stateAttr, expected, actual)
+				}
+			}
+		case []interface{}:
+			actual := v
+			l := len(v)
+			expected := []interface{}{}
+			for i := 0; i < l; i++ {
+				if v, ok := attrs[fmt.Sprintf("%s.%d", st.stateAttr, i)]; ok {
+					expected = append(expected, v)
 				}
 			}
 
-			if !found {
-				return fmt.Errorf("unexpected member entity id %s in group %s", apiMemberEntityId, id)
+			if st.isSubset {
+				if len(expected) > len(actual) {
+					return fmt.Errorf(errFmt, st.stateAttr, expected, actual)
+				}
+
+				var count int
+				for _, v := range expected {
+					for _, a := range actual {
+						if reflect.DeepEqual(v, a) {
+							count++
+						}
+					}
+				}
+				if len(expected) != count {
+					return fmt.Errorf(errFmt, st.stateAttr, expected, actual)
+				}
+			} else {
+				if !reflect.DeepEqual(expected, actual) {
+					return fmt.Errorf(errFmt, st.stateAttr, expected, actual)
+				}
 			}
+
+		case string:
+			if v != s {
+				return fmt.Errorf(errFmt, st.stateAttr, s, v)
+			}
+		default:
+			return fmt.Errorf("unsupported type %T", v)
+		}
+	}
+
+	return nil
+}
+
+func testAccIdentityGroupMemberEntityIdsCheckAttrs(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs := s.Modules[0].Resources[resourceName]
+		if rs == nil || (rs != nil && rs.Primary == nil) {
+			return fmt.Errorf("resource %q not found in state", resourceName)
 		}
 
-		return nil
+		var isSubset bool
+		if rs.Type == "vault_identity_group_member_entity_ids" {
+			v, err := strconv.ParseBool(rs.Primary.Attributes["exclusive"])
+			if err != nil {
+				return err
+			}
+
+			isSubset = !v
+		}
+
+		id := rs.Primary.ID
+		path := identityGroupIDPath(id)
+		tAttrs := []*vaultStateTest{
+			{
+				rs:        resourceName,
+				stateAttr: "group_id",
+				vaultAttr: "id",
+			},
+			{
+				rs:        resourceName,
+				stateAttr: "member_entity_ids",
+				vaultAttr: "member_entity_ids",
+				isSubset:  isSubset,
+			},
+		}
+		return assertVaultState(s, path, tAttrs...)
 	}
 }
 

--- a/vault/resource_identity_group_member_entity_ids_test.go
+++ b/vault/resource_identity_group_member_entity_ids_test.go
@@ -241,6 +241,11 @@ func TestAccIdentityGroupMemberEntityIdsDynamic(t *testing.T) {
 				Config: testAccIdentityGMEIDynamic(groupName, true, tests[:len(tests)-1]...),
 				Check:  testIdentityGMEIMembers(groupName, tests[:len(tests)-1]...),
 			},
+			{
+				// alternate group_name to ensure that `vault_identity_group` doesn't wipe out our identities
+				Config: testAccIdentityGMEIDynamic(groupName+"-new", true, tests...),
+				Check:  testIdentityGMEIMembers(groupName+"-new", tests...),
+			},
 		},
 	})
 }

--- a/website/docs/r/identity_group_member_entity_ids.html.md
+++ b/website/docs/r/identity_group_member_entity_ids.html.md
@@ -98,4 +98,6 @@ The following arguments are supported:
 
 In addition to all arguments above, the following attributes are exported:
 
-* `group_name` - The name of the group that are assigned the member entities.
+* `group_name` - The name of the group that are assigned the member entities.  
+  *Deprecated: The value for group_name may not always be accurate*
+  *use* `data.vault_identity_group.*.group_name`, *or* `vault_identity_group.*.group_name` *instead.*


### PR DESCRIPTION
The `identity_group` resource was removing the `member_entity_ids` when
configured with `external_member_entity_ids`. In this case the
`member_entity_ids` are handled externally and should not be modified by
the `identity_group` resource. The issue only manifested on resource
update when any of the tracked fields had changes.

Fixes:
- completely re-work the tests for
  identity_group_member_entity_ids, making them more reliable
- add test cases that include changing a identity_group's group_name,
  which triggers the issue in the identity_group resource
- make set type operations simpler
- numerous other fixes

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-v -test.run TestAccIdentityGroupMemberEntity*'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -v -test.run TestAccIdentityGroupMemberEntity* -timeout 30m ./...

[...]

=== RUN   TestAccIdentityGroupMemberEntityIdsExclusiveEmpty
--- PASS: TestAccIdentityGroupMemberEntityIdsExclusiveEmpty (9.01s)
=== RUN   TestAccIdentityGroupMemberEntityIdsExclusive
--- PASS: TestAccIdentityGroupMemberEntityIdsExclusive (3.00s)
=== RUN   TestAccIdentityGroupMemberEntityIdsNonExclusiveEmpty
--- PASS: TestAccIdentityGroupMemberEntityIdsNonExclusiveEmpty (4.30s)
=== RUN   TestAccIdentityGroupMemberEntityIdsNonExclusive
--- PASS: TestAccIdentityGroupMemberEntityIdsNonExclusive (4.30s)
=== RUN   TestAccIdentityGroupMemberEntityIdsDynamic
--- PASS: TestAccIdentityGroupMemberEntityIdsDynamic (6.27s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     27.478s
```
