### PR TITLE
Add new allowed_user_key_config field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.5.0 (Unreleased)
+FEATURES:
+* `resource/vault_ssh_secret_backend_role`: support configuring multiple public SSH key lengths in vault-1.10+
+  ([#1413](https://github.com/terraform-providers/terraform-provider-vault/pull/1413))
+
 ## 3.4.1 (March 31, 2022)
 BUGS:
 * `data/azure_access_credentials`: Fix panic when `tenant_id` and `subscription_id` are specified together; add new `environment` override field

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/gosimple/slug v1.11.0
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
+	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-hclog v1.0.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-retryablehttp v0.7.0
@@ -27,5 +28,6 @@ require (
 	github.com/hashicorp/vault/sdk v0.3.1-0.20211214161113-fcc5f22bea02
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/opencontainers/image-spec v1.0.2 // indirect
+	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3
 	golang.org/x/oauth2 v0.0.0-20211005180243-6b3c2da341f1
 )

--- a/vault/resource_ssh_secret_backend_role.go
+++ b/vault/resource_ssh_secret_backend_role.go
@@ -378,7 +378,7 @@ func setSSHRoleKeyConfig(d *schema.ResourceData, role *api.Secret) error {
 		return err
 	}
 
-	newField := "allowed_user_key_lengths"
+	newField := "allowed_user_key_config"
 	legacyField := "allowed_user_key_lengths"
 	// work around to support the allowed_user_key_lengths with Vault 1.10+
 	if _, ok := d.GetOk(legacyField); ok {
@@ -405,7 +405,7 @@ func setSSHRoleKeyConfig(d *schema.ResourceData, role *api.Secret) error {
 		return d.Set(newField, v)
 	} else {
 		// set the key configuration
-		return d.Set("allowed_user_key_config", keyConfigs)
+		return d.Set(newField, keyConfigs)
 	}
 }
 

--- a/vault/resource_ssh_secret_backend_role.go
+++ b/vault/resource_ssh_secret_backend_role.go
@@ -402,7 +402,7 @@ func setSSHRoleKeyConfig(d *schema.ResourceData, role *api.Secret) error {
 			v[keyType] = l
 		}
 
-		return d.Set(newField, v)
+		return d.Set(legacyField, v)
 	} else {
 		// set the key configuration
 		return d.Set(newField, keyConfigs)

--- a/vault/resource_ssh_secret_backend_role.go
+++ b/vault/resource_ssh_secret_backend_role.go
@@ -6,16 +6,175 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
+	"golang.org/x/crypto/ssh"
 )
 
 var (
 	sshSecretBackendRoleBackendFromPathRegex = regexp.MustCompile("^(.+)/roles/.+$")
 	sshSecretBackendRoleNameFromPathRegex    = regexp.MustCompile("^.+/roles/(.+$)")
+	sshRoleSupportPublicKeyTypes             = []string{
+		"rsa", "ecdsa", "ec", "dsa", "ed25519",
+		ssh.KeyAlgoRSA, ssh.KeyAlgoDSA, ssh.KeyAlgoED25519,
+		ssh.KeyAlgoECDSA256, ssh.KeyAlgoECDSA384, ssh.KeyAlgoECDSA521,
+	}
 )
 
 func sshSecretBackendRoleResource() *schema.Resource {
+	s := map[string]*schema.Schema{
+		"name": {
+			Type:        schema.TypeString,
+			Required:    true,
+			ForceNew:    true,
+			Description: "Unique name for the role.",
+		},
+		"backend": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+		"allow_bare_domains": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+		"allow_host_certificates": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+		"allow_subdomains": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+		"allow_user_certificates": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+		"allow_user_key_ids": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+		"allowed_critical_options": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"allowed_domains": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"cidr_list": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"allowed_extensions": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"default_extensions": {
+			Type:     schema.TypeMap,
+			Optional: true,
+		},
+		"default_critical_options": {
+			Type:     schema.TypeMap,
+			Optional: true,
+		},
+		"allowed_users_template": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+		"allowed_users": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"default_user": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"key_id_format": {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		"key_type": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		"allowed_user_key_lengths": {
+			Type:          schema.TypeMap,
+			Optional:      true,
+			ConflictsWith: []string{"allowed_user_key_config"},
+			Deprecated:    "Set in allowed_user_key_config",
+			Elem: &schema.Schema{
+				Type: schema.TypeInt,
+			},
+		},
+		"allowed_user_key_config": {
+			Type:          schema.TypeSet,
+			Optional:      true,
+			Description:   "Set of allowed public key types and their relevant configuration",
+			ConflictsWith: []string{"allowed_user_key_lengths"},
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"type": {
+						Required: true,
+						Type:     schema.TypeString,
+						Description: fmt.Sprintf("Key type, choices:\n%s",
+							strings.Join(sshRoleSupportPublicKeyTypes, ", ")),
+						ValidateDiagFunc: func(i interface{}, path cty.Path) diag.Diagnostics {
+							v := i.(string)
+							for _, allowed := range sshRoleSupportPublicKeyTypes {
+								if v == allowed {
+									return nil
+								}
+							}
+
+							return []diag.Diagnostic{
+								{
+									Severity: diag.Error,
+									Summary:  fmt.Sprintf("Unsupported key type %q specified", v),
+									Detail: fmt.Sprintf(
+										"Supported key types are:\n%s",
+										strings.Join(sshRoleSupportPublicKeyTypes, ", ")),
+									AttributePath: path,
+								},
+							}
+						},
+					},
+					"lengths": {
+						Description: "List of allowed key lengths, vault-1.10 and above",
+						Optional:    true,
+						Type:        schema.TypeList,
+						Elem: &schema.Schema{
+							Type: schema.TypeInt,
+						},
+					},
+				},
+			},
+		},
+		"algorithm_signer": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+		"max_ttl": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+		"ttl": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+	}
+
 	return &schema.Resource{
 		Create: sshSecretBackendRoleWrite,
 		Read:   sshSecretBackendRoleRead,
@@ -26,108 +185,7 @@ func sshSecretBackendRoleResource() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				Description: "Unique name for the role.",
-			},
-			"backend": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"allow_bare_domains": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"allow_host_certificates": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"allow_subdomains": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"allow_user_certificates": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"allow_user_key_ids": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"allowed_critical_options": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"allowed_domains": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"cidr_list": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"allowed_extensions": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"default_extensions": {
-				Type:     schema.TypeMap,
-				Optional: true,
-			},
-			"default_critical_options": {
-				Type:     schema.TypeMap,
-				Optional: true,
-			},
-			"allowed_users_template": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"allowed_users": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"default_user": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"key_id_format": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-			"key_type": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"allowed_user_key_lengths": {
-				Type:     schema.TypeMap,
-				Optional: true,
-			},
-			"algorithm_signer": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			"max_ttl": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-			"ttl": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-		},
+		Schema: s,
 	}
 }
 
