### PR TITLE
Add support for importing PKI config URLs

### DIFF
--- a/vault/resource_pki_secret_backend_config_urls.go
+++ b/vault/resource_pki_secret_backend_config_urls.go
@@ -1,20 +1,38 @@
 package vault
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
 func pkiSecretBackendConfigUrlsResource() *schema.Resource {
 	return &schema.Resource{
-		Create: pkiSecretBackendConfigUrlsCreate,
+		Create: pkiSecretBackendConfigUrlsCreateUpdate,
 		Read:   pkiSecretBackendConfigUrlsRead,
-		Update: pkiSecretBackendConfigUrlsUpdate,
+		Update: pkiSecretBackendConfigUrlsCreateUpdate,
 		Delete: pkiSecretBackendConfigUrlsDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: func(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				id := d.Id()
+				if id == "" {
+					return nil, fmt.Errorf("no path set for import, id=%q", id)
+				}
+
+				parts := strings.Split(util.NormalizeMountPath(id), "/")
+				if err := d.Set("backend", parts[0]); err != nil {
+					return nil, err
+				}
+
+				return []*schema.ResourceData{d}, nil
+			},
+		},
 
 		Schema: map[string]*schema.Schema{
 			"backend": {
@@ -44,31 +62,35 @@ func pkiSecretBackendConfigUrlsResource() *schema.Resource {
 	}
 }
 
-func pkiSecretBackendConfigUrlsCreate(d *schema.ResourceData, meta interface{}) error {
+func pkiSecretBackendConfigUrlsCreateUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*api.Client)
 
 	backend := d.Get("backend").(string)
 
 	path := pkiSecretBackendConfigUrlsPath(backend)
 
-	issuingCertificates := d.Get("issuing_certificates")
-	crlDistributionsPoints := d.Get("crl_distribution_points")
-	ocspServers := d.Get("ocsp_servers")
+	action := "Create"
+	if !d.IsNewResource() {
+		action = "Update"
+	}
 
 	data := map[string]interface{}{
-		"issuing_certificates":    issuingCertificates,
-		"crl_distribution_points": crlDistributionsPoints,
-		"ocsp_servers":            ocspServers,
+		"issuing_certificates":    d.Get("issuing_certificates"),
+		"crl_distribution_points": d.Get("crl_distribution_points"),
+		"ocsp_servers":            d.Get("ocsp_servers"),
 	}
 
-	log.Printf("[DEBUG] Creating URL config on PKI secret backend %q", backend)
+	log.Printf("[DEBUG] %s URL config on PKI secret backend %q", action, backend)
 	_, err := client.Logical().Write(path, data)
 	if err != nil {
-		return fmt.Errorf("error creating URL config PKI secret backend %q: %s", backend, err)
+		return fmt.Errorf("error writing PKI URL config to %q: %w", backend, err)
 	}
-	log.Printf("[DEBUG] Created URL config on PKI secret backend %q", backend)
+	log.Printf("[DEBUG] %sd URL config on PKI secret backend %q", action, backend)
 
-	d.SetId(fmt.Sprintf("%s/config/urls", backend))
+	if d.IsNewResource() {
+		d.SetId(fmt.Sprintf("%s/config/urls", backend))
+	}
+
 	return pkiSecretBackendConfigUrlsRead(d, meta)
 }
 
@@ -76,11 +98,13 @@ func pkiSecretBackendConfigUrlsRead(d *schema.ResourceData, meta interface{}) er
 	client := meta.(*api.Client)
 
 	path := d.Id()
-	backend := pkiSecretBackendConfigUrlsPath(path)
 
-	log.Printf("[DEBUG] Reading URL config from PKI secret backend %q", backend)
+	if path == "" {
+		return fmt.Errorf("no path set, id=%q", d.Id())
+	}
+
+	log.Printf("[DEBUG] Reading URL config from PKI secret path %q", path)
 	config, err := client.Logical().Read(path)
-
 	if err != nil {
 		return fmt.Errorf("error reading URL config on PKI secret backend %q: %s", path, err)
 	}
@@ -91,39 +115,18 @@ func pkiSecretBackendConfigUrlsRead(d *schema.ResourceData, meta interface{}) er
 		return nil
 	}
 
-	d.Set("issuing_certificates", config.Data["issuing_certificates"])
-	d.Set("crl_distribution_points", config.Data["crl_distribution_points"])
-	d.Set("ocsp_servers", config.Data["ocsp_servers"])
+	fields := []string{
+		"issuing_certificates",
+		"crl_distribution_points",
+		"ocsp_servers",
+	}
+	for _, k := range fields {
+		if err := d.Set(k, config.Data[k]); err != nil {
+			return err
+		}
+	}
 
 	return nil
