### PR TITLE
Fix race condition on duplicate entity alias creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ BUGS:
 * `resource/pki_secret_backend_root_sign_intermediate`: Ensure that the `certificate_bundle`, and `ca_chain` 
   do not contain duplicate certificates.  
   ([#1428](https://github.com/hashicorp/terraform-provider-vault/pull/1428))
+* `resource/identity_entity_alias`: Serialize create, update, and delete operations in order to prevent alias 
+  mismatches.
+  ([#1429](https://github.com/hashicorp/terraform-provider-vault/pull/1429))
 
 ## 3.5.0 (April 20, 2022)
 FEATURES:

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/hashicorp/vault/api v1.3.2-0.20211222220726-b046cd9f80eb
 	github.com/hashicorp/vault/sdk v0.3.1-0.20211214161113-fcc5f22bea02
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/mitchellh/mapstructure v1.4.2
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3
 	golang.org/x/oauth2 v0.0.0-20211005180243-6b3c2da341f1

--- a/internal/identity/entity/entity.go
+++ b/internal/identity/entity/entity.go
@@ -1,0 +1,71 @@
+package entity
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/vault/api"
+)
+
+const (
+	IdentityEntityAliasPath = "/identity/entity-alias"
+	IdentityEntityPath      = "/identity/entity"
+)
+
+// GetAliasesByName
+func GetAliasesByName(client *api.Client, name string) ([]*api.Secret, error) {
+	resp, err := client.Logical().List(IdentityEntityAliasPath + "/id")
+	if resp == nil || err != nil {
+		return nil, err
+	}
+
+	var result []*api.Secret
+	for _, id := range resp.Data["keys"].([]interface{}) {
+		config, err := client.Logical().Read(AliasIDPath(id.(string)))
+		if err != nil || config == nil {
+			continue
+		}
+
+		if config.Data["name"].(string) == name {
+			result = append(result, config)
+		}
+	}
+
+	return result, err
+}
+
+// GetAliasesByMountAccessor
+func GetAliasesByMountAccessor(client *api.Client, accessor string) ([]map[string]interface{}, error) {
+	resp, err := client.Logical().List(IdentityEntityPath + "/id")
+	if resp == nil || err != nil {
+		return nil, err
+	}
+
+	result := make([]map[string]interface{}, 0)
+	for _, id := range resp.Data["keys"].([]interface{}) {
+		config, err := client.Logical().Read(IDPath(id.(string)))
+		if err != nil || config == nil {
+			continue
+		}
+
+		if aliases, ok := config.Data["aliases"]; ok {
+			for _, v := range aliases.([]interface{}) {
+				alias := v.(map[string]interface{})
+				if alias["mount_accessor"].(string) == accessor {
+					result = append(result, alias)
+				}
+			}
+		}
+	}
+
+	return result, err
+}
+
+// AliasIDPath
+func AliasIDPath(id string) string {
+	return fmt.Sprintf("%s/id/%s", IdentityEntityAliasPath, id)
+}
+
+// IDPath
+func IDPath(id string) string {
+	return fmt.Sprintf("%s/id/%s", IdentityEntityPath, id)
+}

--- a/internal/identity/entity/entity.go
+++ b/internal/identity/entity/entity.go
@@ -42,7 +42,11 @@ func FindAliases(client *api.Client, params *FindAliasParams) ([]*Alias, error) 
 	var result []*Alias
 	for _, id := range resp.Data["keys"].([]interface{}) {
 		config, err := client.Logical().Read(IDPath(id.(string)))
-		if err != nil || config == nil {
+		if err != nil {
+			return nil, err
+		}
+
+		if config == nil {
 			continue
 		}
 

--- a/internal/identity/entity/entity.go
+++ b/internal/identity/entity/entity.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/vault/api"
+	"github.com/mitchellh/mapstructure"
 )
 
 const (
@@ -11,36 +12,34 @@ const (
 	IdentityEntityPath      = "/identity/entity"
 )
 
-// GetAliasesByName
-func GetAliasesByName(client *api.Client, name string) ([]*api.Secret, error) {
-	resp, err := client.Logical().List(IdentityEntityAliasPath + "/id")
-	if resp == nil || err != nil {
-		return nil, err
-	}
-
-	var result []*api.Secret
-	for _, id := range resp.Data["keys"].([]interface{}) {
-		config, err := client.Logical().Read(AliasIDPath(id.(string)))
-		if err != nil || config == nil {
-			continue
-		}
-
-		if config.Data["name"].(string) == name {
-			result = append(result, config)
-		}
-	}
-
-	return result, err
+type Alias struct {
+	CanonicalId            string                 `mapstructure:"canonical_id"`
+	CreationTime           string                 `mapstructure:"creation_time"`
+	CustomMetadata         map[string]interface{} `mapstructure:"custom_metadata"`
+	ID                     string                 `mapstructure:"id"`
+	LastUpdateTime         string                 `mapstructure:"last_update_time"`
+	Local                  bool                   `mapstructure:"local"`
+	MergedFromCanonicalIds interface{}            `mapstructure:"merged_from_canonical_ids"`
+	Metadata               interface{}            `mapstructure:"metadata"`
+	MountAccessor          string                 `mapstructure:"mount_accessor"`
+	MountPath              string                 `mapstructure:"mount_path"`
+	MountType              string                 `mapstructure:"mount_type"`
+	Name                   string                 `mapstructure:"name"`
 }
 
-// GetAliasesByMountAccessor
-func GetAliasesByMountAccessor(client *api.Client, accessor string) ([]map[string]interface{}, error) {
+// FindAliasParams
+type FindAliasParams struct {
+	Name          string
+	MountAccessor string
+}
+
+func FindAliases(client *api.Client, params *FindAliasParams) ([]*Alias, error) {
 	resp, err := client.Logical().List(IdentityEntityPath + "/id")
 	if resp == nil || err != nil {
 		return nil, err
 	}
 
-	result := make([]map[string]interface{}, 0)
+	var result []*Alias
 	for _, id := range resp.Data["keys"].([]interface{}) {
 		config, err := client.Logical().Read(IDPath(id.(string)))
 		if err != nil || config == nil {
@@ -49,10 +48,20 @@ func GetAliasesByMountAccessor(client *api.Client, accessor string) ([]map[strin
 
 		if aliases, ok := config.Data["aliases"]; ok {
 			for _, v := range aliases.([]interface{}) {
-				alias := v.(map[string]interface{})
-				if alias["mount_accessor"].(string) == accessor {
-					result = append(result, alias)
+				var a Alias
+				if err := mapstructure.Decode(v, &a); err != nil {
+					return nil, err
 				}
+
+				if params.Name != "" && a.Name != params.Name {
+					continue
+				}
+
+				if params.MountAccessor != "" && a.MountAccessor != params.MountAccessor {
+					continue
+				}
+
+				result = append(result, &a)
 			}
 		}
 	}

--- a/internal/identity/entity/entity_test.go
+++ b/internal/identity/entity/entity_test.go
@@ -91,6 +91,8 @@ func (t *testFindAliasHandler) handler() http.HandlerFunc {
 }
 
 func TestFindAliases(t *testing.T) {
+	t.Parallel()
+
 	aliasBob := &Alias{
 		Name:          "bob",
 		MountAccessor: "CC417368-0C63-407A-93AD-2D76A72F58E2",
@@ -179,10 +181,14 @@ func TestFindAliases(t *testing.T) {
 						ID: "C6D3410E-86AF-4A10-9282-4B1E9773932A",
 						Aliases: []*Alias{
 							aliasAlice,
+							{
+								Name:          aliasBob.Name,
+								MountAccessor: aliasAlice.MountAccessor,
+							},
 						},
 					},
 					{
-						ID: "C6D3410E-86AF-4A10-9282-4B1E9773932A",
+						ID: "C6D3410E-86AF-4A10-9282-4B1E9773932B",
 						Aliases: []*Alias{
 							aliasBob,
 						},
@@ -209,7 +215,7 @@ func TestFindAliases(t *testing.T) {
 						},
 					},
 					{
-						ID: "C6D3410E-86AF-4A10-9282-4B1E9773932A",
+						ID: "C6D3410E-86AF-4A10-9282-4B1E9773932B",
 						Aliases: []*Alias{
 							aliasBob,
 						},

--- a/internal/identity/entity/entity_test.go
+++ b/internal/identity/entity/entity_test.go
@@ -1,0 +1,275 @@
+package entity
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/testutil"
+)
+
+type testFindAliasHandler struct {
+	requests      int
+	retryStatus   int
+	wantErrOnList bool
+	wantErrOnRead bool
+	entities      []*Entity
+}
+
+func (t *testFindAliasHandler) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		t.requests++
+
+		wantPath := "/v1" + RootEntityIDPath
+		pathRE := regexp.MustCompile(fmt.Sprintf(`^%s/(.+)`, wantPath))
+		path := req.URL.Path
+		values := req.URL.Query()
+
+		if req.Method != http.MethodGet {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		var data map[string]interface{}
+		if path == wantPath && values.Get("list") == "true" {
+			if t.wantErrOnList {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+
+			var ids []interface{}
+			for _, e := range t.entities {
+				ids = append(ids, e.ID)
+			}
+			data = map[string]interface{}{
+				"keys": ids,
+			}
+		} else {
+			if t.wantErrOnRead {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+
+			match := pathRE.FindStringSubmatch(path)
+			if len(match) > 1 {
+				id := match[1]
+				for _, e := range t.entities {
+					if e.ID == id {
+						b, err := json.Marshal(e)
+						if err != nil {
+							w.WriteHeader(http.StatusInternalServerError)
+							return
+						}
+						if err := json.Unmarshal(b, &data); err != nil {
+							w.WriteHeader(http.StatusInternalServerError)
+							return
+						}
+					}
+				}
+
+			}
+		}
+
+		m, err := json.Marshal(
+			&api.Secret{
+				Data: data,
+			},
+		)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write(m)
+	}
+}
+
+func TestFindAliases(t *testing.T) {
+	aliasBob := &Alias{
+		Name:          "bob",
+		MountAccessor: "CC417368-0C63-407A-93AD-2D76A72F58E2",
+	}
+
+	aliasAlice := &Alias{
+		Name:          "alice",
+		MountAccessor: "CC417368-0C63-407A-93AD-2D76A72F58E3",
+	}
+	tests := []struct {
+		name        string
+		params      *FindAliasParams
+		want        []*Alias
+		findHandler *testFindAliasHandler
+		wantErr     bool
+	}{
+		{
+			name:   "empty",
+			params: &FindAliasParams{},
+			findHandler: &testFindAliasHandler{
+				entities: []*Entity{},
+			},
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name:   "all",
+			params: &FindAliasParams{},
+			findHandler: &testFindAliasHandler{
+				entities: []*Entity{
+					{
+						ID: "C6D3410E-86AF-4A10-9282-4B1E9773932A",
+						Aliases: []*Alias{
+							aliasBob,
+						},
+					},
+					{
+						ID: "C6D3410E-86AF-4A10-9282-4B1E9773932B",
+						Aliases: []*Alias{
+							aliasAlice,
+						},
+					},
+				},
+			},
+			want: []*Alias{
+				aliasBob,
+				aliasAlice,
+			},
+			wantErr: false,
+		},
+		{
+			name: "name-only",
+			params: &FindAliasParams{
+				Name: aliasBob.Name,
+			},
+			findHandler: &testFindAliasHandler{
+				entities: []*Entity{
+					{
+						ID: "C6D3410E-86AF-4A10-9282-4B1E9773932A",
+						Aliases: []*Alias{
+							aliasBob,
+						},
+					},
+					{
+						ID: "C6D3410E-86AF-4A10-9282-4B1E9773932B",
+						Aliases: []*Alias{
+							aliasAlice,
+						},
+					},
+				},
+			},
+			want: []*Alias{
+				aliasBob,
+			},
+			wantErr: false,
+		},
+		{
+			name: "name-and-mount-accessor",
+			params: &FindAliasParams{
+				Name:          aliasBob.Name,
+				MountAccessor: aliasBob.MountAccessor,
+			},
+			findHandler: &testFindAliasHandler{
+				entities: []*Entity{
+					{
+						ID: "C6D3410E-86AF-4A10-9282-4B1E9773932A",
+						Aliases: []*Alias{
+							aliasAlice,
+						},
+					},
+					{
+						ID: "C6D3410E-86AF-4A10-9282-4B1E9773932A",
+						Aliases: []*Alias{
+							aliasBob,
+						},
+					},
+				},
+			},
+			want: []*Alias{
+				aliasBob,
+			},
+			wantErr: false,
+		},
+		{
+			name: "mount-accessor-mismatch",
+			params: &FindAliasParams{
+				Name:          aliasBob.Name,
+				MountAccessor: aliasAlice.MountAccessor,
+			},
+			findHandler: &testFindAliasHandler{
+				entities: []*Entity{
+					{
+						ID: "C6D3410E-86AF-4A10-9282-4B1E9773932A",
+						Aliases: []*Alias{
+							aliasAlice,
+						},
+					},
+					{
+						ID: "C6D3410E-86AF-4A10-9282-4B1E9773932A",
+						Aliases: []*Alias{
+							aliasBob,
+						},
+					},
+				},
+			},
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name: "error-on-list",
+			params: &FindAliasParams{
+				Name:          aliasAlice.Name,
+				MountAccessor: aliasBob.MountAccessor,
+			},
+			findHandler: &testFindAliasHandler{
+				wantErrOnList: true,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:   "error-on-read",
+			params: &FindAliasParams{},
+			findHandler: &testFindAliasHandler{
+				entities: []*Entity{
+					{
+						ID: "C6D3410E-86AF-4A10-9282-4B1E9773932A",
+						Aliases: []*Alias{
+							aliasAlice,
+						},
+					},
+				},
+				wantErrOnRead: true,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := tt.findHandler
+
+			config, ln := testutil.TestHTTPServer(t, r.handler())
+			defer ln.Close()
+
+			config.Address = fmt.Sprintf("http://%s", ln.Addr())
+			c, err := api.NewClient(config)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := FindAliases(c, tt.params)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("FindAliases() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FindAliases() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/vault/resource_identity_entity.go
+++ b/vault/resource_identity_entity.go
@@ -8,10 +8,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/identity/entity"
 	"github.com/hashicorp/terraform-provider-vault/util"
 )
-
-const identityEntityPath = "/identity/entity"
 
 var errEntityNotFound = errors.New("entity not found")
 
@@ -112,7 +111,7 @@ func identityEntityCreate(d *schema.ResourceData, meta interface{}) error {
 
 	name := d.Get("name").(string)
 
-	path := identityEntityPath
+	path := entity.IdentityEntityPath
 
 	data := map[string]interface{}{
 		"name": name,
@@ -148,7 +147,7 @@ func identityEntityUpdate(d *schema.ResourceData, meta interface{}) error {
 	id := d.Id()
 
 	log.Printf("[DEBUG] Updating IdentityEntity %q", id)
-	path := identityEntityIDPath(id)
+	path := entity.IDPath(id)
 
 	vaultMutexKV.Lock(path)
 	defer vaultMutexKV.Unlock(path)
@@ -198,7 +197,7 @@ func identityEntityDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*api.Client)
 	id := d.Id()
 
-	path := identityEntityIDPath(id)
+	path := entity.IDPath(id)
 
 	vaultMutexKV.Lock(path)
 	defer vaultMutexKV.Unlock(path)
@@ -217,7 +216,7 @@ func identityEntityExists(d *schema.ResourceData, meta interface{}) (bool, error
 	client := meta.(*api.Client)
 	id := d.Id()
 
-	path := identityEntityIDPath(id)
+	path := entity.IDPath(id)
 	key := id
 
 	// use the name if no ID is set
@@ -237,11 +236,7 @@ func identityEntityExists(d *schema.ResourceData, meta interface{}) (bool, error
 }
 
 func identityEntityNamePath(name string) string {
-	return fmt.Sprintf("%s/name/%s", identityEntityPath, name)
-}
-
-func identityEntityIDPath(id string) string {
-	return fmt.Sprintf("%s/id/%s", identityEntityPath, id)
+	return fmt.Sprintf("%s/name/%s", entity.IdentityEntityPath, name)
 }
 
 func readIdentityEntityPolicies(client *api.Client, entityID string) ([]interface{}, error) {
@@ -257,7 +252,7 @@ func readIdentityEntityPolicies(client *api.Client, entityID string) ([]interfac
 }
 
 func readIdentityEntity(client *api.Client, entityID string, retry bool) (*api.Secret, error) {
-	path := identityEntityIDPath(entityID)
+	path := entity.IDPath(entityID)
 	log.Printf("[DEBUG] Reading Entity %q from %q", entityID, path)
 
 	return readEntity(client, path, retry)

--- a/vault/resource_identity_entity.go
+++ b/vault/resource_identity_entity.go
@@ -111,7 +111,7 @@ func identityEntityCreate(d *schema.ResourceData, meta interface{}) error {
 
 	name := d.Get("name").(string)
 
-	path := entity.IdentityEntityPath
+	path := entity.RootEntityPath
 
 	data := map[string]interface{}{
 		"name": name,
@@ -147,7 +147,7 @@ func identityEntityUpdate(d *schema.ResourceData, meta interface{}) error {
 	id := d.Id()
 
 	log.Printf("[DEBUG] Updating IdentityEntity %q", id)
-	path := entity.IDPath(id)
+	path := entity.JoinEntityID(id)
 
 	vaultMutexKV.Lock(path)
 	defer vaultMutexKV.Unlock(path)
@@ -197,7 +197,7 @@ func identityEntityDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*api.Client)
 	id := d.Id()
 
-	path := entity.IDPath(id)
+	path := entity.JoinEntityID(id)
 
 	vaultMutexKV.Lock(path)
 	defer vaultMutexKV.Unlock(path)
@@ -216,7 +216,7 @@ func identityEntityExists(d *schema.ResourceData, meta interface{}) (bool, error
 	client := meta.(*api.Client)
 	id := d.Id()
 
-	path := entity.IDPath(id)
+	path := entity.JoinEntityID(id)
 	key := id
 
 	// use the name if no ID is set
@@ -236,7 +236,7 @@ func identityEntityExists(d *schema.ResourceData, meta interface{}) (bool, error
 }
 
 func identityEntityNamePath(name string) string {
-	return fmt.Sprintf("%s/name/%s", entity.IdentityEntityPath, name)
+	return fmt.Sprintf("%s/name/%s", entity.RootEntityPath, name)
 }
 
 func readIdentityEntityPolicies(client *api.Client, entityID string) ([]interface{}, error) {
@@ -252,7 +252,7 @@ func readIdentityEntityPolicies(client *api.Client, entityID string) ([]interfac
 }
 
 func readIdentityEntity(client *api.Client, entityID string, retry bool) (*api.Secret, error) {
-	path := entity.IDPath(entityID)
+	path := entity.JoinEntityID(entityID)
 	log.Printf("[DEBUG] Reading Entity %q from %q", entityID, path)
 
 	return readEntity(client, path, retry)

--- a/vault/resource_identity_entity_alias.go
+++ b/vault/resource_identity_entity_alias.go
@@ -54,7 +54,7 @@ func identityEntityAliasResource() *schema.Resource {
 }
 
 func identityEntityAliasCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	path := entity.IdentityEntityAliasPath
+	path := entity.RootAliasPath
 	vaultMutexKV.Lock(path)
 	defer vaultMutexKV.Unlock(path)
 	client := meta.(*api.Client)
@@ -137,14 +137,14 @@ func identityEntityAliasCreate(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func identityEntityAliasUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	vaultMutexKV.Lock(entity.IdentityEntityAliasPath)
-	defer vaultMutexKV.Unlock(entity.IdentityEntityAliasPath)
+	vaultMutexKV.Lock(entity.RootAliasPath)
+	defer vaultMutexKV.Unlock(entity.RootAliasPath)
 
 	client := meta.(*api.Client)
 	id := d.Id()
 
 	log.Printf("[DEBUG] Updating IdentityEntityAlias %q", id)
-	path := entity.AliasIDPath(id)
+	path := entity.JoinAliasID(id)
 
 	diags := diag.Diagnostics{}
 
@@ -195,7 +195,7 @@ func identityEntityAliasRead(ctx context.Context, d *schema.ResourceData, meta i
 	client := meta.(*api.Client)
 	id := d.Id()
 
-	path := entity.AliasIDPath(id)
+	path := entity.JoinAliasID(id)
 
 	diags := diag.Diagnostics{}
 
@@ -233,12 +233,12 @@ func identityEntityAliasRead(ctx context.Context, d *schema.ResourceData, meta i
 }
 
 func identityEntityAliasDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	vaultMutexKV.Lock(entity.IdentityEntityAliasPath)
-	defer vaultMutexKV.Unlock(entity.IdentityEntityAliasPath)
+	vaultMutexKV.Lock(entity.RootAliasPath)
+	defer vaultMutexKV.Unlock(entity.RootAliasPath)
 	client := meta.(*api.Client)
 	id := d.Id()
 
-	path := entity.AliasIDPath(id)
+	path := entity.JoinAliasID(id)
 
 	diags := diag.Diagnostics{}
 

--- a/vault/resource_identity_entity_alias.go
+++ b/vault/resource_identity_entity_alias.go
@@ -1,9 +1,12 @@
 package vault
 
 import (
+	"context"
 	"fmt"
 	"log"
+	"strings"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
 )
@@ -12,11 +15,10 @@ const identityEntityAliasPath = "/identity/entity-alias"
 
 func identityEntityAliasResource() *schema.Resource {
 	return &schema.Resource{
-		Create: identityEntityAliasCreate,
-		Update: identityEntityAliasUpdate,
-		Read:   identityEntityAliasRead,
-		Delete: identityEntityAliasDelete,
-		Exists: identityEntityAliasExists,
+		CreateContext: identityEntityAliasCreate,
+		UpdateContext: identityEntityAliasUpdate,
+		ReadContext:   identityEntityAliasRead,
+		DeleteContext: identityEntityAliasDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -51,15 +53,16 @@ func identityEntityAliasResource() *schema.Resource {
 	}
 }
 
-func identityEntityAliasCreate(d *schema.ResourceData, meta interface{}) error {
+func identityEntityAliasCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	path := identityEntityAliasPath
+	vaultMutexKV.Lock(path)
+	defer vaultMutexKV.Unlock(path)
 	client := meta.(*api.Client)
 
 	name := d.Get("name").(string)
 	mountAccessor := d.Get("mount_accessor").(string)
 	canonicalID := d.Get("canonical_id").(string)
 	customMetadata := d.Get("custom_metadata").(map[string]interface{})
-
-	path := identityEntityAliasPath
 
 	data := map[string]interface{}{
 		"name":            name,
@@ -68,39 +71,106 @@ func identityEntityAliasCreate(d *schema.ResourceData, meta interface{}) error {
 		"custom_metadata": customMetadata,
 	}
 
-	resp, err := client.Logical().Write(path, data)
+	diags := diag.Diagnostics{}
 
+	var duplicates []string
+	/*
+		aliases, err := getEntityAliasesByName(client, name)
+		if err != nil {
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  fmt.Sprintf("Failed to get entity aliases, err=%s", err),
+			})
+
+			return diags
+		}
+
+		for _, config := range aliases {
+			if config.Data["mount_accessor"].(string) == mountAccessor {
+				duplicates = append(duplicates, config.Data["id"].(string))
+			}
+		}
+	*/
+	a, err := getEntityAliasesByMountAccessor(client, mountAccessor)
 	if err != nil {
-		return fmt.Errorf("error writing IdentityEntityAlias to %q: %s", name, err)
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  fmt.Sprintf("Failed to get entity aliases by mount accessor, err=%s", err),
+		})
+
+		return diags
+	}
+
+	for _, alias := range a {
+		if v, ok := alias["name"]; ok && v.(string) == name {
+			duplicates = append(duplicates, alias["id"].(string))
+		}
+	}
+
+	if len(duplicates) > 0 {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary: fmt.Sprintf(
+				"entity alias %q already exists for mount accessor %q, "+
+					"ids=%q", name, mountAccessor, strings.Join(duplicates, ",")),
+			Detail: "In the case where this error occurred during the creation of more than one alias, " +
+				"it may be necessary to assign a unique alias name to each of affected resources and " +
+				"then rerun the apply. After a successful apply the desired original alias names can then be " +
+				"reassigned",
+		})
+
+		return diags
+	}
+
+	resp, err := client.Logical().Write(path, data)
+	if err != nil {
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary: fmt.Sprintf(
+				"error writing IdentityEntityAlias to %q: %s", name, err),
+		})
+
+		return diags
 	}
 
 	if resp == nil {
-		aliasIDMsg := "Unable to determine alias id."
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary: fmt.Sprintf(
+				"unexpected empty response during entity alias creation name=%q", name),
+		})
 
-		if aliasID, err := findAliasID(client, canonicalID, name, mountAccessor); err == nil {
-			aliasIDMsg = fmt.Sprintf("Alias resource ID %q may be imported.", aliasID)
-		}
+		return diags
 
-		return fmt.Errorf("IdentityEntityAlias %q already exists. %s", name, aliasIDMsg)
 	}
 
 	log.Printf("[DEBUG] Wrote IdentityEntityAlias %q", name)
 
 	d.SetId(resp.Data["id"].(string))
 
-	return identityEntityAliasRead(d, meta)
+	return identityEntityAliasRead(ctx, d, meta)
 }
 
-func identityEntityAliasUpdate(d *schema.ResourceData, meta interface{}) error {
+func identityEntityAliasUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vaultMutexKV.Lock(identityEntityAliasPath)
+	defer vaultMutexKV.Unlock(identityEntityAliasPath)
+
 	client := meta.(*api.Client)
 	id := d.Id()
 
 	log.Printf("[DEBUG] Updating IdentityEntityAlias %q", id)
 	path := identityEntityAliasIDPath(id)
 
+	diags := diag.Diagnostics{}
+
 	resp, err := client.Logical().Read(path)
 	if err != nil {
-		return fmt.Errorf("error updating IdentityEntityAlias %q: %s", id, err)
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  fmt.Sprintf("error updating IdentityEntityAlias %q: %s", id, err),
+		})
+
+		return diags
 	}
 
 	data := map[string]interface{}{
@@ -124,104 +194,130 @@ func identityEntityAliasUpdate(d *schema.ResourceData, meta interface{}) error {
 	_, err = client.Logical().Write(path, data)
 
 	if err != nil {
-		return fmt.Errorf("error updating IdentityEntityAlias %q: %s", id, err)
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  fmt.Sprintf("error updating IdentityEntityAlias %q: %s", id, err),
+		})
+
+		return diags
 	}
 	log.Printf("[DEBUG] Updated IdentityEntityAlias %q", id)
 
-	return identityEntityAliasRead(d, meta)
+	return identityEntityAliasRead(ctx, d, meta)
 }
 
-func identityEntityAliasRead(d *schema.ResourceData, meta interface{}) error {
+func identityEntityAliasRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*api.Client)
 	id := d.Id()
 
 	path := identityEntityAliasIDPath(id)
 
-	log.Printf("[DEBUG] Reading IdentityEntityAlias %s from %q", id, path)
+	diags := diag.Diagnostics{}
+
+	log.Printf("[DEBUG] Reading IdentityEntityAlias %q from %q", id, path)
 	resp, err := client.Logical().Read(path)
 	if err != nil {
-		return fmt.Errorf("error reading IdentityEntityAlias %q: %s", id, err)
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  fmt.Sprintf("error reading IdentityEntityAlias %q: %s", id, err),
+		})
+
+		return diags
 	}
 	log.Printf("[DEBUG] Read IdentityEntityAlias %s", id)
 	if resp == nil {
 		log.Printf("[WARN] IdentityEntityAlias %q not found, removing from state", id)
 		d.SetId("")
-		return nil
+
+		return diags
 	}
 
 	d.SetId(resp.Data["id"].(string))
 	for _, k := range []string{"name", "mount_accessor", "canonical_id", "custom_metadata"} {
 		if err := d.Set(k, resp.Data[k]); err != nil {
-			return fmt.Errorf("error setting state key %q on IdentityEntityAlias %q:  err=%q", k, id, err)
+			diags = append(diags, diag.Diagnostic{
+				Severity: diag.Error,
+				Summary:  fmt.Sprintf("error setting state key %q on IdentityEntityAlias %q:  err=%q", k, id, err),
+			})
+
+			return diags
 		}
 	}
-	return nil
+
+	return diags
 }
 
-func identityEntityAliasDelete(d *schema.ResourceData, meta interface{}) error {
+func identityEntityAliasDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	vaultMutexKV.Lock(identityEntityAliasPath)
+	defer vaultMutexKV.Unlock(identityEntityAliasPath)
 	client := meta.(*api.Client)
 	id := d.Id()
 
 	path := identityEntityAliasIDPath(id)
+
+	diags := diag.Diagnostics{}
 
 	log.Printf("[DEBUG] Deleting IdentityEntityAlias %q", id)
 	_, err := client.Logical().Delete(path)
 	if err != nil {
-		return fmt.Errorf("error IdentityEntityAlias %q", id)
+		diags = append(diags, diag.Diagnostic{
+			Severity: diag.Error,
+			Summary:  fmt.Sprintf("error IdentityEntityAlias %q", id),
+		})
+		return diags
 	}
 	log.Printf("[DEBUG] Deleted IdentityEntityAlias %q", id)
 
-	return nil
+	return diags
 }
 
-func identityEntityAliasExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
-	id := d.Id()
-
-	path := identityEntityAliasIDPath(id)
-	key := id
-
-	// use the name if no ID is set
-	if len(id) == 0 {
-		key = d.Get("name").(string)
-		path = identityEntityAliasNamePath(key)
+func getEntityAliasesByName(client *api.Client, name string) ([]*api.Secret, error) {
+	resp, err := client.Logical().List(identityEntityAliasPath + "/id")
+	if resp == nil || err != nil {
+		return nil, err
 	}
 
-	log.Printf("[DEBUG] Checking if IdentityEntityAlias %q exists", key)
-	resp, err := client.Logical().Read(path)
-	if err != nil {
-		return true, fmt.Errorf("error checking if IdentityEntityAlias %q exists: %s", key, err)
-	}
-	log.Printf("[DEBUG] Checked if IdentityEntityAlias %q exists", key)
+	var result []*api.Secret
+	for _, id := range resp.Data["keys"].([]interface{}) {
+		config, err := client.Logical().Read(identityEntityAliasIDPath(id.(string)))
+		if err != nil || config == nil {
+			continue
+		}
 
-	return resp != nil, nil
-}
-
-func identityEntityAliasNamePath(name string) string {
-	return fmt.Sprintf("%s/name/%s", identityEntityAliasPath, name)
-}
-
-func identityEntityAliasIDPath(id string) string {
-	return fmt.Sprintf("%s/id/%s", identityEntityAliasPath, id)
-}
-
-func findAliasID(client *api.Client, canonicalID, name, mountAccessor string) (string, error) {
-	path := identityEntityIDPath(canonicalID)
-
-	resp, err := client.Logical().Read(path)
-	if err != nil {
-		return "", fmt.Errorf("error reading entity aliases: %s", err)
+		if config.Data["name"].(string) == name {
+			result = append(result, config)
+		}
 	}
 
-	if resp != nil {
-		aliases := resp.Data["aliases"].([]interface{})
-		for _, aliasRaw := range aliases {
-			alias := aliasRaw.(map[string]interface{})
-			if alias["name"] == name && alias["mount_accessor"] == mountAccessor {
-				return alias["id"].(string), nil
+	return result, err
+}
+
+func getEntityAliasesByMountAccessor(client *api.Client, accessor string) ([]map[string]interface{}, error) {
+	resp, err := client.Logical().List(identityEntityPath + "/id")
+	if resp == nil || err != nil {
+		return nil, err
+	}
+
+	result := make([]map[string]interface{}, 0)
+	for _, id := range resp.Data["keys"].([]interface{}) {
+		config, err := client.Logical().Read(identityEntityIDPath(id.(string)))
+		if err != nil || config == nil {
+			continue
+		}
+
+		if aliases, ok := config.Data["aliases"]; ok {
+			for _, v := range aliases.([]interface{}) {
+				alias := v.(map[string]interface{})
+				if alias["mount_accessor"].(string) == accessor {
+					result = append(result, alias)
+				}
 			}
 		}
 	}
 
-	return "", fmt.Errorf("unable to determine alias ID. canonical ID: %q  name: %q  mountAccessor: %q", canonicalID, name, mountAccessor)
+	return result, err
+}
+
+func identityEntityAliasIDPath(id string) string {
+	return fmt.Sprintf("%s/id/%s", identityEntityAliasPath, id)
 }

--- a/vault/resource_identity_entity_alias.go
+++ b/vault/resource_identity_entity_alias.go
@@ -114,7 +114,7 @@ func identityEntityAliasCreate(ctx context.Context, d *schema.ResourceData, meta
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
 			Summary: fmt.Sprintf(
-				"error writing IdentityEntityAlias to %q: %s", name, err),
+				"error writing entity alias to %q: %s", name, err),
 		})
 
 		return diags
@@ -131,7 +131,7 @@ func identityEntityAliasCreate(ctx context.Context, d *schema.ResourceData, meta
 
 	}
 
-	log.Printf("[DEBUG] Wrote IdentityEntityAlias %q", name)
+	log.Printf("[DEBUG] Wrote entity alias %q", name)
 
 	d.SetId(resp.Data["id"].(string))
 
@@ -146,7 +146,7 @@ func identityEntityAliasUpdate(ctx context.Context, d *schema.ResourceData, meta
 	client := meta.(*api.Client)
 	id := d.Id()
 
-	log.Printf("[DEBUG] Updating IdentityEntityAlias %q", id)
+	log.Printf("[DEBUG] Updating entity alias %q", id)
 	path := entity.JoinAliasID(id)
 
 	diags := diag.Diagnostics{}
@@ -155,7 +155,7 @@ func identityEntityAliasUpdate(ctx context.Context, d *schema.ResourceData, meta
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
-			Summary:  fmt.Sprintf("error updating IdentityEntityAlias %q: %s", id, err),
+			Summary:  fmt.Sprintf("error reading entity alias %q: %s", id, err),
 		})
 
 		return diags
@@ -184,12 +184,12 @@ func identityEntityAliasUpdate(ctx context.Context, d *schema.ResourceData, meta
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
-			Summary:  fmt.Sprintf("error updating IdentityEntityAlias %q: %s", id, err),
+			Summary:  fmt.Sprintf("error updating entity alias %q: %s", id, err),
 		})
 
 		return diags
 	}
-	log.Printf("[DEBUG] Updated IdentityEntityAlias %q", id)
+	log.Printf("[DEBUG] Updated entity alias %q", id)
 
 	return identityEntityAliasRead(ctx, d, meta)
 }
@@ -202,19 +202,19 @@ func identityEntityAliasRead(ctx context.Context, d *schema.ResourceData, meta i
 
 	diags := diag.Diagnostics{}
 
-	log.Printf("[DEBUG] Reading IdentityEntityAlias %q from %q", id, path)
+	log.Printf("[DEBUG] Reading entity alias %q from %q", id, path)
 	resp, err := client.Logical().Read(path)
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
-			Summary:  fmt.Sprintf("error reading IdentityEntityAlias %q: %s", id, err),
+			Summary:  fmt.Sprintf("error reading entity alias %q: %s", id, err),
 		})
 
 		return diags
 	}
-	log.Printf("[DEBUG] Read IdentityEntityAlias %s", id)
+	log.Printf("[DEBUG] Read entity alias %s", id)
 	if resp == nil {
-		log.Printf("[WARN] IdentityEntityAlias %q not found, removing from state", id)
+		log.Printf("[WARN] entity alias %q not found, removing from state", id)
 		d.SetId("")
 
 		return diags
@@ -225,7 +225,7 @@ func identityEntityAliasRead(ctx context.Context, d *schema.ResourceData, meta i
 		if err := d.Set(k, resp.Data[k]); err != nil {
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,
-				Summary:  fmt.Sprintf("error setting state key %q on IdentityEntityAlias %q:  err=%q", k, id, err),
+				Summary:  fmt.Sprintf("error setting state key %q on entity alias %q: err=%q", k, id, err),
 			})
 
 			return diags
@@ -247,16 +247,17 @@ func identityEntityAliasDelete(ctx context.Context, d *schema.ResourceData, meta
 
 	diags := diag.Diagnostics{}
 
-	log.Printf("[DEBUG] Deleting IdentityEntityAlias %q", id)
+	baseMsg := fmt.Sprintf("entity alias ID %q on mount_accessor %q", id, d.Get("mount_accessor"))
+	log.Printf("[INFO] Deleting %s", baseMsg)
 	_, err := client.Logical().Delete(path)
 	if err != nil {
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
-			Summary:  fmt.Sprintf("error IdentityEntityAlias %q", id),
+			Summary:  fmt.Sprintf("failed deleting %s, err=%s", baseMsg, err),
 		})
 		return diags
 	}
-	log.Printf("[DEBUG] Deleted IdentityEntityAlias %q", id)
+	log.Printf("[INFO] Successfully deleted %s", baseMsg)
 
 	return diags
 }

--- a/vault/resource_identity_entity_alias_test.go
+++ b/vault/resource_identity_entity_alias_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/identity/entity"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -233,7 +234,7 @@ func testAccCheckIdentityEntityAliasDestroy(s *terraform.State) error {
 		if rs.Type != "vault_identity_entity_alias" {
 			continue
 		}
-		secret, err := client.Logical().Read(identityEntityAliasIDPath(rs.Primary.ID))
+		secret, err := client.Logical().Read(entity.AliasIDPath(rs.Primary.ID))
 		if err != nil {
 			return fmt.Errorf("error checking for identity entity %q: %s", rs.Primary.ID, err)
 		}

--- a/vault/resource_identity_entity_alias_test.go
+++ b/vault/resource_identity_entity_alias_test.go
@@ -34,8 +34,159 @@ func TestAccIdentityEntityAlias(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      nameEntityAlias,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config:      testAccIdentityEntityAliasConfig(entity, true, false),
-				ExpectError: regexp.MustCompile(`IdentityEntityAlias.*already exists.*may be imported`),
+				ExpectError: regexp.MustCompile(`entity alias .+ already exists`),
+			},
+		},
+	})
+}
+
+func TestAccIdentityEntityAliasDuplicateFlow(t *testing.T) {
+	namePrefix := acctest.RandomWithPrefix("test-duplicate-flow")
+	alias := acctest.RandomWithPrefix("alias")
+
+	configTmpl := fmt.Sprintf(`
+variable name_prefix {
+  default = "%s"
+}
+
+variable entity_alias_name_1 {
+  default = "%%s"
+}
+variable entity_alias_name_2 {
+  default = "%%s"
+}
+
+resource "vault_auth_backend" "test" {
+    path = "cert/${var.name_prefix}"
+    type = "cert"
+}
+
+resource "vault_cert_auth_backend_role" "test" {
+    name          = var.name_prefix
+    backend       = vault_auth_backend.test.path
+    certificate   = <<EOT
+%s
+EOT
+}
+
+resource "vault_policy" "test" {
+  name = "${var.name_prefix}-policy"
+
+  policy = <<EOT
+path "secret/my_app" {
+  capabilities = ["update"]
+}
+EOT
+}
+
+resource "vault_identity_entity" "test1" {
+  name = "${var.name_prefix}-1"
+  policies = [
+    "default",
+    vault_policy.test.name,
+  ]
+}
+
+resource "vault_identity_entity" "test2" {
+  name = "${var.name_prefix}-2"
+  policies = [
+    "default",
+    vault_policy.test.name,
+  ]
+}
+
+resource "vault_identity_entity_alias" "test1" {
+    name            = var.entity_alias_name_1
+    mount_accessor  = vault_auth_backend.test.accessor
+    canonical_id    = vault_identity_entity.test1.id
+}
+
+resource "vault_identity_entity_alias" "test2" {
+    name            = var.entity_alias_name_2
+    mount_accessor  = vault_auth_backend.test.accessor
+    canonical_id    = vault_identity_entity.test2.id
+}
+`, namePrefix, testPKICARoot)
+
+	aliasResource1 := "vault_identity_entity_alias.test1"
+	aliasResource2 := "vault_identity_entity_alias.test2"
+	entityResource1 := "vault_identity_entity.test1"
+	entityResource2 := "vault_identity_entity.test2"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckIdentityEntityAliasDestroy,
+		Steps: []resource.TestStep{
+			{
+				// test the case where the apply operation would produce two new aliases having the same name
+				// this should result in one alias being created but not the other.
+				Config:      fmt.Sprintf(configTmpl, alias, alias),
+				ExpectError: regexp.MustCompile(`entity alias .+ already exists`),
+			},
+			{
+				// attempt to recover from alias name duplication failure above
+				// this should result in a clean recovery from the failure above.
+				Config: fmt.Sprintf(configTmpl, alias+"-1", alias+"-2"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						aliasResource1, "mount_accessor",
+						aliasResource2, "mount_accessor"),
+					resource.TestCheckResourceAttr(
+						aliasResource1, "name", alias+"-1"),
+					resource.TestCheckResourceAttr(
+						aliasResource2, "name", alias+"-2"),
+					resource.TestCheckResourceAttrPair(
+						aliasResource1, "canonical_id",
+						entityResource1, "id"),
+					resource.TestCheckResourceAttrPair(
+						aliasResource2, "canonical_id",
+						entityResource2, "id"),
+				),
+			},
+			{
+				ResourceName:      aliasResource1,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      aliasResource2,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				// attempt to get back to the desired alias configuration
+				Config: fmt.Sprintf(configTmpl, alias, alias+"-2"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						aliasResource1, "mount_accessor",
+						aliasResource2, "mount_accessor"),
+					resource.TestCheckResourceAttr(
+						aliasResource1, "name", alias),
+					resource.TestCheckResourceAttr(
+						aliasResource2, "name", alias+"-2"),
+				),
+			},
+			{
+				ResourceName:      aliasResource1,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      aliasResource2,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				// duplicate during an update operation
+				// this should result Vault catching the duplicate and returning an error.
+				Config:      fmt.Sprintf(configTmpl, alias, alias),
+				ExpectError: regexp.MustCompile(`alias with combination of mount accessor and name already exists`),
 			},
 		},
 	})

--- a/vault/resource_identity_entity_alias_test.go
+++ b/vault/resource_identity_entity_alias_test.go
@@ -234,7 +234,7 @@ func testAccCheckIdentityEntityAliasDestroy(s *terraform.State) error {
 		if rs.Type != "vault_identity_entity_alias" {
 			continue
 		}
-		secret, err := client.Logical().Read(entity.AliasIDPath(rs.Primary.ID))
+		secret, err := client.Logical().Read(entity.JoinAliasID(rs.Primary.ID))
 		if err != nil {
 			return fmt.Errorf("error checking for identity entity %q: %s", rs.Primary.ID, err)
 		}

--- a/vault/resource_identity_entity_policies.go
+++ b/vault/resource_identity_entity_policies.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/identity/entity"
 	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
@@ -54,7 +55,7 @@ func identityEntityPoliciesUpdate(d *schema.ResourceData, meta interface{}) erro
 	id := d.Get("entity_id").(string)
 
 	log.Printf("[DEBUG] Updating IdentityEntityPolicies %q", id)
-	path := identityEntityIDPath(id)
+	path := entity.IDPath(id)
 
 	vaultMutexKV.Lock(path)
 	defer vaultMutexKV.Unlock(path)
@@ -137,7 +138,7 @@ func identityEntityPoliciesDelete(d *schema.ResourceData, meta interface{}) erro
 	id := d.Get("entity_id").(string)
 
 	log.Printf("[DEBUG] Deleting IdentityEntityPolicies %q", id)
-	path := identityEntityIDPath(id)
+	path := entity.IDPath(id)
 
 	vaultMutexKV.Lock(path)
 	defer vaultMutexKV.Unlock(path)

--- a/vault/resource_identity_entity_policies.go
+++ b/vault/resource_identity_entity_policies.go
@@ -55,7 +55,7 @@ func identityEntityPoliciesUpdate(d *schema.ResourceData, meta interface{}) erro
 	id := d.Get("entity_id").(string)
 
 	log.Printf("[DEBUG] Updating IdentityEntityPolicies %q", id)
-	path := entity.IDPath(id)
+	path := entity.JoinEntityID(id)
 
 	vaultMutexKV.Lock(path)
 	defer vaultMutexKV.Unlock(path)
@@ -138,7 +138,7 @@ func identityEntityPoliciesDelete(d *schema.ResourceData, meta interface{}) erro
 	id := d.Get("entity_id").(string)
 
 	log.Printf("[DEBUG] Deleting IdentityEntityPolicies %q", id)
-	path := entity.IDPath(id)
+	path := entity.JoinEntityID(id)
 
 	vaultMutexKV.Lock(path)
 	defer vaultMutexKV.Unlock(path)

--- a/vault/resource_identity_entity_policies_test.go
+++ b/vault/resource_identity_entity_policies_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/identity/entity"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 	"github.com/hashicorp/terraform-provider-vault/util"
 )
@@ -122,7 +123,7 @@ func testAccIdentityEntityPoliciesCheckAttrs(resource string) resource.TestCheck
 
 		id := instanceState.ID
 
-		path := identityEntityIDPath(id)
+		path := entity.IDPath(id)
 		client := testProvider.Meta().(*api.Client)
 		resp, err := client.Logical().Read(path)
 		if err != nil {
@@ -217,7 +218,7 @@ func testAccIdentityEntityPoliciesCheckLogical(resource string, policies []strin
 
 		id := instanceState.ID
 
-		path := identityEntityIDPath(id)
+		path := entity.IDPath(id)
 		client := testProvider.Meta().(*api.Client)
 		resp, err := client.Logical().Read(path)
 		if err != nil {

--- a/vault/resource_identity_entity_policies_test.go
+++ b/vault/resource_identity_entity_policies_test.go
@@ -123,7 +123,7 @@ func testAccIdentityEntityPoliciesCheckAttrs(resource string) resource.TestCheck
 
 		id := instanceState.ID
 
-		path := entity.IDPath(id)
+		path := entity.JoinEntityID(id)
 		client := testProvider.Meta().(*api.Client)
 		resp, err := client.Logical().Read(path)
 		if err != nil {
@@ -218,7 +218,7 @@ func testAccIdentityEntityPoliciesCheckLogical(resource string, policies []strin
 
 		id := instanceState.ID
 
-		path := entity.IDPath(id)
+		path := entity.JoinEntityID(id)
 		client := testProvider.Meta().(*api.Client)
 		resp, err := client.Logical().Read(path)
 		if err != nil {

--- a/vault/resource_identity_entity_test.go
+++ b/vault/resource_identity_entity_test.go
@@ -3,7 +3,6 @@ package vault
 import (
 	"encoding/json"
 	"fmt"
-	"net"
 	"net/http"
 	"reflect"
 	"strconv"
@@ -120,7 +119,7 @@ func testAccCheckIdentityEntityDestroy(s *terraform.State) error {
 		if rs.Type != "vault_identity_entity" {
 			continue
 		}
-		secret, err := client.Logical().Read(entity.IDPath(rs.Primary.ID))
+		secret, err := client.Logical().Read(entity.JoinEntityID(rs.Primary.ID))
 		if err != nil {
 			return fmt.Errorf("error checking for identity entity %q: %s", rs.Primary.ID, err)
 		}
@@ -145,7 +144,7 @@ func testAccIdentityEntityCheckAttrs() resource.TestCheckFunc {
 
 		id := instanceState.ID
 
-		path := entity.IDPath(id)
+		path := entity.JoinEntityID(id)
 		client := testProvider.Meta().(*api.Client)
 		resp, err := client.Logical().Read(path)
 		if err != nil {
@@ -309,7 +308,7 @@ func TestReadEntity(t *testing.T) {
 		},
 		{
 			name: "retry-exhausted-default-max-404",
-			path: entity.IDPath("retry-exhausted-default-max-404"),
+			path: entity.JoinEntityID("retry-exhausted-default-max-404"),
 			retryHandler: &testRetryHandler{
 				okAtCount:   0,
 				retryStatus: http.StatusNotFound,
@@ -317,11 +316,11 @@ func TestReadEntity(t *testing.T) {
 			maxRetries:      DefaultMaxHTTPRetriesCCC,
 			expectedRetries: DefaultMaxHTTPRetriesCCC,
 			wantError: fmt.Errorf(`%w: %q`, errEntityNotFound,
-				entity.IDPath("retry-exhausted-default-max-404")),
+				entity.JoinEntityID("retry-exhausted-default-max-404")),
 		},
 		{
 			name: "retry-exhausted-default-max-412",
-			path: entity.IDPath("retry-exhausted-default-max-412"),
+			path: entity.JoinEntityID("retry-exhausted-default-max-412"),
 			retryHandler: &testRetryHandler{
 				okAtCount:   0,
 				retryStatus: http.StatusPreconditionFailed,
@@ -329,11 +328,11 @@ func TestReadEntity(t *testing.T) {
 			maxRetries:      DefaultMaxHTTPRetriesCCC,
 			expectedRetries: DefaultMaxHTTPRetriesCCC,
 			wantError: fmt.Errorf(`failed reading %q`,
-				entity.IDPath("retry-exhausted-default-max-412")),
+				entity.JoinEntityID("retry-exhausted-default-max-412")),
 		},
 		{
 			name: "retry-exhausted-custom-max-404",
-			path: entity.IDPath("retry-exhausted-custom-max-404"),
+			path: entity.JoinEntityID("retry-exhausted-custom-max-404"),
 			retryHandler: &testRetryHandler{
 				okAtCount:   0,
 				retryStatus: http.StatusNotFound,
@@ -341,11 +340,11 @@ func TestReadEntity(t *testing.T) {
 			maxRetries:      5,
 			expectedRetries: 5,
 			wantError: fmt.Errorf(`%w: %q`, errEntityNotFound,
-				entity.IDPath("retry-exhausted-custom-max-404")),
+				entity.JoinEntityID("retry-exhausted-custom-max-404")),
 		},
 		{
 			name: "retry-exhausted-custom-max-412",
-			path: entity.IDPath("retry-exhausted-custom-max-412"),
+			path: entity.JoinEntityID("retry-exhausted-custom-max-412"),
 			retryHandler: &testRetryHandler{
 				okAtCount:   0,
 				retryStatus: http.StatusPreconditionFailed,
@@ -353,7 +352,7 @@ func TestReadEntity(t *testing.T) {
 			maxRetries:      5,
 			expectedRetries: 5,
 			wantError: fmt.Errorf(`failed reading %q`,
-				entity.IDPath("retry-exhausted-custom-max-412")),
+				entity.JoinEntityID("retry-exhausted-custom-max-412")),
 		},
 	}
 
@@ -366,7 +365,7 @@ func TestReadEntity(t *testing.T) {
 
 			r := tt.retryHandler
 
-			config, ln := testHTTPServer(t, r.handler())
+			config, ln := testutil.TestHTTPServer(t, r.handler())
 			defer ln.Close()
 
 			config.Address = fmt.Sprintf("http://%s", ln.Addr())
@@ -473,22 +472,4 @@ func (t *testRetryHandler) handler() http.HandlerFunc {
 			w.WriteHeader(t.retryStatus)
 		}
 	}
-}
-
-// testHTTPServer creates a test HTTP server that handles requests until
-// the listener returned is closed.
-// XXX: copied from github.com/hashicorp/vault/api/client_test.go
-func testHTTPServer(t *testing.T, handler http.Handler) (*api.Config, net.Listener) {
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	server := &http.Server{Handler: handler}
-	go server.Serve(ln)
-
-	config := api.DefaultConfig()
-	config.Address = fmt.Sprintf("http://%s", ln.Addr())
-
-	return config, ln
 }

--- a/vault/resource_identity_entity_test.go
+++ b/vault/resource_identity_entity_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/identity/entity"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -119,7 +120,7 @@ func testAccCheckIdentityEntityDestroy(s *terraform.State) error {
 		if rs.Type != "vault_identity_entity" {
 			continue
 		}
-		secret, err := client.Logical().Read(identityEntityIDPath(rs.Primary.ID))
+		secret, err := client.Logical().Read(entity.IDPath(rs.Primary.ID))
 		if err != nil {
 			return fmt.Errorf("error checking for identity entity %q: %s", rs.Primary.ID, err)
 		}
@@ -144,7 +145,7 @@ func testAccIdentityEntityCheckAttrs() resource.TestCheckFunc {
 
 		id := instanceState.ID
 
-		path := identityEntityIDPath(id)
+		path := entity.IDPath(id)
 		client := testProvider.Meta().(*api.Client)
 		resp, err := client.Logical().Read(path)
 		if err != nil {
@@ -308,7 +309,7 @@ func TestReadEntity(t *testing.T) {
 		},
 		{
 			name: "retry-exhausted-default-max-404",
-			path: identityEntityIDPath("retry-exhausted-default-max-404"),
+			path: entity.IDPath("retry-exhausted-default-max-404"),
 			retryHandler: &testRetryHandler{
 				okAtCount:   0,
 				retryStatus: http.StatusNotFound,
@@ -316,11 +317,11 @@ func TestReadEntity(t *testing.T) {
 			maxRetries:      DefaultMaxHTTPRetriesCCC,
 			expectedRetries: DefaultMaxHTTPRetriesCCC,
 			wantError: fmt.Errorf(`%w: %q`, errEntityNotFound,
-				identityEntityIDPath("retry-exhausted-default-max-404")),
+				entity.IDPath("retry-exhausted-default-max-404")),
 		},
 		{
 			name: "retry-exhausted-default-max-412",
-			path: identityEntityIDPath("retry-exhausted-default-max-412"),
+			path: entity.IDPath("retry-exhausted-default-max-412"),
 			retryHandler: &testRetryHandler{
 				okAtCount:   0,
 				retryStatus: http.StatusPreconditionFailed,
@@ -328,11 +329,11 @@ func TestReadEntity(t *testing.T) {
 			maxRetries:      DefaultMaxHTTPRetriesCCC,
 			expectedRetries: DefaultMaxHTTPRetriesCCC,
 			wantError: fmt.Errorf(`failed reading %q`,
-				identityEntityIDPath("retry-exhausted-default-max-412")),
+				entity.IDPath("retry-exhausted-default-max-412")),
 		},
 		{
 			name: "retry-exhausted-custom-max-404",
-			path: identityEntityIDPath("retry-exhausted-custom-max-404"),
+			path: entity.IDPath("retry-exhausted-custom-max-404"),
 			retryHandler: &testRetryHandler{
 				okAtCount:   0,
 				retryStatus: http.StatusNotFound,
@@ -340,11 +341,11 @@ func TestReadEntity(t *testing.T) {
 			maxRetries:      5,
 			expectedRetries: 5,
 			wantError: fmt.Errorf(`%w: %q`, errEntityNotFound,
-				identityEntityIDPath("retry-exhausted-custom-max-404")),
+				entity.IDPath("retry-exhausted-custom-max-404")),
 		},
 		{
 			name: "retry-exhausted-custom-max-412",
-			path: identityEntityIDPath("retry-exhausted-custom-max-412"),
+			path: entity.IDPath("retry-exhausted-custom-max-412"),
 			retryHandler: &testRetryHandler{
 				okAtCount:   0,
 				retryStatus: http.StatusPreconditionFailed,
@@ -352,7 +353,7 @@ func TestReadEntity(t *testing.T) {
 			maxRetries:      5,
 			expectedRetries: 5,
 			wantError: fmt.Errorf(`failed reading %q`,
-				identityEntityIDPath("retry-exhausted-custom-max-412")),
+				entity.IDPath("retry-exhausted-custom-max-412")),
 		},
 	}
 


### PR DESCRIPTION
Fix race condition on duplicate entity alias creation

The creation of entity aliases should be serialized, since we want to
handle the case when the user is attempting to create duplicate entity
aliases during the same Teraform execution. A duplicate entity alias
shares the same mount accessor and name with another entity alias.

The fix is to lock the /identity/entity-alias/id path on all create,
update, and delete operations. This allows the provider to reliably
detect the duplicate entity alias condition, and prevent duplicate
alias creation.

Other fixes:
- all CRUD functions are of the *Context type, and can return meaningful
diag.Diagnostics
- created a new entity package under internal/identity/entity with some
helper functions


<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #669 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-v -test.run TestAccIdentityEntity*'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -v -test.run TestAccIdentityEntity* -timeout 30m ./...

ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
=== RUN   TestAccIdentityEntityAlias
--- PASS: TestAccIdentityEntityAlias (3.08s)
=== RUN   TestAccIdentityEntityAliasDuplicateFlow
--- PASS: TestAccIdentityEntityAliasDuplicateFlow (6.13s)
=== RUN   TestAccIdentityEntityAlias_Update
--- PASS: TestAccIdentityEntityAlias_Update (3.06s)
=== RUN   TestAccIdentityEntityAlias_Metadata
--- PASS: TestAccIdentityEntityAlias_Metadata (3.07s)
=== RUN   TestAccIdentityEntityPoliciesExclusive
--- PASS: TestAccIdentityEntityPoliciesExclusive (2.98s)
=== RUN   TestAccIdentityEntityPoliciesNonExclusive
--- PASS: TestAccIdentityEntityPoliciesNonExclusive (2.96s)
=== RUN   TestAccIdentityEntity
--- PASS: TestAccIdentityEntity (1.58s)
=== RUN   TestAccIdentityEntityUpdate
--- PASS: TestAccIdentityEntityUpdate (2.81s)
=== RUN   TestAccIdentityEntityUpdateRemoveValues
--- PASS: TestAccIdentityEntityUpdateRemoveValues (2.82s)
=== RUN   TestAccIdentityEntityUpdateRemovePolicies
--- PASS: TestAccIdentityEntityUpdateRemovePolicies (2.85s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     31.782s


...
```