@@ -174,7 +232,6 @@ func sshSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("allowed_users_template"); ok {
 		data["allowed_users_template"] = v.(bool)
-
 	}
 
 	if v, ok := d.GetOk("allowed_users"); ok {
@@ -189,10 +246,6 @@ func sshSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) error {
 		data["key_id_format"] = v.(string)
 	}
 
-	if v, ok := d.GetOk("allowed_user_key_lengths"); ok {
-		data["allowed_user_key_lengths"] = v
-	}
-
 	if v, ok := d.GetOk("algorithm_signer"); ok {
 		data["algorithm_signer"] = v.(string)
 	}
@@ -205,14 +258,55 @@ func sshSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) error {
 		data["ttl"] = v.(string)
 	}
 
+	var isUserKeyConfig bool
+	if v, ok := d.GetOk("allowed_user_key_config"); ok {
+		// post vault-1.10
+		isUserKeyConfig = true
+		vals := make(map[string][]interface{})
+		for _, m := range v.(*schema.Set).List() {
+			val := m.(map[string]interface{})
+			vals[val["type"].(string)] = val["lengths"].([]interface{})
+		}
+		data["allowed_user_key_lengths"] = vals
+	} else if v, ok := d.GetOk("allowed_user_key_lengths"); ok {
+		// pre vault-1.10
+		data["allowed_user_key_lengths"] = v
+	}
+
 	log.Printf("[DEBUG] Writing role %q on SSH backend %q", name, backend)
 	_, err := client.Logical().Write(path, data)
 	if err != nil {
-		return fmt.Errorf("error writing role %q for backend %q: %s", name, backend, err)
+		// in the case where vault does not support a list of key lengths,
+		// we fall back to map[string]interface{}.
+		// TODO: once we support Vault API version semantics,
+		// we can use it rather than checking the error string.
+		if isUserKeyConfig && strings.Contains(err.Error(),
+			"error processing allowed_user_key_lengths") {
+			keyConfigs := make(map[string]interface{}, 0)
+			for k, v := range data["allowed_user_key_lengths"].(map[string][]interface{}) {
+				var l interface{}
+				count := len(v)
+				if count > 0 {
+					l = v[0]
+				}
+				if count > 1 {
+					log.Printf("[WARN] Only single key lengths are supported by the Vault server, "+
+						"but %d are configured for key type %q", count, k)
+				}
+				keyConfigs[k] = l
+			}
+			data["allowed_user_key_lengths"] = keyConfigs
+			_, err = client.Logical().Write(path, data)
+		}
+
+		if err != nil {
+			return fmt.Errorf("error writing role %q for backend %q: %s", name, backend, err)
+		}
 	}
 	log.Printf("[DEBUG] Wrote role %q on SSH backend %q", name, backend)
 
 	d.SetId(path)
