### PR TITLE
PKI: extend revocation support

### DIFF
--- a/vault/resource_pki_secret_backend_intermediate_cert_request_test.go
+++ b/vault/resource_pki_secret_backend_intermediate_cert_request_test.go
@@ -17,6 +17,7 @@ import (
 func TestPkiSecretBackendIntermediateCertRequest_basic(t *testing.T) {
 	path := "pki-" + strconv.Itoa(acctest.RandInt())
 
+	resourceName := "vault_pki_secret_backend_intermediate_cert_request.test"
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
@@ -25,11 +26,11 @@ func TestPkiSecretBackendIntermediateCertRequest_basic(t *testing.T) {
 			{
 				Config: testPkiSecretBackendIntermediateCertRequestConfig_basic(path),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_pki_secret_backend_intermediate_cert_request.test", "backend", path),
-					resource.TestCheckResourceAttr("vault_pki_secret_backend_intermediate_cert_request.test", "type", "internal"),
-					resource.TestCheckResourceAttr("vault_pki_secret_backend_intermediate_cert_request.test", "common_name", "test.my.domain"),
-					resource.TestCheckResourceAttr("vault_pki_secret_backend_intermediate_cert_request.test", "uri_sans.#", "1"),
-					resource.TestCheckResourceAttr("vault_pki_secret_backend_intermediate_cert_request.test", "uri_sans.0", "spiffe://test.my.domain"),
+					resource.TestCheckResourceAttr(resourceName, "backend", path),
+					resource.TestCheckResourceAttr(resourceName, "type", "internal"),
+					resource.TestCheckResourceAttr(resourceName, "common_name", "test.my.domain"),
+					resource.TestCheckResourceAttr(resourceName, "uri_sans.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "uri_sans.0", "spiffe://test.my.domain"),
 				),
 			},
 		},
@@ -62,18 +63,18 @@ func testPkiSecretBackendIntermediateCertRequestDestroy(s *terraform.State) erro
 func testPkiSecretBackendIntermediateCertRequestConfig_basic(path string) string {
 	return fmt.Sprintf(`
 resource "vault_mount" "test" {
-  path = "%s"
-  type = "pki"
-  description = "test"
-  default_lease_ttl_seconds = "86400"
-  max_lease_ttl_seconds = "86400"
+  path                      = "%s"
+  type                      = "pki"
+  description               = "test"
+  default_lease_ttl_seconds = 86400
+  max_lease_ttl_seconds     = 86400
 }
 
 resource "vault_pki_secret_backend_intermediate_cert_request" "test" {
-  depends_on = [ "vault_mount.test" ]
-  backend = vault_mount.test.path
-  type = "internal"
+  backend     = vault_mount.test.path
+  type        = "internal"
   common_name = "test.my.domain"
-  uri_sans = ["spiffe://test.my.domain"]
-}`, path)
+  uri_sans    = ["spiffe://test.my.domain"]
+}
+`, path)
 }

--- a/vault/resource_pki_secret_backend_intermediate_set_signed.go
+++ b/vault/resource_pki_secret_backend_intermediate_set_signed.go
@@ -12,7 +12,7 @@ import (
 func pkiSecretBackendIntermediateSetSignedResource() *schema.Resource {
 	return &schema.Resource{
 		Create: pkiSecretBackendIntermediateSetSignedCreate,
-		Read:   pkiSecretBackendIntermediateSetSignedRead,
+		Read:   pkiSecretBackendCertRead,
 		Delete: pkiSecretBackendIntermediateSetSignedDelete,
 
 		Schema: map[string]*schema.Schema{
@@ -51,11 +51,7 @@ func pkiSecretBackendIntermediateSetSignedCreate(d *schema.ResourceData, meta in
 	log.Printf("[DEBUG] Created intermediate set-signed on PKI secret backend %q", backend)
 
 	d.SetId(path)
-	return pkiSecretBackendIntermediateSetSignedRead(d, meta)
-}
-
-func pkiSecretBackendIntermediateSetSignedRead(d *schema.ResourceData, meta interface{}) error {
-	return nil
+	return pkiSecretBackendCertRead(d, meta)
 }
 
 func pkiSecretBackendIntermediateSetSignedDelete(d *schema.ResourceData, meta interface{}) error {

--- a/vault/resource_pki_secret_backend_intermediate_set_signed_test.go
+++ b/vault/resource_pki_secret_backend_intermediate_set_signed_test.go
@@ -18,6 +18,7 @@ func TestPkiSecretBackendIntermediateSetSigned_basic(t *testing.T) {
 	rootPath := "pki-root-" + strconv.Itoa(acctest.RandInt())
 	intermediatePath := "pki-intermediate-" + strconv.Itoa(acctest.RandInt())
 
+	resourceName := "vault_pki_secret_backend_intermediate_set_signed.test"
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
@@ -26,7 +27,7 @@ func TestPkiSecretBackendIntermediateSetSigned_basic(t *testing.T) {
 			{
 				Config: testPkiSecretBackendIntermediateSetSignedConfig_basic(rootPath, intermediatePath),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_pki_secret_backend_intermediate_set_signed.test", "backend", intermediatePath),
+					resource.TestCheckResourceAttr(resourceName, "backend", intermediatePath),
 				),
 			},
 		},
@@ -59,63 +60,59 @@ func testPkiSecretBackendIntermediateSetSignedDestroy(s *terraform.State) error 
 func testPkiSecretBackendIntermediateSetSignedConfig_basic(rootPath string, intermediatePath string) string {
 	return fmt.Sprintf(`
 resource "vault_mount" "test-root" {
-  path = "%s"
-  type = "pki"
-  description = "test root"
+  path                      = "%s"
+  type                      = "pki"
+  description               = "test root"
   default_lease_ttl_seconds = "8640000"
-  max_lease_ttl_seconds = "8640000"
+  max_lease_ttl_seconds     = "8640000"
 }
 
 resource "vault_mount" "test-intermediate" {
-  depends_on = [ "vault_mount.test-root" ]
-  path = "%s"
-  type = "pki"
-  description = "test intermediate"
+  path                      = "%s"
+  type                      = "pki"
+  description               = "test intermediate"
   default_lease_ttl_seconds = "86400"
-  max_lease_ttl_seconds = "86400"
+  max_lease_ttl_seconds     = "86400"
 }
 
 resource "vault_pki_secret_backend_root_cert" "test" {
-  depends_on = [ "vault_mount.test-intermediate" ]
-  backend = vault_mount.test-root.path
-  type = "internal"
-  common_name = "test Root CA"
-  ttl = "86400"
-  format = "pem"
-  private_key_format = "der"
-  key_type = "rsa"
-  key_bits = 4096
+  backend              = vault_mount.test-root.path
+  type                 = "internal"
+  common_name          = "test Root CA"
+  ttl                  = "86400"
+  format               = "pem"
+  private_key_format   = "der"
+  key_type             = "rsa"
+  key_bits             = 4096
   exclude_cn_from_sans = true
-  ou = "test"
-  organization = "test"
-  country = "test"
-  locality = "test"
-  province = "test"
+  ou                   = "test"
+  organization         = "test"
+  country              = "test"
+  locality             = "test"
+  province             = "test"
 }
 
 resource "vault_pki_secret_backend_intermediate_cert_request" "test" {
-  depends_on = [ "vault_pki_secret_backend_root_cert.test" ]
-  backend = vault_mount.test-intermediate.path
-  type = "internal"
+  backend     = vault_mount.test-intermediate.path
+  type        = vault_pki_secret_backend_root_cert.test.type
   common_name = "test Root CA"
 }
 
 resource "vault_pki_secret_backend_root_sign_intermediate" "test" {
-  depends_on = [ "vault_pki_secret_backend_intermediate_cert_request.test" ]
-  backend = vault_mount.test-root.path
-  csr = vault_pki_secret_backend_intermediate_cert_request.test.csr
-  common_name = "test Intermediate CA"
+  backend              = vault_mount.test-root.path
+  csr                  = vault_pki_secret_backend_intermediate_cert_request.test.csr
+  common_name          = "test Intermediate CA"
   exclude_cn_from_sans = true
-  ou = "test"
-  organization = "test"
-  country = "test"
-  locality = "test"
-  province = "test"
+  ou                   = "test"
+  organization         = "test"
+  country              = "test"
+  locality             = "test"
+  province             = "test"
 }
 
 resource "vault_pki_secret_backend_intermediate_set_signed" "test" {
-  depends_on = [ "vault_pki_secret_backend_root_sign_intermediate.test" ]
-  backend = vault_mount.test-intermediate.path
+  backend     = vault_mount.test-intermediate.path
   certificate = vault_pki_secret_backend_root_sign_intermediate.test.certificate
-}`, rootPath, intermediatePath)
+}
+`, rootPath, intermediatePath)
 }

