### PR TITLE
Add new field `with_lease_start_time` to `data.vault_generic_secret`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ FEATURES:
 * `resource/vault_ssh_secret_backend_role`: support configuring multiple public SSH key lengths in vault-1.10+
   ([#1413](https://github.com/terraform-providers/terraform-provider-vault/pull/1413))
 
+IMPROVEMENTS:
+* `data/vault_generic_secret`: Add new field `with_lease_start_time` to `vault_generic_secret` datasource ([#1414](https://github.com/hashicorp/terraform-provider-vault/pull/1414))
+
 ## 3.4.1 (March 31, 2022)
 BUGS:
 * `data/azure_access_credentials`: Fix panic when `tenant_id` and `subscription_id` are specified together; add new `environment` override field

--- a/vault/data_source_generic_secret.go
+++ b/vault/data_source_generic_secret.go
@@ -33,8 +33,8 @@ func genericSecretDataSource() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
-				Description: "If set to true, exports 'lease_start_time' " +
-					"to the TF state.",
+				Description: "If set to true, stores 'lease_start_time' " +
+					"in the TF state.",
 			},
 
 			"data_json": {

--- a/vault/data_source_generic_secret.go
+++ b/vault/data_source_generic_secret.go
@@ -29,6 +29,14 @@ func genericSecretDataSource() *schema.Resource {
 				Default:  latestSecretVersion,
 			},
 
+			"with_lease_start_time": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+				Description: "If set to true, exports 'lease_start_time' " +
+					"to the TF state.",
+			},
+
 			"data_json": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -91,7 +99,9 @@ func genericSecretDataSourceRead(d *schema.ResourceData, meta interface{}) error
 	// Ignoring error because this value came from JSON in the
 	// first place so no reason why it should fail to re-encode.
 	jsonDataBytes, _ := json.Marshal(secret.Data)
-	d.Set("data_json", string(jsonDataBytes))
+	if err := d.Set("data_json", string(jsonDataBytes)); err != nil {
+		return err
+	}
 
 	// Since our "data" map can only contain string values, we
 	// will take strings from Data and write them in as-is,
@@ -109,12 +119,28 @@ func genericSecretDataSourceRead(d *schema.ResourceData, meta interface{}) error
 			dataMap[k] = string(vBytes)
 		}
 	}
-	d.Set("data", dataMap)
+	if err := d.Set("data", dataMap); err != nil {
+		return err
+	}
 
-	d.Set("lease_id", secret.LeaseID)
-	d.Set("lease_duration", secret.LeaseDuration)
-	d.Set("lease_start_time", time.Now().UTC().Format(time.RFC3339))
-	d.Set("lease_renewable", secret.Renewable)
+	if err := d.Set("lease_id", secret.LeaseID); err != nil {
+		return err
+	}
 
+	if err := d.Set("lease_duration", secret.LeaseDuration); err != nil {
+		return err
+	}
+
+	if err := d.Set("lease_renewable", secret.Renewable); err != nil {
+		return err
+	}
+
+	if v, ok := d.GetOkExists("with_lease_start_time"); ok {
+		if v.(bool) {
+			if err := d.Set("lease_start_time", time.Now().UTC().Format(time.RFC3339)); err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }

--- a/website/docs/d/generic_secret.html.md
+++ b/website/docs/d/generic_secret.html.md
@@ -54,7 +54,9 @@ to see which endpoints support the `GET` method.
 Vault KV secrets engine - version 2 to indicate which version of the secret
 to read.
 
-* `with_lease_start_time` - If set to true, exports `lease_start_time` to the TF state.
+* `with_lease_start_time` - If set to true, stores `lease_start_time` in the TF state.
+ Note that storing the `lease_start_time` in the TF state will cause a persistent drift
+ on every `terraform plan` and will require a `terraform apply`.
 
 ## Required Vault Capabilities
 

--- a/website/docs/d/generic_secret.html.md
+++ b/website/docs/d/generic_secret.html.md
@@ -54,6 +54,8 @@ to see which endpoints support the `GET` method.
 Vault KV secrets engine - version 2 to indicate which version of the secret
 to read.
 
+* `with_lease_start_time` - If set to true, exports `lease_start_time` to the TF state.
+
 ## Required Vault Capabilities
 
 Use of this resource requires the `read` capability on the given path.


### PR DESCRIPTION
This PR adds a new field `with_lease_start_time` to the `vault_generic_secret` data source. If set to `false`, the field `lease_start_time` is not set to the TF state.

Fixes: #873 

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestDataSourceGenericSecret_v2'
=== RUN   TestDataSourceGenericSecret_v2
--- PASS: TestDataSourceGenericSecret_v2 (4.50s)
PASS

$ make testacc TESTARGS='-run=TestDataSourceGenericSecret'
=== RUN   TestDataSourceGenericSecret
--- PASS: TestDataSourceGenericSecret (3.80s)
PASS
```
