### PR TITLE
Properly force a new resource whenenver the cert is near expiry

### DIFF
--- a/vault/resource_pki_secret_backend_cert.go
+++ b/vault/resource_pki_secret_backend_cert.go
@@ -247,7 +247,10 @@ func pkiSecretBackendCertCreate(d *schema.ResourceData, meta interface{}) error 
 }
 
 func checkPKICertExpiry(expiration int64) bool {
-	return time.Now().After(time.Unix(expiration, 0))
+	expiry := time.Unix(expiration, 0)
+	now := time.Now()
+
+	return now.After(expiry)
 }
 
 func pkiCertAutoRenewCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {

--- a/vault/resource_pki_secret_backend_cert.go
+++ b/vault/resource_pki_secret_backend_cert.go
@@ -10,6 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
 func pkiSecretBackendCertResource() *schema.Resource {
@@ -18,7 +20,7 @@ func pkiSecretBackendCertResource() *schema.Resource {
 		Read:          pkiSecretBackendCertRead,
 		Update:        pkiSecretBackendCertUpdate,
 		Delete:        pkiSecretBackendCertDelete,
-		CustomizeDiff: pkiSecretBackendCertDiff,
+		CustomizeDiff: pkiCertAutoRenewCustomizeDiff,
 
 		Schema: map[string]*schema.Schema{
 			"backend": {
@@ -171,6 +173,7 @@ func pkiSecretBackendCertCreate(d *schema.ResourceData, meta interface{}) error 
 
 	commonName := d.Get("common_name").(string)
 
+	// TODO: cleanup this bit...
 	iAltNames := d.Get("alt_names").([]interface{})
 	altNames := make([]string, 0, len(iAltNames))
 	for _, iAltName := range iAltNames {
@@ -243,32 +246,42 @@ func pkiSecretBackendCertCreate(d *schema.ResourceData, meta interface{}) error 
 	return pkiSecretBackendCertRead(d, meta)
 }
 
-func pkiSecretBackendCertNeedsRenewed(autoRenew bool, expiration int, minSecRemaining int) bool {
-	if !autoRenew {
-		return false
+func checkPKICertExpiry(expiration int64, offset int64) (bool, error) {
+	if offset < 0 {
+		offset = 0
 	}
-	expireTime := time.Unix(int64(expiration), 0)
-	renewTime := expireTime.Add(-time.Duration(minSecRemaining) * time.Second)
-	return time.Now().After(renewTime)
+
+	if offset > expiration {
+		return false, fmt.Errorf(
+			"expiry offset %d cannot be greater than the expiration time %d", offset, expiration)
+	}
+
+	return time.Now().UTC().After(time.Unix(expiration-offset, 0)), nil
 }
 
-func pkiSecretBackendCertDiff(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
-	if d.Id() == "" {
+func pkiCertAutoRenewCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	if d.Id() == "" || !d.Get("auto_renew").(bool) {
 		return nil
 	}
 
-	minSeconds := 0
-	if v, ok := d.GetOk("min_seconds_remaining"); ok {
-		minSeconds = v.(int)
+	expired, err := checkPKICertExpiry(
+		int64(d.Get("expiration").(int)),
+		int64(d.Get("min_seconds_remaining").(int)),
+	)
+	if err != nil {
+		return err
 	}
-	if pkiSecretBackendCertNeedsRenewed(d.Get("auto_renew").(bool), d.Get("expiration").(int), minSeconds) {
+
+	if expired {
 		log.Printf("[DEBUG] certificate %q is due for renewal", d.Id())
 		if err := d.SetNewComputed("certificate"); err != nil {
 			return err
 		}
-		if err := d.SetNewComputed("private_key"); err != nil {
+
+		if err := d.ForceNew("certificate"); err != nil {
 			return err
 		}
+
 		return nil
 	}
 
@@ -277,17 +290,29 @@ func pkiSecretBackendCertDiff(_ context.Context, d *schema.ResourceDiff, meta in
 }
 
 func pkiSecretBackendCertRead(d *schema.ResourceData, meta interface{}) error {
+	if d.IsNewResource() {
+		return nil
+	}
+
+	client := meta.(*api.Client)
+	path := d.Get("backend").(string)
+	enabled, err := util.CheckMountEnabled(client, path)
+	if err != nil {
+		log.Printf("[WARN] Failed to check if mount %q exist, preempting the read operation", path)
+		return nil
+	}
+
+	// trigger a resource re-creation whenever the engine's mount has disappeared
+	if !enabled {
+		log.Printf("[WARN] Mount %q does not exist, setting resource for re-creation", path)
+		d.SetId("")
+	}
+
 	return nil
 }
 
 func pkiSecretBackendCertUpdate(d *schema.ResourceData, m interface{}) error {
-	minSeconds := 0
-	if v, ok := d.GetOk("min_seconds_remaining"); ok {
-		minSeconds = v.(int)
-	}
-	if pkiSecretBackendCertNeedsRenewed(d.Get("auto_renew").(bool), d.Get("expiration").(int), minSeconds) {
-		return pkiSecretBackendCertCreate(d, m)
-	}
+	// TODO: add mount gone detection
 	return nil
 }
 

--- a/vault/resource_pki_secret_backend_cert_test.go
+++ b/vault/resource_pki_secret_backend_cert_test.go
@@ -247,7 +247,7 @@ func TestPkiSecretBackendCert_renew(t *testing.T) {
 			},
 			{
 				// test renewal based on cert expiry
-				PreConfig: testWaitCertExpiry(store),
+				PreConfig: testWaitCertExpiry(&store),
 				Config:    testPkiSecretBackendCertConfig_renew(path),
 				Check: resource.ComposeTestCheckFunc(
 					append(checks,
@@ -275,12 +275,11 @@ func TestPkiSecretBackendCert_renew(t *testing.T) {
 	})
 }
 
-func testWaitCertExpiry(store testPKICertStore) func() {
+func testWaitCertExpiry(store *testPKICertStore) func() {
 	return func() {
 		expiry := time.Unix(store.expiration-store.expirationWindow, 0)
 		for {
-			isAfter := time.Now().After(expiry)
-			if isAfter {
+			if time.Now().After(expiry) {
 				return
 			}
 			time.Sleep(250 * time.Millisecond)

--- a/vault/resource_pki_secret_backend_cert_test.go
+++ b/vault/resource_pki_secret_backend_cert_test.go
@@ -126,74 +126,68 @@ func testPkiSecretBackendCertConfig_basic(rootPath, intermediatePath string, wit
 	fragments := []string{
 		fmt.Sprintf(`
 resource "vault_mount" "test-root" {
-  path = "%s"
-  type = "pki"
-  description = "test root"
+  path                      = "%s"
+  type                      = "pki"
+  description               = "test root"
   default_lease_ttl_seconds = "8640000"
-  max_lease_ttl_seconds = "8640000"
+  max_lease_ttl_seconds     = "8640000"
 }
 
 resource "vault_mount" "test-intermediate" {
-  depends_on = [ "vault_mount.test-root" ]
-  path = "%s"
-  type = "pki"
-  description = "test intermediate"
+  path                      = "%s"
+  type                      = "pki"
+  description               = "test intermediate"
   default_lease_ttl_seconds = "86400"
-  max_lease_ttl_seconds = "86400"
+  max_lease_ttl_seconds     = "86400"
 }
 
 resource "vault_pki_secret_backend_root_cert" "test" {
-  depends_on = [ "vault_mount.test-intermediate" ]
-  backend = vault_mount.test-root.path
-  type = "internal"
-  common_name = "my.domain"
-  ttl = "86400"
-  format = "pem"
+  backend            = vault_mount.test-root.path
+  type               = "internal"
+  common_name        = "my.domain"
+  ttl                = "86400"
+  format             = "pem"
   private_key_format = "der"
-  key_type = "rsa"
-  key_bits = 4096
-  ou = "test"
-  organization = "test"
-  country = "test"
-  locality = "test"
-  province = "test"
+  key_type           = "rsa"
+  key_bits           = 4096
+  ou                 = "test"
+  organization       = "test"
+  country            = "test"
+  locality           = "test"
+  province           = "test"
 }
 
 resource "vault_pki_secret_backend_intermediate_cert_request" "test" {
-  depends_on = [ "vault_pki_secret_backend_root_cert.test" ]
-  backend = vault_mount.test-intermediate.path
-  type = "internal"
+  backend     = vault_mount.test-intermediate.path
+  type        = vault_pki_secret_backend_root_cert.test.type
   common_name = "test.my.domain"
 }
 
 resource "vault_pki_secret_backend_root_sign_intermediate" "test" {
-  depends_on = [ "vault_pki_secret_backend_intermediate_cert_request.test" ]
-  backend = vault_mount.test-root.path
-  csr = vault_pki_secret_backend_intermediate_cert_request.test.csr
-  common_name = "test.my.domain"
+  backend               = vault_mount.test-root.path
+  csr                   = vault_pki_secret_backend_intermediate_cert_request.test.csr
+  common_name           = "test.my.domain"
   permitted_dns_domains = [".test.my.domain"]
-  ou = "test"
-  organization = "test"
-  country = "test"
-  locality = "test"
-  province = "test"
+  ou                    = "test"
+  organization          = "test"
+  country               = "test"
+  locality              = "test"
+  province              = "test"
 }
 
 resource "vault_pki_secret_backend_intermediate_set_signed" "test" {
-  depends_on = [ "vault_pki_secret_backend_root_sign_intermediate.test" ]
-  backend = vault_mount.test-intermediate.path
+  backend     = vault_mount.test-intermediate.path
   certificate = vault_pki_secret_backend_root_sign_intermediate.test.certificate
 }
 
 resource "vault_pki_secret_backend_role" "test" {
-  depends_on = [ "vault_pki_secret_backend_intermediate_set_signed.test" ]
-  backend = vault_mount.test-intermediate.path
-  name = "test"
+  backend          = vault_pki_secret_backend_intermediate_set_signed.test.backend
+  name             = "test"
   allowed_domains  = ["test.my.domain"]
   allow_subdomains = true
   allowed_uri_sans = ["spiffe://test.my.domain"]
-  max_ttl = "3600"
-  key_usage = ["DigitalSignature", "KeyAgreement", "KeyEncipherment"]
+  max_ttl          = "3600"
+  key_usage        = ["DigitalSignature", "KeyAgreement", "KeyEncipherment"]
 }
 `, rootPath, intermediatePath),
 	}
@@ -201,8 +195,7 @@ resource "vault_pki_secret_backend_role" "test" {
 	if withCert {
 		fragments = append(fragments, fmt.Sprintf(`
 resource "vault_pki_secret_backend_cert" "test" {
-  depends_on            = ["vault_pki_secret_backend_role.test"]
-  backend               = vault_mount.test-intermediate.path
+  backend               = vault_pki_secret_backend_role.test.backend
   name                  = vault_pki_secret_backend_role.test.name
   common_name           = "cert.test.my.domain"
   uri_sans              = ["spiffe://test.my.domain"]
@@ -298,7 +291,6 @@ resource "vault_mount" "test-root" {
 }
 
 resource "vault_pki_secret_backend_root_cert" "test" {
-  depends_on         = ["vault_mount.test-root"]
   backend            = vault_mount.test-root.path
   type               = "internal"
   common_name        = "my.domain"
@@ -324,8 +316,7 @@ resource "vault_pki_secret_backend_role" "test" {
 }
 
 resource "vault_pki_secret_backend_cert" "test" {
-  depends_on            = ["vault_pki_secret_backend_role.test"]
-  backend               = vault_mount.test-root.path
+  backend               = vault_pki_secret_backend_role.test.backend
   name                  = vault_pki_secret_backend_role.test.name
   common_name           = "cert.test.my.domain"
   ttl                   = "1h"

--- a/vault/resource_pki_secret_backend_cert_test.go
+++ b/vault/resource_pki_secret_backend_cert_test.go
@@ -270,12 +270,9 @@ func TestPkiSecretBackendCert_renew(t *testing.T) {
 
 func testWaitCertExpiry(store *testPKICertStore) func() {
 	return func() {
-		expiry := time.Unix(store.expiration-store.expirationWindow, 0)
-		for {
-			if time.Now().After(expiry) {
-				return
-			}
-			time.Sleep(250 * time.Millisecond)
+		delay := (store.expiration - store.expirationWindow) - time.Now().Unix()
+		if delay > 0 {
+			time.Sleep(time.Duration(delay) * time.Second)
 		}
 	}
 }

--- a/vault/resource_pki_secret_backend_root_cert.go
+++ b/vault/resource_pki_secret_backend_root_cert.go
@@ -25,7 +25,7 @@ func pkiSecretBackendRootCertResource() *schema.Resource {
 		Update: func(data *schema.ResourceData, i interface{}) error {
 			return nil
 		},
-		Read: pkiSecretBackendRootCertRead,
+		Read: pkiSecretBackendCertRead,
 		StateUpgraders: []schema.StateUpgrader{
 			{
 				Version: 0,
@@ -335,28 +335,6 @@ func pkiSecretBackendRootCertCreate(d *schema.ResourceData, meta interface{}) er
 	d.Set("serial_number", resp.Data["serial_number"])
 
 	d.SetId(path)
-
-	return nil
-}
-
-func pkiSecretBackendRootCertRead(d *schema.ResourceData, meta interface{}) error {
-	if d.IsNewResource() {
-		return nil
-	}
-
-	client := meta.(*api.Client)
-	path := d.Get("backend").(string)
-	enabled, err := util.CheckMountEnabled(client, path)
-	if err != nil {
-		log.Printf("[WARN] Failed to check if mount %q exist, preempting the read operation", path)
-		return nil
-	}
-
-	// trigger a resource re-creation whenever the engine's mount has disappeared
-	if !enabled {
-		log.Printf("[WARN] Mount %q does not exist, setting resource for re-creation", path)
-		d.SetId("")
-	}
 
 	return nil
 }

--- a/vault/resource_pki_secret_backend_sign.go
+++ b/vault/resource_pki_secret_backend_sign.go
@@ -1,7 +1,6 @@
 package vault
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -13,11 +12,21 @@ import (
 
 func pkiSecretBackendSignResource() *schema.Resource {
 	return &schema.Resource{
-		Create:        pkiSecretBackendSignCreate,
-		Read:          pkiSecretBackendSignRead,
-		Update:        pkiSecretBackendSignUpdate,
-		Delete:        pkiSecretBackendSignDelete,
-		CustomizeDiff: pkiSecretBackendSignDiff,
+		Create: pkiSecretBackendSignCreate,
+		Delete: pkiSecretBackendSignDelete,
+		Update: func(data *schema.ResourceData, i interface{}) error {
+			return nil
+		},
+		Read: pkiSecretBackendCertRead,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Version: 0,
+				Type:    pkiSecretBackendRootCertV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: pkiSecretBackendRootCertUpgradeV0,
+			},
+		},
+		SchemaVersion: 1,
+		CustomizeDiff: pkiCertAutoRenewCustomizeDiff,
 
 		Schema: map[string]*schema.Schema{
 			"backend": {
@@ -131,7 +140,13 @@ func pkiSecretBackendSignResource() *schema.Resource {
 			"serial": {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Description: "The serial.",
+				Deprecated:  "Use serial_number instead",
+				Description: "The serial number.",
+			},
+			"serial_number": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The certificate's serial number, hex formatted.",
 			},
 			"expiration": {
 				Type:        schema.TypeInt,
@@ -217,45 +232,8 @@ func pkiSecretBackendSignCreate(d *schema.ResourceData, meta interface{}) error 
 	d.Set("expiration", resp.Data["expiration"])
 
 	d.SetId(fmt.Sprintf("%s/%s/%s", backend, name, commonName))
-	return pkiSecretBackendSignRead(d, meta)
-}
 
-func pkiSecretBackendSignDiff(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
-	if d.Id() == "" {
-		return nil
-	}
-
-	minSeconds := 0
-	if v, ok := d.GetOk("min_seconds_remaining"); ok {
-		minSeconds = v.(int)
-	}
-
-	if pkiSecretBackendCertNeedsRenewed(d.Get("auto_renew").(bool), d.Get("expiration").(int), minSeconds) {
-		log.Printf("[DEBUG] certificate %q is due for renewal", d.Id())
-		if err := d.SetNewComputed("certificate"); err != nil {
-			return err
-		}
-		return nil
-	}
-
-	log.Printf("[DEBUG] certificate %q is not due for renewal", d.Id())
-	return nil
-}
-
-func pkiSecretBackendSignRead(d *schema.ResourceData, meta interface{}) error {
-	return nil
-}
-
-func pkiSecretBackendSignUpdate(d *schema.ResourceData, m interface{}) error {
-	minSeconds := 0
-	if v, ok := d.GetOk("min_seconds_remaining"); ok {
-		minSeconds = v.(int)
-	}
-
-	if pkiSecretBackendCertNeedsRenewed(d.Get("auto_renew").(bool), d.Get("expiration").(int), minSeconds) {
-		return pkiSecretBackendSignCreate(d, m)
-	}
-	return nil
+	return pkiSecretBackendCertRead(d, meta)
 }
 
 func pkiSecretBackendSignDelete(d *schema.ResourceData, meta interface{}) error {

--- a/vault/resource_pki_secret_backend_sign.go
+++ b/vault/resource_pki_secret_backend_sign.go
@@ -229,6 +229,7 @@ func pkiSecretBackendSignCreate(d *schema.ResourceData, meta interface{}) error 
 	d.Set("issuing_ca", resp.Data["issuing_ca"])
 	d.Set("ca_chain", resp.Data["ca_chain"])
 	d.Set("serial", resp.Data["serial_number"])
+	d.Set("serial_number", resp.Data["serial_number"])
 	d.Set("expiration", resp.Data["expiration"])
 
 	d.SetId(fmt.Sprintf("%s/%s/%s", backend, name, commonName))

--- a/vault/resource_pki_secret_backend_sign_test.go
+++ b/vault/resource_pki_secret_backend_sign_test.go
@@ -60,80 +60,73 @@ func testPkiSecretBackendSignDestroy(s *terraform.State) error {
 func testPkiSecretBackendSignConfig_basic(rootPath string, intermediatePath string) string {
 	return fmt.Sprintf(`
 resource "vault_mount" "test-root" {
-  path = "%s"
-  type = "pki"
-  description = "test root"
+  path                      = "%s"
+  type                      = "pki"
+  description               = "test root"
   default_lease_ttl_seconds = "8640000"
-  max_lease_ttl_seconds = "8640000"
+  max_lease_ttl_seconds     = "8640000"
 }
 
 resource "vault_mount" "test-intermediate" {
-  depends_on = [ "vault_mount.test-root" ]
-  path = "%s"
-  type = "pki"
-  description = "test intermediate"
+  path                      = "%s"
+  type                      = "pki"
+  description               = "test intermediate"
   default_lease_ttl_seconds = "86400"
-  max_lease_ttl_seconds = "86400"
+  max_lease_ttl_seconds     = "86400"
 }
 
 resource "vault_pki_secret_backend_root_cert" "test" {
-  depends_on = [ "vault_mount.test-intermediate" ]
-  backend = vault_mount.test-root.path
-  type = "internal"
-  common_name = "my.domain"
-  ttl = "86400"
-  format = "pem"
+  backend            = vault_mount.test-root.path
+  type               = "internal"
+  common_name        = "my.domain"
+  ttl                = "86400"
+  format             = "pem"
   private_key_format = "der"
-  key_type = "rsa"
-  key_bits = 4096
-  ou = "test"
-  organization = "test"
-  country = "test"
-  locality = "test"
-  province = "test"
+  key_type           = "rsa"
+  key_bits           = 4096
+  ou                 = "test"
+  organization       = "test"
+  country            = "test"
+  locality           = "test"
+  province           = "test"
 }
 
 resource "vault_pki_secret_backend_intermediate_cert_request" "test" {
-  depends_on = [ "vault_pki_secret_backend_root_cert.test" ]
-  backend = vault_mount.test-intermediate.path
-  type = "internal"
+  backend     = vault_mount.test-intermediate.path
+  type        = vault_pki_secret_backend_root_cert.test.type
   common_name = "test.my.domain"
 }
 
 resource "vault_pki_secret_backend_root_sign_intermediate" "test" {
-  depends_on = [ "vault_pki_secret_backend_intermediate_cert_request.test" ]
-  backend = vault_mount.test-root.path
-  csr = vault_pki_secret_backend_intermediate_cert_request.test.csr
-  common_name = "test.my.domain"
+  backend               = vault_mount.test-root.path
+  csr                   = vault_pki_secret_backend_intermediate_cert_request.test.csr
+  common_name           = "test.my.domain"
   permitted_dns_domains = [".test.my.domain"]
-  ou = "test"
-  organization = "test"
-  country = "test"
-  locality = "test"
-  province = "test"
+  ou                    = "test"
+  organization          = "test"
+  country               = "test"
+  locality              = "test"
+  province              = "test"
 }
 
 resource "vault_pki_secret_backend_intermediate_set_signed" "test" {
-  depends_on = [ "vault_pki_secret_backend_root_sign_intermediate.test" ]
-  backend = vault_mount.test-intermediate.path
+  backend     = vault_mount.test-intermediate.path
   certificate = vault_pki_secret_backend_root_sign_intermediate.test.certificate
 }
 
 resource "vault_pki_secret_backend_role" "test" {
-  depends_on = [ "vault_pki_secret_backend_intermediate_set_signed.test" ]
-  backend = vault_mount.test-intermediate.path
-  name = "test"
+  backend          = vault_pki_secret_backend_intermediate_set_signed.test.backend
+  name             = "test"
   allowed_domains  = ["test.my.domain"]
   allow_subdomains = true
-  max_ttl = "3600"
-  key_usage = ["DigitalSignature", "KeyAgreement", "KeyEncipherment"]
+  max_ttl          = "3600"
+  key_usage        = ["DigitalSignature", "KeyAgreement", "KeyEncipherment"]
 }
 
 resource "vault_pki_secret_backend_sign" "test" {
-  depends_on = [ "vault_pki_secret_backend_role.test" ]
-  backend = vault_mount.test-intermediate.path
-  name = vault_pki_secret_backend_role.test.name
-  csr = <<EOT
+  backend     = vault_pki_secret_backend_role.test.backend
+  name        = vault_pki_secret_backend_role.test.name
+  csr         = <<EOT
 -----BEGIN CERTIFICATE REQUEST-----
 MIIEqDCCApACAQAwYzELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUx
 ITAfBgNVBAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDEcMBoGA1UEAwwTY2Vy
@@ -163,7 +156,8 @@ o3DybUeUmknYjl109rdSf+76nuREICHatxXgN3xCMFuBaN4WLO+ksd6Y1Ys=
 -----END CERTIFICATE REQUEST-----
 EOT
   common_name = "cert.test.my.domain"
-}`, rootPath, intermediatePath)
+}
+`, rootPath, intermediatePath)
 }
 
 func TestPkiSecretBackendSign_renew(t *testing.T) {
@@ -226,44 +220,42 @@ func TestPkiSecretBackendSign_renew(t *testing.T) {
 func testPkiSecretBackendSignConfig_renew(rootPath string) string {
 	return fmt.Sprintf(`
 resource "vault_mount" "test-root" {
-  path = "%s"
-  type = "pki"
-  description = "test root"
+  path                      = "%s"
+  type                      = "pki"
+  description               = "test root"
   default_lease_ttl_seconds = "8640000"
-  max_lease_ttl_seconds = "8640000"
+  max_lease_ttl_seconds     = "8640000"
 }
 
 resource "vault_pki_secret_backend_root_cert" "test" {
-  backend = vault_mount.test-root.path
-  type = "internal"
-  common_name = "my.domain"
-  ttl = "86400"
-  format = "pem"
+  backend            = vault_mount.test-root.path
+  type               = "internal"
+  common_name        = "my.domain"
+  ttl                = "86400"
+  format             = "pem"
   private_key_format = "der"
-  key_type = "rsa"
-  key_bits = 4096
-  ou = "test"
-  organization = "test"
-  country = "test"
-  locality = "test"
-  province = "test"
+  key_type           = "rsa"
+  key_bits           = 4096
+  ou                 = "test"
+  organization       = "test"
+  country            = "test"
+  locality           = "test"
+  province           = "test"
 }
 
 resource "vault_pki_secret_backend_role" "test" {
-  depends_on = [ "vault_pki_secret_backend_root_cert.test" ]
-  backend = vault_mount.test-root.path
-  name = "test"
+  backend          = vault_pki_secret_backend_root_cert.test.backend
+  name             = "test"
   allowed_domains  = ["test.my.domain"]
   allow_subdomains = true
-  max_ttl = "3600"
-  key_usage = ["DigitalSignature", "KeyAgreement", "KeyEncipherment"]
+  max_ttl          = "3600"
+  key_usage        = ["DigitalSignature", "KeyAgreement", "KeyEncipherment"]
 }
 
 resource "vault_pki_secret_backend_sign" "test" {
-  depends_on = [ "vault_pki_secret_backend_role.test" ]
-  backend = vault_mount.test-root.path
-  name = vault_pki_secret_backend_role.test.name
-  csr = <<EOT
+  backend               = vault_mount.test-root.path
+  name                  = vault_pki_secret_backend_role.test.name
+  csr                   = <<EOT
 -----BEGIN CERTIFICATE REQUEST-----
 MIIEqDCCApACAQAwYzELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUx
 ITAfBgNVBAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDEcMBoGA1UEAwwTY2Vy
@@ -292,9 +284,10 @@ OTEc13lWf+B0PU9UJuGTsmpIuImPDVd0EVDayr3mT5dDbqTVDbe8ppf2IswABmf0
 o3DybUeUmknYjl109rdSf+76nuREICHatxXgN3xCMFuBaN4WLO+ksd6Y1Ys=
 -----END CERTIFICATE REQUEST-----
 EOT
-  common_name = "cert.test.my.domain"
-  ttl = "1h"
-  auto_renew = true
+  common_name           = "cert.test.my.domain"
+  ttl                   = "1h"
+  auto_renew            = true
   min_seconds_remaining = "3595"
-}`, rootPath)
+}
+`, rootPath)
 }


### PR DESCRIPTION
Affected resources:
- resource_pki_secret_backend_cert
- resource_pki_secret_backend_sign

The previous approach would leave some computed values out of sync
whenever the certificate was within the expiry window. This was
because it attempted to leverage a combination of schema CustomizeDiff,
and Update functions, rather than taking advantage of the ability to
mark the resource as requiring replacement with the CustomizeDiff
function itself.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #835

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ time make testacc TESTARGS='-v -test.run Test*Pki*'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -v -test.run Test*Pki* -timeout 30m ./...

[...]

ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
=== RUN   TestPkiSecretBackendCert_basic
--- PASS: TestPkiSecretBackendCert_basic (6.87s)
=== RUN   TestPkiSecretBackendCert_revoke
--- PASS: TestPkiSecretBackendCert_revoke (8.54s)
=== RUN   TestPkiSecretBackendCert_renew
--- PASS: TestPkiSecretBackendCert_renew (11.08s)
=== RUN   TestPkiSecretBackendConfigCA_basic
--- PASS: TestPkiSecretBackendConfigCA_basic (1.71s)
=== RUN   TestPkiSecretBackendConfigUrls_basic
--- PASS: TestPkiSecretBackendConfigUrls_basic (3.16s)
=== RUN   TestPkiSecretBackendCrlConfig_basic
--- PASS: TestPkiSecretBackendCrlConfig_basic (3.87s)
=== RUN   TestPkiSecretBackendIntermediateCertRequest_basic
--- PASS: TestPkiSecretBackendIntermediateCertRequest_basic (1.86s)
=== RUN   TestPkiSecretBackendIntermediateSetSigned_basic
--- PASS: TestPkiSecretBackendIntermediateSetSigned_basic (3.32s)
=== RUN   TestPkiSecretBackendRole_basic
--- PASS: TestPkiSecretBackendRole_basic (3.05s)
=== RUN   TestPkiSecretBackendRootCertificate_basic
--- PASS: TestPkiSecretBackendRootCertificate_basic (10.92s)
=== RUN   TestPkiSecretBackendRootSignIntermediate_basic_default
--- PASS: TestPkiSecretBackendRootSignIntermediate_basic_default (2.86s)
=== RUN   TestPkiSecretBackendRootSignIntermediate_basic_pem
--- PASS: TestPkiSecretBackendRootSignIntermediate_basic_pem (4.25s)
=== RUN   TestPkiSecretBackendRootSignIntermediate_basic_der
--- PASS: TestPkiSecretBackendRootSignIntermediate_basic_der (3.53s)
=== RUN   TestPkiSecretBackendRootSignIntermediate_basic_pem_bundle
--- PASS: TestPkiSecretBackendRootSignIntermediate_basic_pem_bundle (6.56s)
=== RUN   TestPkiSecretBackendRootSignIntermediate_basic_pem_bundle_multiple_intermediates
--- PASS: TestPkiSecretBackendRootSignIntermediate_basic_pem_bundle_multiple_intermediates (3.28s)
=== RUN   TestPkiSecretBackendSign_basic
--- PASS: TestPkiSecretBackendSign_basic (3.75s)
=== RUN   TestPkiSecretBackendSign_renew
--- PASS: TestPkiSecretBackendSign_renew (13.42s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     (cached)
make testacc TESTARGS='-v -test.run Test*Pki*'  4.74s user 5.53s system 386% cpu 2.657 total


...
```
