### PR TITLE
Set delete_all_versions on read() for generic_secret

### DIFF
--- a/vault/resource_generic_secret.go
+++ b/vault/resource_generic_secret.go
@@ -209,8 +209,12 @@ func genericSecretResourceRead(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("error marshaling JSON for %q: %s", path, err)
 		}
 
-		d.Set("data_json", string(jsonData))
-		d.Set("path", path)
+		if err := d.Set("data_json", string(jsonData)); err != nil {
+			return err
+		}
+		if err := d.Set("path", path); err != nil {
+			return err
+		}
 	} else {
 		// Populate data from data_json from state
 		err := json.Unmarshal([]byte(d.Get("data_json").(string)), &data)
@@ -219,7 +223,10 @@ func genericSecretResourceRead(d *schema.ResourceData, meta interface{}) error {
 		}
 		log.Printf("[WARN] vault_generic_secret does not refresh when disable_read is set to true")
 	}
-	d.Set("disable_read", !shouldRead)
+
+	if err := d.Set("disable_read", !shouldRead); err != nil {
+		return err
+	}
 
 	// Since our "data" map can only contain string values, we
 	// will take strings from Data and write them in as-is,
@@ -239,6 +246,13 @@ func genericSecretResourceRead(d *schema.ResourceData, meta interface{}) error {
 			dataMap[k] = string(vBytes)
 		}
 	}
-	d.Set("data", dataMap)
+	if err := d.Set("data", dataMap); err != nil {
+		return err
+	}
+
+	if err := d.Set("delete_all_versions", d.Get("delete_all_versions")); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/vault/resource_generic_secret_test.go
+++ b/vault/resource_generic_secret_test.go
@@ -14,6 +14,8 @@ import (
 
 func TestResourceGenericSecret(t *testing.T) {
 	path := acctest.RandomWithPrefix("secretsv1/test")
+	resourceName := "vault_generic_secret.test"
+
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
 		PreCheck:  func() { testutil.TestAccPreCheck(t) },
@@ -26,12 +28,18 @@ func TestResourceGenericSecret(t *testing.T) {
 				Config: testResourceGenericSecret_updateConfig,
 				Check:  testResourceGenericSecret_updateCheck,
 			},
+			{
+				ImportState:  true,
+				ResourceName: resourceName,
+			},
 		},
 	})
 }
 
 func TestResourceGenericSecret_deleted(t *testing.T) {
 	path := acctest.RandomWithPrefix("secretsv1/test")
+	resourceName := "vault_generic_secret.test"
+
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
 		PreCheck:  func() { testutil.TestAccPreCheck(t) },
@@ -39,6 +47,10 @@ func TestResourceGenericSecret_deleted(t *testing.T) {
 			{
 				Config: testResourceGenericSecret_initialConfig(path),
 				Check:  testResourceGenericSecret_initialCheck(path),
+			},
+			{
+				ImportState:  true,
+				ResourceName: resourceName,
 			},
 			{
 				PreConfig: func() {
@@ -51,12 +63,18 @@ func TestResourceGenericSecret_deleted(t *testing.T) {
 				Config: testResourceGenericSecret_initialConfig(path),
 				Check:  testResourceGenericSecret_initialCheck(path),
 			},
+			{
+				ImportState:  true,
+				ResourceName: resourceName,
+			},
 		},
 	})
 }
 
 func TestResourceGenericSecret_deleteAllVersions(t *testing.T) {
 	path := acctest.RandomWithPrefix("secretsv2/test")
+	resourceName := "vault_generic_secret.test"
+
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
@@ -67,8 +85,16 @@ func TestResourceGenericSecret_deleteAllVersions(t *testing.T) {
 				Check:  testResourceGenericSecret_initialCheck_v2(path, "zap", 1),
 			},
 			{
+				ImportState:  true,
+				ResourceName: resourceName,
+			},
+			{
 				Config: testResourceGenericSecret_initialConfig_v2(path, true),
 				Check:  testResourceGenericSecret_initialCheck_v2(path, "zoop", 2),
+			},
+			{
+				ImportState:  true,
+				ResourceName: resourceName,
 			},
 		},
 	})


### PR DESCRIPTION
Other fixes:
- test import for all test-cases
- ensure Set() errors are handled

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #1295 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ time make testacc TESTARGS='-v -test.count 1 -test.run TestResourceGenericSecret*'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -v -test.count 1 -test.run TestResourceGenericSecret* -timeout 30m ./...


--- PASS: TestResourceGenericSecret (3.51s)
=== RUN   TestResourceGenericSecret_deleted
--- PASS: TestResourceGenericSecret_deleted (3.61s)
=== RUN   TestResourceGenericSecret_deleteAllVersions
--- PASS: TestResourceGenericSecret_deleteAllVersions (3.57s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     13.267s
make testacc TESTARGS='-v -test.count 1 -test.run TestResourceGenericSecret*'  38.21s user 15.37s system 266% cpu 20.136 total

```