+
 	return sshSecretBackendRoleRead(d, meta)
 }
 
@@ -246,30 +340,104 @@ func sshSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 		d.SetId("")
 		return nil
 	}
-	d.Set("name", name)
-	d.Set("backend", backend)
-	d.Set("key_type", role.Data["key_type"])
-	d.Set("allow_bare_domains", role.Data["allow_bare_domains"])
-	d.Set("allow_host_certificates", role.Data["allow_host_certificates"])
-	d.Set("allow_subdomains", role.Data["allow_subdomains"])
-	d.Set("allow_user_certificates", role.Data["allow_user_certificates"])
-	d.Set("allow_user_key_ids", role.Data["allow_user_key_ids"])
-	d.Set("allowed_critical_options", role.Data["allowed_critical_options"])
-	d.Set("allowed_domains", role.Data["allowed_domains"])
-	d.Set("cidr_list", role.Data["cidr_list"])
-	d.Set("allowed_extensions", role.Data["allowed_extensions"])
-	d.Set("default_extensions", role.Data["default_extensions"])
-	d.Set("default_critical_options", role.Data["default_critical_options"])
-	d.Set("allowed_users_template", role.Data["allowed_users_template"])
-	d.Set("allowed_users", role.Data["allowed_users"])
-	d.Set("default_user", role.Data["default_user"])
-	d.Set("key_id_format", role.Data["key_id_format"])
-	d.Set("allowed_user_key_lengths", role.Data["allowed_user_key_lengths"])
-	d.Set("max_ttl", role.Data["max_ttl"])
-	d.Set("ttl", role.Data["ttl"])
-	d.Set("algorithm_signer", role.Data["algorithm_signer"])
+
+	if err := d.Set("name", name); err != nil {
+		return err
+	}
+
+	if err := d.Set("backend", backend); err != nil {
+		return err
+	}
+
+	fields := []string{
+		"key_type", "allow_bare_domains", "allow_host_certificates",
+		"allow_subdomains", "allow_user_certificates", "allow_user_key_ids",
+		"allowed_critical_options", "allowed_domains",
+		"cidr_list", "allowed_extensions", "default_extensions",
+		"default_critical_options", "allowed_users_template",
+		"allowed_users", "default_user", "key_id_format",
+		"max_ttl", "ttl", "algorithm_signer",
+	}
+
+	for _, k := range fields {
+		if err := d.Set(k, role.Data[k]); err != nil {
+			return err
+		}
+	}
+
+	if err := setSSHRoleKeyConfig(d, role); err != nil {
+		return err
+	}
 
 	return nil
