### PR TITLE
Properly handle nil member_entity_ids in response.

### DIFF
--- a/vault/resource_identity_group_member_entity_ids.go
+++ b/vault/resource_identity_group_member_entity_ids.go
@@ -70,7 +70,7 @@ func identityGroupMemberEntityIdsUpdate(d *schema.ResourceData, meta interface{}
 
 	var curIDS []interface{}
 	if t, ok := resp.Data["type"]; ok && t.(string) != "external" {
-		if v, ok := resp.Data["member_entity_ids"]; ok {
+		if v, ok := resp.Data["member_entity_ids"]; ok && v != nil {
 			curIDS = v.([]interface{})
 		}
 
@@ -194,7 +194,7 @@ func identityGroupMemberEntityIdsDelete(d *schema.ResourceData, meta interface{}
 			data["member_entity_ids"] = make([]string, 0)
 		} else {
 			set := map[interface{}]bool{}
-			if v, ok := resp.Data["member_entity_ids"]; ok {
+			if v, ok := resp.Data["member_entity_ids"]; ok && v != nil {
 				for _, id := range v.([]interface{}) {
 					set[id] = true
 				}


### PR DESCRIPTION

```
$ time make testacc TESTARGS='-v -test.count 1 -test.run TestAccIdentityGroupMemberEntityIds*'

PASS
ok      github.com/hashicorp/terraform-provider-vault/util      0.515s [no tests to run]
=== RUN   TestAccIdentityGroupMemberEntityIdsExclusiveEmpty
--- PASS: TestAccIdentityGroupMemberEntityIdsExclusiveEmpty (4.93s)
=== RUN   TestAccIdentityGroupMemberEntityIdsExclusive
--- PASS: TestAccIdentityGroupMemberEntityIdsExclusive (2.93s)
=== RUN   TestAccIdentityGroupMemberEntityIdsNonExclusiveEmpty
--- PASS: TestAccIdentityGroupMemberEntityIdsNonExclusiveEmpty (4.16s)
=== RUN   TestAccIdentityGroupMemberEntityIdsNonExclusive
--- PASS: TestAccIdentityGroupMemberEntityIdsNonExclusive (4.27s)
=== RUN   TestAccIdentityGroupMemberEntityIdsDynamic
--- PASS: TestAccIdentityGroupMemberEntityIdsDynamic (9.60s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     30.257s
make testacc   58.36s user 24.41s system 213% cpu 38.827 total

```
