### PR TITLE
Allow `description` to be updated for `vault_auth_backend` resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ BUGS:
 * `resource/identity_entity_alias`: Serialize create, update, and delete operations in order to prevent alias 
   mismatches.
   ([#1429](https://github.com/hashicorp/terraform-provider-vault/pull/1429))
+* `resource/auth_backend`: Remove `ForceNew` behavior when updating `description` ([#1439](https://github.com/hashicorp/terraform-provider-vault/pull/1439))
 
 ## 3.5.0 (April 20, 2022)
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ BUGS:
 * `database_secret*`: Ignore mongodb-atlas `private_key` on read from Vault.
   mismatches.  
   ([#1436](https://github.com/hashicorp/terraform-provider-vault/issues/1436))
-* `resource/auth_backend`: Remove `ForceNew` behavior when updating `description` ([#1439](https://github.com/hashicorp/terraform-provider-vault/pull/1439))
+* `resource/auth_backend`: Remove `ForceNew` behavior when updating `description`
+  ([#1439](https://github.com/hashicorp/terraform-provider-vault/pull/1439))
 
 ## 3.5.0 (April 20, 2022)
 FEATURES:

--- a/vault/auth_mount.go
+++ b/vault/auth_mount.go
@@ -88,7 +88,11 @@ func authMountInfoGet(client *api.Client, path string) (*api.AuthMount, error) {
 func authMountTune(client *api.Client, path string, configured interface{}) error {
 	tune := expandAuthMethodTune(configured.(*schema.Set).List())
 
-	err := client.Sys().TuneMount(path, tune)
+	return tuneMount(client, path, tune)
+}
+
+func tuneMount(client *api.Client, path string, input api.MountConfigInput) error {
+	err := client.Sys().TuneMount(path, input)
 	if err != nil {
 		return err
 	}

--- a/vault/auth_mount.go
+++ b/vault/auth_mount.go
@@ -86,9 +86,9 @@ func authMountInfoGet(client *api.Client, path string) (*api.AuthMount, error) {
 }
 
 func authMountTune(client *api.Client, path string, configured interface{}) error {
-	tune := expandAuthMethodTune(configured.(*schema.Set).List())
+	input := expandAuthMethodTune(configured.(*schema.Set).List())
 
-	return tuneMount(client, path, tune)
+	return tuneMount(client, path, input)
 }
 
 func tuneMount(client *api.Client, path string, input api.MountConfigInput) error {
@@ -129,7 +129,6 @@ func getAuthMountIfPresent(client *api.Client, path string) (*api.AuthMount, err
 	configuredPath := path + "/"
 
 	for authBackendPath, auth := range auths {
-
 		if authBackendPath == configuredPath {
 			return auth, nil
 		}

--- a/vault/resource_auth_backend_test.go
+++ b/vault/resource_auth_backend_test.go
@@ -65,7 +65,7 @@ resource "vault_auth_backend" "test" {
 	description = "Test auth backend"
 	type 		= "github"
 	path 		= "%s"
-	local = true
+	local 		= true
 }`, path)
 }
 
@@ -75,7 +75,7 @@ resource "vault_auth_backend" "test" {
 	description = "Test auth backend updated"
 	type 		= "github"
 	path 		= "%s"
-	local = true
+	local 		= true
 }`, path)
 }
 
@@ -143,14 +143,6 @@ func testResourceAuth_initialCheck(expectedPath string) resource.TestCheckFunc {
 		return nil
 	}
 }
-
-//var testResourceAuth_updateConfig = `
-//
-//resource "vault_auth_backend" "test" {
-//	type = "ldap"
-//}
-//
-//`
 
 func testResourceAuth_updateCheck(s *terraform.State) error {
 	resourceState := s.Modules[0].Resources["vault_auth_backend.test"]

--- a/vault/resource_auth_backend_test.go
+++ b/vault/resource_auth_backend_test.go
@@ -14,6 +14,8 @@ import (
 
 func TestResourceAuth(t *testing.T) {
 	path := "github-" + acctest.RandString(10)
+
+	resourceName := "vault_auth_backend.test"
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
 		PreCheck:  func() { testutil.TestAccPreCheck(t) },
@@ -23,8 +25,12 @@ func TestResourceAuth(t *testing.T) {
 				Check:  testResourceAuth_initialCheck(path),
 			},
 			{
-				Config: testResourceAuth_updateConfig,
-				Check:  testResourceAuth_updateCheck,
+				Config: testResourceAuth_updatedConfig(path),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "description", "Test auth backend updated"),
+					resource.TestCheckResourceAttr(resourceName, "type", "github"),
+					resource.TestCheckResourceAttr(resourceName, "path", path),
+				),
 			},
 		},
 	})
@@ -57,6 +63,16 @@ func testResourceAuth_initialConfig(path string) string {
 	return fmt.Sprintf(`
 resource "vault_auth_backend" "test" {
 	description = "Test auth backend"
+	type 		= "github"
+	path 		= "%s"
+	local = true
+}`, path)
+}
+
+func testResourceAuth_updatedConfig(path string) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "test" {
+	description = "Test auth backend updated"
 	type 		= "github"
 	path 		= "%s"
 	local = true
@@ -128,13 +144,13 @@ func testResourceAuth_initialCheck(expectedPath string) resource.TestCheckFunc {
 	}
 }
 
-var testResourceAuth_updateConfig = `
-
-resource "vault_auth_backend" "test" {
-	type = "ldap"
-}
-
-`
+//var testResourceAuth_updateConfig = `
+//
+//resource "vault_auth_backend" "test" {
+//	type = "ldap"
+//}
+//
+//`
 
 func testResourceAuth_updateCheck(s *terraform.State) error {
 	resourceState := s.Modules[0].Resources["vault_auth_backend.test"]

--- a/vault/structures.go
+++ b/vault/structures.go
@@ -6,8 +6,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
 func expandAuthMethodTune(rawL []interface{}) api.MountConfigInput {


### PR DESCRIPTION
Relates OR Closes #1430 


Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestResourceAuth'
=== RUN   TestResourceAuth
--- PASS: TestResourceAuth (2.98s)
PASS
```