+}
+
+func setSSHRoleKeyConfig(d *schema.ResourceData, role *api.Secret) error {
+	keyConfigs, err := getSSHRoleKeyConfig(role)
+	if err != nil {
+		return err
+	}
+
+	newField := "allowed_user_key_lengths"
+	legacyField := "allowed_user_key_lengths"
+	// work around to support the allowed_user_key_lengths with Vault 1.10+
+	if _, ok := d.GetOk(legacyField); ok {
+		v := make(map[string]interface{})
+		for _, val := range keyConfigs {
+			keyType := val["type"].(string)
+			lengths := val["lengths"].([]interface{})
+			var l interface{}
+			count := len(lengths)
+			if count > 0 {
+				l = lengths[0]
+			}
+
+			if count > 1 {
+				log.Printf("[WARN] Vault 1.10+ returned more than one "+
+					"key length for key type %q, specify key lengths in a "+
+					"%q block instead of %q with values %v",
+					newField, keyType, legacyField, lengths)
+			}
+
+			v[keyType] = l
+		}
+
+		return d.Set(newField, v)
+	} else {
+		// set the key configuration
+		return d.Set("allowed_user_key_config", keyConfigs)
+	}
+}
+
+func getSSHRoleKeyConfig(role *api.Secret) ([]map[string]interface{}, error) {
+	keyConfigs := make([]map[string]interface{}, 0)
+
+	l, ok := role.Data["allowed_user_key_lengths"].(map[string]interface{})
+	if !ok {
+		return nil, nil
+	}
+
+	for keyType, i := range l {
+		var lengths []interface{}
+		switch v := i.(type) {
+		// vault-1.10+ response
+		case []interface{}:
+			lengths = v
+		// vault-1.9- response
+		case interface{}:
+			lengths = append(lengths, v)
+		default:
+			return nil, fmt.Errorf("unexpected value type %T returned for "+
+				"allowed_user_key_lengths in vault response", v)
+		}
+
+		keyConfigs = append(keyConfigs, map[string]interface{}{
+			"type":    keyType,
+			"lengths": lengths,
+		})
+	}
+
+	return keyConfigs, nil
 }
 
 func sshSecretBackendRoleDelete(d *schema.ResourceData, meta interface{}) error {

--- a/vault/resource_ssh_secret_backend_role.go
+++ b/vault/resource_ssh_secret_backend_role.go
@@ -149,7 +149,7 @@ func sshSecretBackendRoleResource() *schema.Resource {
 					},
 					"lengths": {
 						Description: "List of allowed key lengths, vault-1.10 and above",
-						Optional:    true,
+						Required:    true,
 						Type:        schema.TypeList,
 						Elem: &schema.Schema{
 							Type: schema.TypeInt,

--- a/vault/resource_ssh_secret_backend_role_test.go
+++ b/vault/resource_ssh_secret_backend_role_test.go
@@ -2,6 +2,8 @@ package vault
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -12,10 +14,60 @@ import (
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
-func TestAccSSHSecretBackendRole_basic(t *testing.T) {
-	t.Skipf("Skip until VAULT-5535 is fixed")
+func TestAccSSHSecretBackendRole(t *testing.T) {
 	backend := acctest.RandomWithPrefix("tf-test/ssh")
 	name := acctest.RandomWithPrefix("tf-test-role")
+
+	resourceName := "vault_ssh_secret_backend_role.test_role"
+
+	commonCheckFuncs := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(resourceName, "name", name),
+		resource.TestCheckResourceAttr(resourceName, "backend", backend),
+	}
+
+	initialCheckFuncs := append(commonCheckFuncs,
+		resource.TestCheckResourceAttr(resourceName, "allow_bare_domains", "false"),
+		resource.TestCheckResourceAttr(resourceName, "allow_host_certificates", "false"),
+		resource.TestCheckResourceAttr(resourceName, "allow_subdomains", "false"),
+		resource.TestCheckResourceAttr(resourceName, "allow_user_certificates", "true"),
+		resource.TestCheckResourceAttr(resourceName, "allow_user_key_ids", "false"),
+		resource.TestCheckResourceAttr(resourceName, "allowed_critical_options", ""),
+		resource.TestCheckResourceAttr(resourceName, "allowed_domains", ""),
+		resource.TestCheckResourceAttr(resourceName, "allowed_extensions", ""),
+		resource.TestCheckResourceAttr(resourceName, "default_extensions.%", "0"),
+		resource.TestCheckResourceAttr(resourceName, "default_critical_options.%", "0"),
+		resource.TestCheckResourceAttr(resourceName, "allowed_users_template", "false"),
+		resource.TestCheckResourceAttr(resourceName, "allowed_users", ""),
+		resource.TestCheckResourceAttr(resourceName, "default_user", ""),
+		resource.TestCheckResourceAttr(resourceName, "key_id_format", ""),
+		resource.TestCheckResourceAttr(resourceName, "key_type", "ca"),
+		resource.TestCheckResourceAttr(resourceName, "allowed_user_key_config_lengths.%", "0"),
+		resource.TestCheckResourceAttr(resourceName, "algorithm_signer", "default"),
+		resource.TestCheckResourceAttr(resourceName, "max_ttl", "0"),
+		resource.TestCheckResourceAttr(resourceName, "ttl", "0"),
+	)
+
+	updateCheckFuncs := append(commonCheckFuncs,
+		resource.TestCheckResourceAttr(resourceName, "allow_bare_domains", "true"),
+		resource.TestCheckResourceAttr(resourceName, "allow_host_certificates", "true"),
+		resource.TestCheckResourceAttr(resourceName, "allow_subdomains", "true"),
+		resource.TestCheckResourceAttr(resourceName, "allow_user_certificates", "false"),
+		resource.TestCheckResourceAttr(resourceName, "allow_user_key_ids", "true"),
+		resource.TestCheckResourceAttr(resourceName, "allowed_critical_options", "foo,bar"),
+		resource.TestCheckResourceAttr(resourceName, "allowed_domains", "example.com,foo.com"),
+		resource.TestCheckResourceAttr(resourceName, "allowed_extensions", "ext1,ext2"),
+		resource.TestCheckResourceAttr(resourceName, "default_extensions.ext1", ""),
+		resource.TestCheckResourceAttr(resourceName, "default_critical_options.opt1", ""),
+		resource.TestCheckResourceAttr(resourceName, "allowed_users_template", "true"),
+		resource.TestCheckResourceAttr(resourceName, "allowed_users", "usr1,usr2"),
+		resource.TestCheckResourceAttr(resourceName, "default_user", "usr"),
+		resource.TestCheckResourceAttr(resourceName, "key_id_format", "{{role_name}}-test"),
+		resource.TestCheckResourceAttr(resourceName, "key_type", "ca"),
+		resource.TestCheckResourceAttr(resourceName, "algorithm_signer", "rsa-sha2-256"),
+		resource.TestCheckResourceAttr(resourceName, "max_ttl", "86400"),
+		resource.TestCheckResourceAttr(resourceName, "ttl", "43200"),
+	)
+
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
@@ -23,62 +75,47 @@ func TestAccSSHSecretBackendRole_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSSHSecretBackendRoleConfig_basic(name, backend),
+				Check:  resource.ComposeTestCheckFunc(initialCheckFuncs...),
+			},
+			{
+				Config: testAccSSHSecretBackendRoleConfig_updated(name, backend, false, true),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "name", name),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "backend", backend),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allow_bare_domains", "false"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allow_host_certificates", "false"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allow_subdomains", "false"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allow_user_certificates", "true"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allow_user_key_ids", "false"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allowed_critical_options", ""),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allowed_domains", ""),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allowed_extensions", ""),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "default_extensions.%", "0"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "default_critical_options.%", "0"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allowed_users_template", "false"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allowed_users", ""),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "default_user", ""),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "key_id_format", ""),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "key_type", "ca"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allowed_user_key_lengths.%", "0"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "algorithm_signer", "default"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "max_ttl", "0"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "ttl", "0"),
+					resource.ComposeTestCheckFunc(updateCheckFuncs...),
+					resource.TestCheckResourceAttr(resourceName, "allowed_user_key_lengths.rsa", "2048"),
 				),
 			},
 			{
-				Config: testAccSSHSecretBackendRoleConfig_updated(name, backend),
+				Config: testAccSSHSecretBackendRoleConfig_updated(
+					name, backend, true, true),
+				ExpectError: regexp.MustCompile(`"allowed_user_key_config": conflicts with allowed_user_key_lengths`),
+				Destroy:     false,
+			},
+			{
+				Config: testAccSSHSecretBackendRoleConfig_updated(
+					name, backend, true, false),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "name", name),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "backend", backend),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allow_bare_domains", "true"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allow_host_certificates", "true"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allow_subdomains", "true"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allow_user_certificates", "false"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allow_user_key_ids", "true"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allowed_critical_options", "foo,bar"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allowed_domains", "example.com,foo.com"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allowed_extensions", "ext1,ext2"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "default_extensions.ext1", ""),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "default_critical_options.opt1", ""),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allowed_users_template", "true"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allowed_users", "usr1,usr2"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "default_user", "usr"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "key_id_format", "{{role_name}}-test"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "key_type", "ca"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allowed_user_key_lengths.rsa", "1"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "algorithm_signer", "rsa-sha2-256"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "max_ttl", "86400"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "ttl", "43200"),
+					resource.ComposeTestCheckFunc(updateCheckFuncs...),
+					resource.TestCheckResourceAttr(resourceName, "allowed_user_key_config.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_user_key_config.0.type", "rsa"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_user_key_config.0.lengths.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_user_key_config.0.lengths.0", "2048"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_user_key_config.0.lengths.1", "3072"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_user_key_config.0.lengths.2", "4096"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_user_key_config.1.type", "ec"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_user_key_config.1.lengths.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_user_key_config.1.lengths.0", "256"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
 func TestAccSSHSecretBackendRoleOTP_basic(t *testing.T) {
-	t.Skipf("Skip until VAULT-5535 is fixed")
 	backend := acctest.RandomWithPrefix("tf-test/ssh")
 	name := acctest.RandomWithPrefix("tf-test-role")
 	resource.Test(t, resource.TestCase{
@@ -95,50 +132,6 @@ func TestAccSSHSecretBackendRoleOTP_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "default_user", "usr"),
 					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "cidr_list", "0.0.0.0/0"),
 				),
-			},
-		},
-	})
-}
-
-func TestAccSSHSecretBackendRole_import(t *testing.T) {
-	t.Skipf("Skip until VAULT-5535 is fixed")
-	backend := acctest.RandomWithPrefix("tf-test/ssh")
-	name := acctest.RandomWithPrefix("tf-test-role")
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testutil.TestAccPreCheck(t) },
-		Providers:    testProviders,
-		CheckDestroy: testAccSSHSecretBackendRoleCheckDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccSSHSecretBackendRoleConfig_updated(name, backend),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "name", name),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "backend", backend),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allow_bare_domains", "true"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allow_host_certificates", "true"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allow_subdomains", "true"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allow_user_certificates", "false"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allow_user_key_ids", "true"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allowed_critical_options", "foo,bar"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allowed_domains", "example.com,foo.com"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allowed_extensions", "ext1,ext2"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "default_extensions.ext1", ""),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "default_critical_options.opt1", ""),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allowed_users_template", "true"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allowed_users", "usr1,usr2"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "default_user", "usr"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "key_id_format", "{{role_name}}-test"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "key_type", "ca"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "allowed_user_key_lengths.rsa", "1"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "algorithm_signer", "rsa-sha2-256"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "max_ttl", "86400"),
-					resource.TestCheckResourceAttr("vault_ssh_secret_backend_role.test_role", "ttl", "43200"),
-				),
-			},
-			{
-				ResourceName:      "vault_ssh_secret_backend_role.test_role",
-				ImportState:       true,
-				ImportStateVerify: true,
 			},
 		},
 	})
