### PR TITLE
Ignore mongodb-atlas private_key on read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ BUGS:
 * `resource/identity_entity_alias`: Serialize create, update, and delete operations in order to prevent alias 
   mismatches.
   ([#1429](https://github.com/hashicorp/terraform-provider-vault/pull/1429))
+* `database_secret*`: Ignore mongodb-atlas `private_key` on read from Vault.
+  mismatches.  
+  ([#1436](https://github.com/hashicorp/terraform-provider-vault/issues/1436))
+
 
 ## 3.5.0 (April 20, 2022)
 FEATURES:

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -251,11 +251,13 @@ func TestAccDatabaseSecretBackendConnection_mongodbatlas(t *testing.T) {
 	MaybeSkipDBTests(t, dbEngineMongoDBAtlas)
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
-	values := testutil.SkipTestEnvUnset(t, "MONGODB_ATLAS_PUBLIC_KEY")
-	publicKey := values[0]
+	values := testutil.SkipTestEnvUnset(t,
+		"MONGODB_ATLAS_PUBLIC_KEY",
+		"MONGODB_ATLAS_PRIVATE_KEY",
+		"MONGODB_ATLAS_PROJECT_ID")
 
-	privateKey := os.Getenv("MONGODB_ATLAS_PRIVATE_KEY")
-	projectID := os.Getenv("MONGODB_ATLAS_PROJECT_ID")
+	publicKey, privateKey, projectID := values[0], values[1], values[0]
+
 	backend := acctest.RandomWithPrefix("tf-test-db")
 	pluginName := dbEngineMongoDBAtlas.DefaultPluginName()
 	name := acctest.RandomWithPrefix("db")


### PR DESCRIPTION
Additional fixes:
- ensure that multiple `monogodbatlas` resources can be properly
  configured.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1436

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
