### PR TITLE
Support LDAP username_as_alias Attribute

### DIFF
--- a/vault/resource_ldap_auth_backend.go
+++ b/vault/resource_ldap_auth_backend.go
@@ -108,9 +108,10 @@ func ldapAuthBackendResource() *schema.Resource {
 			Computed: true,
 		},
 		"username_as_alias": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Computed: true,
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Computed:    true,
+			Description: "Force the auth method to use the username passed by the user as the alias name.",
 		},
 		"use_token_groups": {
 			Type:     schema.TypeBool,

--- a/vault/resource_ldap_auth_backend.go
+++ b/vault/resource_ldap_auth_backend.go
@@ -279,7 +279,7 @@ func ldapAuthBackendUpdate(d *schema.ResourceData, meta interface{}) error {
 		data["groupattr"] = v.(string)
 	}
 
-	if v, ok := d.GetOk("username_as_alias"); ok {
+	if v, ok := d.GetOkExists("username_as_alias"); ok {
 		data["username_as_alias"] = v.(bool)
 	}
 

--- a/vault/resource_ldap_auth_backend.go
+++ b/vault/resource_ldap_auth_backend.go
@@ -107,6 +107,11 @@ func ldapAuthBackendResource() *schema.Resource {
 			Optional: true,
 			Computed: true,
 		},
+		"username_as_alias": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Computed: true,
+		},
 		"use_token_groups": {
 			Type:     schema.TypeBool,
 			Optional: true,
@@ -273,6 +278,10 @@ func ldapAuthBackendUpdate(d *schema.ResourceData, meta interface{}) error {
 		data["groupattr"] = v.(string)
 	}
 
+	if v, ok := d.GetOk("username_as_alias"); ok {
+		data["username_as_alias"] = v.(bool)
+	}
+
 	if v, ok := d.GetOkExists("use_token_groups"); ok {
 		data["use_token_groups"] = v.(bool)
 	}
@@ -355,6 +364,7 @@ func ldapAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("groupfilter", resp.Data["groupfilter"])
 	d.Set("groupdn", resp.Data["groupdn"])
 	d.Set("groupattr", resp.Data["groupattr"])
+	d.Set("username_as_alias", resp.Data["username_as_alias"])
 	d.Set("use_token_groups", resp.Data["use_token_groups"])
 
 	// `bindpass`, `client_tls_cert` and `client_tls_key` cannot be read out from the API

--- a/vault/resource_ldap_auth_backend_test.go
+++ b/vault/resource_ldap_auth_backend_test.go
@@ -198,6 +198,7 @@ func testLDAPAuthBackendCheck_attrs(path string) resource.TestCheckFunc {
 			"deny_null_bind":       "deny_null_bind",
 			"upndomain":            "upndomain",
 			"groupfilter":          "groupfilter",
+			"username_as_alias":    "username_as_alias",
 			"groupdn":              "groupdn",
 			"groupattr":            "groupattr",
 			"use_token_groups":     "use_token_groups",
@@ -285,6 +286,7 @@ resource "vault_ldap_auth_backend" "test" {
     deny_null_bind         = true
     description            = "example"
 	userfilter             = "({{.UserAttr}}={{.Username}})"
+    username_as_alias      = true
     use_token_groups = %s
 }
 `, path, local, use_token_groups)

--- a/vault/resource_ldap_auth_backend_test.go
+++ b/vault/resource_ldap_auth_backend_test.go
@@ -285,7 +285,7 @@ resource "vault_ldap_auth_backend" "test" {
     discoverdn             = false
     deny_null_bind         = true
     description            = "example"
-	userfilter             = "({{.UserAttr}}={{.Username}})"
+    userfilter             = "({{.UserAttr}}={{.Username}})"
     username_as_alias      = true
     use_token_groups = %s
 }

--- a/website/docs/r/ldap_auth_backend.html.md
+++ b/website/docs/r/ldap_auth_backend.html.md
@@ -67,6 +67,8 @@ The following arguments are supported:
 
 * `groupattr` - (Optional) LDAP attribute to follow on objects returned by groupfilter
 
+* `username_as_alias` - (Optional) Force the auth method to use the username passed by the user as the alias name.
+
 * `use_token_groups` - (Optional) Use the Active Directory tokenGroups constructed attribute of the user to find the group memberships
 
 * `path` - (Optional) Path to mount the LDAP auth backend under


### PR DESCRIPTION
Related to https://github.com/hashicorp/terraform-provider-vault/pull/1378 and https://www.vaultproject.io/docs/release-notes/1.10.0#ldap-auth-method-entity-alias-mapping, we would like to configure the `username_as_alias` attribute with Terraform. Thanks @FalcoSuessgott for the excellent PR template.

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
```release-note
IMPROVEMENTS: 

resource/vault_ldap_auth_backend - support "username_as_alias" attribute
```

Output from acceptance testing:

```
VAULT_TOKEN="root" VAULT_ADDR="http://127.0.0.1:8200" make testacc TESTARGS='-run=LDAPAuthBackend'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -run=LDAPAuthBackend -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/codegen   (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
?       github.com/hashicorp/terraform-provider-vault/testutil  [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
=== RUN   TestLDAPAuthBackendGroup_import
--- PASS: TestLDAPAuthBackendGroup_import (4.95s)
=== RUN   TestLDAPAuthBackendGroup_basic
--- PASS: TestLDAPAuthBackendGroup_basic (1.69s)
=== RUN   TestLDAPAuthBackend_import
--- PASS: TestLDAPAuthBackend_import (1.96s)
=== RUN   TestLDAPAuthBackend_basic
--- PASS: TestLDAPAuthBackend_basic (7.07s)
=== RUN   TestLDAPAuthBackend_tls
--- PASS: TestLDAPAuthBackend_tls (7.20s)
=== RUN   TestLDAPAuthBackendUser_import
--- PASS: TestLDAPAuthBackendUser_import (2.02s)
=== RUN   TestLDAPAuthBackendUser_basic
--- PASS: TestLDAPAuthBackendUser_basic (1.65s)
=== RUN   TestLDAPAuthBackendUser_noGroups
--- PASS: TestLDAPAuthBackendUser_noGroups (1.74s)
=== RUN   TestLDAPAuthBackendUser_oneGroup
--- PASS: TestLDAPAuthBackendUser_oneGroup (1.72s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     30.043s
```