@@ -163,53 +156,97 @@ func testAccSSHSecretBackendRoleCheckDestroy(s *terraform.State) error {
 }
 
 func testAccSSHSecretBackendRoleConfig_basic(name, path string) string {
-	return fmt.Sprintf(`
+	config := fmt.Sprintf(`
 resource "vault_mount" "example" {
   path = "%s"
   type = "ssh"
 }
 
 resource "vault_ssh_secret_backend_role" "test_role" {
-	name                    = "%s"
-	backend                 = vault_mount.example.path
-	key_type                = "ca"
-	allow_user_certificates = true
+  name                    = "%s"
+  backend                 = vault_mount.example.path
+  key_type                = "ca"
+  allow_user_certificates = true
 }
 
 `, path, name)
+
+	return config
 }
 
-func testAccSSHSecretBackendRoleConfig_updated(name, path string) string {
-	return fmt.Sprintf(`
+func testAccSSHSecretBackendRoleConfig_updated(name, path string, withAllowedUserKeys,
+	withAllowedUserKeyLen bool,
+) string {
+	fragments := []string{
+		fmt.Sprintf(`
 resource "vault_mount" "example" {
   path = "%s"
   type = "ssh"
-}
+}`, path),
+	}
 
+	if withAllowedUserKeys {
+		fragments = append(fragments, `
+  locals {
+    allowed_user_keys = [
+      {
+        type    = "rsa"
+        lengths = [2048, 3072, 4096]
+      },
+      {
+        type    = "ec"
+        lengths = [256]
+      },
+    ]
+  }
+`)
+	}
+	fragments = append(fragments, fmt.Sprintf(`
 resource "vault_ssh_secret_backend_role" "test_role" {
-	name                     = "%s"
-	backend                  = vault_mount.example.path
-	allow_bare_domains       = true
-	allow_host_certificates  = true
-	allow_subdomains         = true
-	allow_user_certificates  = false
-	allow_user_key_ids       = true
-	allowed_critical_options = "foo,bar"
-	allowed_domains          = "example.com,foo.com"
-	allowed_extensions       = "ext1,ext2"
-	default_extensions       = { "ext1" = "" }
-	default_critical_options = { "opt1" = "" }
-        allowed_users_template   = true
-        allowed_users            = "usr1,usr2"
-	default_user             = "usr"
-	key_id_format            = "{{role_name}}-test"
-	key_type                 = "ca"
-	allowed_user_key_lengths = { "rsa" = 1 }
-	algorithm_signer         = "rsa-sha2-256"
-	max_ttl                  = "86400"
-	ttl                      = "43200"
-}
-`, path, name)
+  name                     = "%s"
+  backend                  = vault_mount.example.path
+  allow_bare_domains       = true
+  allow_host_certificates  = true
+  allow_subdomains         = true
+  allow_user_certificates  = false
+  allow_user_key_ids       = true
+  allowed_critical_options = "foo,bar"
+  allowed_domains          = "example.com,foo.com"
+  allowed_extensions       = "ext1,ext2"
+  default_extensions       = { "ext1" = "" }
+  default_critical_options = { "opt1" = "" }
+  allowed_users_template   = true
+  allowed_users            = "usr1,usr2"
+  default_user             = "usr"
+  key_id_format            = "{{role_name}}-test"
+  key_type                 = "ca"
+  algorithm_signer         = "rsa-sha2-256"
+  max_ttl                  = "86400"
+  ttl                      = "43200"
+`, name))
+
+	if withAllowedUserKeys {
+		fragments = append(fragments, `dynamic "allowed_user_key_config" {
+			for_each = local.allowed_user_keys
+			content {
+				type    = allowed_user_key_config.value["type"]
+				lengths = allowed_user_key_config.value["lengths"]
+			}
+		}
+`)
+	}
+
+	if withAllowedUserKeyLen {
+		fragments = append(fragments, `
+  allowed_user_key_lengths = {
+    "rsa" = 2048
+  }
+`)
+	}
+
+	config := strings.Join(fragments, "\n") + "}\n"
+
+	return config
 }
 
 func testAccSSHSecretBackendRoleOTPConfig_basic(name, path string) string {

--- a/website/docs/r/ssh_secret_backend_role.html.md
+++ b/website/docs/r/ssh_secret_backend_role.html.md
@@ -77,11 +77,43 @@ The following arguments are supported:
 
 * `algorithm_signer` - (Optional) When supplied, this value specifies a signing algorithm for the key. Possible values: ssh-rsa, rsa-sha2-256, rsa-sha2-512.
 
-* `allowed_user_key_lengths` - (Optional) Specifies a map of ssh key types and their expected sizes which are allowed to be signed by the CA type.
+* `allowed_user_key_config` - (Optional) Set of configuration blocks to define allowed  
+  user key configuration, like key type and their lengths. Can be specified multiple times.  
+  *See [Configuration-Options](#allowed-user-key-configuration) for more info*
+ 
+* `allowed_user_key_lengths` - (Optional) Specifies a map of ssh key types and their expected sizes which 
+ are allowed to be signed by the CA type.  
+ *Deprecated: use* [allowed_user_key_config](#allowed_user_key_config) *instead*
 
 * `max_ttl` - (Optional) Specifies the maximum Time To Live value.
 
 * `ttl` - (Optional) Specifies the Time To Live value.
+
+
+### Allowed User Key Configuration
+* `type` - (Required) The SSH public key type.  
+  *Supported key types are:*  
+  `rsa`, `ecdsa`, `ec`, `dsa`, `ed25519`, `ssh-rsa`, `ssh-dss`, `ssh-ed25519`,
+  `ecdsa-sha2-nistp256`, `ecdsa-sha2-nistp384`, `ecdsa-sha2-nistp521`
+
+* `lengths` - (Required) A list of allowed key lengths as integers. 
+  For key types that do not support setting the length a value of `[0]` should be used.
+  Setting multiple lengths is only supported on Vault 1.10+. For prior releases `length`
+  must be set to a single element list.
+
+Example configuration blocks that might be included in the `vault_ssh_secret_backend_role`
+
+```hcl
+  allowed_user_key_config {
+    type    = "rsa"
+    lengths = [2048, 4096]
+  }
+
+  allowed_user_key_config {
+    type    = "dss"
+    lengths = [2048, 4096]
+  }
+```
 
 
 ## Attributes Reference


### PR DESCRIPTION
This fix introduces a new configuration block for the
ssh_secret_backend_role resource, which supports the new vault-1.10
updates to the allowed_user_key_lengths parameter. The new config block
is meant to supersede the current allowed_user_key_lengths provider
field.

Example role config:
```hcl
resource "vault_ssh_secret_backend_role" "demo" {
  name    = "role1"
  backend = vault_mount.demo.path

  allowed_user_key_config {
    type    = "rsa"
    lengths = [2048, 4096]
  }

  allowed_user_key_config {
    type    = "dss"
    lengths = [2048, 4096]
  }
}
```
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
