### PR TITLE
auth/jwt: adds user_claim_json_pointer and max_age to roles

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
           MSSQL_URL: "sqlserver://sa:${{ secrets.MSSQL_SA_PASSWORD }}@mssql:1433"
           POSTGRES_URL: "postgres://postgres:secret@postgres:5432/database?sslmode=disable"
         run: |
-          make testacc-ent TESTARGS='-v' SKIP_MSSQL_MULTI_CI=true SKIP_RAFT_TESTS=true
+          make testacc-ent TESTARGS='-v' SKIP_MSSQL_MULTI_CI=true SKIP_RAFT_TESTS=true SKIP_VAULT_NEXT_TESTS=true
       - name: "Generate Vault API Path Coverage Report"
         run: |
           go run cmd/coverage/main.go -openapi-doc=./testdata/openapi.json

--- a/vault/resource_jwt_auth_backend_role.go
+++ b/vault/resource_jwt_auth_backend_role.go
@@ -385,11 +385,11 @@ func jwtAuthBackendRoleDataToWrite(d *schema.ResourceData, create bool) map[stri
 	data["user_claim"] = d.Get("user_claim").(string)
 
 	if v, ok := d.GetOkExists("user_claim_json_pointer"); ok {
-		data["user_claim_json_pointer"] = v.(bool)
+		data["user_claim_json_pointer"] = v
 	}
 
 	if v, ok := d.GetOk("max_age"); ok {
-		data["max_age"] = v.(int)
+		data["max_age"] = v
 	}
 
 	if dataList := util.TerraformSetToStringArray(d.Get("allowed_redirect_uris")); len(dataList) > 0 {

--- a/vault/resource_jwt_auth_backend_role.go
+++ b/vault/resource_jwt_auth_backend_role.go
@@ -119,6 +119,17 @@ func jwtAuthBackendRoleResource() *schema.Resource {
 			Default:     false,
 			Description: "Log received OIDC tokens and claims when debug-level logging is active. Not recommended in production since sensitive information may be present in OIDC responses.",
 		},
+		"user_claim_json_pointer": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Specifies if the user_claim value uses JSON pointer syntax for referencing claims. By default, the user_claim value will not use JSON pointer.",
+		},
+		"max_age": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Description: "Specifies the allowable elapsed time in seconds since the last time the user was actively authenticated.",
+		},
 		"backend": {
 			Type:        schema.TypeString,
 			Optional:    true,
@@ -277,6 +288,12 @@ func jwtAuthBackendRoleRead(_ context.Context, d *schema.ResourceData, meta inte
 	if v, ok := resp.Data["verbose_oidc_logging"]; ok {
 		d.Set("verbose_oidc_logging", v)
 	}
+	if v, ok := resp.Data["user_claim_json_pointer"]; ok {
+		d.Set("user_claim_json_pointer", v)
+	}
+	if v, ok := resp.Data["max_age"]; ok {
+		d.Set("max_age", v)
+	}
 
 	d.Set("backend", backend)
 	d.Set("role_name", role)
@@ -366,6 +383,14 @@ func jwtAuthBackendRoleDataToWrite(d *schema.ResourceData, create bool) map[stri
 
 	data["bound_audiences"] = util.TerraformSetToStringArray(d.Get("bound_audiences"))
 	data["user_claim"] = d.Get("user_claim").(string)
+
+	if v, ok := d.GetOkExists("user_claim_json_pointer"); ok {
+		data["user_claim_json_pointer"] = v.(bool)
+	}
+
+	if v, ok := d.GetOk("max_age"); ok {
+		data["max_age"] = v.(int)
+	}
 
 	if dataList := util.TerraformSetToStringArray(d.Get("allowed_redirect_uris")); len(dataList) > 0 {
 		data["allowed_redirect_uris"] = dataList

--- a/vault/resource_jwt_auth_backend_role.go
+++ b/vault/resource_jwt_auth_backend_role.go
@@ -382,11 +382,8 @@ func jwtAuthBackendRoleDataToWrite(d *schema.ResourceData, create bool) map[stri
 	updateTokenFields(d, data, create)
 
 	data["bound_audiences"] = util.TerraformSetToStringArray(d.Get("bound_audiences"))
-	data["user_claim"] = d.Get("user_claim").(string)
-
-	if v, ok := d.GetOkExists("user_claim_json_pointer"); ok {
-		data["user_claim_json_pointer"] = v
-	}
+	data["user_claim"] = d.Get("user_claim")
+	data["user_claim_json_pointer"] = d.Get("user_claim_json_pointer")
 
 	if v, ok := d.GetOk("max_age"); ok {
 		data["max_age"] = v

--- a/vault/resource_jwt_auth_backend_role_test.go
+++ b/vault/resource_jwt_auth_backend_role_test.go
@@ -16,7 +16,10 @@ func TestAccJWTAuthBackendRole_import(t *testing.T) {
 	backend := acctest.RandomWithPrefix("jwt")
 	role := acctest.RandomWithPrefix("test-role")
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		PreCheck: func() {
+			testutil.TestAccPreCheck(t)
+			testutil.SkipTestEnvSet(t, testutil.EnvVarSkipVaultNext)
+		},
 		Providers:    testProviders,
 		CheckDestroy: testAccCheckJWTAuthBackendRoleDestroy,
 		Steps: []resource.TestStep{
@@ -88,7 +91,10 @@ func TestAccJWTAuthBackendRole_basic(t *testing.T) {
 	role := acctest.RandomWithPrefix("test-role")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		PreCheck: func() {
+			testutil.TestAccPreCheck(t)
+			testutil.SkipTestEnvSet(t, testutil.EnvVarSkipVaultNext)
+		},
 		Providers:    testProviders,
 		CheckDestroy: testAccCheckJWTAuthBackendRoleDestroy,
 		Steps: []resource.TestStep{
@@ -205,7 +211,10 @@ func TestAccJWTAuthBackendRole_full(t *testing.T) {
 	role := acctest.RandomWithPrefix("test-role")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		PreCheck: func() {
+			testutil.TestAccPreCheck(t)
+			testutil.SkipTestEnvSet(t, testutil.EnvVarSkipVaultNext)
+		},
 		Providers:    testProviders,
 		CheckDestroy: testAccCheckJWTAuthBackendRoleDestroy,
 		Steps: []resource.TestStep{
@@ -269,7 +278,10 @@ func TestAccJWTAuthBackendRoleOIDC_full(t *testing.T) {
 	role := acctest.RandomWithPrefix("test-role")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		PreCheck: func() {
+			testutil.TestAccPreCheck(t)
+			testutil.SkipTestEnvSet(t, testutil.EnvVarSkipVaultNext)
+		},
 		Providers:    testProviders,
 		CheckDestroy: testAccCheckJWTAuthBackendRoleDestroy,
 		Steps: []resource.TestStep{
@@ -428,7 +440,10 @@ func TestAccJWTAuthBackendRole_fullUpdate(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		PreCheck: func() {
+			testutil.TestAccPreCheck(t)
+			testutil.SkipTestEnvSet(t, testutil.EnvVarSkipVaultNext)
+		},
 		Providers:    testProviders,
 		CheckDestroy: testAccCheckJWTAuthBackendRoleDestroy,
 		Steps: []resource.TestStep{

--- a/vault/resource_jwt_auth_backend_role_test.go
+++ b/vault/resource_jwt_auth_backend_role_test.go
@@ -119,6 +119,8 @@ func TestAccJWTAuthBackendRole_basic(t *testing.T) {
 						"bound_claims_type", "string"),
 					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
 						"user_claim", "https://vault/user"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"user_claim_json_pointer", "false"),
 				),
 			},
 		},
@@ -527,8 +529,8 @@ resource "vault_auth_backend" "jwt" {
 
 resource "vault_jwt_auth_backend_role" "role" {
   backend = vault_auth_backend.jwt.path
-	role_name = "%s"
-	role_type = "jwt"
+  role_name = "%s"
+  role_type = "jwt"
 
   bound_audiences = ["https://myco.test"]
   user_claim = "https://vault/user"
@@ -544,8 +546,8 @@ resource "vault_auth_backend" "jwt" {
 
 resource "vault_jwt_auth_backend_role" "role" {
   backend = vault_auth_backend.jwt.path
-	role_name = "%s"
-	role_type = "jwt"
+  role_name = "%s"
+  role_type = "jwt"
 
   bound_audiences = ["https://myco.test"]
   user_claim = "https://vault/user"

--- a/vault/resource_jwt_auth_backend_role_test.go
+++ b/vault/resource_jwt_auth_backend_role_test.go
@@ -13,13 +13,12 @@ import (
 )
 
 func TestAccJWTAuthBackendRole_import(t *testing.T) {
+	testutil.SkipTestEnvSet(t, testutil.EnvVarSkipVaultNext)
+
 	backend := acctest.RandomWithPrefix("jwt")
 	role := acctest.RandomWithPrefix("test-role")
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testutil.TestAccPreCheck(t)
-			testutil.SkipTestEnvSet(t, testutil.EnvVarSkipVaultNext)
-		},
+		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
 		CheckDestroy: testAccCheckJWTAuthBackendRoleDestroy,
 		Steps: []resource.TestStep{
@@ -87,14 +86,12 @@ func TestAccJWTAuthBackendRole_import(t *testing.T) {
 }
 
 func TestAccJWTAuthBackendRole_basic(t *testing.T) {
+	testutil.SkipTestEnvSet(t, testutil.EnvVarSkipVaultNext)
+
 	backend := acctest.RandomWithPrefix("jwt")
 	role := acctest.RandomWithPrefix("test-role")
-
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testutil.TestAccPreCheck(t)
-			testutil.SkipTestEnvSet(t, testutil.EnvVarSkipVaultNext)
-		},
+		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
 		CheckDestroy: testAccCheckJWTAuthBackendRoleDestroy,
 		Steps: []resource.TestStep{
@@ -207,14 +204,12 @@ func TestAccJWTAuthBackendRole_update(t *testing.T) {
 }
 
 func TestAccJWTAuthBackendRole_full(t *testing.T) {
+	testutil.SkipTestEnvSet(t, testutil.EnvVarSkipVaultNext)
+
 	backend := acctest.RandomWithPrefix("jwt")
 	role := acctest.RandomWithPrefix("test-role")
-
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testutil.TestAccPreCheck(t)
-			testutil.SkipTestEnvSet(t, testutil.EnvVarSkipVaultNext)
-		},
+		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
 		CheckDestroy: testAccCheckJWTAuthBackendRoleDestroy,
 		Steps: []resource.TestStep{
@@ -274,14 +269,12 @@ func TestAccJWTAuthBackendRole_full(t *testing.T) {
 }
 
 func TestAccJWTAuthBackendRoleOIDC_full(t *testing.T) {
+	testutil.SkipTestEnvSet(t, testutil.EnvVarSkipVaultNext)
+
 	backend := acctest.RandomWithPrefix("oidc")
 	role := acctest.RandomWithPrefix("test-role")
-
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testutil.TestAccPreCheck(t)
-			testutil.SkipTestEnvSet(t, testutil.EnvVarSkipVaultNext)
-		},
+		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
 		CheckDestroy: testAccCheckJWTAuthBackendRoleDestroy,
 		Steps: []resource.TestStep{
@@ -385,6 +378,8 @@ func TestAccJWTAuthBackendRoleOIDC_disableParsing(t *testing.T) {
 }
 
 func TestAccJWTAuthBackendRole_fullUpdate(t *testing.T) {
+	testutil.SkipTestEnvSet(t, testutil.EnvVarSkipVaultNext)
+
 	backend := acctest.RandomWithPrefix("jwt")
 	role := acctest.RandomWithPrefix("test-role")
 
@@ -440,10 +435,7 @@ func TestAccJWTAuthBackendRole_fullUpdate(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			testutil.TestAccPreCheck(t)
-			testutil.SkipTestEnvSet(t, testutil.EnvVarSkipVaultNext)
-		},
+		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
 		CheckDestroy: testAccCheckJWTAuthBackendRoleDestroy,
 		Steps: []resource.TestStep{

--- a/vault/resource_jwt_auth_backend_role_test.go
+++ b/vault/resource_jwt_auth_backend_role_test.go
@@ -69,6 +69,8 @@ func TestAccJWTAuthBackendRole_import(t *testing.T) {
 						"not_before_leeway", "120"),
 					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
 						"verbose_oidc_logging", "true"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"user_claim_json_pointer", "true"),
 				),
 			},
 			{
@@ -324,6 +326,10 @@ func TestAccJWTAuthBackendRoleOIDC_full(t *testing.T) {
 						"claim_mappings.preferred_language", "language"),
 					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
 						"verbose_oidc_logging", "true"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"user_claim_json_pointer", "true"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"max_age", "120"),
 				),
 			},
 		},
@@ -415,6 +421,8 @@ func TestAccJWTAuthBackendRole_fullUpdate(t *testing.T) {
 			"verbose_oidc_logging", "true"),
 		resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
 			"bound_claims.%", "0"),
+		resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+			"user_claim_json_pointer", "true"),
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -479,6 +487,8 @@ func TestAccJWTAuthBackendRole_fullUpdate(t *testing.T) {
 						"not_before_leeway", "0"),
 					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
 						"verbose_oidc_logging", "false"),
+					resource.TestCheckResourceAttr("vault_jwt_auth_backend_role.role",
+						"user_claim_json_pointer", "false"),
 				),
 			},
 			// Repeat test case again to remove attributes like `bound_claims`
@@ -570,6 +580,7 @@ resource "vault_jwt_auth_backend_role" "role" {
   not_before_leeway = 120
 
   verbose_oidc_logging = true
+  user_claim_json_pointer = true
 }`, backend, role)
 }
 
@@ -614,6 +625,8 @@ resource "vault_jwt_auth_backend_role" "role" {
   }
 
   verbose_oidc_logging = true
+  user_claim_json_pointer = true
+  max_age = 120
 }`, backend, role)
 }
 
@@ -658,8 +671,8 @@ resource "vault_auth_backend" "jwt" {
 
 resource "vault_jwt_auth_backend_role" "role" {
   backend = vault_auth_backend.jwt.path
-	role_name = "%s"
-	role_type = "jwt"
+  role_name = "%s"
+  role_type = "jwt"
 
   bound_subject = "sl29dlldsfj3uECzsU3Sbmh0F29Fios1@update"
   token_bound_cidrs = ["10.150.0.0/20", "10.152.0.0/20"]
@@ -675,5 +688,6 @@ resource "vault_jwt_auth_backend_role" "role" {
     department = "engineering-*-admin"
     sector = "7g"
   }
+  user_claim_json_pointer = false
 }`, backend, role)
 }

--- a/website/docs/r/jwt_auth_backend_role.html.md
+++ b/website/docs/r/jwt_auth_backend_role.html.md
@@ -69,6 +69,10 @@ The following arguments are supported:
   the user; this will be used as the name for the Identity entity alias created
   due to a successful login.
 
+* `user_claim_json_pointer` - (Optional) Specifies if the `user_claim` value uses
+  [JSON pointer](https://www.vaultproject.io/docs/auth/jwt#claim-specifications-and-json-pointer) 
+  syntax for referencing claims. By default, the `user_claim` value will not use JSON pointer.
+
 * `bound_subject` - (Optional) If set, requires that the `sub` claim matches
   this value.
 
@@ -112,6 +116,9 @@ The following arguments are supported:
 * `verbose_oidc_logging` - (Optional) Log received OIDC tokens and claims when debug-level
   logging is active. Not recommended in production since sensitive information may be present
   in OIDC responses.
+
+* `max_age` - (Optional) Specifies the allowable elapsed time in seconds since the last time 
+  the user was actively authenticated with the OIDC provider.
 
 ### Common Token Arguments
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Relates OR Closes: N/A

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):

```release-note
* `resource/vault_jwt_auth_backend`: Adds support for `user_claim_json_pointer` and `max_age` (#1478)
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-count=1 -run=TestAccJWTAuth'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -count=1 -run=TestAccJWTAuth -timeout 30m ./...
=== RUN   TestAccJWTAuthBackendRole_import
--- PASS: TestAccJWTAuthBackendRole_import (1.62s)
=== RUN   TestAccJWTAuthBackendRole_basic
--- PASS: TestAccJWTAuthBackendRole_basic (1.07s)
=== RUN   TestAccJWTAuthBackendRole_update
--- PASS: TestAccJWTAuthBackendRole_update (1.91s)
=== RUN   TestAccJWTAuthBackendRole_full
--- PASS: TestAccJWTAuthBackendRole_full (1.10s)
=== RUN   TestAccJWTAuthBackendRoleOIDC_full
--- PASS: TestAccJWTAuthBackendRoleOIDC_full (1.57s)
=== RUN   TestAccJWTAuthBackendRoleOIDC_disableParsing
--- PASS: TestAccJWTAuthBackendRoleOIDC_disableParsing (1.24s)
=== RUN   TestAccJWTAuthBackendRole_fullUpdate
--- PASS: TestAccJWTAuthBackendRole_fullUpdate (2.81s)
=== RUN   TestAccJWTAuthBackend
--- PASS: TestAccJWTAuthBackend (3.89s)
=== RUN   TestAccJWTAuthBackendProviderConfig
--- PASS: TestAccJWTAuthBackendProviderConfig (1.11s)
=== RUN   TestAccJWTAuthBackend_OIDC
--- PASS: TestAccJWTAuthBackend_OIDC (1.17s)
=== RUN   TestAccJWTAuthBackend_invalid
--- PASS: TestAccJWTAuthBackend_invalid (0.30s)
=== RUN   TestAccJWTAuthBackend_missingMandatory
--- PASS: TestAccJWTAuthBackend_missingMandatory (1.91s)
=== RUN   TestAccJWTAuthBackendProviderConfigConversionBool
--- PASS: TestAccJWTAuthBackendProviderConfigConversionBool (0.00s)
=== RUN   TestAccJWTAuthBackendProviderConfigConversionInt
--- PASS: TestAccJWTAuthBackendProviderConfigConversionInt (0.00s)
=== RUN   TestAccJWTAuthBackendProviderConfig_negative
    resource_jwt_auth_backend_test.go:380: true
--- SKIP: TestAccJWTAuthBackendProviderConfig_negative (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     21.384s
```