-}
-
-func pkiSecretBackendConfigUrlsUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
-
-	backend := d.Get("backend").(string)
-
-	path := pkiSecretBackendConfigUrlsPath(backend)
-
-	issuingCertificates := d.Get("issuing_certificates")
-	crlDistributionsPoints := d.Get("crl_distribution_points")
-	ocspServers := d.Get("ocsp_servers")
-
-	data := map[string]interface{}{
-		"issuing_certificates":    issuingCertificates,
-		"crl_distribution_points": crlDistributionsPoints,
-		"ocsp_servers":            ocspServers,
-	}
-
-	log.Printf("[DEBUG] Updating URL config on PKI secret backend %q", backend)
-	_, err := client.Logical().Write(path, data)
-	if err != nil {
-		return fmt.Errorf("error updating URL config for PKI secret backend %q: %s", backend, err)
-	}
-	log.Printf("[DEBUG] Updated URL config on PKI secret backend %q", backend)
-
-	return pkiSecretBackendConfigUrlsRead(d, meta)
-
 }
 
 func pkiSecretBackendConfigUrlsDelete(d *schema.ResourceData, meta interface{}) error {

--- a/website/docs/r/pki_secret_backend_config_urls.html.md
+++ b/website/docs/r/pki_secret_backend_config_urls.html.md
@@ -13,9 +13,19 @@ Allows setting the issuing certificate endpoints, CRL distribution points, and O
 ## Example Usage
 
 ```hcl
-resource "vault_pki_secret_backend_config_urls" "config_urls" {
-  backend              = vault_mount.pki.path
-  issuing_certificates = ["http://127.0.0.1:8200/v1/pki/ca"]
+resource "vault_mount" "root" {
+  path                      = "pki-root"
+  type                      = "pki"
+  description               = "root PKI"
+  default_lease_ttl_seconds = 8640000
+  max_lease_ttl_seconds     = 8640000
+}
+
+resource "vault_pki_secret_backend_config_urls" "example" {
+  backend = vault_mount.root.path
+  issuing_certificates = [
+    "http://127.0.0.1:8200/v1/pki/ca",
+  ]
 }
 ```
 
@@ -34,3 +44,13 @@ The following arguments are supported:
 ## Attributes Reference
 
 No additional attributes are exported by this resource.
+
+## Import
+
+The PKI config URLs can be imported using the resources `id`. 
+In the case of the example above the `id` would be `pki-root/config/urls`, 
+where the `pki-root` component is the resource's `backend`, e.g.
+
+```
+$ terraform import vault_pki_secret_backend_config_urls.example pki-root/config/urls
+```

--- a/website/docs/r/pki_secret_backend_config_urls.html.md
+++ b/website/docs/r/pki_secret_backend_config_urls.html.md
@@ -47,7 +47,7 @@ No additional attributes are exported by this resource.
 
 ## Import
 
-The PKI config URLs can be imported using the resources `id`. 
+The PKI config URLs can be imported using the resource's `id`. 
 In the case of the example above the `id` would be `pki-root/config/urls`, 
 where the `pki-root` component is the resource's `backend`, e.g.
 


### PR DESCRIPTION
Other fixes:
- Unify create and update funcs
- Test the update case

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #934

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
 $ time make testacc TESTARGS='-v -test.count 1 -test.run Test*Pki*'           

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -v -test.count 1 -test.run Test*Pki* -timeout 30m ./...

PASS
ok      github.com/hashicorp/terraform-provider-vault/util      0.575s [no tests to run]
=== RUN   TestPkiSecretBackendCert_basic
--- PASS: TestPkiSecretBackendCert_basic (11.21s)
=== RUN   TestPkiSecretBackendCert_renew
--- PASS: TestPkiSecretBackendCert_renew (10.54s)
=== RUN   TestPkiSecretBackendConfigCA_basic
--- PASS: TestPkiSecretBackendConfigCA_basic (1.60s)
=== RUN   TestPkiSecretBackendConfigUrls_basic
--- PASS: TestPkiSecretBackendConfigUrls_basic (3.11s)
=== RUN   TestPkiSecretBackendCrlConfig_basic
--- PASS: TestPkiSecretBackendCrlConfig_basic (3.53s)
=== RUN   TestPkiSecretBackendIntermediateCertRequest_basic
--- PASS: TestPkiSecretBackendIntermediateCertRequest_basic (1.78s)
=== RUN   TestPkiSecretBackendIntermediateSetSigned_basic
--- PASS: TestPkiSecretBackendIntermediateSetSigned_basic (2.94s)
=== RUN   TestPkiSecretBackendRole_basic
--- PASS: TestPkiSecretBackendRole_basic (5.30s)
=== RUN   TestPkiSecretBackendRootCertificate_basic
--- PASS: TestPkiSecretBackendRootCertificate_basic (10.61s)
=== RUN   TestPkiSecretBackendRootSignIntermediate_basic_default
--- PASS: TestPkiSecretBackendRootSignIntermediate_basic_default (4.69s)
=== RUN   TestPkiSecretBackendRootSignIntermediate_basic_pem
--- PASS: TestPkiSecretBackendRootSignIntermediate_basic_pem (2.33s)
=== RUN   TestPkiSecretBackendRootSignIntermediate_basic_der
--- PASS: TestPkiSecretBackendRootSignIntermediate_basic_der (3.08s)
=== RUN   TestPkiSecretBackendRootSignIntermediate_basic_pem_bundle
--- PASS: TestPkiSecretBackendRootSignIntermediate_basic_pem_bundle (2.92s)
=== RUN   TestPkiSecretBackendRootSignIntermediate_basic_pem_bundle_multiple_intermediates
--- PASS: TestPkiSecretBackendRootSignIntermediate_basic_pem_bundle_multiple_intermediates (3.48s)
=== RUN   TestPkiSecretBackendSign_basic
--- PASS: TestPkiSecretBackendSign_basic (4.05s)
=== RUN   TestPkiSecretBackendSign_renew
--- PASS: TestPkiSecretBackendSign_renew (12.09s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     86.141s
make testacc TESTARGS='-v -test.count 1 -test.run Test*Pki*'  75.88s user 30.69s system 114% cpu 1:33.28 total

```
