### PR TITLE
Fix TTL handling in PKI role

### DIFF
--- a/vault/resource_pki_secret_backend_role.go
+++ b/vault/resource_pki_secret_backend_role.go
@@ -43,21 +43,15 @@ func pkiSecretBackendRoleResource() *schema.Resource {
 			},
 			"ttl": {
 				Type:        schema.TypeString,
-				Required:    false,
 				Optional:    true,
+				Computed:    true,
 				Description: "The TTL.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return old == "0"
-				},
 			},
 			"max_ttl": {
 				Type:        schema.TypeString,
-				Required:    false,
 				Optional:    true,
+				Computed:    true,
 				Description: "The maximum TTL.",
-				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return old == "0"
-				},
 			},
 			"allow_localhost": {
 				Type:        schema.TypeBool,

--- a/vault/resource_pki_secret_backend_role_test.go
+++ b/vault/resource_pki_secret_backend_role_test.go
@@ -16,58 +16,81 @@ func TestPkiSecretBackendRole_basic(t *testing.T) {
 	backend := acctest.RandomWithPrefix("pki")
 	name := acctest.RandomWithPrefix("role")
 	resourceName := "vault_pki_secret_backend_role.test"
+
+	checks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(resourceName, "name", name),
+		resource.TestCheckResourceAttr(resourceName, "backend", backend),
+		resource.TestCheckResourceAttr(resourceName, "allow_localhost", "true"),
+		resource.TestCheckResourceAttr(resourceName, "allowed_domains.#", "1"),
+		resource.TestCheckResourceAttr(resourceName, "allowed_domains.0", "test.domain"),
+		resource.TestCheckResourceAttr(resourceName, "allow_bare_domains", "false"),
+		resource.TestCheckResourceAttr(resourceName, "allow_subdomains", "true"),
+		resource.TestCheckResourceAttr(resourceName, "allow_glob_domains", "false"),
+		resource.TestCheckResourceAttr(resourceName, "allow_any_name", "false"),
+		resource.TestCheckResourceAttr(resourceName, "enforce_hostnames", "true"),
+		resource.TestCheckResourceAttr(resourceName, "allow_ip_sans", "true"),
+		resource.TestCheckResourceAttr(resourceName, "allowed_uri_sans.0", "uri.test.domain"),
+		resource.TestCheckResourceAttr(resourceName, "allowed_other_sans.0", "1.2.3.4.5.5;UTF8:test"),
+		resource.TestCheckResourceAttr(resourceName, "server_flag", "true"),
+		resource.TestCheckResourceAttr(resourceName, "client_flag", "true"),
+		resource.TestCheckResourceAttr(resourceName, "code_signing_flag", "false"),
+		resource.TestCheckResourceAttr(resourceName, "email_protection_flag", "false"),
+		resource.TestCheckResourceAttr(resourceName, "key_type", "rsa"),
+		resource.TestCheckResourceAttr(resourceName, "key_bits", "2048"),
+		resource.TestCheckResourceAttr(resourceName, "email_protection_flag", "false"),
+		resource.TestCheckResourceAttr(resourceName, "email_protection_flag", "false"),
+		resource.TestCheckResourceAttr(resourceName, "key_usage.#", "3"),
+		resource.TestCheckResourceAttr(resourceName, "key_usage.0", "DigitalSignature"),
+		resource.TestCheckResourceAttr(resourceName, "key_usage.1", "KeyAgreement"),
+		resource.TestCheckResourceAttr(resourceName, "key_usage.2", "KeyEncipherment"),
+		resource.TestCheckResourceAttr(resourceName, "ext_key_usage.#", "0"),
+		resource.TestCheckResourceAttr(resourceName, "use_csr_common_name", "true"),
+		resource.TestCheckResourceAttr(resourceName, "use_csr_sans", "true"),
+		resource.TestCheckResourceAttr(resourceName, "ou.0", "test"),
+		resource.TestCheckResourceAttr(resourceName, "organization.0", "test"),
+		resource.TestCheckResourceAttr(resourceName, "country.0", "test"),
+		resource.TestCheckResourceAttr(resourceName, "locality.0", "test"),
+		resource.TestCheckResourceAttr(resourceName, "province.0", "test"),
+		resource.TestCheckResourceAttr(resourceName, "street_address.0", "123 test"),
+		resource.TestCheckResourceAttr(resourceName, "postal_code.0", "12345"),
+		resource.TestCheckResourceAttr(resourceName, "generate_lease", "false"),
+		resource.TestCheckResourceAttr(resourceName, "no_store", "false"),
+		resource.TestCheckResourceAttr(resourceName, "require_cn", "true"),
+		resource.TestCheckResourceAttr(resourceName, "policy_identifiers.#", "1"),
+		resource.TestCheckResourceAttr(resourceName, "policy_identifiers.0", "1.2.3.4"),
+		resource.TestCheckResourceAttr(resourceName, "basic_constraints_valid_for_non_ca", "false"),
+		resource.TestCheckResourceAttr(resourceName, "not_before_duration", "45m"),
+	}
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		CheckDestroy: testPkiSecretBackendRoleCheckDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testPkiSecretBackendRoleConfig_basic(name, backend),
+				Config: testPkiSecretBackendRoleConfig_basic(name, backend, 3600, 7200),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, "backend", backend),
-					resource.TestCheckResourceAttr(resourceName, "ttl", "3600"),
-					resource.TestCheckResourceAttr(resourceName, "max_ttl", "7200"),
-					resource.TestCheckResourceAttr(resourceName, "allow_localhost", "true"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_domains.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_domains.0", "test.domain"),
-					resource.TestCheckResourceAttr(resourceName, "allow_bare_domains", "false"),
-					resource.TestCheckResourceAttr(resourceName, "allow_subdomains", "true"),
-					resource.TestCheckResourceAttr(resourceName, "allow_glob_domains", "false"),
-					resource.TestCheckResourceAttr(resourceName, "allow_any_name", "false"),
-					resource.TestCheckResourceAttr(resourceName, "enforce_hostnames", "true"),
-					resource.TestCheckResourceAttr(resourceName, "allow_ip_sans", "true"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_uri_sans.0", "uri.test.domain"),
-					resource.TestCheckResourceAttr(resourceName, "allowed_other_sans.0", "1.2.3.4.5.5;UTF8:test"),
-					resource.TestCheckResourceAttr(resourceName, "server_flag", "true"),
-					resource.TestCheckResourceAttr(resourceName, "client_flag", "true"),
-					resource.TestCheckResourceAttr(resourceName, "code_signing_flag", "false"),
-					resource.TestCheckResourceAttr(resourceName, "email_protection_flag", "false"),
-					resource.TestCheckResourceAttr(resourceName, "key_type", "rsa"),
-					resource.TestCheckResourceAttr(resourceName, "key_bits", "2048"),
-					resource.TestCheckResourceAttr(resourceName, "email_protection_flag", "false"),
-					resource.TestCheckResourceAttr(resourceName, "email_protection_flag", "false"),
-					resource.TestCheckResourceAttr(resourceName, "key_usage.#", "3"),
-					resource.TestCheckResourceAttr(resourceName, "key_usage.0", "DigitalSignature"),
-					resource.TestCheckResourceAttr(resourceName, "key_usage.1", "KeyAgreement"),
-					resource.TestCheckResourceAttr(resourceName, "key_usage.2", "KeyEncipherment"),
-					resource.TestCheckResourceAttr(resourceName, "ext_key_usage.#", "0"),
-					resource.TestCheckResourceAttr(resourceName, "use_csr_common_name", "true"),
-					resource.TestCheckResourceAttr(resourceName, "use_csr_sans", "true"),
-					resource.TestCheckResourceAttr(resourceName, "ou.0", "test"),
-					resource.TestCheckResourceAttr(resourceName, "organization.0", "test"),
-					resource.TestCheckResourceAttr(resourceName, "country.0", "test"),
-					resource.TestCheckResourceAttr(resourceName, "locality.0", "test"),
-					resource.TestCheckResourceAttr(resourceName, "province.0", "test"),
-					resource.TestCheckResourceAttr(resourceName, "street_address.0", "123 test"),
-					resource.TestCheckResourceAttr(resourceName, "postal_code.0", "12345"),
-					resource.TestCheckResourceAttr(resourceName, "generate_lease", "false"),
-					resource.TestCheckResourceAttr(resourceName, "no_store", "false"),
-					resource.TestCheckResourceAttr(resourceName, "require_cn", "true"),
-					resource.TestCheckResourceAttr(resourceName, "policy_identifiers.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "policy_identifiers.0", "1.2.3.4"),
-					resource.TestCheckResourceAttr(resourceName, "basic_constraints_valid_for_non_ca", "false"),
-					resource.TestCheckResourceAttr(resourceName, "not_before_duration", "45m"),
+					append(checks,
+						resource.TestCheckResourceAttr(resourceName, "ttl", "3600"),
+						resource.TestCheckResourceAttr(resourceName, "max_ttl", "7200"),
+					)...,
+				),
+			},
+			{
+				Config: testPkiSecretBackendRoleConfig_basic(name, backend, 0, 0),
+				Check: resource.ComposeTestCheckFunc(
+					append(checks,
+						resource.TestCheckResourceAttr(resourceName, "ttl", "0"),
+						resource.TestCheckResourceAttr(resourceName, "max_ttl", "0"),
+					)...,
+				),
+			},
+			{
+				Config: testPkiSecretBackendRoleConfig_basic(name, backend, 3600, 7200),
+				Check: resource.ComposeTestCheckFunc(
+					append(checks,
+						resource.TestCheckResourceAttr(resourceName, "ttl", "3600"),
+						resource.TestCheckResourceAttr(resourceName, "max_ttl", "7200"),
+					)...,
 				),
 			},
 			{
@@ -123,7 +146,7 @@ func TestPkiSecretBackendRole_basic(t *testing.T) {
 	})
 }
 
