### PR TITLE
Add `key_type` and `key_bits` to `vault_ssh_secret_backend_ca`

### DIFF
--- a/vault/resource_ssh_secret_backend_ca.go
+++ b/vault/resource_ssh_secret_backend_ca.go
@@ -36,6 +36,19 @@ func sshSecretBackendCAResource() *schema.Resource {
 				ForceNew:    true,
 				Description: "Whether Vault should generate the signing key pair internally.",
 			},
+			"key_type": {
+				Type:        schema.TypeString,
+				Default:     "ssh-rsa",
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Specifies the desired key type for the generated SSH CA key when `generate_signing_key` is set to `true`.",
+			},
+			"key_bits": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Specifies the desired key bits for the generated SSH CA key when `generate_signing_key` is set to `true`.",
+			},
 			"private_key": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -68,6 +81,12 @@ func sshSecretBackendCACreate(d *schema.ResourceData, meta interface{}) error {
 	}
 	if publicKey, ok := d.Get("public_key").(string); ok {
 		data["public_key"] = publicKey
+	}
+	if keyType, ok := d.Get("key_type").(string); ok {
+		data["key_type"] = keyType
+	}
+	if keyBits, ok := d.Get("key_bits").(int); ok {
+		data["key_bits"] = keyBits
 	}
 
 	log.Printf("[DEBUG] Writing CA information on SSH backend %q", backend)
@@ -109,7 +128,7 @@ func sshSecretBackendCARead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("public_key", secret.Data["public_key"])
 	d.Set("backend", backend)
 
-	// the API doesn't return private_key and generate_signing_key
+	// the API doesn't return private_key, generate_signing_key, key_type, or key_bits.
 	// So... if they drift, they drift.
 
 	return nil

--- a/website/docs/r/ssh_secret_backend_ca.html.md
+++ b/website/docs/r/ssh_secret_backend_ca.html.md
@@ -31,6 +31,10 @@ The following arguments are supported:
 
 * `generate_signing_key` - (Optional) Whether Vault should generate the signing key pair internally. Defaults to true
 
+* `key_type` - (Optional) Specifies the desired key type for the generated SSH CA key when `generate_signing_key` is set to `true`.
+
+* `key_bits` - (Optional) Specifies the desired key bits for the generated SSH CA key when `generate_signing_key` is set to `true`.
+
 * `public_key` - (Optional) The public key part the SSH CA key pair; required if generate_signing_key is false.
 
 * `private_key` - (Optional) The private key part the SSH CA key pair; required if generate_signing_key is false.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add `key_type` and `key_bits` to `vault_ssh_secret_backend_ca`.
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -run=TestAccXXX -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/codegen   (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
?       github.com/hashicorp/terraform-provider-vault/testutil  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     (cached) [no tests to run]
```
