### PR TITLE
Update the way that the certificate bundle is generated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## 3.5.0 (Unreleased)
+## 3.6.0 (Unreleased)
+BUGS:
+* `resource/pki_secret_backend_root_sign_intermediate`: Ensure that the `certificate_bundle`, and `ca_chain` 
+  do not contain duplicate certificates.  
+  ([#1428](https://github.com/hashicorp/terraform-provider-vault/pull/1428))
+
+## 3.5.0 (April 20, 2022)
 FEATURES:
 * Add MFA support: new resources `vault_mfa_okta`, `vault_mfa_totp`, `vault_mfa_pingid` ([#1395](https://github.com/hashicorp/terraform-provider-vault/pull/1395))
 * *New* `resource/database_secrets_mount`: Configures any number of database secrets engines under 


### PR DESCRIPTION
De-duplicate all certs from a PEM bundle by first decoding all blocks.
    
- update all related unit tests so that they are passing again.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-v -test.run TestPkiSecretBackendCert*'                

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -v -test.run TestPkiSecretBackendCert* -timeout 30m ./...

ok      github.com/hashicorp/terraform-provider-vault/util      0.473s [no tests to run]
=== RUN   TestPkiSecretBackendCert_basic
--- PASS: TestPkiSecretBackendCert_basic (5.80s)
=== RUN   TestPkiSecretBackendCert_revoke
--- PASS: TestPkiSecretBackendCert_revoke (5.60s)
=== RUN   TestPkiSecretBackendCert_renew
--- PASS: TestPkiSecretBackendCert_renew (11.81s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     24.317s

=== RUN   Test_setCAChain
=== RUN   Test_setCAChain/empty-ca-chain-pem
=== RUN   Test_setCAChain/empty-ca-chain-pem-bundle
=== RUN   Test_setCAChain/empty-ca-chain-2-pem
=== RUN   Test_setCAChain/empty-ca-chain-2-duplicate-pem
=== RUN   Test_setCAChain/empty-ca-chain-2-pem-bundle
=== RUN   Test_setCAChain/empty-ca-chain-2-duplicate-pem-bundle
=== RUN   Test_setCAChain/empty-ca-chain-der
=== RUN   Test_setCAChain/absent-ca-chain-der
=== RUN   Test_setCAChain/populated-ca-chain
=== RUN   Test_setCAChain/invalid-ca-chain-type
=== RUN   Test_setCAChain/missing-intermediate-cert
=== RUN   Test_setCAChain/missing-issuing-ca
--- PASS: Test_setCAChain (0.00s)
    --- PASS: Test_setCAChain/empty-ca-chain-pem (0.00s)
    --- PASS: Test_setCAChain/empty-ca-chain-pem-bundle (0.00s)
    --- PASS: Test_setCAChain/empty-ca-chain-2-pem (0.00s)
    --- PASS: Test_setCAChain/empty-ca-chain-2-duplicate-pem (0.00s)
    --- PASS: Test_setCAChain/empty-ca-chain-2-pem-bundle (0.00s)
    --- PASS: Test_setCAChain/empty-ca-chain-2-duplicate-pem-bundle (0.00s)
    --- PASS: Test_setCAChain/empty-ca-chain-der (0.00s)
    --- PASS: Test_setCAChain/absent-ca-chain-der (0.00s)
    --- PASS: Test_setCAChain/populated-ca-chain (0.00s)
    --- PASS: Test_setCAChain/invalid-ca-chain-type (0.00s)
    --- PASS: Test_setCAChain/missing-intermediate-cert (0.00s)
    --- PASS: Test_setCAChain/missing-issuing-ca (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     0.670s

=== RUN   Test_pkiSecretRootSignIntermediateRUpgradeV0
=== RUN   Test_pkiSecretRootSignIntermediateRUpgradeV0/basic
=== RUN   Test_pkiSecretRootSignIntermediateRUpgradeV0/invalid-no-issuing-ca
=== RUN   Test_pkiSecretRootSignIntermediateRUpgradeV0/invalid-no-certificate
--- PASS: Test_pkiSecretRootSignIntermediateRUpgradeV0 (0.00s)
    --- PASS: Test_pkiSecretRootSignIntermediateRUpgradeV0/basic (0.00s)
    --- PASS: Test_pkiSecretRootSignIntermediateRUpgradeV0/invalid-no-issuing-ca (0.00s)
    --- PASS: Test_pkiSecretRootSignIntermediateRUpgradeV0/invalid-no-certificate (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     1.732s

```
