### PR TITLE
Remove read operation on entity alias update

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -322,3 +322,25 @@ func CheckMountEnabled(client *api.Client, path string) (bool, error) {
 
 	return ok, nil
 }
+
+// GetAPIRequestData to pass to Vault from schema.ResourceData.
+// The fieldMap specifies the schema field to its vault constituent.
+// If the vault field is empty, then two fields are mapped 1:1.
+func GetAPIRequestData(d *schema.ResourceData, fieldMap map[string]string) map[string]interface{} {
+	data := make(map[string]interface{})
+	for k1, k2 := range fieldMap {
+		if k2 == "" {
+			k2 = k1
+		}
+
+		sv := d.Get(k1)
+		switch v := sv.(type) {
+		case *schema.Set:
+			data[k2] = v.List()
+		default:
+			data[k2] = sv
+		}
+	}
+
+	return data
+}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -255,3 +255,113 @@ func TestPathParameters(t *testing.T) {
 		})
 	}
 }
+
+func TestGetAPIRequestData(t *testing.T) {
+	tests := []struct {
+		name string
+		d    map[string]*schema.Schema
+		m    map[string]string
+		sm   map[string]interface{}
+		want map[string]interface{}
+	}{
+		{
+			name: "basic-default",
+			d: map[string]*schema.Schema{
+				"name": {
+					Type: schema.TypeString,
+				},
+			},
+			m: map[string]string{
+				"name": "",
+			},
+			sm: map[string]interface{}{
+				"name": "bob",
+			},
+			want: map[string]interface{}{
+				"name": "bob",
+			},
+		},
+		{
+			name: "basic-remap",
+			d: map[string]*schema.Schema{
+				"name": {
+					Type: schema.TypeString,
+				},
+			},
+			m: map[string]string{
+				"name": "nom",
+			},
+			sm: map[string]interface{}{
+				"name": "bob",
+			},
+			want: map[string]interface{}{
+				"nom": "bob",
+			},
+		},
+		{
+			name: "map",
+			d: map[string]*schema.Schema{
+				"name": {
+					Type: schema.TypeString,
+				},
+				"parts": {
+					Type: schema.TypeMap,
+				},
+			},
+			m: map[string]string{
+				"name":  "",
+				"parts": "",
+			},
+			sm: map[string]interface{}{
+				"name": "bob",
+				"parts": map[string]interface{}{
+					"bolt": "0.60",
+				},
+			},
+			want: map[string]interface{}{
+				"name": "bob",
+				"parts": map[string]interface{}{
+					"bolt": "0.60",
+				},
+			},
+		},
+		{
+			name: "set",
+			d: map[string]*schema.Schema{
+				"name": {
+					Type: schema.TypeString,
+				},
+				"parts": {
+					Type: schema.TypeSet,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+			},
+			m: map[string]string{
+				"name":  "",
+				"parts": "",
+			},
+			sm: map[string]interface{}{
+				"name": "alice",
+				"parts": []interface{}{
+					"bolt",
+				},
+			},
+			want: map[string]interface{}{
+				"name": "alice",
+				"parts": []interface{}{
+					"bolt",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := schema.TestResourceDataRaw(t, tt.d, tt.sm)
+			if got := GetAPIRequestData(r, tt.m); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetAPIRequestData() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The `identityEntityAliasUpdate` function was performing a read operation
when it should not have been. The read operation should be constrained
to the defined ReadContext.

- add new GetAPIRequestData() function that generalizes the translation
  of schema.ResourceData values to their Vault request data equivalents.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
 $ time make testacc TESTARGS='-v -test.run TestAccIdentityEntityAlias*'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -v -test.run TestAccIdentityEntityAlias* -timeout 30m ./...

ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
=== RUN   TestAccIdentityEntityAlias
--- PASS: TestAccIdentityEntityAlias (3.14s)
=== RUN   TestAccIdentityEntityAliasDuplicateFlow
--- PASS: TestAccIdentityEntityAliasDuplicateFlow (7.48s)
=== RUN   TestAccIdentityEntityAlias_Update
--- PASS: TestAccIdentityEntityAlias_Update (3.09s)
=== RUN   TestAccIdentityEntityAlias_Metadata
--- PASS: TestAccIdentityEntityAlias_Metadata (3.07s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     19.717s
make testacc TESTARGS='-v -test.run TestAccIdentityEntityAlias*'  42.40s user 18.94s system 229% cpu 26.747 total


...
```
