### PR TITLE
Force new root CA resource creation on out of band changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## 3.6.0 (Unreleased)
+IMPROVEMENTS:
+* `resource/pki_secret_backend_root_cert`: Force new root CA resource creation on out-of-band changes.  
+  ([#1428](https://github.com/hashicorp/terraform-provider-vault/pull/1428))
+
 BUGS:
 * `resource/pki_secret_backend_root_sign_intermediate`: Ensure that the `certificate_bundle`, and `ca_chain` 
   do not contain duplicate certificates.  

--- a/testutil/testutl.go
+++ b/testutil/testutl.go
@@ -1,0 +1,1 @@
+package testutil

--- a/testutil/testutl.go
+++ b/testutil/testutl.go
@@ -1,1 +1,0 @@
-package testutil

--- a/util/util.go
+++ b/util/util.go
@@ -42,7 +42,11 @@ func ToStringArray(input []interface{}) []string {
 }
 
 func Is404(err error) bool {
-	return strings.Contains(err.Error(), "Code: 404")
+	return IsHTTPErrorCode(err, http.StatusNotFound)
+}
+
+func IsHTTPErrorCode(err error, code int) bool {
+	return strings.Contains(err.Error(), fmt.Sprintf("Code: %d", code))
 }
 
 func CalculateConflictsWith(self string, group []string) []string {

--- a/util/util.go
+++ b/util/util.go
@@ -318,9 +318,7 @@ func CheckMountEnabled(client *api.Client, path string) (bool, error) {
 		return false, err
 	}
 
-	if _, ok := mounts[NormalizeMountPath(path)]; !ok {
-		return true, nil
-	}
+	_, ok := mounts[NormalizeMountPath(path)]
 
-	return false, nil
+	return ok, nil
 }

--- a/vault/resource_pki_secret_backend_root_cert.go
+++ b/vault/resource_pki_secret_backend_root_cert.go
@@ -338,7 +338,7 @@ func pkiSecretBackendRootCertRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	// trigger a resource re-creation whenever the engine's mount has disappeared
-	if enabled {
+	if !enabled {
 		log.Printf("[WARN] Mount %q does not exist, setting resource for re-creation", path)
 		d.SetId("")
 	}

--- a/vault/resource_pki_secret_backend_root_cert.go
+++ b/vault/resource_pki_secret_backend_root_cert.go
@@ -1,21 +1,59 @@
 package vault
 
 import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
+	"io"
 	"log"
+	"net/http"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/vault/api"
+	"github.com/hashicorp/vault/sdk/helper/certutil"
+
+	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
 func pkiSecretBackendRootCertResource() *schema.Resource {
 	return &schema.Resource{
 		Create: pkiSecretBackendRootCertCreate,
-		Read:   pkiSecretBackendRootCertRead,
-		Update: pkiSecretBackendRootCertUpdate,
 		Delete: pkiSecretBackendRootCertDelete,
+		Update: func(data *schema.ResourceData, i interface{}) error {
+			return nil
+		},
+		Read: func(data *schema.ResourceData, i interface{}) error {
+			return nil
+		},
+		CustomizeDiff: func(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+			client := meta.(*api.Client)
+			cert, err := getCACertificate(client, d.Get("backend").(string))
+			if err != nil {
+				return err
+			}
+
+			if cert != nil {
+				key := "serial"
+				cur := d.Get(key).(string)
+				n := certutil.GetHexFormatted(cert.SerialNumber.Bytes(), ":")
+				if err := d.SetNew(key, n); err != nil {
+					return err
+				}
+
+				o, _ := d.GetChange(key)
+				// don't force new on new resources
+				if o.(string) != "" && cur != n {
+					if err := d.ForceNew(key); err != nil {
+						return err
+					}
+				}
+
+			}
+			return nil
+		},
 
 		Schema: map[string]*schema.Schema{
 			"backend": {
@@ -177,7 +215,7 @@ func pkiSecretBackendRootCertResource() *schema.Resource {
 			"certificate": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The certicate.",
+				Description: "The certificate.",
 			},
 			"issuing_ca": {
 				Type:        schema.TypeString,
@@ -281,15 +319,43 @@ func pkiSecretBackendRootCertCreate(d *schema.ResourceData, meta interface{}) er
 	d.Set("serial", resp.Data["serial_number"])
 
 	d.SetId(path)
-	return pkiSecretBackendRootCertRead(d, meta)
-}
 
-func pkiSecretBackendRootCertRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func pkiSecretBackendRootCertUpdate(d *schema.ResourceData, m interface{}) error {
-	return nil
+func getCACertificate(client *api.Client, mount string) (*x509.Certificate, error) {
+	path := fmt.Sprintf("/v1/%s/ca/pem", mount)
+	req := client.NewRequest(http.MethodGet, path)
+	req.ClientToken = ""
+	resp, err := client.RawRequest(req)
+	if err != nil {
+		if util.IsHTTPErrorCode(err, http.StatusNotFound) || util.IsHTTPErrorCode(err, http.StatusForbidden) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	if resp == nil {
+		return nil, fmt.Errorf("expected a response body, got nil response")
+	}
+
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Printf("[INFO] Reading current CA")
+	b, _ := pem.Decode(data)
+	if b != nil {
+		cert, err := x509.ParseCertificate(b.Bytes)
+		if err != nil {
+			return nil, err
+		}
+		return cert, nil
+	}
+
+	return nil, nil
 }
 
 func pkiSecretBackendRootCertDelete(d *schema.ResourceData, meta interface{}) error {

--- a/vault/resource_pki_secret_backend_root_cert.go
+++ b/vault/resource_pki_secret_backend_root_cert.go
@@ -25,9 +25,6 @@ func pkiSecretBackendRootCertResource() *schema.Resource {
 		Update: func(data *schema.ResourceData, i interface{}) error {
 			return nil
 		},
-		//Read: func(data *schema.ResourceData, i interface{}) error {
-		//	return nil
-		//},
 		Read: pkiSecretBackendRootCertRead,
 		CustomizeDiff: func(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
 			key := "serial"

--- a/vault/resource_pki_secret_backend_root_cert_test.go
+++ b/vault/resource_pki_secret_backend_root_cert_test.go
@@ -17,6 +17,25 @@ import (
 func TestPkiSecretBackendRootCertificate_basic(t *testing.T) {
 	path := "pki-" + strconv.Itoa(acctest.RandInt())
 
+	resourceName := "vault_pki_secret_backend_root_cert.test"
+
+	checks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(resourceName, "backend", path),
+		resource.TestCheckResourceAttr(resourceName, "type", "internal"),
+		resource.TestCheckResourceAttr(resourceName, "common_name", "test Root CA"),
+		resource.TestCheckResourceAttr(resourceName, "ttl", "86400"),
+		resource.TestCheckResourceAttr(resourceName, "format", "pem"),
+		resource.TestCheckResourceAttr(resourceName, "private_key_format", "der"),
+		resource.TestCheckResourceAttr(resourceName, "key_type", "rsa"),
+		resource.TestCheckResourceAttr(resourceName, "key_bits", "4096"),
+		resource.TestCheckResourceAttr(resourceName, "ou", "test"),
+		resource.TestCheckResourceAttr(resourceName, "organization", "test"),
+		resource.TestCheckResourceAttr(resourceName, "country", "test"),
+		resource.TestCheckResourceAttr(resourceName, "locality", "test"),
+		resource.TestCheckResourceAttr(resourceName, "province", "test"),
+		resource.TestCheckResourceAttrSet(resourceName, "serial"),
+	}
+
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
@@ -24,22 +43,52 @@ func TestPkiSecretBackendRootCertificate_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testPkiSecretBackendRootCertificateConfig_basic(path),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_pki_secret_backend_root_cert.test", "backend", path),
-					resource.TestCheckResourceAttr("vault_pki_secret_backend_root_cert.test", "type", "internal"),
-					resource.TestCheckResourceAttr("vault_pki_secret_backend_root_cert.test", "common_name", "test Root CA"),
-					resource.TestCheckResourceAttr("vault_pki_secret_backend_root_cert.test", "ttl", "86400"),
-					resource.TestCheckResourceAttr("vault_pki_secret_backend_root_cert.test", "format", "pem"),
-					resource.TestCheckResourceAttr("vault_pki_secret_backend_root_cert.test", "private_key_format", "der"),
-					resource.TestCheckResourceAttr("vault_pki_secret_backend_root_cert.test", "key_type", "rsa"),
-					resource.TestCheckResourceAttr("vault_pki_secret_backend_root_cert.test", "key_bits", "4096"),
-					resource.TestCheckResourceAttr("vault_pki_secret_backend_root_cert.test", "ou", "test"),
-					resource.TestCheckResourceAttr("vault_pki_secret_backend_root_cert.test", "organization", "test"),
-					resource.TestCheckResourceAttr("vault_pki_secret_backend_root_cert.test", "country", "test"),
-					resource.TestCheckResourceAttr("vault_pki_secret_backend_root_cert.test", "locality", "test"),
-					resource.TestCheckResourceAttr("vault_pki_secret_backend_root_cert.test", "province", "test"),
-					resource.TestCheckResourceAttrSet("vault_pki_secret_backend_root_cert.test", "serial"),
-				),
+				Check:  resource.ComposeTestCheckFunc(checks...),
+			},
+			{
+				PreConfig: func() {
+					client := testProvider.Meta().(*api.Client)
+					_, err := client.Logical().Delete(fmt.Sprintf("%s/root", path))
+					if err != nil {
+						t.Fatal(err)
+					}
+				},
+				Config: testPkiSecretBackendRootCertificateConfig_basic(path),
+			},
+			{
+				// test unmounted backend
+				PreConfig: func() {
+					client := testProvider.Meta().(*api.Client)
+					if err := client.Sys().Unmount(path); err != nil {
+						t.Fatal(err)
+					}
+				},
+				Config: testPkiSecretBackendRootCertificateConfig_basic(path),
+			},
+			{
+				// test out of band update to the root CA
+				PreConfig: func() {
+					client := testProvider.Meta().(*api.Client)
+					_, err := client.Logical().Delete(fmt.Sprintf("%s/root", path))
+					if err != nil {
+						t.Fatal(err)
+					}
+					genPath := pkiSecretBackendIntermediateSetSignedReadPath(path, "internal")
+					resp, err := client.Logical().Write(genPath,
+						map[string]interface{}{
+							"common_name": "out-of-band",
+						},
+					)
+					if err != nil {
+						t.Fatal(err)
+					}
+
+					if resp == nil {
+						t.Fatalf("empty response for write on path %s", genPath)
+					}
+				},
+				Config: testPkiSecretBackendRootCertificateConfig_basic(path),
+				Check:  resource.ComposeTestCheckFunc(checks...),
 			},
 		},
 	})
@@ -69,30 +118,32 @@ func testPkiSecretBackendRootCertificateDestroy(s *terraform.State) error {
 }
 
 func testPkiSecretBackendRootCertificateConfig_basic(path string) string {
-	return fmt.Sprintf(`
+	config := fmt.Sprintf(`
 resource "vault_mount" "test" {
-  path = "%s"
-  type = "pki"
-  description = "test"
+  path                      = "%s"
+  type                      = "pki"
+  description               = "test"
   default_lease_ttl_seconds = "86400"
   max_lease_ttl_seconds     = "86400"
 }
 
 resource "vault_pki_secret_backend_root_cert" "test" {
-  depends_on = [ "vault_mount.test" ]
-  backend = vault_mount.test.path
-  type = "internal"
-  common_name = "test Root CA"
-  ttl = "86400"
-  format = "pem"
-  private_key_format = "der"
-  key_type = "rsa"
-  key_bits = 4096
+  backend              = vault_mount.test.path
+  type                 = "internal"
+  common_name          = "test Root CA"
+  ttl                  = "86400"
+  format               = "pem"
+  private_key_format   = "der"
+  key_type             = "rsa"
+  key_bits             = 4096
   exclude_cn_from_sans = true
-  ou = "test"
-  organization = "test"
-  country = "test"
-  locality = "test"
-  province = "test"
-}`, path)
+  ou                   = "test"
+  organization         = "test"
+  country              = "test"
+  locality             = "test"
+  province             = "test"
+}
+`, path)
+
+	return config
 }

--- a/website/docs/r/pki_secret_backend_root_cert.html.md
+++ b/website/docs/r/pki_secret_backend_root_cert.html.md
@@ -88,8 +88,10 @@ The following arguments are supported:
 
 In addition to the fields above, the following attributes are exported:
 
-* `certificate` - The certificate
+* `certificate` - The certificate.
 
-* `issuing_ca` - The issuing CA
+* `issuing_ca` - The issuing CA certificate.
 
-* `serial` - The serial
+* `serial` - Deprecated, use `serial_number` instead.
+ 
+* `serial_number` - The certificate's serial number, hex formatted.

--- a/website/docs/r/pki_secret_backend_sign.html.md
+++ b/website/docs/r/pki_secret_backend_sign.html.md
@@ -97,6 +97,10 @@ In addition to the fields above, the following attributes are exported:
 
 * `ca_chain` - The CA chain
 
-* `serial` - The serial
+* `serial_number` - The certificate's serial number, hex formatted.
 
 * `expiration` - The expiration date of the certificate in unix epoch format
+
+## Deprecations
+
+* `serial` - Use `serial_number` instead.


### PR DESCRIPTION
This fix will trigger the recreation a `pki_secret_backend_root_cert` resource
for the following cases:

- the secret engine's mount has been removed
- the CA certificate has been regenerated outside of Terraform.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #939

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
$ time make testacc TESTARGS='-v -test.run TestPkiSecretBackendRootCertificate_basic'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -v -test.run TestPkiSecretBackendRootCertificate_basic -timeout 30m ./...

ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
=== RUN   TestPkiSecretBackendRootCertificate_basic
--- PASS: TestPkiSecretBackendRootCertificate_basic (11.66s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     (cached)
make testacc TESTARGS='-v -test.run TestPkiSecretBackendRootCertificate_basic  4.29s user 4.48s system 132% cpu 6.621 total


...
```
