### PR TITLE
feat: Vault Azure Auth

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.16.0
 	github.com/hashicorp/vault v1.10.3
 	github.com/hashicorp/vault/api v1.6.0
+	github.com/hashicorp/vault/api/auth/azure v0.1.0
 	github.com/hashicorp/vault/sdk v0.5.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1044,6 +1044,8 @@ github.com/hashicorp/vault/api v1.4.1/go.mod h1:LkMdrZnWNrFaQyYYazWVn7KshilfDidg
 github.com/hashicorp/vault/api v1.6.0 h1:B8UUYod1y1OoiGHq9GtpiqSnGOUEWHaA26AY8RQEDY4=
 github.com/hashicorp/vault/api v1.6.0/go.mod h1:h1K70EO2DgnBaTz5IsL6D5ERsNt5Pce93ueVS2+t0Xc=
 github.com/hashicorp/vault/api/auth/approle v0.1.0/go.mod h1:mHOLgh//xDx4dpqXoq6tS8Ob0FoCFWLU2ibJ26Lfmag=
+github.com/hashicorp/vault/api/auth/azure v0.1.0 h1:/I6kEMo5v1TdPDYDRqVXuwacTlatVrsf+tfGro2BpK8=
+github.com/hashicorp/vault/api/auth/azure v0.1.0/go.mod h1:hjAhi7Ezr6Uh479LXjCN1EJXTjCiLtIiNbIavC91+80=
 github.com/hashicorp/vault/api/auth/userpass v0.1.0/go.mod h1:0orUbtkEwbEPmaQ+wvfrOddGBimLJnuN8A/J0PNfBks=
 github.com/hashicorp/vault/sdk v0.1.14-0.20190730042320-0dc007d98cc8/go.mod h1:B+hVj7TpuQY1Y/GPbCpffmgd+tSEwvhkWnjtSYCaS2M=
 github.com/hashicorp/vault/sdk v0.1.14-0.20200215195600-2ca765f0a500/go.mod h1:WX57W2PwkrOPQ6rVQk+dy5/htHIaB4aBM70EwKThu10=

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -198,7 +198,7 @@ The `auth_login` configuration block accepts the following arguments:
 
 * `method` - (Optional) When configured, will enable auth method specific operations.
   For example, when set to `aws`, the provider will automatically sign login requests
-  for AWS authentication. Valid values include: `aws`.
+  for AWS authentication. Valid values include: `aws` and `azure`.
 
 * `parameters` - (Optional) A map of key-value parameters to send when authenticating
   against the auth backend. Refer to [Vault API documentation](https://www.vaultproject.io/api-docs/auth) for a particular auth method
@@ -322,6 +322,24 @@ provider "vault" {
     parameters = {
       role = "dev-role-iam"
       header_value = "vault.example.com"
+    }
+  }
+}
+```
+
+### Example `auth_login` With Azure Signing
+
+Sign AWS metadata for instance profile login requests:
+
+```hcl
+provider "vault" {
+  address = "http://127.0.0.1:8200"
+  auth_login {
+    path = "auth/azure/login"
+    method = "azure"
+    parameters = {
+      role     = "dev-role-azure"
+      resource = "https://management.azure.com"
     }
   }
 }


### PR DESCRIPTION
* added the azure auth method

```hcl
provider vault {
  address = "https://vault.acme.corp"
  auth_login {
    path = "auth/azure/login"
    method = "azure"
    parameters = {
      role = "some-vault-role"
      resource = "https://management.azure.com"
    }
  }
}
```

The implementation relies on Vault's Azure specifics methods to be authenticated on Azure.

```go
import "github.com/hashicorp/vault/api/auth/azure"
...
role := authLoginParameters["role"].(string)
  resource := authLoginParameters["resource"].(string)
  loginOpts := []azure.LoginOption{
  azure.WithResource(resource),
}
azureLogin, err := azure.NewAzureAuth(role, loginOpts...)
```

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1415

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* `provider`: Added the Azure authentication method
```

Output from acceptance testing:

No acceptance tests added for the specific Azure Auth