-func testPkiSecretBackendRoleConfig_basic(name, path string) string {
+func testPkiSecretBackendRoleConfig_basic(name, path string, roleTTL, maxTTL int) string {
 	return fmt.Sprintf(`
 resource "vault_mount" "pki" {
   path = "%s"
@@ -131,45 +154,46 @@ resource "vault_mount" "pki" {
 }
 
 resource "vault_pki_secret_backend_role" "test" {
-  depends_on = [ "vault_mount.pki" ]
-  backend = vault_mount.pki.path
-  name = "%s"
-  ttl = 3600
-  max_ttl = 7200
-  allow_localhost = true
-  allowed_domains = ["test.domain"]
-  allow_bare_domains = false
-  allow_subdomains = true
-  allow_glob_domains = false
-  allow_any_name = false
-  enforce_hostnames = true
-  allow_ip_sans = true
-  allowed_uri_sans = ["uri.test.domain"]
-  allowed_other_sans = ["1.2.3.4.5.5;UTF8:test"]
-  server_flag = true
-  client_flag = true
-  code_signing_flag = false
-  email_protection_flag = false
-  key_type = "rsa"
-  key_bits = 2048
-  ext_key_usage = []
-  use_csr_common_name = true
-  use_csr_sans = true
-  ou = ["test"]
-  organization = ["test"]
-  country = ["test"]
-  locality = ["test"]
-  province = ["test"]
-  street_address = ["123 test"]
-  postal_code = ["12345"]
-  generate_lease = false
-  no_store = false
-  require_cn = true
-  policy_identifiers = ["1.2.3.4"]
+  depends_on                         = ["vault_mount.pki"]
+  backend                            = vault_mount.pki.path
+  name                               = "%s"
+  ttl                                = %d
+  max_ttl                            = %d
+  allow_localhost                    = true
+  allowed_domains                    = ["test.domain"]
+  allow_bare_domains                 = false
+  allow_subdomains                   = true
+  allow_glob_domains                 = false
+  allow_any_name                     = false
+  enforce_hostnames                  = true
+  allow_ip_sans                      = true
+  allowed_uri_sans                   = ["uri.test.domain"]
+  allowed_other_sans                 = ["1.2.3.4.5.5;UTF8:test"]
+  server_flag                        = true
+  client_flag                        = true
+  code_signing_flag                  = false
+  email_protection_flag              = false
+  key_type                           = "rsa"
+  key_bits                           = 2048
+  ext_key_usage                      = []
+  use_csr_common_name                = true
+  use_csr_sans                       = true
+  ou                                 = ["test"]
+  organization                       = ["test"]
+  country                            = ["test"]
+  locality                           = ["test"]
+  province                           = ["test"]
+  street_address                     = ["123 test"]
+  postal_code                        = ["12345"]
+  generate_lease                     = false
+  no_store                           = false
+  require_cn                         = true
+  policy_identifiers                 = ["1.2.3.4"]
   basic_constraints_valid_for_non_ca = false
-  not_before_duration = "45m"
-  allowed_serial_numbers = ["*"]
-}`, path, name)
+  not_before_duration                = "45m"
+  allowed_serial_numbers             = ["*"]
+}
+`, path, name, roleTTL, maxTTL)
 }
 
 func testPkiSecretBackendRoleConfig_updated(name, path string) string {

--- a/website/docs/r/pki_secret_backend_role.html.md
+++ b/website/docs/r/pki_secret_backend_role.html.md
@@ -40,9 +40,9 @@ The following arguments are supported:
 
 * `name` - (Required) The name to identify this role within the backend. Must be unique within the backend.
 
-* `ttl` - (Optional) The TTL
+* `ttl` - (Optional, integer) The TTL, in seconds, for any certificate issued against this role.
 
-* `max_ttl` - (Optional) The maximum TTL
+* `max_ttl` - (Optional, integer) The maximum lease TTL, in seconds, for the role.
 
 * `allow_localhost` - (Optional) Flag to allow certificates for localhost
 


### PR DESCRIPTION
Drop the DiffSuppressFunc()'s for `max_ttl` and `ttl` since they prevent
properly detecting changes. Make them `computed` values instead.

Closes #418 

Output from acceptance testing:

```
$ time make testacc TESTARGS='-v -test.count 1 -test.run Test*Pki*'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -v -test.count 1 -test.run Test*Pki* -timeout 30m ./...

ok      github.com/hashicorp/terraform-provider-vault/util      0.414s [no tests to run]
=== RUN   TestPkiSecretBackendCert_basic
--- PASS: TestPkiSecretBackendCert_basic (5.54s)
=== RUN   TestPkiSecretBackendCert_revoke
--- PASS: TestPkiSecretBackendCert_revoke (8.40s)
=== RUN   TestPkiSecretBackendCert_renew
--- PASS: TestPkiSecretBackendCert_renew (16.01s)
=== RUN   TestPkiSecretBackendConfigCA_basic
--- PASS: TestPkiSecretBackendConfigCA_basic (1.63s)
=== RUN   TestPkiSecretBackendConfigUrls_basic
--- PASS: TestPkiSecretBackendConfigUrls_basic (7.24s)
=== RUN   TestPkiSecretBackendCrlConfig_basic
--- PASS: TestPkiSecretBackendCrlConfig_basic (6.60s)
=== RUN   TestPkiSecretBackendIntermediateCertRequest_basic
--- PASS: TestPkiSecretBackendIntermediateCertRequest_basic (1.87s)
=== RUN   TestPkiSecretBackendIntermediateSetSigned_basic
--- PASS: TestPkiSecretBackendIntermediateSetSigned_basic (4.41s)
=== RUN   TestPkiSecretBackendRole_basic
--- PASS: TestPkiSecretBackendRole_basic (9.80s)
=== RUN   TestPkiSecretBackendRootCertificate_basic
--- PASS: TestPkiSecretBackendRootCertificate_basic (12.36s)
=== RUN   TestPkiSecretBackendRootSignIntermediate_basic_default
--- PASS: TestPkiSecretBackendRootSignIntermediate_basic_default (10.11s)
=== RUN   TestPkiSecretBackendRootSignIntermediate_basic_pem
--- PASS: TestPkiSecretBackendRootSignIntermediate_basic_pem (3.62s)
=== RUN   TestPkiSecretBackendRootSignIntermediate_basic_der
--- PASS: TestPkiSecretBackendRootSignIntermediate_basic_der (2.93s)
=== RUN   TestPkiSecretBackendRootSignIntermediate_basic_pem_bundle
--- PASS: TestPkiSecretBackendRootSignIntermediate_basic_pem_bundle (4.54s)
=== RUN   TestPkiSecretBackendRootSignIntermediate_basic_pem_bundle_multiple_intermediates
--- PASS: TestPkiSecretBackendRootSignIntermediate_basic_pem_bundle_multiple_intermediates (4.05s)
=== RUN   TestPkiSecretBackendSign_basic
--- PASS: TestPkiSecretBackendSign_basic (3.18s)
=== RUN   TestPkiSecretBackendSign_renew
--- PASS: TestPkiSecretBackendSign_renew (13.47s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     118.037s
make testacc TESTARGS='-v -test.count 1 -test.run Test*Pki*'  75.17s user 29.98s system 84% cpu 2:04.49 total

```