--- a/vault/resource_pki_secret_backend_root_cert.go
+++ b/vault/resource_pki_secret_backend_root_cert.go
@@ -29,8 +29,8 @@ func pkiSecretBackendRootCertResource() *schema.Resource {
 		StateUpgraders: []schema.StateUpgrader{
 			{
 				Version: 0,
-				Type:    pkiSecretBackendRootCertV0().CoreConfigSchema().ImpliedType(),
-				Upgrade: pkiSecretBackendRootCertUpgradeV0,
+				Type:    pkiSecretSerialNumberResourceV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: pkiSecretSerialNumberUpgradeV0,
 			},
 		},
 		SchemaVersion: 1,
@@ -105,7 +105,7 @@ func pkiSecretBackendRootCertResource() *schema.Resource {
 			"uri_sans": {
 				Type:        schema.TypeList,
 				Optional:    true,
-				Description: "List of alterative URIs.",
+				Description: "List of alternative URIs.",
 				ForceNew:    true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -396,7 +396,7 @@ func pkiSecretBackendIntermediateSetSignedDeletePath(backend string) string {
 	return strings.Trim(backend, "/") + "/root"
 }
 
-func pkiSecretBackendRootCertV0() *schema.Resource {
+func pkiSecretSerialNumberResourceV0() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"serial_number": {
@@ -408,7 +408,7 @@ func pkiSecretBackendRootCertV0() *schema.Resource {
 	}
 }
 
-func pkiSecretBackendRootCertUpgradeV0(
+func pkiSecretSerialNumberUpgradeV0(
 	_ context.Context, rawState map[string]interface{}, _ interface{},
 ) (map[string]interface{}, error) {
 	rawState["serial_number"] = rawState["serial"]

--- a/vault/resource_pki_secret_backend_root_cert_test.go
+++ b/vault/resource_pki_secret_backend_root_cert_test.go
@@ -20,7 +20,7 @@ func TestPkiSecretBackendRootCertificate_basic(t *testing.T) {
 
 	resourceName := "vault_pki_secret_backend_root_cert.test"
 
-	var store testPKICertStore
+	store := &testPKICertStore{}
 
 	checks := []resource.TestCheckFunc{
 		resource.TestCheckResourceAttr(resourceName, "backend", path),
@@ -49,7 +49,7 @@ func TestPkiSecretBackendRootCertificate_basic(t *testing.T) {
 				Config: testPkiSecretBackendRootCertificateConfig_basic(path),
 				Check: resource.ComposeTestCheckFunc(
 					append(checks,
-						testCapturePKICert(resourceName, &store),
+						testCapturePKICert(resourceName, store),
 					)...,
 				),
 			},
@@ -64,8 +64,8 @@ func TestPkiSecretBackendRootCertificate_basic(t *testing.T) {
 				Config: testPkiSecretBackendRootCertificateConfig_basic(path),
 				Check: resource.ComposeTestCheckFunc(
 					append(checks,
-						testPKICertReIssued(resourceName, &store),
-						testCapturePKICert(resourceName, &store),
+						testPKICertReIssued(resourceName, store),
+						testCapturePKICert(resourceName, store),
 					)...,
 				),
 			},
@@ -94,7 +94,7 @@ func TestPkiSecretBackendRootCertificate_basic(t *testing.T) {
 				Config: testPkiSecretBackendRootCertificateConfig_basic(path),
 				Check: resource.ComposeTestCheckFunc(
 					append(checks,
-						testPKICertReIssued(resourceName, &store),
+						testPKICertReIssued(resourceName, store),
 					)...,
 				),
 			},
@@ -156,7 +156,7 @@ resource "vault_pki_secret_backend_root_cert" "test" {
 	return config
 }
 
-func Test_pkiSecretBackendRootCertUpgradeV0(t *testing.T) {
+func Test_pkiSecretSerialNumberUpgradeV0(t *testing.T) {
 	tests := []struct {
 		name     string
 		rawState map[string]interface{}
@@ -176,16 +176,16 @@ func Test_pkiSecretBackendRootCertUpgradeV0(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := pkiSecretBackendRootCertUpgradeV0(nil, tt.rawState, nil)
+			got, err := pkiSecretSerialNumberUpgradeV0(nil, tt.rawState, nil)
 
 			if tt.wantErr {
 				if err == nil {
-					t.Fatalf("pkiSecretBackendRootCertUpgradeV0() error = %#v, wantErr %#v", err, tt.wantErr)
+					t.Fatalf("pkiSecretSerialNumberUpgradeV0() error = %#v, wantErr %#v", err, tt.wantErr)
 				}
 			}
 
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("pkiSecretBackendRootCertUpgradeV0() got = %#v, want %#v", got, tt.want)
+				t.Errorf("pkiSecretSerialNumberUpgradeV0() got = %#v, want %#v", got, tt.want)
 			}
 		})
 	}

--- a/vault/resource_pki_secret_backend_sign.go
+++ b/vault/resource_pki_secret_backend_sign.go
@@ -21,8 +21,8 @@ func pkiSecretBackendSignResource() *schema.Resource {
 		StateUpgraders: []schema.StateUpgrader{
 			{
 				Version: 0,
-				Type:    pkiSecretBackendRootCertV0().CoreConfigSchema().ImpliedType(),
-				Upgrade: pkiSecretBackendRootCertUpgradeV0,
+				Type:    pkiSecretSerialNumberResourceV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: pkiSecretSerialNumberUpgradeV0,
 			},
 		},
 		SchemaVersion: 1,
@@ -83,7 +83,7 @@ func pkiSecretBackendSignResource() *schema.Resource {
 			"uri_sans": {
 				Type:        schema.TypeList,
 				Optional:    true,
-				Description: "List of alterative URIs.",
+				Description: "List of alternative URIs.",
 				ForceNew:    true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,

--- a/website/docs/r/pki_secret_backend_cert.html.md
+++ b/website/docs/r/pki_secret_backend_cert.html.md
@@ -79,5 +79,3 @@ In addition to the fields above, the following attributes are exported:
 * `serial_number` - The serial number
 
 * `expiration` - The expiration date of the certificate in unix epoch format
- 
-* `revoke` - Boolean value denoting whether the certificate will be revoked on resource destruction.

--- a/website/docs/r/pki_secret_backend_root_sign_intermediate.html.md
+++ b/website/docs/r/pki_secret_backend_root_sign_intermediate.html.md
@@ -68,6 +68,8 @@ The following arguments are supported:
 
 * `postal_code` - (Optional) The postal code
 
+* `revoke` - If set to `true`, the certificate will be revoked on resource destruction.
+
 ## Attributes Reference
 
 In addition to the fields above, the following attributes are exported:
@@ -80,5 +82,9 @@ In addition to the fields above, the following attributes are exported:
 
 * `certificate_bundle` - The concatenation of the intermediate CA and the issuing CA certificates (PEM encoded). 
   Requires the `format` to be set to any of: pem, pem_bundle. The value will be empty for all other formats.
+ 
+* `serial_number` - The certificate's serial number, hex formatted.
 
-* `serial` - The serial
+## Deprecations
+
+* `serial` - Use `serial_number` instead.

--- a/website/docs/r/pki_secret_backend_sign.html.md
+++ b/website/docs/r/pki_secret_backend_sign.html.md
@@ -75,7 +75,7 @@ The following arguments are supported:
 
 * `ip_sans` - (Optional) List of alternative IPs
 
-* `uri_sans` - (Optional) List of alterative URIs
+* `uri_sans` - (Optional) List of alternative URIs
 
 * `ttl` - (Optional) Time to live
 


### PR DESCRIPTION
Other fixes:

- de-duplicate PKI cert revoke tests
- fix typos in PKI docs

Output from acceptance testing:

```
$ time make testacc TESTARGS='-v -test.count 1 -test.run Test*Pki*'             

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -v -test.count 1 -test.run Test*Pki* -timeout 30m ./...

=== RUN   TestPkiSecretBackendCert_basic
--- PASS: TestPkiSecretBackendCert_basic (6.60s)
=== RUN   TestPkiSecretBackendCert_renew
--- PASS: TestPkiSecretBackendCert_renew (16.00s)
=== RUN   TestPkiSecretBackendConfigCA_basic
--- PASS: TestPkiSecretBackendConfigCA_basic (1.63s)
=== RUN   TestPkiSecretBackendConfigUrls_basic
--- PASS: TestPkiSecretBackendConfigUrls_basic (2.81s)
=== RUN   TestPkiSecretBackendCrlConfig_basic
--- PASS: TestPkiSecretBackendCrlConfig_basic (4.28s)
=== RUN   TestPkiSecretBackendIntermediateCertRequest_basic
--- PASS: TestPkiSecretBackendIntermediateCertRequest_basic (1.75s)
=== RUN   TestPkiSecretBackendIntermediateSetSigned_basic
--- PASS: TestPkiSecretBackendIntermediateSetSigned_basic (4.20s)
=== RUN   TestPkiSecretBackendRole_basic
--- PASS: TestPkiSecretBackendRole_basic (2.96s)
=== RUN   TestPkiSecretBackendRootCertificate_basic
--- PASS: TestPkiSecretBackendRootCertificate_basic (7.67s)
=== RUN   TestPkiSecretBackendRootSignIntermediate_basic_default
--- PASS: TestPkiSecretBackendRootSignIntermediate_basic_default (4.21s)
=== RUN   TestPkiSecretBackendRootSignIntermediate_basic_pem
--- PASS: TestPkiSecretBackendRootSignIntermediate_basic_pem (2.91s)
=== RUN   TestPkiSecretBackendRootSignIntermediate_basic_der
--- PASS: TestPkiSecretBackendRootSignIntermediate_basic_der (3.59s)
=== RUN   TestPkiSecretBackendRootSignIntermediate_basic_pem_bundle
--- PASS: TestPkiSecretBackendRootSignIntermediate_basic_pem_bundle (3.72s)
=== RUN   TestPkiSecretBackendRootSignIntermediate_basic_pem_bundle_multiple_intermediates
--- PASS: TestPkiSecretBackendRootSignIntermediate_basic_pem_bundle_multiple_intermediates (5.54s)
=== RUN   TestPkiSecretBackendSign_basic
--- PASS: TestPkiSecretBackendSign_basic (5.13s)
=== RUN   TestPkiSecretBackendSign_renew
--- PASS: TestPkiSecretBackendSign_renew (13.53s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     89.286s
make testacc TESTARGS='-v -test.count 1 -test.run Test*Pki*'  75.92s user 30.32s system 109% cpu 1:37.05 total

```
