### PR TITLE
Support setting namespace per resource (#1305)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,6 @@ $ cd $GOPATH/src/github.com/hashicorp/terraform-provider-vault
 $ make build
 ```
 
-Using the provider
-----------------------
-
 Developing the Provider
 ---------------------------
 
@@ -94,3 +91,35 @@ If you wish to run specific tests, use the `TESTARGS` environment variable:
 ```sh
 TESTARGS="--run DataSourceAWSAccessCredentials" make testacc
 ```
+
+Using a local development build
+----------------------
+
+It's possible to use a local build of the Vault provider with Terraform directly.
+This is useful when testing the provider outside the acceptance test framework.
+
+Configure Terraform to use the development build of the provider.
+
+> **warning**: backup your `~/.terraformrc` before running this command:
+ 
+```shell
+cat > ~/.terraformrc <<HERE
+provider_installation {
+  dev_overrides {
+    "hashicorp/vault" = "$HOME/.terraform.d/plugins"
+  }
+  
+  # For all other providers, install them directly from their origin provider
+  # registries as normal. If you omit this, Terraform will _only_ use
+  # the dev_overrides block, and so no other providers will be available.
+  direct {}
+}
+HERE
+```
+
+Then execute the `dev` make target from the project root.
+```shell
+make dev
+```
+Now Terraform is set up to use the `dev` provider build instead of the provider 
+from the HashiCorp registry.

--- a/eval/namespace-enhancements/README.md
+++ b/eval/namespace-enhancements/README.md
@@ -1,0 +1,60 @@
+### Public Evaluation: Enhanced Vault namespace support
+
+This directory contains sample Terraform code which demonstrates an enhanced way 
+of provisioning resources under Vault namespaces. It assumes the following:
+
+- Terraform is installed
+- The provider development requirements are satisfied *see the top level README.md for more info*
+- Root access to a Vault Enterprise server
+
+#### Setup Terraform to use a local build of the Vault provider
+
+> **warning**: backup your `~/.terraformrc` before running this command:
+
+```shell
+cat > ~/.terraformrc <<HERE
+provider_installation {
+  dev_overrides {
+    "hashicorp/vault" = "$HOME/.terraform.d/plugins"
+  }
+  
+  # For all other providers, install them directly from their origin provider
+  # registries as normal. If you omit this, Terraform will _only_ use
+  # the dev_overrides block, and so no other providers will be available.
+  direct {}
+}
+HERE
+```
+
+Then execute the `dev` make target from the project root.
+```shell
+make dev
+```
+
+Now Terraform is set up to use the `dev` provider build instead of the provider
+from the HashiCorp registry.
+
+####  The basic example
+
+Provision a generic KV secret in multiple namespaces using a single `provider{}` block.
+
+Ensure that the `VAULT_TOKEN` and `VAULT_ADDR` environment variables are properly set, 
+or an alternative auth method is configured.
+
+*from the repo root*:
+
+Apply the example
+```shell
+pushd eval/namespace-enhancements/examples/basic/.
+terraform init
+terraform apply
+terraform output -json
+popd
+```
+
+Destroy the example
+```shell
+pushd eval/namespace-enhancements/examples/basic/.
+terraform destroy
+popd
+```

--- a/eval/namespace-enhancements/examples/basic/main.tf
+++ b/eval/namespace-enhancements/examples/basic/main.tf
@@ -1,0 +1,35 @@
+# single provider block
+provider "vault" {}
+
+locals {
+  # provide namespaces as a set
+  namespaces = toset(var.namespaces)
+}
+
+resource "vault_namespace" "demo" {
+  # leverage the for_each meta-argument
+  for_each = local.namespaces
+  path     = each.key
+}
+
+resource "vault_mount" "demo" {
+  for_each  = local.namespaces
+  namespace = vault_namespace.demo[each.key].path
+  path      = "secretsv1"
+  type      = "kv"
+  options = {
+    version = "1"
+  }
+}
+
+resource "vault_generic_secret" "demo" {
+  for_each = local.namespaces
+  # Support namespace at the level of the resource and data source
+  namespace = vault_mount.demo[each.key].namespace
+  path      = "${vault_mount.demo[each.key].path}/secret"
+  data_json = jsonencode(
+    {
+      "baz" = "qux"
+    }
+  )
+}

--- a/eval/namespace-enhancements/examples/basic/outputs.tf
+++ b/eval/namespace-enhancements/examples/basic/outputs.tf
@@ -1,0 +1,8 @@
+output "mount_path" {
+  value = values(vault_mount.demo)[*].path
+}
+
+output "secret_data" {
+  sensitive = true
+  value     = values(vault_generic_secret.demo)[*].data
+}

--- a/eval/namespace-enhancements/examples/basic/variables.tf
+++ b/eval/namespace-enhancements/examples/basic/variables.tf
@@ -1,0 +1,7 @@
+variable "namespaces" {
+  default = [
+    "ns-1",
+    "ns-2",
+    "ns-3",
+  ]
+}

--- a/generated/datasources/transform/decode/role_name.go
+++ b/generated/datasources/transform/decode/role_name.go
@@ -9,8 +9,9 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
-	"github.com/hashicorp/vault/api"
 )
 
 const roleNameEndpoint = "/transform/decode/{role_name}"
@@ -73,7 +74,10 @@ func RoleNameDataSource() *schema.Resource {
 }
 
 func readRoleNameResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	path := d.Get("path").(string)
 	vaultPath := util.ParsePath(path, roleNameEndpoint, d)
 	log.Printf("[DEBUG] Writing %q", vaultPath)

--- a/generated/datasources/transform/encode/role_name.go
+++ b/generated/datasources/transform/encode/role_name.go
@@ -9,8 +9,9 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
-	"github.com/hashicorp/vault/api"
 )
 
 const roleNameEndpoint = "/transform/encode/{role_name}"
@@ -73,7 +74,10 @@ func RoleNameDataSource() *schema.Resource {
 }
 
 func readRoleNameResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	path := d.Get("path").(string)
 	vaultPath := util.ParsePath(path, roleNameEndpoint, d)
 	log.Printf("[DEBUG] Writing %q", vaultPath)

--- a/generated/resources/transform/alphabet/name.go
+++ b/generated/resources/transform/alphabet/name.go
@@ -9,8 +9,9 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
-	"github.com/hashicorp/vault/api"
 )
 
 const nameEndpoint = "/transform/alphabet/{name}"
@@ -50,8 +51,12 @@ func NameResource() *schema.Resource {
 		Schema: fields,
 	}
 }
+
 func createNameResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	path := d.Get("path").(string)
 	vaultPath := util.ParsePath(path, nameEndpoint, d)
 	log.Printf("[DEBUG] Creating %q", vaultPath)
@@ -72,7 +77,10 @@ func createNameResource(d *schema.ResourceData, meta interface{}) error {
 }
 
 func readNameResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	vaultPath := d.Id()
 	log.Printf("[DEBUG] Reading %q", vaultPath)
 
@@ -104,7 +112,10 @@ func readNameResource(d *schema.ResourceData, meta interface{}) error {
 }
 
 func updateNameResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	vaultPath := d.Id()
 	log.Printf("[DEBUG] Updating %q", vaultPath)
 
@@ -120,7 +131,10 @@ func updateNameResource(d *schema.ResourceData, meta interface{}) error {
 }
 
 func deleteNameResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	vaultPath := d.Id()
 	log.Printf("[DEBUG] Deleting %q", vaultPath)
 
@@ -136,7 +150,10 @@ func deleteNameResource(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceNameExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
 	vaultPath := d.Id()
 	log.Printf("[DEBUG] Checking if %q exists", vaultPath)
 

--- a/generated/resources/transform/alphabet/name_test.go
+++ b/generated/resources/transform/alphabet/name_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	sdk_schema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/schema"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 	"github.com/hashicorp/terraform-provider-vault/vault"
@@ -58,7 +58,7 @@ func TestAlphabetName(t *testing.T) {
 }
 
 func destroy(s *terraform.State) error {
-	client := nameTestProvider.SchemaProvider().Meta().(*api.Client)
+	client := nameTestProvider.SchemaProvider().Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_transform_alphabet_name" {

--- a/generated/resources/transform/role/name.go
+++ b/generated/resources/transform/role/name.go
@@ -9,8 +9,9 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
-	"github.com/hashicorp/vault/api"
 )
 
 const nameEndpoint = "/transform/role/{name}"
@@ -51,8 +52,12 @@ func NameResource() *schema.Resource {
 		Schema: fields,
 	}
 }
+
 func createNameResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	path := d.Get("path").(string)
 	vaultPath := util.ParsePath(path, nameEndpoint, d)
 	log.Printf("[DEBUG] Creating %q", vaultPath)
@@ -73,7 +78,10 @@ func createNameResource(d *schema.ResourceData, meta interface{}) error {
 }
 
 func readNameResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	vaultPath := d.Id()
 	log.Printf("[DEBUG] Reading %q", vaultPath)
 
@@ -105,7 +113,10 @@ func readNameResource(d *schema.ResourceData, meta interface{}) error {
 }
 
 func updateNameResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	vaultPath := d.Id()
 	log.Printf("[DEBUG] Updating %q", vaultPath)
 
@@ -121,7 +132,10 @@ func updateNameResource(d *schema.ResourceData, meta interface{}) error {
 }
 
 func deleteNameResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	vaultPath := d.Id()
 	log.Printf("[DEBUG] Deleting %q", vaultPath)
 
@@ -137,7 +151,10 @@ func deleteNameResource(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceNameExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
 	vaultPath := d.Id()
 	log.Printf("[DEBUG] Checking if %q exists", vaultPath)
 

--- a/generated/resources/transform/role/name_test.go
+++ b/generated/resources/transform/role/name_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	sdk_schema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/schema"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 	"github.com/hashicorp/terraform-provider-vault/vault"
@@ -61,7 +61,7 @@ func TestRoleName(t *testing.T) {
 }
 
 func destroy(s *terraform.State) error {
-	client := nameTestProvider.SchemaProvider().Meta().(*api.Client)
+	client := nameTestProvider.SchemaProvider().Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_transform_role_name" {

--- a/generated/resources/transform/template/name.go
+++ b/generated/resources/transform/template/name.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
@@ -96,7 +96,10 @@ Only applicable to FPE transformations.`,
 }
 
 func createNameResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	path := d.Get("path").(string)
 	vaultPath := util.ParsePath(path, nameEndpoint, d)
 	log.Printf("[DEBUG] Creating %q", vaultPath)
@@ -111,7 +114,10 @@ func createNameResource(d *schema.ResourceData, meta interface{}) error {
 }
 
 func readNameResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	vaultPath := d.Id()
 	log.Printf("[DEBUG] Reading %q", vaultPath)
 
@@ -147,7 +153,10 @@ func readNameResource(d *schema.ResourceData, meta interface{}) error {
 }
 
 func updateNameResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	vaultPath := d.Id()
 	log.Printf("[DEBUG] Updating %q", vaultPath)
 
@@ -170,7 +179,10 @@ func requestData(d *schema.ResourceData, fields []string) map[string]interface{}
 }
 
 func deleteNameResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	vaultPath := d.Id()
 	log.Printf("[DEBUG] Deleting %q", vaultPath)
 
@@ -186,7 +198,10 @@ func deleteNameResource(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceNameExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
 	vaultPath := d.Id()
 	log.Printf("[DEBUG] Checking if %q exists", vaultPath)
 

--- a/generated/resources/transform/template/name_test.go
+++ b/generated/resources/transform/template/name_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	sdk_schema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
 	"github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/schema"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 	"github.com/hashicorp/terraform-provider-vault/vault"
@@ -78,7 +78,7 @@ func TestTemplateName(t *testing.T) {
 }
 
 func destroy(s *terraform.State) error {
-	client := nameTestProvider.SchemaProvider().Meta().(*api.Client)
+	client := nameTestProvider.SchemaProvider().Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_transform_template_name" {

--- a/generated/resources/transform/transformation/name.go
+++ b/generated/resources/transform/transformation/name.go
@@ -9,8 +9,9 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
-	"github.com/hashicorp/vault/api"
 )
 
 const nameEndpoint = "/transform/transformation/{name}"
@@ -78,8 +79,12 @@ func NameResource() *schema.Resource {
 		Schema: fields,
 	}
 }
+
 func createNameResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	path := d.Get("path").(string)
 	vaultPath := util.ParsePath(path, nameEndpoint, d)
 	log.Printf("[DEBUG] Creating %q", vaultPath)
@@ -112,7 +117,10 @@ func createNameResource(d *schema.ResourceData, meta interface{}) error {
 }
 
 func readNameResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	vaultPath := d.Id()
 	log.Printf("[DEBUG] Reading %q", vaultPath)
 
@@ -169,7 +177,10 @@ func readNameResource(d *schema.ResourceData, meta interface{}) error {
 }
 
 func updateNameResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	vaultPath := d.Id()
 	log.Printf("[DEBUG] Updating %q", vaultPath)
 
@@ -197,7 +208,10 @@ func updateNameResource(d *schema.ResourceData, meta interface{}) error {
 }
 
 func deleteNameResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	vaultPath := d.Id()
 	log.Printf("[DEBUG] Deleting %q", vaultPath)
 
@@ -213,7 +227,10 @@ func deleteNameResource(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceNameExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
 	vaultPath := d.Id()
 	log.Printf("[DEBUG] Checking if %q exists", vaultPath)
 

--- a/generated/resources/transform/transformation/name_test.go
+++ b/generated/resources/transform/transformation/name_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	sdk_schema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/schema"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 	"github.com/hashicorp/terraform-provider-vault/vault"
@@ -104,7 +104,7 @@ func TestTransformationName(t *testing.T) {
 }
 
 func destroy(s *terraform.State) error {
-	client := nameTestProvider.SchemaProvider().Meta().(*api.Client)
+	client := nameTestProvider.SchemaProvider().Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_transform_transformation_name" {

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -1,0 +1,13 @@
+package consts
+
+const (
+	// common field names
+	FieldPath       = "path"
+	FieldParameters = "parameters"
+	FieldMethod     = "method"
+	FieldNamespace  = "namespace"
+
+	// env vars
+	EnvVarVaultNamespaceImport = "TERRAFORM_VAULT_NAMESPACE_IMPORT"
+	EnvVarSkipChildToken       = "TERRAFORM_VAULT_SKIP_CHILD_TOKEN"
+)

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -1,0 +1,409 @@
+package provider
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-secure-stdlib/awsutil"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/vault/api"
+	"github.com/hashicorp/vault/command/config"
+
+	"github.com/hashicorp/terraform-provider-vault/helper"
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+)
+
+var MaxHTTPRetriesCCC int
+
+// ProviderMeta provides resources with access to the Vault client and
+// other bits
+type ProviderMeta struct {
+	client       *api.Client
+	resourceData *schema.ResourceData
+	clientCache  map[string]*api.Client
+	m            sync.RWMutex
+}
+
+// GetClient returns the providers default Vault client.
+func (p *ProviderMeta) GetClient() *api.Client {
+	return p.client
+}
+
+// GetNSClient returns a namespaced Vault client.
+// The provided namespace will always be set relative to the default client's
+// namespace.
+func (p *ProviderMeta) GetNSClient(ns string) (*api.Client, error) {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	if err := p.validate(); err != nil {
+		return nil, err
+	}
+
+	if ns == "" {
+		return nil, fmt.Errorf("empty namespace not allowed")
+	}
+
+	ns = strings.Trim(ns, "/")
+	if root, ok := p.resourceData.GetOk(consts.FieldNamespace); ok && root.(string) != "" {
+		ns = fmt.Sprintf("%s/%s", root, ns)
+	}
+
+	if p.clientCache == nil {
+		p.clientCache = make(map[string]*api.Client)
+	}
+
+	if v, ok := p.clientCache[ns]; ok {
+		return v, nil
+	}
+
+	c, err := p.client.Clone()
+	if err != nil {
+		return nil, err
+	}
+
+	c.SetNamespace(ns)
+	p.clientCache[ns] = c
+
+	return c, nil
+}
+
+func (p *ProviderMeta) validate() error {
+	if p.client == nil {
+		return fmt.Errorf("root api.Client not set, init with NewProviderMeta()")
+	}
+
+	if p.resourceData == nil {
+		return fmt.Errorf("provider ResourceData not set, init with NewProviderMeta()")
+	}
+
+	return nil
+}
+
+// NewProviderMeta sets up the Provider to service Vault requests.
+// It is meant to be used as a schema.ConfigureFunc.
+func NewProviderMeta(d *schema.ResourceData) (interface{}, error) {
+	clientConfig := api.DefaultConfig()
+	addr := d.Get("address").(string)
+	if addr != "" {
+		clientConfig.Address = addr
+	}
+
+	clientAuthI := d.Get("client_auth").([]interface{})
+	if len(clientAuthI) > 1 {
+		return nil, fmt.Errorf("client_auth block may appear only once")
+	}
+
+	clientAuthCert := ""
+	clientAuthKey := ""
+	if len(clientAuthI) == 1 {
+		clientAuth := clientAuthI[0].(map[string]interface{})
+		clientAuthCert = clientAuth["cert_file"].(string)
+		clientAuthKey = clientAuth["key_file"].(string)
+	}
+
+	err := clientConfig.ConfigureTLS(&api.TLSConfig{
+		CACert:        d.Get("ca_cert_file").(string),
+		CAPath:        d.Get("ca_cert_dir").(string),
+		Insecure:      d.Get("skip_tls_verify").(bool),
+		TLSServerName: d.Get("tls_server_name").(string),
+
+		ClientCert: clientAuthCert,
+		ClientKey:  clientAuthKey,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to configure TLS for Vault API: %s", err)
+	}
+
+	clientConfig.HttpClient.Transport = helper.NewTransport(
+		"Vault",
+		clientConfig.HttpClient.Transport,
+		helper.DefaultTransportOptions(),
+	)
+
+	// enable ReadYourWrites to support read-after-write on Vault Enterprise
+	clientConfig.ReadYourWrites = true
+
+	// set default MaxRetries
+	clientConfig.MaxRetries = DefaultMaxHTTPRetries
+
+	client, err := api.NewClient(clientConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to configure Vault API: %s", err)
+	}
+
+	// setting this is critical for proper namespace handling
+	client.SetCloneHeaders(true)
+
+	// setting this is critical for proper client cloning
+	client.SetCloneToken(true)
+
+	// Set headers if provided
+	headers := d.Get("headers").([]interface{})
+	parsedHeaders := client.Headers().Clone()
+
+	if parsedHeaders == nil {
+		parsedHeaders = make(http.Header)
+	}
+
+	for _, h := range headers {
+		header := h.(map[string]interface{})
+		if name, ok := header["name"]; ok {
+			parsedHeaders.Add(name.(string), header["value"].(string))
+		}
+	}
+	client.SetHeaders(parsedHeaders)
+
+	client.SetMaxRetries(d.Get("max_retries").(int))
+
+	MaxHTTPRetriesCCC = d.Get("max_retries_ccc").(int)
+
+	// Try and get the token from the config or token helper
+	token, err := GetToken(d)
+	if err != nil {
+		return nil, err
+	}
+
+	// Attempt to use auth/<mount>login if 'auth_login' is provided in provider config
+	authLoginI := d.Get("auth_login").([]interface{})
+	if len(authLoginI) > 1 {
+		return "", fmt.Errorf("auth_login block may appear only once")
+	}
+
+	if len(authLoginI) == 1 {
+		authLogin := authLoginI[0].(map[string]interface{})
+		authLoginPath := authLogin[consts.FieldPath].(string)
+		authLoginNamespace := ""
+		if authLoginNamespaceI, ok := authLogin[consts.FieldNamespace]; ok {
+			authLoginNamespace = authLoginNamespaceI.(string)
+			client.SetNamespace(authLoginNamespace)
+		}
+		authLoginParameters := authLogin[consts.FieldParameters].(map[string]interface{})
+
+		method := authLogin[consts.FieldMethod].(string)
+		if method == "aws" {
+			logger := hclog.Default()
+			if logging.IsDebugOrHigher() {
+				logger.SetLevel(hclog.Debug)
+			} else {
+				logger.SetLevel(hclog.Error)
+			}
+			if err := signAWSLogin(authLoginParameters, logger); err != nil {
+				return nil, fmt.Errorf("error signing AWS login request: %s", err)
+			}
+		}
+
+		secret, err := client.Logical().Write(authLoginPath, authLoginParameters)
+		if err != nil {
+			return nil, err
+		}
+		token = secret.Auth.ClientToken
+	}
+	if token != "" {
+		client.SetToken(token)
+	}
+	if client.Token() == "" {
+		return nil, errors.New("no vault token found")
+	}
+
+	skipChildToken := d.Get("skip_child_token").(bool)
+	if !skipChildToken {
+		err := setChildToken(d, client)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Set the namespace to the requested namespace, if provided
+	namespace := d.Get(consts.FieldNamespace).(string)
+	if namespace != "" {
+		client.SetNamespace(namespace)
+	}
+
+	return &ProviderMeta{
+		resourceData: d,
+		client:       client,
+	}, nil
+}
+
+// GetClient is meant to be called from a schema.Resource function.
+// It ensures that the returned api.Client's matches the resource's configured
+// namespace. The value for the namespace is resolved from *schema.ResourceData,
+// *schema.ResourceDiff, or *terraform.InstanceState.
+func GetClient(i interface{}, meta interface{}) (*api.Client, error) {
+	p, ok := meta.(*ProviderMeta)
+	if p == nil || !ok {
+		return nil, fmt.Errorf("meta argument must be a ProviderMeta")
+	}
+
+	var ns string
+	switch v := i.(type) {
+	case *schema.ResourceData:
+		if v, ok := v.GetOk(consts.FieldNamespace); ok {
+			ns = v.(string)
+		}
+	case *schema.ResourceDiff:
+		if v, ok := v.GetOk(consts.FieldNamespace); ok {
+			ns = v.(string)
+		}
+	case *terraform.InstanceState:
+		ns = v.Attributes[consts.FieldNamespace]
+	default:
+		return nil, fmt.Errorf("GetClient() called with unsupported type %T", v)
+	}
+
+	if ns == "" {
+		// in order to import namespaced resources the user must provide
+		// the namespace from an environment variable.
+		ns = os.Getenv(consts.EnvVarVaultNamespaceImport)
+		if ns != "" {
+			log.Printf("[DEBUG] Value for %q set from environment", consts.FieldNamespace)
+		}
+	}
+
+	if ns != "" {
+		return p.GetNSClient(ns)
+	}
+
+	return p.GetClient(), nil
+}
+
+func setChildToken(d *schema.ResourceData, c *api.Client) error {
+	tokenName := d.Get("token_name").(string)
+	if tokenName == "" {
+		tokenName = "terraform"
+	}
+
+	// In order to enforce our relatively-short lease TTL, we derive a
+	// temporary child token that inherits all of the policies of the
+	// token we were given but expires after max_lease_ttl_seconds.
+	//
+	// The intent here is that Terraform will need to re-fetch any
+	// secrets on each run and so we limit the exposure risk of secrets
+	// that end up stored in the Terraform state, assuming that they are
+	// credentials that Vault is able to revoke.
+	//
+	// Caution is still required with state files since not all secrets
+	// can explicitly be revoked, and this limited scope won't apply to
+	// any secrets that are *written* by Terraform to Vault.
+
+	// Set the namespace to the token's namespace only for the
+	// child token creation
+	tokenInfo, err := c.Auth().Token().LookupSelf()
+	if err != nil {
+		return err
+	}
+	if tokenNamespaceRaw, ok := tokenInfo.Data["namespace_path"]; ok {
+		tokenNamespace := tokenNamespaceRaw.(string)
+		if tokenNamespace != "" {
+			c.SetNamespace(tokenNamespace)
+		}
+	}
+
+	renewable := false
+	childTokenLease, err := c.Auth().Token().Create(&api.TokenCreateRequest{
+		DisplayName:    tokenName,
+		TTL:            fmt.Sprintf("%ds", d.Get("max_lease_ttl_seconds").(int)),
+		ExplicitMaxTTL: fmt.Sprintf("%ds", d.Get("max_lease_ttl_seconds").(int)),
+		Renewable:      &renewable,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create limited child token: %s", err)
+	}
+
+	childToken := childTokenLease.Auth.ClientToken
+	policies := childTokenLease.Auth.Policies
+
+	log.Printf("[INFO] Using Vault token with the following policies: %s", strings.Join(policies, ", "))
+
+	// Set the token to the generated child token
+	c.SetToken(childToken)
+
+	return nil
+}
+
+func signAWSLogin(parameters map[string]interface{}, logger hclog.Logger) error {
+	var accessKey, secretKey, securityToken string
+	if val, ok := parameters["aws_access_key_id"].(string); ok {
+		accessKey = val
+	}
+
+	if val, ok := parameters["aws_secret_access_key"].(string); ok {
+		secretKey = val
+	}
+
+	if val, ok := parameters["aws_security_token"].(string); ok {
+		securityToken = val
+	}
+
+	creds, err := awsutil.RetrieveCreds(accessKey, secretKey, securityToken, logger)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve AWS credentials: %s", err)
+	}
+
+	var headerValue, stsRegion string
+	if val, ok := parameters["header_value"].(string); ok {
+		headerValue = val
+	}
+
+	if val, ok := parameters["sts_region"].(string); ok {
+		stsRegion = val
+	}
+
+	loginData, err := awsutil.GenerateLoginData(creds, headerValue, stsRegion, logger)
+	if err != nil {
+		return fmt.Errorf("failed to generate AWS login data: %s", err)
+	}
+
+	parameters["iam_http_request_method"] = loginData["iam_http_request_method"]
+	parameters["iam_request_url"] = loginData["iam_request_url"]
+	parameters["iam_request_headers"] = loginData["iam_request_headers"]
+	parameters["iam_request_body"] = loginData["iam_request_body"]
+
+	return nil
+}
+
+func GetToken(d *schema.ResourceData) (string, error) {
+	if token := d.Get("token").(string); token != "" {
+		return token, nil
+	}
+
+	if addAddr := d.Get("add_address_to_env").(string); addAddr == "true" {
+		if addr := d.Get("address").(string); addr != "" {
+			addrEnvVar := api.EnvVaultAddress
+			if current, exists := os.LookupEnv(addrEnvVar); exists {
+				defer func() {
+					os.Setenv(addrEnvVar, current)
+				}()
+			} else {
+				defer func() {
+					os.Unsetenv(addrEnvVar)
+				}()
+			}
+			if err := os.Setenv(addrEnvVar, addr); err != nil {
+				return "", err
+			}
+		}
+	}
+
+	// Use ~/.vault-token, or the configured token helper.
+	tokenHelper, err := config.DefaultTokenHelper()
+	if err != nil {
+		return "", fmt.Errorf("error getting token helper: %s", err)
+	}
+	token, err := tokenHelper.Get()
+	if err != nil {
+		return "", fmt.Errorf("error getting token: %s", err)
+	}
+	return strings.TrimSpace(token), nil
+}
+
+const DefaultMaxHTTPRetries = 2

--- a/internal/provider/meta_test.go
+++ b/internal/provider/meta_test.go
@@ -1,0 +1,345 @@
+package provider
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/vault/api"
+	vault_consts "github.com/hashicorp/vault/sdk/helper/consts"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+)
+
+func TestProviderMeta_GetNSClient(t *testing.T) {
+	rootClient, err := api.NewClient(api.DefaultConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name         string
+		client       *api.Client
+		resourceData *schema.ResourceData
+		ns           string
+		expectNs     string
+		wantErr      bool
+		expectErr    error
+		calls        int
+	}{
+		{
+			name:         "no-client",
+			client:       nil,
+			resourceData: &schema.ResourceData{},
+			wantErr:      true,
+			expectErr:    errors.New("root api.Client not set, init with NewProviderMeta()"),
+		},
+		{
+			name:         "no-resource-data",
+			client:       &api.Client{},
+			resourceData: nil,
+			wantErr:      true,
+			expectErr:    errors.New("provider ResourceData not set, init with NewProviderMeta()"),
+		},
+		{
+			name:   "basic-no-root-ns",
+			client: rootClient,
+			resourceData: schema.TestResourceDataRaw(t,
+				map[string]*schema.Schema{
+					"namespace": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+				},
+				map[string]interface{}{},
+			),
+			ns:       "foo",
+			expectNs: "foo",
+		},
+		{
+			name:   "basic-root-ns",
+			client: rootClient,
+			resourceData: schema.TestResourceDataRaw(t,
+				map[string]*schema.Schema{
+					"namespace": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+				},
+				map[string]interface{}{
+					"namespace": "bar",
+				},
+			),
+			ns:       "foo",
+			expectNs: "bar/foo",
+			calls:    5,
+		},
+		{
+			name:   "basic-root-ns-trimmed",
+			client: rootClient,
+			resourceData: schema.TestResourceDataRaw(t,
+				map[string]*schema.Schema{
+					"namespace": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+				},
+				map[string]interface{}{
+					"namespace": "bar",
+				},
+			),
+			ns:       "/foo/",
+			expectNs: "bar/foo",
+			calls:    5,
+		},
+	}
+
+	assertClientCache := func(t *testing.T, p *ProviderMeta, expectedCache map[string]*api.Client) {
+		t.Helper()
+
+		if !reflect.DeepEqual(expectedCache, p.clientCache) {
+			t.Errorf("GetNSClient() expected Client cache %#v, actual %#v", expectedCache, p.clientCache)
+		}
+	}
+
+	assertClientNs := func(t *testing.T, c *api.Client, expectNs string) {
+		actualNs := c.Headers().Get(vault_consts.NamespaceHeaderName)
+		if actualNs != expectNs {
+			t.Errorf("GetNSClient() got ns = %v, want %v", actualNs, expectNs)
+		}
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &ProviderMeta{
+				client:       tt.client,
+				resourceData: tt.resourceData,
+			}
+			got, err := p.GetNSClient(tt.ns)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetNSClient() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("GetNSClient() expected an err, actual %#v", err)
+				}
+
+				if !reflect.DeepEqual(err, tt.expectErr) {
+					t.Errorf("GetNSClient() expected err %#v, actual %#v", tt.expectErr, err)
+				}
+
+				var expectedCache map[string]*api.Client
+				assertClientCache(t, p, expectedCache)
+
+				return
+			}
+
+			assertClientCache(t, p, map[string]*api.Client{
+				tt.expectNs: got,
+			})
+			assertClientNs(t, got, tt.expectNs)
+
+			// test cache locking
+			if tt.calls > 0 {
+				var wg sync.WaitGroup
+				p.clientCache = nil
+				wg.Add(tt.calls)
+				for i := 0; i < tt.calls; i++ {
+					go func() {
+						defer wg.Done()
+						got, err := p.GetNSClient(tt.ns)
+						if err != nil {
+							t.Error(err)
+							return
+						}
+
+						assertClientCache(t, p, map[string]*api.Client{
+							tt.expectNs: got,
+						})
+						assertClientNs(t, got, tt.expectNs)
+					}()
+				}
+				wg.Wait()
+			}
+		})
+	}
+}
+
+func TestGetClient(t *testing.T) {
+	rootClient, err := api.NewClient(api.DefaultConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// testing schema.ResourceDiff is not covered here
+	// since its field members are private.
+
+	rscData := func(t *testing.T, set bool, ns string) interface{} {
+		i := schema.TestResourceDataRaw(t,
+			map[string]*schema.Schema{
+				consts.FieldNamespace: {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			},
+			map[string]interface{}{},
+		)
+		if set {
+			if err := i.Set(consts.FieldNamespace, ns); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return i
+	}
+
+	instanceState := func(_ *testing.T, set bool, ns string) interface{} {
+		i := &terraform.InstanceState{
+			Attributes: map[string]string{},
+		}
+		if set {
+			i.Attributes[consts.FieldNamespace] = ns
+		}
+		return i
+	}
+
+	tests := []struct {
+		name      string
+		meta      *ProviderMeta
+		ifcNS     string
+		envNS     string
+		want      string
+		wantErr   bool
+		expectErr error
+		setAttr   bool
+		ifaceFunc func(t *testing.T, set bool, ns string) interface{}
+	}{
+		{
+			name:  "rsc-data",
+			ifcNS: "ns1-rsc-data",
+			meta: &ProviderMeta{
+				client:       rootClient,
+				resourceData: nil,
+			},
+			ifaceFunc: rscData,
+			want:      "ns1-rsc-data",
+			setAttr:   true,
+		},
+		{
+			name:  "inst-state",
+			ifcNS: "ns1-inst-state",
+			meta: &ProviderMeta{
+				client:       rootClient,
+				resourceData: nil,
+			},
+			want:      "ns1-inst-state",
+			setAttr:   true,
+			ifaceFunc: instanceState,
+		},
+		{
+			name: "import-env",
+			meta: &ProviderMeta{
+				client:       rootClient,
+				resourceData: nil,
+			},
+			ifaceFunc: instanceState,
+			envNS:     "ns1-import-env",
+			want:      "ns1-import-env",
+			setAttr:   false,
+		},
+		{
+			name: "ignore-env-rsc-data",
+			meta: &ProviderMeta{
+				client:       rootClient,
+				resourceData: nil,
+			},
+			ifaceFunc: rscData,
+			ifcNS:     "ns1",
+			envNS:     "ns1-import-env",
+			want:      "ns1",
+			setAttr:   true,
+		},
+		{
+			name: "ignore-env-inst-state",
+			meta: &ProviderMeta{
+				client:       rootClient,
+				resourceData: nil,
+			},
+			ifaceFunc: instanceState,
+			ifcNS:     "ns1",
+			envNS:     "ns1-import-env",
+			want:      "ns1",
+			setAttr:   true,
+		},
+		{
+			name: "error-unsupported-type",
+			meta: &ProviderMeta{
+				client:       rootClient,
+				resourceData: nil,
+			},
+			ifaceFunc: func(t *testing.T, set bool, ns string) interface{} {
+				return nil
+			},
+			wantErr:   true,
+			expectErr: fmt.Errorf("GetClient() called with unsupported type <nil>"),
+		},
+		{
+			name:      "error-not-provider-meta",
+			meta:      nil,
+			wantErr:   true,
+			expectErr: fmt.Errorf("meta argument must be a ProviderMeta"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.meta != nil {
+				tt.meta.resourceData = schema.TestResourceDataRaw(t,
+					map[string]*schema.Schema{
+						consts.FieldNamespace: {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+					map[string]interface{}{},
+				)
+			}
+
+			var i interface{}
+			if tt.ifaceFunc != nil {
+				i = tt.ifaceFunc(t, tt.setAttr, tt.ifcNS)
+			}
+
+			// set ns in env
+			if tt.envNS != "" {
+				if err := os.Setenv(consts.EnvVarVaultNamespaceImport, tt.envNS); err != nil {
+					t.Fatal(err)
+				}
+				defer os.Unsetenv(consts.EnvVarVaultNamespaceImport)
+			}
+
+			got, err := GetClient(i, tt.meta)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("GetClient() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+				if !reflect.DeepEqual(err, tt.expectErr) {
+					t.Errorf("GetClient() expected err %#v, actual %#v", tt.expectErr, err)
+				}
+				return
+			}
+
+			actual := got.Headers().Get(vault_consts.NamespaceHeaderName)
+			if !reflect.DeepEqual(actual, tt.want) {
+				t.Errorf("GetClient() got = %v, want %v", actual, tt.want)
+			}
+		})
+	}
+}

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -24,7 +24,7 @@ const (
 )
 
 func TestAccPreCheck(t *testing.T) {
-	FatalTestEnvUnset(t, "VAULT_ADDR", "VAULT_TOKEN")
+	FatalTestEnvUnset(t, api.EnvVaultAddress, api.EnvVaultToken)
 }
 
 func TestEntPreCheck(t *testing.T) {

--- a/vault/data_identity_entity.go
+++ b/vault/data_identity_entity.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 var (
@@ -195,7 +197,6 @@ func identityEntityDataSource() *schema.Resource {
 func identityEntityLookup(client *api.Client, data map[string]interface{}) (*api.Secret, error) {
 	log.Print("[DEBUG] Looking up IdentityEntity")
 	resp, err := client.Logical().Write("identity/lookup/entity", data)
-
 	if err != nil {
 		return nil, fmt.Errorf("Error reading Identity Entity '%v': %s", data, err)
 	}
@@ -213,10 +214,12 @@ func identityEntityLookup(client *api.Client, data map[string]interface{}) (*api
 }
 
 func identityEntityDataSourceRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	data := map[string]interface{}{}
-
 	if v, ok := d.GetOk("entity_name"); ok {
 		data["name"] = v.(string)
 	}
@@ -235,7 +238,6 @@ func identityEntityDataSourceRead(d *schema.ResourceData, meta interface{}) erro
 
 	log.Print("[DEBUG] Reading IdentityEntity")
 	resp, err := identityEntityLookup(client, data)
-
 	if err != nil {
 		return err
 	}

--- a/vault/data_identity_entity_test.go
+++ b/vault/data_identity_entity_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -69,7 +69,7 @@ func testDataSourceIdentityEntity_check() resource.TestCheckFunc {
 		}
 
 		id := instanceState.ID
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 		resp, err := identityEntityLookup(client, map[string]interface{}{"id": id})
 		if err != nil {

--- a/vault/data_identity_group.go
+++ b/vault/data_identity_group.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 var (
@@ -170,7 +172,6 @@ func identityGroupDataSource() *schema.Resource {
 func identityGroupLookup(client *api.Client, data map[string]interface{}) (*api.Secret, error) {
 	log.Print("[DEBUG] Looking up IdentityGroup")
 	resp, err := client.Logical().Write("identity/lookup/group", data)
-
 	if err != nil {
 		return nil, fmt.Errorf("Error reading Identity Group '%v': %s", data, err)
 	}
@@ -188,7 +189,10 @@ func identityGroupLookup(client *api.Client, data map[string]interface{}) (*api.
 }
 
 func identityGroupDataSourceRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	data := map[string]interface{}{}
 
@@ -210,7 +214,6 @@ func identityGroupDataSourceRead(d *schema.ResourceData, meta interface{}) error
 
 	log.Print("[DEBUG] Reading IdentityGroup")
 	resp, err := identityGroupLookup(client, data)
-
 	if err != nil {
 		return err
 	}

--- a/vault/data_identity_group_test.go
+++ b/vault/data_identity_group_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -69,7 +69,7 @@ func testDataSourceIdentityGroup_check(resource string) resource.TestCheckFunc {
 		}
 
 		id := instanceState.ID
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 		resp, err := identityGroupLookup(client, map[string]interface{}{"id": id})
 		if err != nil {

--- a/vault/data_identity_oidc_client_creds.go
+++ b/vault/data_identity_oidc_client_creds.go
@@ -5,7 +5,8 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func identityOIDCClientCredsDataSource() *schema.Resource {
@@ -33,7 +34,10 @@ func identityOIDCClientCredsDataSource() *schema.Resource {
 }
 
 func readOIDCClientCredsResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	name := d.Get("name").(string)
 	path := getOIDCClientPath(name)
 

--- a/vault/data_identity_oidc_openid_config.go
+++ b/vault/data_identity_oidc_openid_config.go
@@ -7,7 +7,8 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 const identityOIDCOpenIDConfigPathSuffix = "/.well-known/openid-configuration"
@@ -104,7 +105,10 @@ func identityOIDCOpenIDConfigDataSource() *schema.Resource {
 }
 
 func readOIDCOpenIDConfigResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	name := d.Get("name").(string)
 	path := "/v1/" + getOIDCProviderPath(name) + identityOIDCOpenIDConfigPathSuffix
 	r := client.NewRequest("GET", path)

--- a/vault/data_identity_oidc_openid_config_test.go
+++ b/vault/data_identity_oidc_openid_config_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/vault/api"
 
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
@@ -21,7 +22,7 @@ func TestDataSourceIdentityOIDCOpenIDConfig(t *testing.T) {
 	keyName := acctest.RandomWithPrefix("test-key")
 	clientName := acctest.RandomWithPrefix("test-client")
 
-	u, err := url.Parse(os.Getenv("VAULT_ADDR"))
+	u, err := url.Parse(os.Getenv(api.EnvVaultAddress))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/vault/data_identity_oidc_public_keys.go
+++ b/vault/data_identity_oidc_public_keys.go
@@ -7,7 +7,8 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 const identityOIDCPublicKeysPathSuffix = "/.well-known/keys"
@@ -35,7 +36,10 @@ func identityOIDCPublicKeysDataSource() *schema.Resource {
 }
 
 func readOIDCPublicKeysResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	name := d.Get("name").(string)
 	path := "/v1/" + getOIDCProviderPath(name) + identityOIDCPublicKeysPathSuffix
 	r := client.NewRequest("GET", path)

--- a/vault/data_source_ad_credentials.go
+++ b/vault/data_source_ad_credentials.go
@@ -2,9 +2,11 @@ package vault
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
 	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func adAccessCredentialsDataSource() *schema.Resource {
@@ -42,7 +44,11 @@ func adAccessCredentialsDataSource() *schema.Resource {
 }
 
 func readCredsResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	backend := d.Get("backend").(string)
 	role := d.Get("role").(string)
 	path := fmt.Sprintf("%s/creds/%s", backend, role)

--- a/vault/data_source_approle_auth_backend_role_id.go
+++ b/vault/data_source_approle_auth_backend_role_id.go
@@ -6,7 +6,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func approleAuthBackendRoleIDDataSource() *schema.Resource {
@@ -41,7 +42,10 @@ func approleAuthBackendRoleIDDataSource() *schema.Resource {
 }
 
 func approleAuthBackendRoleIDRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := approleAuthBackendRolePath(d.Get("backend").(string), d.Get("role_name").(string))
 

--- a/vault/data_source_auth_backend.go
+++ b/vault/data_source_auth_backend.go
@@ -5,7 +5,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func authBackendDataSource() *schema.Resource {
@@ -57,7 +58,10 @@ func authBackendDataSource() *schema.Resource {
 }
 
 func authBackendDataSourceRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	targetPath := d.Get("path").(string)
 

--- a/vault/data_source_aws_access_credentials.go
+++ b/vault/data_source_aws_access_credentials.go
@@ -14,7 +14,8 @@ import (
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 const (
@@ -125,7 +126,10 @@ func awsAccessCredentialsDataSource() *schema.Resource {
 }
 
 func awsAccessCredentialsDataSourceRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 	credType := d.Get("type").(string)

--- a/vault/data_source_azure_access_credentials.go
+++ b/vault/data_source_azure_access_credentials.go
@@ -14,6 +14,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/sdk/helper/pointerutil"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func azureAccessCredentialsDataSource() *schema.Resource {
@@ -109,7 +111,10 @@ Some possible values: AzurePublicCloud, AzureGovernmentCloud`,
 }
 
 func azureAccessCredentialsDataSourceRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 	role := d.Get("role").(string)
@@ -204,21 +209,21 @@ func azureAccessCredentialsDataSourceRead(d *schema.ResourceData, meta interface
 	}
 
 	clientOptions := &arm.ClientOptions{}
-	var e string
+	var environment string
 	if v, ok := d.GetOk("environment"); ok {
-		e = v.(string)
+		environment = v.(string)
 	} else {
 		data, err := getConfigData()
 		if err != nil {
 			return err
 		}
 		if v, ok := data["environment"]; ok && v.(string) != "" {
-			e = v.(string)
+			environment = v.(string)
 		}
 	}
 
-	if e != "" {
-		env, err := azure.EnvironmentFromName(e)
+	if environment != "" {
+		env, err := azure.EnvironmentFromName(environment)
 		if err != nil {
 			return err
 		}

--- a/vault/data_source_gcp_auth_backend_role.go
+++ b/vault/data_source_gcp_auth_backend_role.go
@@ -6,21 +6,20 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
-var (
-	gcpRoleFields = []string{
-		"role_id",
-		"type",
-		"bound_service_accounts",
-		"bound_projects",
-		"bound_zones",
-		"bound_regions",
-		"bound_instance_groups",
-		"token_policies",
-	}
-)
+var gcpRoleFields = []string{
+	"role_id",
+	"type",
+	"bound_service_accounts",
+	"bound_projects",
+	"bound_zones",
+	"bound_regions",
+	"bound_instance_groups",
+	"token_policies",
+}
 
 func gcpAuthBackendRoleDataSource() *schema.Resource {
 	fields := map[string]*schema.Schema{
@@ -110,7 +109,10 @@ func gcpAuthBackendRoleDataSource() *schema.Resource {
 }
 
 func gcpAuthBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := gcpRoleResourcePath(d.Get("backend").(string), d.Get("role_name").(string))
 

--- a/vault/data_source_generic_secret.go
+++ b/vault/data_source_generic_secret.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/hashicorp/vault/api"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func genericSecretDataSource() *schema.Resource {
@@ -79,7 +79,10 @@ func genericSecretDataSource() *schema.Resource {
 }
 
 func genericSecretDataSourceRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Get("path").(string)
 

--- a/vault/data_source_kubernetes_auth_backend_config.go
+++ b/vault/data_source_kubernetes_auth_backend_config.go
@@ -1,12 +1,13 @@
 package vault
 
 import (
+	"fmt"
+	"log"
 	"strings"
 
-	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
-	"log"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func kubernetesAuthBackendConfigDataSource() *schema.Resource {
@@ -66,7 +67,10 @@ func kubernetesAuthBackendConfigDataSource() *schema.Resource {
 }
 
 func kubernetesAuthBackendConfigDataSourceRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := kubernetesAuthBackendConfigPath(d.Get("backend").(string))
 

--- a/vault/data_source_kubernetes_auth_backend_role.go
+++ b/vault/data_source_kubernetes_auth_backend_role.go
@@ -6,7 +6,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func kubernetesAuthBackendRoleDataSource() *schema.Resource {
@@ -63,7 +64,10 @@ func kubernetesAuthBackendRoleDataSource() *schema.Resource {
 }
 
 func kubernetesAuthBackendRoleDataSourceRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 	role := d.Get("role_name").(string)

--- a/vault/data_source_nomad_credentials.go
+++ b/vault/data_source_nomad_credentials.go
@@ -5,7 +5,8 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func nomadAccessCredentialsDataSource() *schema.Resource {
@@ -38,7 +39,11 @@ func nomadAccessCredentialsDataSource() *schema.Resource {
 }
 
 func readNomadCredsResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	backend := d.Get("backend").(string)
 	role := d.Get("role").(string)
 	path := fmt.Sprintf("%s/creds/%s", backend, role)

--- a/vault/data_source_transit_decrypt.go
+++ b/vault/data_source_transit_decrypt.go
@@ -3,8 +3,10 @@ package vault
 import (
 	"encoding/base64"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func transitDecryptDataSource() *schema.Resource {
@@ -43,7 +45,10 @@ func transitDecryptDataSource() *schema.Resource {
 }
 
 func transitDecryptDataSourceRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 	key := d.Get("key").(string)

--- a/vault/data_source_transit_encrypt.go
+++ b/vault/data_source_transit_encrypt.go
@@ -3,9 +3,10 @@ package vault
 import (
 	"encoding/base64"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/hashicorp/vault/api"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func transitEncryptDataSource() *schema.Resource {
@@ -49,7 +50,10 @@ func transitEncryptDataSource() *schema.Resource {
 }
 
 func transitEncryptDataSourceRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 	key := d.Get("key").(string)

--- a/vault/import_generic_secret_test.go
+++ b/vault/import_generic_secret_test.go
@@ -1,6 +1,7 @@
 package vault
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -10,17 +11,50 @@ import (
 )
 
 func TestAccGenericSecret_importBasic(t *testing.T) {
-	path := acctest.RandomWithPrefix("secretsv1/test-")
+	mount := "secretsv1"
+	name := acctest.RandomWithPrefix("test")
+	path := fmt.Sprintf("%s/%s", mount, name)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testutil.TestAccPreCheck(t) },
 		Providers: testProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testResourceGenericSecret_initialConfig(path),
+				Config: testResourceGenericSecret_initialConfig(mount, name),
 				Check:  testResourceGenericSecret_initialCheck(path),
 			},
 			{
 				ResourceName:            "vault_generic_secret.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"delete_all_versions"},
+			},
+		},
+	})
+}
+
+func TestAccGenericSecret_importBasicNS(t *testing.T) {
+	// TODO: investigate why namespace field is not honoured during import.
+	// Work around is to set the namespace in the provider{} for import.
+	t.Skip("VAULT-4254: namespaced resource imports require provider config")
+
+	ns := acctest.RandomWithPrefix("ns")
+	mount := "secretsv1"
+	name := acctest.RandomWithPrefix("test")
+	path := fmt.Sprintf("%s/%s", mount, name)
+	resourceName := "vault_generic_secret.test"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testutil.TestEntPreCheck(t) },
+		Providers: testProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceGenericSecret_initialConfigNS(ns, mount, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "namespace", ns),
+					testResourceGenericSecret_initialCheck(path),
+				),
+			},
+			{
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"delete_all_versions"},

--- a/vault/password_policy.go
+++ b/vault/password_policy.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func readPasswordPolicy(client *api.Client, name string) (map[string]interface{}, error) {
@@ -37,7 +39,10 @@ func readPasswordPolicy(client *api.Client, name string) (map[string]interface{}
 }
 
 func passwordPolicyDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	name := d.Id()
 
@@ -56,12 +61,14 @@ func passwordPolicyDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func passwordPolicyRead(attributes []string, d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	name := d.Id()
 
 	policy, err := readPasswordPolicy(client, name)
-
 	if err != nil {
 		return fmt.Errorf("error reading from Vault: %s", err)
 	}
@@ -75,7 +82,10 @@ func passwordPolicyRead(attributes []string, d *schema.ResourceData, meta interf
 }
 
 func passwordPolicyWrite(attributes []string, d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	name := d.Get("name").(string)
 

--- a/vault/provider_test.go
+++ b/vault/provider_test.go
@@ -11,9 +11,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/command/config"
 	"github.com/mitchellh/go-homedir"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -85,7 +88,7 @@ func TestAccAuthLoginProviderConfigure(t *testing.T) {
 	})
 
 	rootProviderData := rootProviderResource.TestResourceData()
-	if _, err := providerConfigure(rootProviderData); err != nil {
+	if _, err := provider.NewProviderMeta(rootProviderData); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -108,7 +111,7 @@ func TestTokenReadProviderConfigureWithHeaders(t *testing.T) {
 	})
 
 	rootProviderData := rootProviderResource.TestResourceData()
-	if _, err := providerConfigure(rootProviderData); err != nil {
+	if _, err := provider.NewProviderMeta(rootProviderData); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -121,7 +124,7 @@ func TestAccNamespaceProviderConfigure(t *testing.T) {
 		Schema: rootProvider.Schema,
 	}
 	rootProviderData := rootProviderResource.TestResourceData()
-	if _, err := providerConfigure(rootProviderData); err != nil {
+	if _, err := provider.NewProviderMeta(rootProviderData); err != nil {
 		t.Fatal(err)
 	}
 
@@ -147,8 +150,8 @@ func TestAccNamespaceProviderConfigure(t *testing.T) {
 	}
 	nsProviderData := nsProviderResource.TestResourceData()
 	nsProviderData.Set("namespace", namespacePath)
-	nsProviderData.Set("token", os.Getenv("VAULT_TOKEN"))
-	if _, err := providerConfigure(nsProviderData); err != nil {
+	nsProviderData.Set("token", os.Getenv(api.EnvVaultToken))
+	if _, err := provider.NewProviderMeta(nsProviderData); err != nil {
 		t.Fatal(err)
 	}
 
@@ -234,7 +237,7 @@ func testResourceApproleLoginCheckAttrs(t *testing.T) resource.TestCheckFunc {
 		}
 		approleProviderData := approleProviderResource.TestResourceData()
 		approleProviderData.Set("auth_login", authLoginData)
-		_, err := providerConfigure(approleProviderData)
+		_, err := provider.NewProviderMeta(approleProviderData)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -291,7 +294,7 @@ func testResourceAdminPeriodicOrphanTokenCheckAttrs(namespacePath string, t *tes
 		ns2ProviderData := ns2ProviderResource.TestResourceData()
 		ns2ProviderData.Set("namespace", namespacePath)
 		ns2ProviderData.Set("token", vaultToken)
-		if _, err := providerConfigure(ns2ProviderData); err != nil {
+		if _, err := provider.NewProviderMeta(ns2ProviderData); err != nil {
 			t.Fatal(err)
 		}
 
@@ -354,9 +357,9 @@ func TestAccProviderToken(t *testing.T) {
 	}
 
 	// Create a "resource" we can use for constructing ResourceData.
-	provider := Provider()
+	p := Provider()
 	providerResource := &schema.Resource{
-		Schema: provider.Schema,
+		Schema: p.Schema,
 	}
 
 	type testcase struct {
@@ -373,7 +376,7 @@ func TestAccProviderToken(t *testing.T) {
 			expectedToken: "",
 		},
 		{
-			// The provider will read the token file "~/.vault-token".
+			// The p will read the token file "~/.vault-token".
 			name:          "File",
 			fileToken:     true,
 			expectedToken: "file-token",
@@ -423,8 +426,8 @@ func TestAccProviderToken(t *testing.T) {
 				d.Set("token", "schema-token")
 			}
 
-			// Get and check the provider token.
-			token, err := providerToken(d)
+			// Get and check the p token.
+			token, err := provider.GetToken(d)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -516,7 +519,7 @@ func TestAccTokenName(t *testing.T) {
 }
 
 func TestAccChildToken(t *testing.T) {
-	defer os.Unsetenv("TERRAFORM_VAULT_SKIP_CHILD_TOKEN")
+	defer os.Unsetenv(consts.EnvVarSkipChildToken)
 
 	checkTokenUsed := func(expectChildToken bool) resource.TestCheckFunc {
 		if expectChildToken {
@@ -526,7 +529,7 @@ func TestAccChildToken(t *testing.T) {
 		} else {
 			// If the child token setting was disabled, the used token
 			// should match the user-provided VAULT_TOKEN
-			return checkSelfToken("id", os.Getenv("VAULT_TOKEN"))
+			return checkSelfToken("id", os.Getenv(api.EnvVaultToken))
 		}
 	}
 
@@ -591,12 +594,12 @@ func TestAccChildToken(t *testing.T) {
 				{
 					PreConfig: func() {
 						if test.useChildTokenEnv {
-							err := os.Setenv("TERRAFORM_VAULT_SKIP_CHILD_TOKEN", test.skipChildTokenEnv)
+							err := os.Setenv(consts.EnvVarSkipChildToken, test.skipChildTokenEnv)
 							if err != nil {
 								t.Fatal(err)
 							}
 						} else {
-							err := os.Unsetenv("TERRAFORM_VAULT_SKIP_CHILD_TOKEN")
+							err := os.Unsetenv(consts.EnvVarSkipChildToken)
 							if err != nil {
 								t.Fatal(err)
 							}
@@ -731,7 +734,7 @@ func TestAccProviderVaultAddrEnv(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.vaultAddrEnv != "" {
-				unset, err := tempSetenv("VAULT_ADDR", tc.vaultAddrEnv)
+				unset, err := tempSetenv(api.EnvVaultAddress, tc.vaultAddrEnv)
 				defer failIfErr(t, unset)
 				if err != nil {
 					t.Fatal(err)
@@ -747,7 +750,7 @@ func TestAccProviderVaultAddrEnv(t *testing.T) {
 			}
 
 			// Get and check the provider token.
-			token, err := providerToken(d)
+			token, err := provider.GetToken(d)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/vault/resource_ad_secret_backend.go
+++ b/vault/resource_ad_secret_backend.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -220,7 +221,11 @@ func adSecretBackendResource() *schema.Resource {
 }
 
 func createConfigResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	backend := d.Get("backend").(string)
 	description := d.Get("description").(string)
 	defaultTTL := d.Get("default_lease_ttl_seconds").(int)
@@ -343,7 +348,10 @@ func createConfigResource(d *schema.ResourceData, meta interface{}) error {
 }
 
 func readConfigResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 	log.Printf("[DEBUG] Reading %q", path)
@@ -517,7 +525,11 @@ func readConfigResource(d *schema.ResourceData, meta interface{}) error {
 func updateConfigResource(d *schema.ResourceData, meta interface{}) error {
 	backend := d.Id()
 
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	defaultTTL := d.Get("default_lease_ttl_seconds").(int)
 	maxTTL := d.Get("max_lease_ttl_seconds").(int)
 	tune := api.MountConfigInput{}
@@ -638,7 +650,11 @@ func updateConfigResource(d *schema.ResourceData, meta interface{}) error {
 }
 
 func deleteConfigResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	vaultPath := d.Id()
 	log.Printf("[DEBUG] Unmounting AD backend %q", vaultPath)
 

--- a/vault/resource_ad_secret_backend_test.go
+++ b/vault/resource_ad_secret_backend_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -56,7 +56,7 @@ func TestADSecretBackend(t *testing.T) {
 }
 
 func testAccADSecretBackendCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	mounts, err := client.Sys().ListMounts()
 	if err != nil {

--- a/vault/resource_ad_secret_library.go
+++ b/vault/resource_ad_secret_library.go
@@ -7,8 +7,9 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
-	"github.com/hashicorp/vault/api"
 )
 
 var (
@@ -71,7 +72,11 @@ func adSecretBackendLibraryResource() *schema.Resource {
 }
 
 func createLibraryResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	backend := d.Get("backend").(string)
 	set := d.Get("name").(string)
 	setPath := fmt.Sprintf("%s/library/%s", backend, set)
@@ -105,7 +110,11 @@ func createLibraryResource(d *schema.ResourceData, meta interface{}) error {
 }
 
 func readLibraryResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	setPath := d.Id()
 	log.Printf("[DEBUG] Reading %q", setPath)
 
@@ -165,7 +174,11 @@ func readLibraryResource(d *schema.ResourceData, meta interface{}) error {
 }
 
 func updateLibraryResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	setPath := d.Id()
 	log.Printf("[DEBUG] Updating %q", setPath)
 
@@ -194,7 +207,11 @@ func updateLibraryResource(d *schema.ResourceData, meta interface{}) error {
 }
 
 func deleteLibraryResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	setPath := d.Id()
 	log.Printf("[DEBUG] Deleting %q", setPath)
 

--- a/vault/resource_ad_secret_library_test.go
+++ b/vault/resource_ad_secret_library_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -76,7 +76,7 @@ func TestAccADSecretBackendLibrary_import(t *testing.T) {
 }
 
 func testAccADSecretBackendLibraryCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_ad_secret_library" {

--- a/vault/resource_ad_secret_roles.go
+++ b/vault/resource_ad_secret_roles.go
@@ -7,8 +7,9 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
-	"github.com/hashicorp/vault/api"
 )
 
 var (
@@ -67,7 +68,11 @@ func adSecretBackendRoleResource() *schema.Resource {
 }
 
 func createRoleResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	backend := d.Get("backend").(string)
 	role := d.Get("role").(string)
 	rolePath := fmt.Sprintf("%s/roles/%s", backend, role)
@@ -93,7 +98,11 @@ func createRoleResource(d *schema.ResourceData, meta interface{}) error {
 }
 
 func readRoleResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	rolePath := d.Id()
 	log.Printf("[DEBUG] Reading %q", rolePath)
 
@@ -148,7 +157,11 @@ func readRoleResource(d *schema.ResourceData, meta interface{}) error {
 }
 
 func updateRoleResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	rolePath := d.Id()
 	log.Printf("[DEBUG] Updating %q", rolePath)
 
@@ -167,7 +180,11 @@ func updateRoleResource(d *schema.ResourceData, meta interface{}) error {
 }
 
 func deleteRoleResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	rolePath := d.Id()
 	log.Printf("[DEBUG] Deleting %q", rolePath)
 

--- a/vault/resource_ad_secret_roles_test.go
+++ b/vault/resource_ad_secret_roles_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -73,7 +73,7 @@ func TestAccADSecretBackendRole_import(t *testing.T) {
 }
 
 func testAccADSecretBackendRoleCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_ad_secret_role" {

--- a/vault/resource_alicloud_auth_backend_role.go
+++ b/vault/resource_alicloud_auth_backend_role.go
@@ -8,7 +8,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func alicloudAuthBackendRoleResource() *schema.Resource {
@@ -83,7 +84,10 @@ func alicloudAuthBackendRoleUpdateFields(d *schema.ResourceData, data map[string
 }
 
 func alicloudAuthBackendRoleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 
 	backend := d.Get("backend").(string)
 	role := d.Get("role").(string)
@@ -106,7 +110,11 @@ func alicloudAuthBackendRoleCreate(ctx context.Context, d *schema.ResourceData, 
 }
 
 func alicloudAuthBackendRoleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
+
 	path := d.Id()
 
 	data := map[string]interface{}{}
@@ -123,7 +131,11 @@ func alicloudAuthBackendRoleUpdate(ctx context.Context, d *schema.ResourceData, 
 }
 
 func alicloudAuthBackendRoleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
+
 	path := d.Id()
 
 	log.Printf("[DEBUG] Reading AliCloud role %q", path)
@@ -168,7 +180,11 @@ func alicloudAuthBackendRoleRead(_ context.Context, d *schema.ResourceData, meta
 }
 
 func alicloudAuthBackendRoleDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
+
 	path := d.Id()
 
 	log.Printf("[DEBUG] Deleting AliCloud role %q", path)
@@ -179,18 +195,4 @@ func alicloudAuthBackendRoleDelete(_ context.Context, d *schema.ResourceData, me
 	log.Printf("[DEBUG] Deleted AliCloud role %q", path)
 
 	return nil
-}
-
-func alicloudAuthBackendRoleExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
-	path := d.Id()
-
-	log.Printf("[DEBUG] Checking if AliCloud Auth Backend role %q exists", path)
-	resp, err := client.Logical().Read(path)
-	if err != nil {
-		return true, fmt.Errorf("error checking for existence of AliCloud Auth Backend resource config %q: %s", path, err)
-	}
-	log.Printf("[DEBUG] Checked if AliCloud Auth Backend role %q exists", path)
-
-	return resp != nil, nil
 }

--- a/vault/resource_alicloud_auth_backend_role_test.go
+++ b/vault/resource_alicloud_auth_backend_role_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -50,7 +50,7 @@ func TestAlicloudAuthBackendRole_basic(t *testing.T) {
 }
 
 func testAlicloudAuthBackedRoleDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_alicloud_auth_backend_role" {

--- a/vault/resource_approle_auth_backend_login.go
+++ b/vault/resource_approle_auth_backend_login.go
@@ -7,8 +7,10 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
 func approleAuthBackendLoginResource() *schema.Resource {
@@ -88,7 +90,10 @@ func approleAuthBackendLoginResource() *schema.Resource {
 }
 
 func approleAuthBackendLoginCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 
@@ -116,7 +121,10 @@ func approleAuthBackendLoginCreate(d *schema.ResourceData, meta interface{}) err
 }
 
 func approleAuthBackendLoginRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	log.Printf("[DEBUG] Reading token %q", d.Id())
 	resp, err := client.Auth().Token().LookupAccessor(d.Id())
@@ -155,7 +163,11 @@ func approleAuthBackendLoginRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func approleAuthBackendLoginDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	accessor := d.Id()
 
 	log.Printf("[DEBUG] Revoking token %q", accessor)
@@ -169,7 +181,11 @@ func approleAuthBackendLoginDelete(d *schema.ResourceData, meta interface{}) err
 }
 
 func approleAuthBackendLoginExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
+
 	accessor := d.Id()
 
 	log.Printf("[DEBUG] Checking if token %q exists", accessor)

--- a/vault/resource_approle_auth_backend_role.go
+++ b/vault/resource_approle_auth_backend_role.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
@@ -123,7 +123,10 @@ func approleAuthBackendRoleUpdateFields(d *schema.ResourceData, data map[string]
 }
 
 func approleAuthBackendRoleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 
 	backend := d.Get("backend").(string)
 	role := d.Get("role_name").(string)
@@ -173,7 +176,11 @@ func approleAuthBackendRoleCreate(ctx context.Context, d *schema.ResourceData, m
 }
 
 func approleAuthBackendRoleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
+
 	path := d.Id()
 
 	backend, err := approleAuthBackendRoleBackendFromPath(path)
@@ -240,7 +247,11 @@ func approleAuthBackendRoleRead(_ context.Context, d *schema.ResourceData, meta 
 }
 
 func approleAuthBackendRoleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
+
 	path := d.Id()
 
 	log.Printf("[DEBUG] Updating AppRole auth backend role %q", path)
@@ -273,7 +284,11 @@ func approleAuthBackendRoleUpdate(ctx context.Context, d *schema.ResourceData, m
 }
 
 func approleAuthBackendRoleDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
+
 	path := d.Id()
 
 	log.Printf("[DEBUG] Deleting AppRole auth backend role %q", path)

--- a/vault/resource_approle_auth_backend_role_secret_id.go
+++ b/vault/resource_approle_auth_backend_role_secret_id.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
@@ -117,7 +117,10 @@ func approleAuthBackendRoleSecretIDResource(name string) *schema.Resource {
 }
 
 func approleAuthBackendRoleSecretIDCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 	role := d.Get("role_name").(string)
@@ -197,7 +200,11 @@ func approleAuthBackendRoleSecretIDCreate(d *schema.ResourceData, meta interface
 }
 
 func approleAuthBackendRoleSecretIDRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	id := d.Id()
 
 	backend, role, accessor, wrapped, err := approleAuthBackendRoleSecretIDParseID(id)
@@ -276,7 +283,11 @@ func approleAuthBackendRoleSecretIDRead(d *schema.ResourceData, meta interface{}
 }
 
 func approleAuthBackendRoleSecretIDDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	id := d.Id()
 	backend, role, accessor, wrapped, err := approleAuthBackendRoleSecretIDParseID(id)
 	if err != nil {
@@ -306,7 +317,11 @@ func approleAuthBackendRoleSecretIDDelete(d *schema.ResourceData, meta interface
 }
 
 func approleAuthBackendRoleSecretIDExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
+
 	id := d.Id()
 
 	backend, role, accessor, wrapped, err := approleAuthBackendRoleSecretIDParseID(id)

--- a/vault/resource_approle_auth_backend_role_secret_id_test.go
+++ b/vault/resource_approle_auth_backend_role_secret_id_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/sdk/helper/consts"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -181,7 +181,7 @@ func TestAccAppRoleAuthBackendRoleSecretID_full(t *testing.T) {
 }
 
 func testAccCheckAppRoleAuthBackendRoleSecretIDDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_approle_auth_backend_role_secret_id" {
@@ -282,7 +282,7 @@ provider "vault" {
 
 func testAssertClientNamespace(expectedNS string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 		actualNS := client.Headers().Get(consts.NamespaceHeaderName)
 		if actualNS != expectedNS {
 			return fmt.Errorf("expected namespace %v, actual %v", expectedNS, actualNS)

--- a/vault/resource_approle_auth_backend_role_test.go
+++ b/vault/resource_approle_auth_backend_role_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -310,7 +310,7 @@ func TestAccAppRoleAuthBackendRole_fullUpdate(t *testing.T) {
 }
 
 func testAccCheckAppRoleAuthBackendRoleDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_approle_auth_backend_role" {

--- a/vault/resource_audit.go
+++ b/vault/resource_audit.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func auditResource() *schema.Resource {
@@ -56,7 +58,10 @@ func auditResource() *schema.Resource {
 }
 
 func auditWrite(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	description := d.Get("description").(string)
 	local := d.Get("local").(bool)
@@ -91,7 +96,10 @@ func auditWrite(d *schema.ResourceData, meta interface{}) error {
 }
 
 func auditDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 
@@ -105,7 +113,10 @@ func auditDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func auditRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 

--- a/vault/resource_audit_test.go
+++ b/vault/resource_audit_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -88,7 +89,7 @@ func testResourceAudit_initialCheck(expectedPath string) resource.TestCheckFunc 
 }
 
 func findAudit(path string) (*api.Audit, error) {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	path = path + "/"
 

--- a/vault/resource_auth_backend.go
+++ b/vault/resource_auth_backend.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func AuthBackendResource() *schema.Resource {
@@ -66,7 +68,10 @@ func AuthBackendResource() *schema.Resource {
 }
 
 func authBackendWrite(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	mountType := d.Get("type").(string)
 	path := d.Get("path").(string)
@@ -92,7 +97,10 @@ func authBackendWrite(d *schema.ResourceData, meta interface{}) error {
 }
 
 func authBackendDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 
@@ -106,7 +114,10 @@ func authBackendDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func authBackendRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 
@@ -140,7 +151,10 @@ func authBackendRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func authBackendUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 	log.Printf("[DEBUG] Updating auth %s in Vault", path)

--- a/vault/resource_auth_backend_test.go
+++ b/vault/resource_auth_backend_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -37,7 +38,7 @@ func TestResourceAuth(t *testing.T) {
 }
 
 func testAccCheckAuthBackendDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	auths, err := client.Sys().ListAuth()
 	if err != nil {
@@ -113,7 +114,7 @@ func testResourceAuth_initialCheck(expectedPath string) resource.TestCheckFunc {
 			return fmt.Errorf("unexpected auth local")
 		}
 
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 		auths, err := client.Sys().ListAuth()
 		if err != nil {
 			return fmt.Errorf("error reading back auth: %s", err)
@@ -165,7 +166,7 @@ func testResourceAuth_updateCheck(s *terraform.State) error {
 		return fmt.Errorf("unexpected auth name")
 	}
 
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 	auths, err := client.Sys().ListAuth()
 	if err != nil {
 		return fmt.Errorf("error reading back auth: %s", err)
@@ -259,7 +260,7 @@ resource "vault_auth_backend" "test" {
 
 func checkAuthMount(backend string, checker func(*api.AuthMount) error) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 		auths, err := client.Sys().ListAuth()
 		if err != nil {
 			return fmt.Errorf("error reading back auth: %s", err)

--- a/vault/resource_aws_auth_backend_cert.go
+++ b/vault/resource_aws_auth_backend_cert.go
@@ -9,7 +9,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 var (
@@ -64,7 +65,10 @@ func awsAuthBackendCertResource() *schema.Resource {
 }
 
 func awsAuthBackendCertCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 	certType := d.Get("type").(string)
@@ -91,7 +95,10 @@ func awsAuthBackendCertCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func awsAuthBackendCertRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 
@@ -130,7 +137,11 @@ func awsAuthBackendCertRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func awsAuthBackendCertDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	path := d.Id()
 
 	log.Printf("[DEBUG] Removing cert %q from AWS auth backend", path)
@@ -144,7 +155,10 @@ func awsAuthBackendCertDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func awsAuthBackendCertExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
 
 	path := d.Id()
 

--- a/vault/resource_aws_auth_backend_cert_test.go
+++ b/vault/resource_aws_auth_backend_cert_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -55,7 +55,7 @@ func TestAccAWSAuthBackendCert_basic(t *testing.T) {
 }
 
 func testAccCheckAWSAuthBackendCertDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_aws_auth_backend_cert" {
 			continue
@@ -105,7 +105,7 @@ func testAccAWSAuthBackendCertCheck_attrs(backend, name string) resource.TestChe
 			return fmt.Errorf("expected ID to be %q, got %q", "auth/"+backend+"/config/certificate/"+name, endpoint)
 		}
 
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 		resp, err := client.Logical().Read(endpoint)
 		if err != nil {
 			return fmt.Errorf("error reading back AWS auth certificate from %q: %s", endpoint, err)

--- a/vault/resource_aws_auth_backend_client.go
+++ b/vault/resource_aws_auth_backend_client.go
@@ -7,7 +7,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func awsAuthBackendClientResource() *schema.Resource {
@@ -75,7 +76,10 @@ func awsAuthBackendClientResource() *schema.Resource {
 }
 
 func awsAuthBackendWrite(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	// if backend comes from the config, it won't have the StateFunc
 	// applied yet, so we need to apply it again.
@@ -121,7 +125,10 @@ func awsAuthBackendWrite(d *schema.ResourceData, meta interface{}) error {
 }
 
 func awsAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	log.Printf("[DEBUG] Reading AWS auth backend client config")
 	secret, err := client.Logical().Read(d.Id())
@@ -153,7 +160,10 @@ func awsAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func awsAuthBackendDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	log.Printf("[DEBUG] Deleting AWS auth backend client config from %q", d.Id())
 	_, err := client.Logical().Delete(d.Id())
@@ -166,7 +176,10 @@ func awsAuthBackendDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func awsAuthBackendExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
 
 	log.Printf("[DEBUG] Checking if AWS auth backend client is configured at %q", d.Id())
 	secret, err := client.Logical().Read(d.Id())

--- a/vault/resource_aws_auth_backend_client_test.go
+++ b/vault/resource_aws_auth_backend_client_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -115,7 +115,7 @@ func TestAccAWSAuthBackendClientStsRegionNoEndpoint(t *testing.T) {
 }
 
 func testAccCheckAWSAuthBackendClientDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_aws_auth_backend_client" {
@@ -150,7 +150,7 @@ func testAccAWSAuthBackendClientCheck_attrs(backend string) resource.TestCheckFu
 			return fmt.Errorf("expected ID to be %q, got %q", "auth/"+backend+"/config/client", endpoint)
 		}
 
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 		resp, err := client.Logical().Read(endpoint)
 		if err != nil {
 			return fmt.Errorf("error reading back AWS auth client config from %q: %s", endpoint, err)

--- a/vault/resource_aws_auth_backend_identity_whitelist.go
+++ b/vault/resource_aws_auth_backend_identity_whitelist.go
@@ -7,12 +7,11 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
-var (
-	awsAuthBackendIdentityWhitelistBackendFromPathRegex = regexp.MustCompile("^auth/(.+)/config/tidy/identity-whitelist$")
-)
+var awsAuthBackendIdentityWhitelistBackendFromPathRegex = regexp.MustCompile("^auth/(.+)/config/tidy/identity-whitelist$")
 
 func awsAuthBackendIdentityWhitelistResource() *schema.Resource {
 	return &schema.Resource{
@@ -52,7 +51,10 @@ func awsAuthBackendIdentityWhitelistResource() *schema.Resource {
 }
 
 func awsAuthBackendIdentityWhitelistWrite(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 	data := map[string]interface{}{}
@@ -81,7 +83,10 @@ func awsAuthBackendIdentityWhitelistWrite(d *schema.ResourceData, meta interface
 }
 
 func awsAuthBackendIdentityWhitelistRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 
@@ -110,7 +115,11 @@ func awsAuthBackendIdentityWhitelistRead(d *schema.ResourceData, meta interface{
 }
 
 func awsAuthBackendIdentityWhitelistDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	path := d.Id()
 
 	log.Printf("[DEBUG] Removing identity whitelist %q from AWS auth backend", path)
@@ -124,7 +133,10 @@ func awsAuthBackendIdentityWhitelistDelete(d *schema.ResourceData, meta interfac
 }
 
 func awsAuthBackendIdentityWhitelistExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
 
 	path := d.Id()
 

--- a/vault/resource_aws_auth_backend_identity_whitelist_test.go
+++ b/vault/resource_aws_auth_backend_identity_whitelist_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -50,7 +50,7 @@ func TestAccAWSAuthBackendIdentityWhitelist_basic(t *testing.T) {
 }
 
 func testAccCheckAWSAuthBackendIdentityWhitelistDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_aws_auth_backend_identity_whitelist" {
 			continue
@@ -98,7 +98,7 @@ func testAccAWSAuthBackendIdentityWhitelistCheck_attrs(backend string) resource.
 			return fmt.Errorf("expected ID to be %q, got %q", "auth/"+backend+"/config/tidy/identity-whitelist", endpoint)
 		}
 
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 		resp, err := client.Logical().Read(endpoint)
 		if err != nil {
 			return fmt.Errorf("error reading back AWS auth bavkend identity whitelist config from %q: %s", endpoint, err)

--- a/vault/resource_aws_auth_backend_login.go
+++ b/vault/resource_aws_auth_backend_login.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/hashicorp/vault/api"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func awsAuthBackendLoginResource() *schema.Resource {
@@ -150,7 +150,10 @@ func awsAuthBackendLoginCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func awsAuthBackendLoginRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := strings.Trim(d.Get("backend").(string), "/")
 	path := "auth/" + backend + "/login"
@@ -230,7 +233,10 @@ func awsAuthBackendLoginRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func awsAuthBackendLoginDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	accessor := d.Get("accessor").(string)
 	token, ok := d.GetOk("client_token")

--- a/vault/resource_aws_auth_backend_role.go
+++ b/vault/resource_aws_auth_backend_role.go
@@ -9,7 +9,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 var (
@@ -196,7 +197,10 @@ func setSlice(d *schema.ResourceData, tfFieldName, vaultFieldName string, data m
 }
 
 func awsAuthBackendRoleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 
 	backend := d.Get("backend").(string)
 	role := d.Get("role").(string)
@@ -300,7 +304,10 @@ func awsAuthBackendRoleCreate(ctx context.Context, d *schema.ResourceData, meta 
 }
 
 func awsAuthBackendRoleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 	path := d.Id()
 
 	backend, err := awsAuthBackendRoleBackendFromPath(path)
@@ -401,7 +408,11 @@ func awsAuthBackendRoleRead(_ context.Context, d *schema.ResourceData, meta inte
 }
 
 func awsAuthBackendRoleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
+
 	path := d.Id()
 
 	log.Printf("[DEBUG] Updating AWS auth backend role %q", path)
@@ -507,7 +518,10 @@ func isEc2(authType, inferred string) bool {
 }
 
 func awsAuthBackendRoleDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 	path := d.Id()
 
 	log.Printf("[DEBUG] Deleting AWS auth backend role %q", path)

--- a/vault/resource_aws_auth_backend_role_tag.go
+++ b/vault/resource_aws_auth_backend_role_tag.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/hashicorp/vault/api"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func awsAuthBackendRoleTagResource() *schema.Resource {
@@ -76,7 +76,10 @@ func awsAuthBackendRoleTagResource() *schema.Resource {
 }
 
 func awsAuthBackendRoleTagResourceCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 	role := d.Get("role").(string)

--- a/vault/resource_aws_auth_backend_role_test.go
+++ b/vault/resource_aws_auth_backend_role_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -210,7 +210,7 @@ func TestAccAWSAuthBackendRole_iamUpdate(t *testing.T) {
 }
 
 func testAccCheckAWSAuthBackendRoleDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_aws_auth_backend_role" {
@@ -245,7 +245,7 @@ func testAccAWSAuthBackendRoleCheck_attrs(backend, role string) resource.TestChe
 			return fmt.Errorf("expected ID to be %q, got %q instead", "auth/"+backend+"/role/"+role, endpoint)
 		}
 
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 		resp, err := client.Logical().Read(endpoint)
 		if err != nil {
 			return fmt.Errorf("%q doesn't exist", endpoint)

--- a/vault/resource_aws_auth_backend_roletag_blacklist.go
+++ b/vault/resource_aws_auth_backend_roletag_blacklist.go
@@ -7,12 +7,11 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
-var (
-	awsAuthBackendRoleTagBlacklistBackendFromPathRegex = regexp.MustCompile("^auth/(.+)/config/tidy/roletag-blacklist$")
-)
+var awsAuthBackendRoleTagBlacklistBackendFromPathRegex = regexp.MustCompile("^auth/(.+)/config/tidy/roletag-blacklist$")
 
 func awsAuthBackendRoleTagBlacklistResource() *schema.Resource {
 	return &schema.Resource{
@@ -53,7 +52,10 @@ func awsAuthBackendRoleTagBlacklistResource() *schema.Resource {
 }
 
 func awsAuthBackendRoleTagBlacklistWrite(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 	data := map[string]interface{}{
@@ -65,7 +67,6 @@ func awsAuthBackendRoleTagBlacklistWrite(d *schema.ResourceData, meta interface{
 
 	log.Printf("[DEBUG] Configuring AWS auth backend roletag blacklist %q", path)
 	_, err := client.Logical().Write(path, data)
-
 	if err != nil {
 		d.SetId("")
 		return fmt.Errorf("Error configuring AWS auth backend roletag blacklist %q: %s", path, err)
@@ -78,7 +79,10 @@ func awsAuthBackendRoleTagBlacklistWrite(d *schema.ResourceData, meta interface{
 }
 
 func awsAuthBackendRoleTagBlacklistRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 
@@ -109,7 +113,11 @@ func awsAuthBackendRoleTagBlacklistRead(d *schema.ResourceData, meta interface{}
 }
 
 func awsAuthBackendRoleTagBlacklistDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	path := d.Id()
 
 	log.Printf("[DEBUG] Removing roletag blacklist %q from AWS auth backend", path)
@@ -123,7 +131,10 @@ func awsAuthBackendRoleTagBlacklistDelete(d *schema.ResourceData, meta interface
 }
 
 func awsAuthBackendRoleTagBlacklistExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
 
 	path := d.Id()
 

--- a/vault/resource_aws_auth_backend_roletag_blacklist_test.go
+++ b/vault/resource_aws_auth_backend_roletag_blacklist_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -87,7 +87,7 @@ func TestAccAWSAuthBackendRoleTagBlacklist_updated(t *testing.T) {
 }
 
 func testAccCheckAWSAuthBackendRoleTagBlacklistDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_aws_auth_backend_roletag_blacklist" {
 			continue
@@ -163,7 +163,7 @@ func testAccAWSAuthBackendRoleTagBlacklistCheck_attrs(backend string) resource.T
 			return fmt.Errorf("expected ID to be %q, got %q", "auth/"+backend+"/config/tidy/roletag-blacklist", endpoint)
 		}
 
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 		resp, err := client.Logical().Read(endpoint)
 		if err != nil {
 			return fmt.Errorf("error reading back AWS auth bavkend roletag blacklist config from %q: %s", endpoint, err)

--- a/vault/resource_aws_auth_backend_sts_role.go
+++ b/vault/resource_aws_auth_backend_sts_role.go
@@ -7,7 +7,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 var (
@@ -53,7 +54,10 @@ func awsAuthBackendSTSRoleResource() *schema.Resource {
 }
 
 func awsAuthBackendSTSRoleCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 	accountID := d.Get("account_id").(string)
@@ -78,7 +82,10 @@ func awsAuthBackendSTSRoleCreate(d *schema.ResourceData, meta interface{}) error
 }
 
 func awsAuthBackendSTSRoleRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 
@@ -111,7 +118,10 @@ func awsAuthBackendSTSRoleRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func awsAuthBackendSTSRoleUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	stsRole := d.Get("sts_role").(string)
 	path := d.Id()
@@ -129,7 +139,10 @@ func awsAuthBackendSTSRoleUpdate(d *schema.ResourceData, meta interface{}) error
 }
 
 func awsAuthBackendSTSRoleDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 	log.Printf("[DEBUG] Deleting STS role %q from AWS auth backend", path)
@@ -143,7 +156,10 @@ func awsAuthBackendSTSRoleDelete(d *schema.ResourceData, meta interface{}) error
 }
 
 func awsAuthBackendSTSRoleExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
 
 	path := d.Id()
 	log.Printf("[DEBUG] Checking if STS role %q exists in AWS auth backend", path)

--- a/vault/resource_aws_auth_backend_sts_role_test.go
+++ b/vault/resource_aws_auth_backend_sts_role_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -58,7 +58,7 @@ func TestAccAWSAuthBackendSTSRole_basic(t *testing.T) {
 }
 
 func testAccCheckAWSAuthBackendSTSRoleDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_aws_auth_backend_sts_role" {
@@ -93,7 +93,7 @@ func testAccAWSAuthBackendSTSRoleCheck_attrs(backend, accountID, stsRole string)
 			return fmt.Errorf("expected ID to be %q, got %q instead", "auth/"+backend+"/config/sts/"+accountID, endpoint)
 		}
 
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 		resp, err := client.Logical().Read(endpoint)
 		if err != nil {
 			return fmt.Errorf("error reading back sts role from %q: %s", endpoint, err)

--- a/vault/resource_aws_secret_backend.go
+++ b/vault/resource_aws_secret_backend.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func awsSecretBackendResource() *schema.Resource {
@@ -96,7 +98,10 @@ func awsSecretBackendResource() *schema.Resource {
 }
 
 func awsSecretBackendCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Get("path").(string)
 	description := d.Get("description").(string)
@@ -156,7 +161,10 @@ func awsSecretBackendCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func awsSecretBackendRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 
@@ -226,7 +234,10 @@ func awsSecretBackendRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func awsSecretBackendUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 	d.Partial(true)
@@ -279,7 +290,10 @@ func awsSecretBackendUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func awsSecretBackendDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 
@@ -293,7 +307,11 @@ func awsSecretBackendDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func awsSecretBackendExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
+
 	path := d.Id()
 	log.Printf("[DEBUG] Checking if AWS backend exists at %q", path)
 	mounts, err := client.Sys().ListMounts()

--- a/vault/resource_aws_secret_backend_role.go
+++ b/vault/resource_aws_secret_backend_role.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
@@ -100,7 +100,10 @@ func awsSecretBackendRoleResource(name string) *schema.Resource {
 }
 
 func awsSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 	name := d.Get("name").(string)
@@ -136,7 +139,6 @@ func awsSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) error {
 		} else {
 			return fmt.Errorf("permissions_boundary_arn is only valid when credential_type is iam_user")
 		}
-
 	}
 	if d.HasChange("policy_document") {
 		data["policy_document"] = policyDocument
@@ -188,7 +190,10 @@ func awsSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) error {
 }
 
 func awsSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 	pathPieces := strings.Split(path, "/")
@@ -244,7 +249,10 @@ func awsSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func awsSecretBackendRoleDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 	log.Printf("[DEBUG] Deleting role %q", path)
@@ -257,7 +265,10 @@ func awsSecretBackendRoleDelete(d *schema.ResourceData, meta interface{}) error 
 }
 
 func awsSecretBackendRoleExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
 
 	path := d.Id()
 	log.Printf("[DEBUG] Checking if %q exists", path)

--- a/vault/resource_aws_secret_backend_role_test.go
+++ b/vault/resource_aws_secret_backend_role_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -115,7 +115,7 @@ func TestAccAWSSecretBackendRole_nested(t *testing.T) {
 }
 
 func testAccAWSSecretBackendRoleCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_aws_secret_backend_role" {
@@ -203,7 +203,6 @@ func testAccAWSSecretBackendRoleCheckUpdatedAttributes(name, backend string) res
 
 func testAccAWSSecretBackendRoleConfig_basic(name, path, accessKey, secretKey string) string {
 	resources := []string{
-
 		fmt.Sprintf(`
 resource "vault_aws_secret_backend" "test" {
   path = "%s"

--- a/vault/resource_aws_secret_backend_test.go
+++ b/vault/resource_aws_secret_backend_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -104,7 +104,7 @@ func TestAccAWSSecretBackend_usernameTempl(t *testing.T) {
 }
 
 func testAccAWSSecretBackendCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	mounts, err := client.Sys().ListMounts()
 	if err != nil {

--- a/vault/resource_azure_auth_backend_config.go
+++ b/vault/resource_azure_auth_backend_config.go
@@ -6,7 +6,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func azureAuthBackendConfigResource() *schema.Resource {
@@ -65,7 +66,7 @@ func azureAuthBackendConfigResource() *schema.Resource {
 }
 
 func azureAuthBackendWrite(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*api.Client)
+	config := meta.(*provider.ProviderMeta).GetClient()
 
 	// if backend comes from the config, it won't have the StateFunc
 	// applied yet, so we need to apply it again.
@@ -99,7 +100,7 @@ func azureAuthBackendWrite(d *schema.ResourceData, meta interface{}) error {
 }
 
 func azureAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*api.Client)
+	config := meta.(*provider.ProviderMeta).GetClient()
 
 	log.Printf("[DEBUG] Reading Azure auth backend config")
 	secret, err := config.Logical().Read(d.Id())
@@ -129,7 +130,7 @@ func azureAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func azureAuthBackendDelete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*api.Client)
+	config := meta.(*provider.ProviderMeta).GetClient()
 
 	log.Printf("[DEBUG] Deleting Azure auth backend config from %q", d.Id())
 	_, err := config.Logical().Delete(d.Id())
@@ -142,7 +143,7 @@ func azureAuthBackendDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func azureAuthBackendExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	config := meta.(*api.Client)
+	config := meta.(*provider.ProviderMeta).GetClient()
 
 	log.Printf("[DEBUG] Checking if Azure auth backend is configured at %q", d.Id())
 	secret, err := config.Logical().Read(d.Id())

--- a/vault/resource_azure_auth_backend_config_test.go
+++ b/vault/resource_azure_auth_backend_config_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -53,7 +53,7 @@ func TestAccAzureAuthBackendConfig_basic(t *testing.T) {
 }
 
 func testAccCheckAzureAuthBackendConfigDestroy(s *terraform.State) error {
-	config := testProvider.Meta().(*api.Client)
+	config := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_azure_auth_backend_config" {
@@ -106,7 +106,7 @@ func testAccAzureAuthBackendConfigCheck_attrs(backend string) resource.TestCheck
 			return fmt.Errorf("expected ID to be %q, got %q", "auth/"+backend+"/config", endpoint)
 		}
 
-		config := testProvider.Meta().(*api.Client)
+		config := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 		resp, err := config.Logical().Read(endpoint)
 		if err != nil {
 			return fmt.Errorf("error reading back Azure auth config from %q: %s", endpoint, err)

--- a/vault/resource_azure_auth_backend_role.go
+++ b/vault/resource_azure_auth_backend_role.go
@@ -9,7 +9,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 var (
@@ -101,7 +102,10 @@ func azureAuthBackendRoleResource() *schema.Resource {
 }
 
 func azureAuthBackendRoleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 
 	backend := d.Get("backend").(string)
 	role := d.Get("role").(string)
@@ -178,7 +182,10 @@ func azureAuthBackendRoleCreate(ctx context.Context, d *schema.ResourceData, met
 }
 
 func azureAuthBackendRoleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 	path := d.Id()
 
 	backend, err := azureAuthBackendRoleBackendFromPath(path)
@@ -240,7 +247,10 @@ func azureAuthBackendRoleRead(_ context.Context, d *schema.ResourceData, meta in
 }
 
 func azureAuthBackendRoleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 	path := d.Id()
 
 	log.Printf("[DEBUG] Updating Azure auth backend role %q", path)
@@ -307,7 +317,10 @@ func azureAuthBackendRoleUpdate(ctx context.Context, d *schema.ResourceData, met
 }
 
 func azureAuthBackendRoleDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 	path := d.Id()
 
 	log.Printf("[DEBUG] Deleting Azure auth backend role %q", path)

--- a/vault/resource_azure_auth_backend_role_test.go
+++ b/vault/resource_azure_auth_backend_role_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -70,7 +70,7 @@ func TestAzureAuthBackendRole(t *testing.T) {
 }
 
 func testAzureAuthBackendRoleDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_azure_auth_backend_role" {
@@ -104,7 +104,7 @@ func testAzureAuthBackendRoleCheck_attrs(backend, name string) resource.TestChec
 			return fmt.Errorf("expected ID to be %q, got %q instead", endpoint, instanceState.ID)
 		}
 
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 		authMounts, err := client.Sys().ListAuth()
 		if err != nil {
 			return err

--- a/vault/resource_azure_secret_backend.go
+++ b/vault/resource_azure_secret_backend.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func azureSecretBackendResource() *schema.Resource {
@@ -84,7 +86,10 @@ func azureSecretBackendResource() *schema.Resource {
 }
 
 func azureSecretBackendCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Get("path").(string)
 	description := d.Get("description").(string)
@@ -116,7 +121,10 @@ func azureSecretBackendCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func azureSecretBackendRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 
@@ -172,7 +180,10 @@ func azureSecretBackendRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func azureSecretBackendUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 
@@ -189,7 +200,10 @@ func azureSecretBackendUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func azureSecretBackendDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 
@@ -203,7 +217,11 @@ func azureSecretBackendDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func azureSecretBackendExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
+
 	path := d.Id()
 	log.Printf("[DEBUG] Checking if Azure backend exists at %q", path)
 	mounts, err := client.Sys().ListMounts()

--- a/vault/resource_azure_secret_backend_role.go
+++ b/vault/resource_azure_secret_backend_role.go
@@ -7,7 +7,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func azureSecretBackendRoleResource() *schema.Resource {
@@ -103,7 +104,6 @@ func azureSecretBackendRoleResource() *schema.Resource {
 }
 
 func azureSecretBackendRoleUpdateFields(d *schema.ResourceData, data map[string]interface{}) error {
-
 	if v, ok := d.GetOk("azure_roles"); ok {
 		rawAzureList := v.(*schema.Set).List()
 
@@ -151,7 +151,10 @@ func azureSecretBackendRoleUpdateFields(d *schema.ResourceData, data map[string]
 }
 
 func azureSecretBackendRoleCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 	role := d.Get("role").(string)
@@ -177,7 +180,11 @@ func azureSecretBackendRoleCreate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func azureSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	path := d.Id()
 
 	log.Printf("[DEBUG] Reading Azure Secret role %q", path)
@@ -221,7 +228,11 @@ func azureSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error 
 }
 
 func azureSecretBackendRoleDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	path := d.Id()
 
 	log.Printf("[DEBUG] Deleting Azure Secret role %q", path)

--- a/vault/resource_azure_secret_backend_role_test.go
+++ b/vault/resource_azure_secret_backend_role_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -52,7 +52,7 @@ func TestAzureSecretBackendRole(t *testing.T) {
 }
 
 func testAccAzureSecretBackendRoleCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	mounts, err := client.Sys().ListMounts()
 	if err != nil {

--- a/vault/resource_azure_secret_backend_test.go
+++ b/vault/resource_azure_secret_backend_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -61,7 +61,7 @@ func TestAzureSecretBackend(t *testing.T) {
 }
 
 func testAccAzureSecretBackendCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	mounts, err := client.Sys().ListMounts()
 	if err != nil {

--- a/vault/resource_cert_auth_backend_role.go
+++ b/vault/resource_cert_auth_backend_role.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/hashicorp/vault/api"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func certAuthBackendRoleResource() *schema.Resource {
@@ -113,7 +113,10 @@ func certCertResourcePath(backend, name string) string {
 }
 
 func certAuthResourceWrite(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 
 	backend := d.Get("backend").(string)
 	name := d.Get("name").(string)
@@ -166,7 +169,10 @@ func certAuthResourceWrite(ctx context.Context, d *schema.ResourceData, meta int
 }
 
 func certAuthResourceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 	path := d.Id()
 
 	data := map[string]interface{}{}
@@ -213,7 +219,10 @@ func certAuthResourceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 }
 
 func certAuthResourceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 	path := d.Id()
 
 	log.Printf("[DEBUG] Reading cert %q", path)
@@ -308,7 +317,10 @@ func certAuthResourceRead(_ context.Context, d *schema.ResourceData, meta interf
 }
 
 func certAuthResourceDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 	path := d.Id()
 
 	log.Printf("[DEBUG] Deleting cert %q", path)

--- a/vault/resource_cert_auth_backend_role_test.go
+++ b/vault/resource_cert_auth_backend_role_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -122,7 +122,7 @@ func TestCertAuthBackend(t *testing.T) {
 }
 
 func testCertAuthBackendDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_cert_auth_backend_role" {
@@ -156,7 +156,7 @@ func testCertAuthBackendCheck_attrs(backend, name string) resource.TestCheckFunc
 			return fmt.Errorf("expected ID to be %q, got %q instead", endpoint, instanceState.ID)
 		}
 
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 		authMounts, err := client.Sys().ListAuth()
 		if err != nil {
 			return err

--- a/vault/resource_consul_secret_backend.go
+++ b/vault/resource_consul_secret_backend.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func consulSecretBackendResource() *schema.Resource {
@@ -102,7 +104,10 @@ func consulSecretBackendResource() *schema.Resource {
 }
 
 func consulSecretBackendCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Get("path").(string)
 	address := d.Get("address").(string)
@@ -154,7 +159,10 @@ func consulSecretBackendCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func consulSecretBackendRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 	configPath := consulSecretBackendConfigPath(path)
@@ -200,7 +208,10 @@ func consulSecretBackendRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func consulSecretBackendUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 	configPath := consulSecretBackendConfigPath(path)
@@ -240,7 +251,10 @@ func consulSecretBackendUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func consulSecretBackendDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 
@@ -254,7 +268,10 @@ func consulSecretBackendDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func consulSecretBackendExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
 
 	path := d.Id()
 

--- a/vault/resource_consul_secret_backend_role.go
+++ b/vault/resource_consul_secret_backend_role.go
@@ -7,7 +7,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 var (
@@ -108,7 +109,10 @@ func consulSecretBackendRoleGetBackend(d *schema.ResourceData) string {
 }
 
 func consulSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	name := d.Get("name").(string)
 
@@ -156,7 +160,10 @@ func consulSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) erro
 }
 
 func consulSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	upgradeOldID(d)
 
@@ -230,7 +237,10 @@ func consulSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func consulSecretBackendRoleDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 
@@ -244,7 +254,10 @@ func consulSecretBackendRoleDelete(d *schema.ResourceData, meta interface{}) err
 }
 
 func consulSecretBackendRoleExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
 
 	upgradeOldID(d)
 

--- a/vault/resource_consul_secret_backend_role_test.go
+++ b/vault/resource_consul_secret_backend_role_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -75,7 +75,7 @@ func TestConsulSecretBackendRole(t *testing.T) {
 }
 
 func testAccConsulSecretBackendRoleCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_consul_secret_backend_role" {

--- a/vault/resource_consul_secret_backend_test.go
+++ b/vault/resource_consul_secret_backend_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -106,7 +106,7 @@ func TestConsulSecretBackend(t *testing.T) {
 }
 
 func testAccConsulSecretBackendCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	mounts, err := client.Sys().ListMounts()
 	if err != nil {

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
@@ -1304,7 +1305,10 @@ func setDatabaseConnectionDataWithDisableEscaping(d *schema.ResourceData, prefix
 func databaseSecretBackendConnectionCreateOrUpdate(
 	d *schema.ResourceData, meta interface{},
 ) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	engine, err := getDBEngine(d)
 	if err != nil {
@@ -1411,7 +1415,10 @@ func getSortedPluginPrefixes() ([]string, error) {
 }
 
 func databaseSecretBackendConnectionRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 
@@ -1633,7 +1640,11 @@ func getConnectionDetailsMongoDBAtlas(d *schema.ResourceData, prefix string, res
 }
 
 func databaseSecretBackendConnectionDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	path := d.Id()
 
 	log.Printf("[DEBUG] Removing database connection config %q", path)
@@ -1647,7 +1658,10 @@ func databaseSecretBackendConnectionDelete(d *schema.ResourceData, meta interfac
 }
 
 func databaseSecretBackendConnectionExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
 
 	path := d.Id()
 

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -21,6 +21,7 @@ import (
 	mssqlhelper "github.com/hashicorp/vault/helper/testhelpers/mssql"
 	"github.com/hashicorp/vault/sdk/database/helper/dbutil"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -594,7 +595,7 @@ func TestAccDatabaseSecretBackendConnectionTemplatedUpdateExcludePassword_mysql(
 				Config: testAccDatabaseSecretBackendConnectionConfigTemplated_mysql(name, backend, testConnURL, secondaryRootUsername, secondaryRootPassword, 10),
 				PreConfig: func() {
 					path := fmt.Sprintf("%s/rotate-root/%s", backend, name)
-					client := testProvider.Meta().(*api.Client)
+					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 					resp, err := client.Logical().Write(path, map[string]interface{}{})
 					if err != nil {
 						t.Error(err)
@@ -876,7 +877,7 @@ resource "vault_database_secret_backend_connection" "test" {
 }
 
 func testAccDatabaseSecretBackendConnectionCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_database_secret_backend_connection" {

--- a/vault/resource_database_secret_backend_role.go
+++ b/vault/resource_database_secret_backend_role.go
@@ -8,7 +8,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 var (
@@ -85,7 +86,10 @@ func databaseSecretBackendRoleResource() *schema.Resource {
 }
 
 func databaseSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 	name := d.Get("name").(string)
@@ -125,7 +129,10 @@ func databaseSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) er
 }
 
 func databaseSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 
@@ -212,7 +219,10 @@ func databaseSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func databaseSecretBackendRoleDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 	log.Printf("[DEBUG] Deleting role %q", path)
@@ -225,7 +235,10 @@ func databaseSecretBackendRoleDelete(d *schema.ResourceData, meta interface{}) e
 }
 
 func databaseSecretBackendRoleExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
 
 	path := d.Id()
 	log.Printf("[DEBUG] Checking if %q exists", path)

--- a/vault/resource_database_secret_backend_role_test.go
+++ b/vault/resource_database_secret_backend_role_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -87,7 +87,7 @@ func TestAccDatabaseSecretBackendRole_basic(t *testing.T) {
 }
 
 func testAccDatabaseSecretBackendRoleCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_database_secret_backend_role" {

--- a/vault/resource_database_secret_backend_static_role.go
+++ b/vault/resource_database_secret_backend_static_role.go
@@ -8,7 +8,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 var (
@@ -75,7 +76,10 @@ func databaseSecretBackendStaticRoleResource() *schema.Resource {
 }
 
 func databaseSecretBackendStaticRoleWrite(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 	name := d.Get("name").(string)
@@ -105,7 +109,10 @@ func databaseSecretBackendStaticRoleWrite(d *schema.ResourceData, meta interface
 }
 
 func databaseSecretBackendStaticRoleRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 
@@ -165,7 +172,10 @@ func databaseSecretBackendStaticRoleRead(d *schema.ResourceData, meta interface{
 }
 
 func databaseSecretBackendStaticRoleDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 	log.Printf("[DEBUG] Deleting static role %q", path)
@@ -178,7 +188,10 @@ func databaseSecretBackendStaticRoleDelete(d *schema.ResourceData, meta interfac
 }
 
 func databaseSecretBackendStaticRoleExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
 
 	path := d.Id()
 	log.Printf("[DEBUG] Checking if %q exists", path)

--- a/vault/resource_database_secret_backend_static_role_test.go
+++ b/vault/resource_database_secret_backend_static_role_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -99,7 +99,7 @@ func TestAccDatabaseSecretBackendStaticRole_basic(t *testing.T) {
 }
 
 func testAccDatabaseSecretBackendStaticRoleCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_database_secret_backend_static_role" {

--- a/vault/resource_database_secrets_mount.go
+++ b/vault/resource_database_secrets_mount.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 type dbConfigStore struct {
@@ -209,7 +211,10 @@ func setCommonDatabaseSchema(s schemaMap) schemaMap {
 }
 
 func databaseSecretsMountCreateOrUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	var root string
 	if d.IsNewResource() {
@@ -259,7 +264,10 @@ func databaseSecretsMountCreateOrUpdate(d *schema.ResourceData, meta interface{}
 }
 
 func databaseSecretsMountRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	if err := readMount(d, meta, true); err != nil {
 		return err

--- a/vault/resource_database_secrets_mount_test.go
+++ b/vault/resource_database_secrets_mount_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 	mssqlhelper "github.com/hashicorp/vault/helper/testhelpers/mssql"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -69,7 +69,7 @@ func TestAccDatabaseSecretsMount_mssql(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					client := testProvider.Meta().(*api.Client)
+					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 					resp, err := client.Logical().Read(fmt.Sprintf("%s/creds/%s", backend, "dev"))
 					if err != nil {
 						t.Fatal(err)
@@ -169,7 +169,7 @@ func TestAccDatabaseSecretsMount_mssql_multi(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					client := testProvider.Meta().(*api.Client)
+					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 					for _, role := range []string{"dev1", "dev2"} {
 						resp, err := client.Logical().Read(fmt.Sprintf("%s/creds/%s", backend, role))
@@ -321,7 +321,7 @@ resource "vault_database_secret_backend_role" "test2" {
 }
 
 func testAccDatabaseSecretsMountCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_database_secrets_mount" {

--- a/vault/resource_egp_policy_test.go
+++ b/vault/resource_egp_policy_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -42,7 +42,7 @@ func TestAccEndpointGoverningPolicy(t *testing.T) {
 }
 
 func testAccEndpointGoverningPolicyCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_egp_policy" {
 			continue

--- a/vault/resource_gcp_auth_backend.go
+++ b/vault/resource_gcp_auth_backend.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 const (
@@ -17,7 +19,6 @@ const (
 
 func gcpAuthBackendResource() *schema.Resource {
 	return &schema.Resource{
-
 		Create: gcpAuthBackendWrite,
 		Update: gcpAuthBackendUpdate,
 		Read:   gcpAuthBackendRead,
@@ -113,7 +114,10 @@ func gcpAuthBackendConfigPath(path string) string {
 }
 
 func gcpAuthBackendWrite(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	authType := gcpAuthType
 	path := d.Get("path").(string)
@@ -137,7 +141,10 @@ func gcpAuthBackendWrite(d *schema.ResourceData, meta interface{}) error {
 }
 
 func gcpAuthBackendUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := gcpAuthBackendConfigPath(d.Id())
 	data := map[string]interface{}{}
@@ -148,7 +155,6 @@ func gcpAuthBackendUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Writing gcp config %q", path)
 	_, err := client.Logical().Write(path, data)
-
 	if err != nil {
 		d.SetId("")
 		return fmt.Errorf("error writing gcp config %q: %s", path, err)
@@ -159,7 +165,11 @@ func gcpAuthBackendUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func gcpAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	path := gcpAuthBackendConfigPath(d.Id())
 
 	log.Printf("[DEBUG] Reading gcp auth backend config %q", path)
@@ -198,7 +208,11 @@ func gcpAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func gcpAuthBackendDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	path := d.Id()
 
 	log.Printf("[DEBUG] Deleting gcp auth backend %q", path)
@@ -212,7 +226,11 @@ func gcpAuthBackendDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func gcpAuthBackendExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
+
 	path := gcpAuthBackendConfigPath(d.Id())
 
 	log.Printf("[DEBUG] Checking if gcp auth backend %q exists", path)

--- a/vault/resource_gcp_auth_backend_role.go
+++ b/vault/resource_gcp_auth_backend_role.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/hashicorp/vault/api"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 var (
@@ -169,7 +169,10 @@ func gcpRoleUpdateFields(d *schema.ResourceData, data map[string]interface{}, cr
 }
 
 func gcpAuthResourceCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 
 	backend := d.Get("backend").(string)
 	role := d.Get("role").(string)
@@ -192,7 +195,10 @@ func gcpAuthResourceCreate(ctx context.Context, d *schema.ResourceData, meta int
 }
 
 func gcpAuthResourceUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 	path := d.Id()
 
 	data := map[string]interface{}{}
@@ -209,7 +215,10 @@ func gcpAuthResourceUpdate(ctx context.Context, d *schema.ResourceData, meta int
 }
 
 func gcpAuthResourceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 	path := d.Id()
 
 	log.Printf("[DEBUG] Reading GCP role %q", path)
@@ -275,7 +284,10 @@ func gcpAuthResourceRead(_ context.Context, d *schema.ResourceData, meta interfa
 }
 
 func gcpAuthResourceDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 	path := d.Id()
 
 	log.Printf("[DEBUG] Deleting GCP role %q", path)

--- a/vault/resource_gcp_auth_backend_role_test.go
+++ b/vault/resource_gcp_auth_backend_role_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -135,7 +135,7 @@ func TestGCPAuthBackendRole_gce(t *testing.T) {
 }
 
 func testGCPAuthBackendRoleDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_gcp_auth_backend_role" {
@@ -169,7 +169,7 @@ func testGCPAuthBackendRoleCheck_attrs(backend, name string) resource.TestCheckF
 			return fmt.Errorf("expected ID to be %q, got %q instead", endpoint, instanceState.ID)
 		}
 
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 		authMounts, err := client.Sys().ListAuth()
 		if err != nil {
 			return err

--- a/vault/resource_gcp_auth_backend_test.go
+++ b/vault/resource_gcp_auth_backend_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -67,7 +67,7 @@ func TestGCPAuthBackend_import(t *testing.T) {
 }
 
 func testGCPAuthBackendDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_gcp_auth_backend" {

--- a/vault/resource_gcp_secret_backend.go
+++ b/vault/resource_gcp_secret_backend.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func gcpSecretBackendResource(name string) *schema.Resource {
@@ -81,7 +83,10 @@ func gcpSecretBackendResource(name string) *schema.Resource {
 }
 
 func gcpSecretBackendCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Get("path").(string)
 	description := d.Get("description").(string)
@@ -127,7 +132,10 @@ func gcpSecretBackendCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func gcpSecretBackendRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 
@@ -157,7 +165,10 @@ func gcpSecretBackendRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func gcpSecretBackendUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 	d.Partial(true)
@@ -190,7 +201,10 @@ func gcpSecretBackendUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func gcpSecretBackendDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 
@@ -204,7 +218,11 @@ func gcpSecretBackendDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func gcpSecretBackendExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
+
 	path := d.Id()
 	log.Printf("[DEBUG] Checking if GCP backend exists at %q", path)
 	mounts, err := client.Sys().ListMounts()

--- a/vault/resource_gcp_secret_backend_test.go
+++ b/vault/resource_gcp_secret_backend_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -47,7 +47,7 @@ func TestGCPSecretBackend(t *testing.T) {
 }
 
 func testAccGCPSecretBackendCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	mounts, err := client.Sys().ListMounts()
 	if err != nil {

--- a/vault/resource_gcp_secret_roleset.go
+++ b/vault/resource_gcp_secret_roleset.go
@@ -9,7 +9,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 var (
@@ -109,7 +110,10 @@ func gcpSecretRolesetResource() *schema.Resource {
 }
 
 func gcpSecretRolesetCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 	roleset := d.Get("roleset").(string)
@@ -132,7 +136,11 @@ func gcpSecretRolesetCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func gcpSecretRolesetRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	path := d.Id()
 
 	backend, err := gcpSecretRolesetBackendFromPath(path)
@@ -192,7 +200,11 @@ func gcpSecretRolesetRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func gcpSecretRolesetUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	path := d.Id()
 
 	data := map[string]interface{}{}
@@ -210,7 +222,11 @@ func gcpSecretRolesetUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func gcpSecretRolesetDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	path := d.Id()
 
 	log.Printf("[DEBUG] Deleting GCP secrets backend roleset %q", path)
@@ -244,7 +260,11 @@ func gcpSecretRolesetUpdateFields(d *schema.ResourceData, data map[string]interf
 }
 
 func gcpSecretRolesetExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
+
 	path := d.Id()
 	log.Printf("[DEBUG] Checking if %q exists", path)
 	secret, err := client.Logical().Read(path)

--- a/vault/resource_gcp_secret_roleset_test.go
+++ b/vault/resource_gcp_secret_roleset_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -120,7 +120,7 @@ func testGCPSecretRoleset_attrs(backend, roleset string) resource.TestCheckFunc 
 			return fmt.Errorf("expected ID to be %q, got %q instead", backend+"/roleset/"+roleset, endpoint)
 		}
 
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 		resp, err := client.Logical().Read(endpoint)
 		if err != nil {
 			return fmt.Errorf("%q doesn't exist", endpoint)
@@ -290,7 +290,7 @@ func testGCPSecretRoleset_serviceAccountEmail(serviceAccountEmail *string, check
 }
 
 func testGCPSecretRolesetDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_gcp_secret_roleset" {

--- a/vault/resource_gcp_secret_static_account.go
+++ b/vault/resource_gcp_secret_static_account.go
@@ -7,7 +7,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 var (
@@ -96,7 +97,10 @@ func gcpSecretStaticAccountResource() *schema.Resource {
 }
 
 func gcpSecretStaticAccountCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 	staticAccount := d.Get("static_account").(string)
@@ -119,7 +123,11 @@ func gcpSecretStaticAccountCreate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func gcpSecretStaticAccountRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	path := d.Id()
 
 	backend, err := gcpSecretStaticAccountBackendFromPath(path)
@@ -175,7 +183,11 @@ func gcpSecretStaticAccountRead(d *schema.ResourceData, meta interface{}) error 
 }
 
 func gcpSecretStaticAccountUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	path := d.Id()
 
 	data := map[string]interface{}{}
@@ -193,7 +205,11 @@ func gcpSecretStaticAccountUpdate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func gcpSecretStaticAccountDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	path := d.Id()
 
 	log.Printf("[DEBUG] Deleting GCP secrets backend static account %q", path)
@@ -229,7 +245,11 @@ func gcpSecretStaticAccountUpdateFields(d *schema.ResourceData, data map[string]
 }
 
 func gcpSecretStaticAccountExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
+
 	path := d.Id()
 	log.Printf("[DEBUG] Checking if %q exists", path)
 	secret, err := client.Logical().Read(path)

--- a/vault/resource_gcp_secret_static_account_test.go
+++ b/vault/resource_gcp_secret_static_account_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 	"golang.org/x/oauth2/google"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -143,7 +143,7 @@ func testGCPSecretStaticAccount_attrs(backend, staticAccount string) resource.Te
 			return fmt.Errorf("expected ID to be %q, got %q instead", backend+"/static-account/"+staticAccount, endpoint)
 		}
 
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 		resp, err := client.Logical().Read(endpoint)
 		if err != nil {
 			return fmt.Errorf("%q doesn't exist", endpoint)
@@ -291,7 +291,7 @@ func testGCPSecretStaticAccount_attrs(backend, staticAccount string) resource.Te
 }
 
 func testGCPSecretStaticAccountDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_gcp_secret_static_account" {

--- a/vault/resource_generic_endpoint.go
+++ b/vault/resource_generic_endpoint.go
@@ -6,7 +6,8 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func genericEndpointResource(name string) *schema.Resource {
@@ -88,7 +89,10 @@ func genericEndpointResource(name string) *schema.Resource {
 }
 
 func genericEndpointResourceWrite(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	var data map[string]interface{}
 	err := json.Unmarshal([]byte(d.Get("data_json").(string)), &data)
@@ -151,7 +155,10 @@ func genericEndpointResourceDelete(d *schema.ResourceData, meta interface{}) err
 	shouldDelete := !d.Get("disable_delete").(bool)
 
 	if shouldDelete {
-		client := meta.(*api.Client)
+		client, e := provider.GetClient(d, meta)
+		if e != nil {
+			return e
+		}
 
 		path := d.Id()
 
@@ -172,7 +179,10 @@ func genericEndpointResourceRead(d *schema.ResourceData, meta interface{}) error
 	ignore_absent_fields := d.Get("ignore_absent_fields").(bool)
 
 	if shouldRead {
-		client := meta.(*api.Client)
+		client, e := provider.GetClient(d, meta)
+		if e != nil {
+			return e
+		}
 
 		log.Printf("[DEBUG] Reading %s from Vault", path)
 		data, err := client.Logical().Read(path)

--- a/vault/resource_generic_endpoint_test.go
+++ b/vault/resource_generic_endpoint_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -173,7 +173,7 @@ func testResourceGenericEndpoint_initialCheck(s *terraform.State) error {
 
 func testResourceGenericEndpoint_destroyCheck(path string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "vault_generic_endpoint" {

--- a/vault/resource_generic_secret_test.go
+++ b/vault/resource_generic_secret_test.go
@@ -2,6 +2,7 @@ package vault
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -9,23 +10,26 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
 func TestResourceGenericSecret(t *testing.T) {
-	path := acctest.RandomWithPrefix("secretsv1/test")
+	mount := acctest.RandomWithPrefix("secretsv1")
+	name := acctest.RandomWithPrefix("test")
+	path := fmt.Sprintf("%s/%s", mount, name)
 	resourceName := "vault_generic_secret.test"
-
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
 		PreCheck:  func() { testutil.TestAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: testResourceGenericSecret_initialConfig(path),
+				Config: testResourceGenericSecret_initialConfig(mount, name),
 				Check:  testResourceGenericSecret_initialCheck(path),
 			},
 			{
-				Config: testResourceGenericSecret_updateConfig,
+				Config: testResourceGenericSecret_updateConfig(mount, name),
 				Check:  testResourceGenericSecret_updateCheck,
 			},
 			{
@@ -36,16 +40,67 @@ func TestResourceGenericSecret(t *testing.T) {
 	})
 }
 
-func TestResourceGenericSecret_deleted(t *testing.T) {
-	path := acctest.RandomWithPrefix("secretsv1/test")
+func TestResourceGenericSecretNS(t *testing.T) {
+	ns := acctest.RandomWithPrefix("ns")
+	mount := acctest.RandomWithPrefix("secretsv1")
+	name := acctest.RandomWithPrefix("test")
+	path := fmt.Sprintf("%s/%s", mount, name)
 	resourceName := "vault_generic_secret.test"
 
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testutil.TestEntPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceGenericSecret_initialConfigNS(ns, mount, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "namespace", ns),
+					testResourceGenericSecret_initialCheck(path),
+				),
+			},
+			{
+				// unfortunately two steps are needed when testing import,
+				// since the tf-plugin-sdk does not allow for specifying environment variables :(
+				// neither does have any support for generic post-step functions.
+				// It is possible that this will cause issues if we ever want to support parallel tests.
+				// We would have to update the SDK to suport specifying extra env vars by step.
+				PreConfig: func() {
+					t.Setenv(consts.EnvVarVaultNamespaceImport, ns)
+				},
+				ImportState:  true,
+				ResourceName: resourceName,
+			},
+			{
+				// needed for the import step above :(
+				Config: testResourceGenericSecret_initialConfigNS(ns, mount, name),
+				PreConfig: func() {
+					os.Unsetenv(consts.EnvVarVaultNamespaceImport)
+				},
+				PlanOnly: true,
+			},
+			{
+				Config: testResourceGenericSecret_updateConfig(mount, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr(resourceName, "namespace"),
+					testResourceGenericSecret_updateCheck,
+				),
+			},
+		},
+	})
+}
+
+func TestResourceGenericSecret_deleted(t *testing.T) {
+	resourceName := "vault_generic_secret.test"
+
+	mount := acctest.RandomWithPrefix("secretsv1")
+	name := acctest.RandomWithPrefix("test")
+	path := fmt.Sprintf("%s/%s", mount, name)
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
 		PreCheck:  func() { testutil.TestAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: testResourceGenericSecret_initialConfig(path),
+				Config: testResourceGenericSecret_initialConfig(mount, name),
 				Check:  testResourceGenericSecret_initialCheck(path),
 			},
 			{
@@ -54,13 +109,13 @@ func TestResourceGenericSecret_deleted(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					client := testProvider.Meta().(*api.Client)
+					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 					_, err := client.Logical().Delete(path)
 					if err != nil {
 						t.Fatalf("unable to manually delete the secret via the SDK: %s", err)
 					}
 				},
-				Config: testResourceGenericSecret_initialConfig(path),
+				Config: testResourceGenericSecret_initialConfig(mount, name),
 				Check:  testResourceGenericSecret_initialCheck(path),
 			},
 			{
@@ -100,10 +155,10 @@ func TestResourceGenericSecret_deleteAllVersions(t *testing.T) {
 	})
 }
 
-func testResourceGenericSecret_initialConfig(path string) string {
+func testResourceGenericSecret_initialConfig(mount, name string) string {
 	return fmt.Sprintf(`
 resource "vault_mount" "v1" {
-	path = "secretsv1"
+	path = "%s"
 	type = "kv"
 	options = {
 		version = "1"
@@ -111,14 +166,62 @@ resource "vault_mount" "v1" {
 }
 
 resource "vault_generic_secret" "test" {
-    depends_on = ["vault_mount.v1"]
-    path = "%s"
+    path = "${vault_mount.v1.path}/%s"
     data_json = <<EOT
 {
     "zip": "zap"
 }
 EOT
-}`, path)
+}`, mount, name)
+}
+
+func testResourceGenericSecret_updateConfig(mount, name string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "v1" {
+	path = "%s"
+	type = "kv"
+	options = {
+		version = "1"
+	}
+}
+
+resource "vault_generic_secret" "test" {
+    path = "${vault_mount.v1.path}/%s"
+    data_json = <<EOT
+{
+    "zip": "zoop"
+}
+EOT
+}
+`, mount, name)
+}
+
+func testResourceGenericSecret_initialConfigNS(ns, mount, name string) string {
+	result := fmt.Sprintf(`
+resource "vault_namespace" "ns1" {
+    path = "%s"
+}
+
+resource "vault_mount" "v1" {
+    namespace = vault_namespace.ns1.path
+	path = "%s"
+	type = "kv"
+	options = {
+		version = "1"
+	}
+}
+
+resource "vault_generic_secret" "test" {
+    namespace = vault_mount.v1.namespace
+    path = "${vault_mount.v1.path}/%s"
+    data_json = <<EOT
+{
+    "zip": "zap"
+}
+EOT
+}`, ns, mount, name)
+
+	return result
 }
 
 func testResourceGenericSecret_initialConfig_v2(path string, isUpdate bool) string {
@@ -168,21 +271,24 @@ func testResourceGenericSecret_initialCheck(expectedPath string) resource.TestCh
 			return fmt.Errorf("resource not found in state")
 		}
 
-		instanceState := resourceState.Primary
-		if instanceState == nil {
+		state := resourceState.Primary
+		if state == nil {
 			return fmt.Errorf("resource has no primary instance")
 		}
 
-		path := instanceState.ID
+		path := state.ID
 
-		if path != instanceState.Attributes["path"] {
+		if path != state.Attributes["path"] {
 			return fmt.Errorf("id doesn't match path")
 		}
 		if path != expectedPath {
 			return fmt.Errorf("unexpected secret path")
 		}
 
-		client := testProvider.Meta().(*api.Client)
+		client, err := provider.GetClient(state, testProvider.Meta())
+		if err != nil {
+			return err
+		}
 
 		secret, err := client.Logical().Read(path)
 		if err != nil {
@@ -196,7 +302,7 @@ func testResourceGenericSecret_initialCheck(expectedPath string) resource.TestCh
 		}
 
 		// Test the map
-		if got, want := instanceState.Attributes["data.zip"], "zap"; got != want {
+		if got, want := state.Attributes["data.zip"], "zap"; got != want {
 			return fmt.Errorf("data[\"zip\"] contains %s; want %s", got, want)
 		}
 
@@ -225,7 +331,7 @@ func testResourceGenericSecret_initialCheck_v2(expectedPath string, wantValue st
 			return fmt.Errorf("unexpected secret path")
 		}
 
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 		// Checking KV-V2 Secrets
 		resp, err := client.Logical().List("secretsv2/metadata")
@@ -279,7 +385,7 @@ func testResourceGenericSecret_checkVersions(client *api.Client, keyName string,
 }
 
 func testAllVersionDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_generic_secret" {
@@ -296,35 +402,17 @@ func testAllVersionDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testResourceGenericSecret_updateConfig = `
-
-resource "vault_mount" "v1" {
-	path = "secretsv1"
-	type = "kv"
-	options = {
-		version = "1"
-	}
-}
-
-resource "vault_generic_secret" "test" {
-    path = "${vault_mount.v1.path}/foo"
-    disable_read = false
-    data_json = <<EOT
-{
-    "zip": "zoop"
-}
-EOT
-}
-
-`
-
 func testResourceGenericSecret_updateCheck(s *terraform.State) error {
 	resourceState := s.Modules[0].Resources["vault_generic_secret.test"]
-	instanceState := resourceState.Primary
+	state := resourceState.Primary
 
-	path := instanceState.ID
+	path := state.ID
 
-	client := testProvider.Meta().(*api.Client)
+	client, err := provider.GetClient(state, testProvider.Meta())
+	if err != nil {
+		return err
+	}
+
 	secret, err := client.Logical().Read(path)
 	if err != nil {
 		return fmt.Errorf("error reading back secret: %s", err)

--- a/vault/resource_github_auth_backend.go
+++ b/vault/resource_github_auth_backend.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
@@ -69,9 +70,12 @@ func githubAuthBackendResource() *schema.Resource {
 }
 
 func githubAuthBackendCreate(d *schema.ResourceData, meta interface{}) error {
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	var description string
 
-	client := meta.(*api.Client)
 	path := strings.Trim(d.Get("path").(string), "/")
 
 	if v, ok := d.GetOk("description"); ok {
@@ -95,8 +99,10 @@ func githubAuthBackendCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func githubAuthBackendUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
-
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	path := "auth/" + d.Id()
 	configPath := path + "/config"
 
@@ -151,7 +157,11 @@ func githubAuthBackendUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func githubAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	path := "auth/" + d.Id()
 	configPath := path + "/config"
 
@@ -201,5 +211,5 @@ func githubAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func githubAuthBackendDelete(d *schema.ResourceData, meta interface{}) error {
-	return authMountDisable(meta.(*api.Client), d.Id())
+	return authMountDisable(meta.(*provider.ProviderMeta).GetClient(), d.Id())
 }

--- a/vault/resource_github_auth_backend_test.go
+++ b/vault/resource_github_auth_backend_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -193,7 +194,7 @@ func TestAccGithubAuthBackend_importTuning(t *testing.T) {
 
 func testAccCheckAuthMountExists(n string, out *api.AuthMount) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 		return authMountExistsHelper(n, s, client, out)
 	}
 }
@@ -203,7 +204,7 @@ func testAccCheckGithubAuthMountDestroy(s *terraform.State) error {
 }
 
 func testAccCheckAuthMountDestroy(s *terraform.State, resType string) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 	return authMountDestroyHelper(s, client, resType)
 }
 

--- a/vault/resource_github_team.go
+++ b/vault/resource_github_team.go
@@ -6,7 +6,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func githubTeamResource() *schema.Resource {
@@ -58,7 +59,11 @@ func githubTeamCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func githubTeamUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	path := d.Id()
 
 	data := map[string]interface{}{}
@@ -80,7 +85,11 @@ func githubTeamUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func githubTeamRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	path := d.Id()
 
 	dt, err := client.Logical().Read(path)
@@ -108,7 +117,10 @@ func githubTeamRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func githubTeamDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	_, err := client.Logical().Delete(d.Id())
 	if err != nil {

--- a/vault/resource_github_team_test.go
+++ b/vault/resource_github_team_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -100,7 +100,7 @@ func TestGithubTeamBackEndPath(t *testing.T) {
 }
 
 func testAccGithubTeamCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 	for _, r := range s.RootModule().Resources {
 		if r.Type != "vault_github_team" {
 			continue

--- a/vault/resource_github_user.go
+++ b/vault/resource_github_user.go
@@ -6,7 +6,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func githubUserResource() *schema.Resource {
@@ -57,7 +58,11 @@ func githubUserCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func githubUserUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	path := d.Id()
 
 	data := map[string]interface{}{}
@@ -79,7 +84,11 @@ func githubUserUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func githubUserRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	path := d.Id()
 
 	dt, err := client.Logical().Read(path)
@@ -107,7 +116,10 @@ func githubUserRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func githubUserDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	_, err := client.Logical().Delete(d.Id())
 	if err != nil {

--- a/vault/resource_github_user_test.go
+++ b/vault/resource_github_user_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -83,7 +83,7 @@ func TestGithubUserBackEndPath(t *testing.T) {
 }
 
 func testAccGithubUserCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 	for _, r := range s.RootModule().Resources {
 		if r.Type != "vault_github_user" {
 			continue

--- a/vault/resource_identity_entity.go
+++ b/vault/resource_identity_entity.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/vault/api"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/identity/entity"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
@@ -107,7 +108,10 @@ func identityEntityUpdateFields(d *schema.ResourceData, data map[string]interfac
 }
 
 func identityEntityCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	name := d.Get("name").(string)
 
@@ -143,7 +147,11 @@ func identityEntityCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func identityEntityUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	id := d.Id()
 
 	log.Printf("[DEBUG] Updating IdentityEntity %q", id)
@@ -166,7 +174,11 @@ func identityEntityUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func identityEntityRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	id := d.Id()
 
 	log.Printf("[DEBUG] Read IdentityEntity %s", id)
@@ -194,7 +206,11 @@ func identityEntityRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func identityEntityDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	id := d.Id()
 
 	path := entity.JoinEntityID(id)
@@ -213,7 +229,11 @@ func identityEntityDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func identityEntityExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
+
 	id := d.Id()
 
 	path := entity.JoinEntityID(id)
@@ -267,7 +287,7 @@ func readEntity(client *api.Client, path string, retry bool) (*api.Secret, error
 		if err != nil {
 			return nil, fmt.Errorf("error cloning client: %w", err)
 		}
-		util.SetupCCCRetryClient(client, maxHTTPRetriesCCC)
+		util.SetupCCCRetryClient(client, provider.MaxHTTPRetriesCCC)
 	}
 
 	resp, err := client.Logical().Read(path)

--- a/vault/resource_identity_entity_alias.go
+++ b/vault/resource_identity_entity_alias.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/identity/entity"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
@@ -59,7 +59,10 @@ func identityEntityAliasCreate(ctx context.Context, d *schema.ResourceData, meta
 	lock()
 	defer unlock()
 
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 
 	path := entity.RootAliasPath
 	name := d.Get("name").(string)
@@ -141,14 +144,17 @@ func identityEntityAliasUpdate(ctx context.Context, d *schema.ResourceData, meta
 	lock()
 	defer unlock()
 
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
+
 	id := d.Id()
 
 	log.Printf("[DEBUG] Updating entity alias %q", id)
 	path := entity.JoinAliasID(id)
 
 	diags := diag.Diagnostics{}
-
 	data := util.GetAPIRequestData(d, map[string]string{
 		"name":            "",
 		"mount_accessor":  "",
@@ -170,7 +176,11 @@ func identityEntityAliasUpdate(ctx context.Context, d *schema.ResourceData, meta
 }
 
 func identityEntityAliasRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
+
 	id := d.Id()
 
 	path := entity.JoinAliasID(id)
@@ -214,7 +224,11 @@ func identityEntityAliasDelete(ctx context.Context, d *schema.ResourceData, meta
 	lock()
 	defer unlock()
 
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
+
 	id := d.Id()
 
 	path := entity.JoinAliasID(id)

--- a/vault/resource_identity_entity_alias_test.go
+++ b/vault/resource_identity_entity_alias_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/identity/entity"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -186,7 +186,7 @@ resource "vault_identity_entity_alias" "test2" {
 			{
 				// delete one of the alias's to ensure an update operation re-creates it.
 				PreConfig: func() {
-					client := testProvider.Meta().(*api.Client)
+					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 					aliases, err := entity.FindAliases(client, &entity.FindAliasParams{
 						Name: alias,
 					})
@@ -259,7 +259,7 @@ func TestAccIdentityEntityAlias_Update(t *testing.T) {
 }
 
 func testAccCheckIdentityEntityAliasDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_identity_entity_alias" {

--- a/vault/resource_identity_entity_policies.go
+++ b/vault/resource_identity_entity_policies.go
@@ -5,9 +5,9 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/identity/entity"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
@@ -51,7 +51,11 @@ func identityEntityPoliciesResource() *schema.Resource {
 }
 
 func identityEntityPoliciesUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	id := d.Get("entity_id").(string)
 
 	log.Printf("[DEBUG] Updating IdentityEntityPolicies %q", id)
@@ -95,7 +99,11 @@ func identityEntityPoliciesUpdate(d *schema.ResourceData, meta interface{}) erro
 }
 
 func identityEntityPoliciesRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	id := d.Id()
 
 	log.Printf("[DEBUG] Read IdentityEntityPolicies %s", id)
@@ -134,7 +142,11 @@ func identityEntityPoliciesRead(d *schema.ResourceData, meta interface{}) error 
 }
 
 func identityEntityPoliciesDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	id := d.Get("entity_id").(string)
 
 	log.Printf("[DEBUG] Deleting IdentityEntityPolicies %q", id)

--- a/vault/resource_identity_entity_policies_test.go
+++ b/vault/resource_identity_entity_policies_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/identity/entity"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 	"github.com/hashicorp/terraform-provider-vault/util"
 )
@@ -72,7 +72,7 @@ func TestAccIdentityEntityPoliciesNonExclusive(t *testing.T) {
 }
 
 func testAccCheckidentityEntityPoliciesDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_identity_entity_policies" {
@@ -124,7 +124,7 @@ func testAccIdentityEntityPoliciesCheckAttrs(resource string) resource.TestCheck
 		id := instanceState.ID
 
 		path := entity.JoinEntityID(id)
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 		resp, err := client.Logical().Read(path)
 		if err != nil {
 			return fmt.Errorf("%q doesn't exist", path)
@@ -219,7 +219,7 @@ func testAccIdentityEntityPoliciesCheckLogical(resource string, policies []strin
 		id := instanceState.ID
 
 		path := entity.JoinEntityID(id)
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 		resp, err := client.Logical().Read(path)
 		if err != nil {
 			return fmt.Errorf("%q doesn't exist", path)

--- a/vault/resource_identity_entity_test.go
+++ b/vault/resource_identity_entity_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/vault/api"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/identity/entity"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -118,7 +119,7 @@ func TestAccIdentityEntityUpdateRemovePolicies(t *testing.T) {
 }
 
 func testAccCheckIdentityEntityDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_identity_entity" {
@@ -294,9 +295,9 @@ func TestReadEntity(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			defer func() {
-				maxHTTPRetriesCCC = DefaultMaxHTTPRetriesCCC
+				provider.MaxHTTPRetriesCCC = DefaultMaxHTTPRetriesCCC
 			}()
-			maxHTTPRetriesCCC = tt.maxRetries
+			provider.MaxHTTPRetriesCCC = tt.maxRetries
 
 			r := tt.retryHandler
 

--- a/vault/resource_identity_group.go
+++ b/vault/resource_identity_group.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
@@ -154,7 +155,10 @@ func identityGroupUpdateFields(d *schema.ResourceData, data map[string]interface
 }
 
 func identityGroupCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	name := d.Get("name").(string)
 	typeValue := d.Get("type").(string)
@@ -194,7 +198,11 @@ func identityGroupCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func identityGroupUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	id := d.Id()
 
 	log.Printf("[DEBUG] Updating IdentityGroup %q", id)
@@ -219,7 +227,11 @@ func identityGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func identityGroupRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	id := d.Id()
 
 	log.Printf("[DEBUG] Read IdentityGroup %s", id)
@@ -249,7 +261,11 @@ func identityGroupRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func identityGroupDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	id := d.Id()
 
 	path := identityGroupIDPath(id)
@@ -268,7 +284,11 @@ func identityGroupDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func identityGroupExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
+
 	id := d.Id()
 	key := id
 

--- a/vault/resource_identity_group_alias.go
+++ b/vault/resource_identity_group_alias.go
@@ -5,7 +5,8 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 const identityGroupAliasPath = "/identity/group-alias"
@@ -44,7 +45,10 @@ func identityGroupAliasResource() *schema.Resource {
 }
 
 func identityGroupAliasCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	name := d.Get("name").(string)
 	mountAccessor := d.Get("mount_accessor").(string)
@@ -59,7 +63,6 @@ func identityGroupAliasCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	resp, err := client.Logical().Write(path, data)
-
 	if err != nil {
 		return fmt.Errorf("error writing IdentityGroupAlias to %q: %s", name, err)
 	}
@@ -70,7 +73,11 @@ func identityGroupAliasCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func identityGroupAliasUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	id := d.Id()
 
 	log.Printf("[DEBUG] Updating IdentityGroupAlias %q", id)
@@ -108,7 +115,11 @@ func identityGroupAliasUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func identityGroupAliasRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	id := d.Id()
 
 	path := identityGroupAliasIDPath(id)
@@ -135,7 +146,11 @@ func identityGroupAliasRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func identityGroupAliasDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	id := d.Id()
 
 	path := identityGroupAliasIDPath(id)
@@ -151,7 +166,11 @@ func identityGroupAliasDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func identityGroupAliasExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
+
 	id := d.Id()
 
 	path := identityGroupAliasIDPath(id)

--- a/vault/resource_identity_group_alias_test.go
+++ b/vault/resource_identity_group_alias_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -73,7 +73,7 @@ func TestAccIdentityGroupAliasUpdate(t *testing.T) {
 }
 
 func testAccCheckIdentityGroupAliasDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_identity_group_alias" {

--- a/vault/resource_identity_group_member_entity_ids.go
+++ b/vault/resource_identity_group_member_entity_ids.go
@@ -5,7 +5,8 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func identityGroupMemberEntityIdsResource() *schema.Resource {
@@ -54,7 +55,10 @@ func identityGroupMemberEntityIdsUpdate(d *schema.ResourceData, meta interface{}
 	vaultMutexKV.Lock(path)
 	defer vaultMutexKV.Unlock(path)
 
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	log.Printf("[DEBUG] Updating IdentityGroupMemberEntityIds %q", gid)
 
@@ -118,7 +122,11 @@ func identityGroupMemberEntityIdsUpdate(d *schema.ResourceData, meta interface{}
 }
 
 func identityGroupMemberEntityIdsRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	id := d.Id()
 
 	log.Printf("[DEBUG] Read IdentityGroupMemberEntityIds %s", id)
@@ -174,7 +182,10 @@ func identityGroupMemberEntityIdsDelete(d *schema.ResourceData, meta interface{}
 	vaultMutexKV.Lock(path)
 	defer vaultMutexKV.Unlock(path)
 
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	log.Printf("[DEBUG] Deleting IdentityGroupMemberEntityIds %q", id)
 

--- a/vault/resource_identity_group_member_entity_ids_test.go
+++ b/vault/resource_identity_group_member_entity_ids_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 	"github.com/hashicorp/terraform-provider-vault/util"
 )
@@ -353,7 +353,7 @@ func (r *memberEntityTester) CheckMemberEntities(resourceName string) resource.T
 }
 
 func testAccCheckidentityGroupMemberEntityIdsDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_identity_group_member_entity_ids" {
@@ -401,7 +401,7 @@ type vaultStateTest struct {
 }
 
 func assertVaultState(tfs *terraform.State, path string, stateTests ...*vaultStateTest) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 	resp, err := client.Logical().Read(path)
 	if err != nil {
 		return fmt.Errorf("%q doesn't exist", path)

--- a/vault/resource_identity_group_policies.go
+++ b/vault/resource_identity_group_policies.go
@@ -5,8 +5,8 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
@@ -50,7 +50,11 @@ func identityGroupPoliciesResource() *schema.Resource {
 }
 
 func identityGroupPoliciesUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	id := d.Get("group_id").(string)
 
 	log.Printf("[DEBUG] Updating IdentityGroupPolicies %q", id)
@@ -94,7 +98,11 @@ func identityGroupPoliciesUpdate(d *schema.ResourceData, meta interface{}) error
 }
 
 func identityGroupPoliciesRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	id := d.Id()
 
 	log.Printf("[DEBUG] Read IdentityGroupPolicies %s", id)
@@ -143,7 +151,11 @@ func identityGroupPoliciesRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func identityGroupPoliciesDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	id := d.Get("group_id").(string)
 
 	log.Printf("[DEBUG] Deleting IdentityGroupPolicies %q", id)

--- a/vault/resource_identity_group_policies_test.go
+++ b/vault/resource_identity_group_policies_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 	"github.com/hashicorp/terraform-provider-vault/util"
 )
@@ -68,7 +68,7 @@ func TestAccIdentityGroupPoliciesNonExclusive(t *testing.T) {
 }
 
 func testAccCheckidentityGroupPoliciesDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_identity_group_policies" {
@@ -120,7 +120,7 @@ func testAccIdentityGroupPoliciesCheckAttrs(resource string) resource.TestCheckF
 		id := instanceState.ID
 
 		path := identityGroupIDPath(id)
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 		resp, err := client.Logical().Read(path)
 		if err != nil {
 			return fmt.Errorf("%q doesn't exist", path)
@@ -215,7 +215,7 @@ func testAccIdentityGroupPoliciesCheckLogical(resource string, policies []string
 		id := instanceState.ID
 
 		path := identityGroupIDPath(id)
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 		resp, err := client.Logical().Read(path)
 		if err != nil {
 			return fmt.Errorf("%q doesn't exist", path)

--- a/vault/resource_identity_group_test.go
+++ b/vault/resource_identity_group_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -149,7 +149,7 @@ resource "vault_identity_group" "test_upper" {
 }
 
 func testAccCheckIdentityGroupDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_identity_group" {
@@ -181,7 +181,7 @@ func testAccIdentityGroupCheckAttrs() resource.TestCheckFunc {
 		id := instanceState.ID
 
 		path := identityGroupIDPath(id)
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 		resp, err := client.Logical().Read(path)
 		if err != nil {
 			return fmt.Errorf("%q doesn't exist", path)

--- a/vault/resource_identity_oidc.go
+++ b/vault/resource_identity_oidc.go
@@ -5,7 +5,8 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 const identityOidcPathTemplate = "identity/oidc/config"
@@ -34,7 +35,11 @@ func identityOidcUpdateFields(d *schema.ResourceData, data map[string]interface{
 }
 
 func identityOidcCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	path := identityOidcPathTemplate
 
 	data := make(map[string]interface{})
@@ -43,7 +48,6 @@ func identityOidcCreate(d *schema.ResourceData, meta interface{}) error {
 	identityOidcUpdateFields(d, data)
 
 	_, err := client.Logical().Write(path, data)
-
 	if err != nil {
 		return fmt.Errorf("error writing IdentityOidc %s: %s", addr, err)
 	}
@@ -55,7 +59,11 @@ func identityOidcCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func identityOidcUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	path := identityOidcPathTemplate
 	addr := d.Id()
 
@@ -66,7 +74,6 @@ func identityOidcUpdate(d *schema.ResourceData, meta interface{}) error {
 	identityOidcUpdateFields(d, data)
 
 	_, err := client.Logical().Write(path, data)
-
 	if err != nil {
 		return fmt.Errorf("error updating IdentityOidc for %s: %s", addr, err)
 	}
@@ -76,7 +83,11 @@ func identityOidcUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func identityOidcRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	path := identityOidcPathTemplate
 	addr := d.Id()
 
@@ -101,7 +112,11 @@ func identityOidcRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func identityOidcDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	addr := d.Id()
 	path := identityOidcPathTemplate
 
@@ -121,7 +136,11 @@ func identityOidcDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func identityOidcExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
+
 	addr := d.Id()
 	path := identityOidcPathTemplate
 

--- a/vault/resource_identity_oidc_assignment.go
+++ b/vault/resource_identity_oidc_assignment.go
@@ -5,7 +5,8 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 const identityOIDCAssignmentPathPrefix = "identity/oidc/assignment"
@@ -67,7 +68,10 @@ func getOIDCAssignmentPath(name string) string {
 }
 
 func identityOIDCAssignmentCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	name := d.Get("name").(string)
 	path := getOIDCAssignmentPath(name)
 
@@ -84,7 +88,10 @@ func identityOIDCAssignmentCreateUpdate(d *schema.ResourceData, meta interface{}
 }
 
 func identityOIDCAssignmentRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	path := d.Id()
 
 	log.Printf("[DEBUG] Reading OIDC Assignment for %s", path)
@@ -110,7 +117,10 @@ func identityOIDCAssignmentRead(d *schema.ResourceData, meta interface{}) error 
 }
 
 func identityOIDCAssignmentDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	path := d.Id()
 
 	log.Printf("[DEBUG] Deleting OIDC Assignment %s", path)

--- a/vault/resource_identity_oidc_assignment_test.go
+++ b/vault/resource_identity_oidc_assignment_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -88,7 +88,7 @@ resource "vault_identity_oidc_assignment" "test" {
 }
 
 func testAccCheckOIDCAssignmentDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_identity_oidc_assignment" {

--- a/vault/resource_identity_oidc_client.go
+++ b/vault/resource_identity_oidc_client.go
@@ -5,7 +5,8 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 const identityOIDCClientPathPrefix = "identity/oidc/client"
@@ -108,7 +109,10 @@ func getOIDCClientPath(name string) string {
 }
 
 func identityOIDCClientCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	name := d.Get("name").(string)
 	path := getOIDCClientPath(name)
 
@@ -125,7 +129,10 @@ func identityOIDCClientCreateUpdate(d *schema.ResourceData, meta interface{}) er
 }
 
 func identityOIDCClientRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	path := d.Id()
 
 	log.Printf("[DEBUG] Reading OIDC Client for %s", path)
@@ -157,7 +164,10 @@ func identityOIDCClientRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func identityOIDCClientDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	path := d.Id()
 
 	log.Printf("[DEBUG] Deleting OIDC Client %s", path)

--- a/vault/resource_identity_oidc_client_test.go
+++ b/vault/resource_identity_oidc_client_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -126,7 +126,7 @@ resource "vault_identity_oidc_client" "client" {
 }
 
 func testAccCheckOIDCClientDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_identity_oidc_client" {

--- a/vault/resource_identity_oidc_key.go
+++ b/vault/resource_identity_oidc_key.go
@@ -7,18 +7,18 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 const identityOidcKeyPathTemplate = "identity/oidc/key/%s"
 
-var (
-	identityOidcKeyFields = []string{
-		"rotation_period",
-		"verification_ttl",
-		"algorithm",
-		"allowed_client_ids",
-	}
-)
+var identityOidcKeyFields = []string{
+	"rotation_period",
+	"verification_ttl",
+	"algorithm",
+	"allowed_client_ids",
+}
 
 func identityOidcKey() *schema.Resource {
 	return &schema.Resource{
@@ -82,7 +82,10 @@ func identityOidcKeyUpdateFields(d *schema.ResourceData, data map[string]interfa
 }
 
 func identityOidcKeyCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	name := d.Get("name").(string)
 	path := identityOidcKeyPath(name)
@@ -103,7 +106,11 @@ func identityOidcKeyCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func identityOidcKeyUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	name := d.Id()
 	path := identityOidcKeyPath(name)
 
@@ -123,7 +130,11 @@ func identityOidcKeyUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func identityOidcKeyRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	name := d.Id()
 
 	resp, err := identityOidcKeyApiRead(name, client)
@@ -147,7 +158,11 @@ func identityOidcKeyRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func identityOidcKeyDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	name := d.Id()
 	path := identityOidcKeyPath(name)
 
@@ -165,12 +180,15 @@ func identityOidcKeyDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func identityOidcKeyExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
+
 	name := d.Id()
 
 	log.Printf("[DEBUG] Checking if IdentityOidcKey %s exists", name)
 	key, err := identityOidcKeyApiRead(name, client)
-
 	if err != nil {
 		return true, fmt.Errorf("error checking if IdentityOidcKey %s exists: %q", name, err)
 	}

--- a/vault/resource_identity_oidc_key_allowed_client_id.go
+++ b/vault/resource_identity_oidc_key_allowed_client_id.go
@@ -5,8 +5,9 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
-	"github.com/hashicorp/vault/api"
 )
 
 func identityOidcKeyAllowedClientId() *schema.Resource {
@@ -34,7 +35,11 @@ func identityOidcKeyAllowedClientId() *schema.Resource {
 }
 
 func identityOidcKeyAllowedClientIdWrite(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	name := d.Get("key_name").(string)
 	path := identityOidcKeyPath(name)
 	clientID := d.Get("allowed_client_id").(string)
@@ -66,7 +71,11 @@ func identityOidcKeyAllowedClientIdWrite(d *schema.ResourceData, meta interface{
 }
 
 func identityOidcKeyAllowedClientIdRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	name := d.Get("key_name").(string)
 	clientID := d.Get("allowed_client_id").(string)
 
@@ -91,7 +100,11 @@ func identityOidcKeyAllowedClientIdRead(d *schema.ResourceData, meta interface{}
 }
 
 func identityOidcKeyAllowedClientIdDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	name := d.Get("key_name").(string)
 	path := identityOidcKeyPath(name)
 	clientID := d.Get("allowed_client_id").(string)

--- a/vault/resource_identity_oidc_key_allowed_client_id_test.go
+++ b/vault/resource_identity_oidc_key_allowed_client_id_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 	"github.com/hashicorp/terraform-provider-vault/util"
 )
@@ -55,7 +55,7 @@ func TestAccIdentityOidcKeyAllowedClientId(t *testing.T) {
 }
 
 func testAccCheckIdentityOidcKeyAllowedClientIdDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_identity_oidc_key_allowed_client_id" {
@@ -90,7 +90,7 @@ func testAccIdentityOidcKeyAllowedClientIdCheckAttrs(clientIDResource string, cl
 		}
 
 		id := instanceState.ID
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 		resp, err := identityOidcKeyApiRead(id, client)
 		if err != nil {
 			return err

--- a/vault/resource_identity_oidc_key_test.go
+++ b/vault/resource_identity_oidc_key_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -93,7 +93,7 @@ func TestAccIdentityOidcKeyUpdate(t *testing.T) {
 }
 
 func testAccCheckIdentityOidcKeyDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_identity_oidc_key" {
@@ -124,7 +124,7 @@ func testAccIdentityOidcKeyCheckAttrs() resource.TestCheckFunc {
 
 		id := instanceState.ID
 		path := identityOidcKeyPath(id)
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 		resp, err := identityOidcKeyApiRead(id, client)
 		if err != nil {
 			return fmt.Errorf("%q doesn't exist", id)

--- a/vault/resource_identity_oidc_provider.go
+++ b/vault/resource_identity_oidc_provider.go
@@ -5,7 +5,8 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 const identityOIDCProviderPathPrefix = "identity/oidc/provider"
@@ -98,7 +99,10 @@ func getOIDCProviderPath(name string) string {
 }
 
 func identityOIDCProviderCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	name := d.Get("name").(string)
 	path := getOIDCProviderPath(name)
 
@@ -125,7 +129,10 @@ func identityOIDCProviderCreateUpdate(d *schema.ResourceData, meta interface{}) 
 }
 
 func identityOIDCProviderRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	path := d.Id()
 
 	log.Printf("[DEBUG] Reading OIDC Provider for %s", path)
@@ -152,7 +159,10 @@ func identityOIDCProviderRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func identityOIDCProviderDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	path := d.Id()
 
 	log.Printf("[DEBUG] Deleting OIDC Provider %s", path)

--- a/vault/resource_identity_oidc_provider_test.go
+++ b/vault/resource_identity_oidc_provider_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -93,7 +93,7 @@ resource "vault_identity_oidc_provider" "test" {
 }
 
 func testAccCheckOIDCProviderDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_identity_oidc_provider" {

--- a/vault/resource_identity_oidc_role.go
+++ b/vault/resource_identity_oidc_role.go
@@ -5,7 +5,8 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 const identityOidcRolePathTemplate = "identity/oidc/role/%s"
@@ -67,7 +68,10 @@ func identityOidcRoleUpdateFields(d *schema.ResourceData, data map[string]interf
 }
 
 func identityOidcRoleCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	name := d.Get("name").(string)
 
@@ -78,7 +82,6 @@ func identityOidcRoleCreate(d *schema.ResourceData, meta interface{}) error {
 	identityOidcRoleUpdateFields(d, data)
 
 	_, err := client.Logical().Write(path, data)
-
 	if err != nil {
 		return fmt.Errorf("error writing IdentityOidcRole %s: %s", path, err)
 	}
@@ -90,7 +93,11 @@ func identityOidcRoleCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func identityOidcRoleUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	name := d.Id()
 	path := identityOidcRolePath(name)
 	log.Printf("[DEBUG] Updating IdentityOidcRole %s at %s", name, path)
@@ -100,7 +107,6 @@ func identityOidcRoleUpdate(d *schema.ResourceData, meta interface{}) error {
 	identityOidcRoleUpdateFields(d, data)
 
 	_, err := client.Logical().Write(path, data)
-
 	if err != nil {
 		return fmt.Errorf("error updating IdentityOidcRole %s: %s", name, err)
 	}
@@ -110,7 +116,11 @@ func identityOidcRoleUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func identityOidcRoleRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	name := d.Id()
 	path := identityOidcRolePath(name)
 
@@ -136,7 +146,11 @@ func identityOidcRoleRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func identityOidcRoleDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	name := d.Id()
 	path := identityOidcRolePath(name)
 
@@ -151,7 +165,11 @@ func identityOidcRoleDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func identityOidcRoleExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
+
 	name := d.Id()
 	path := identityOidcRolePath(name)
 

--- a/vault/resource_identity_oidc_role_test.go
+++ b/vault/resource_identity_oidc_role_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -116,7 +116,7 @@ func TestAccIdentityOidcRoleUpdate(t *testing.T) {
 }
 
 func testAccCheckIdentityOidcRoleDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_identity_oidc_role" {
@@ -148,7 +148,7 @@ func testAccIdentityOidcRoleCheckAttrs() resource.TestCheckFunc {
 		id := instanceState.ID
 
 		path := identityOidcRolePath(id)
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 		resp, err := client.Logical().Read(path)
 		if err != nil {
 			return fmt.Errorf("%q doesn't exist", path)

--- a/vault/resource_identity_oidc_scope.go
+++ b/vault/resource_identity_oidc_scope.go
@@ -5,7 +5,8 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 const identityOIDCScopePathPrefix = "identity/oidc/scope"
@@ -61,7 +62,10 @@ func getOIDCScopePath(name string) string {
 }
 
 func identityOIDCScopeCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	name := d.Get("name").(string)
 	path := getOIDCScopePath(name)
 
@@ -78,7 +82,10 @@ func identityOIDCScopeCreateUpdate(d *schema.ResourceData, meta interface{}) err
 }
 
 func identityOIDCScopeRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	path := d.Id()
 
 	log.Printf("[DEBUG] Reading OIDC Scope for %s", path)
@@ -104,7 +111,10 @@ func identityOIDCScopeRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func identityOIDCScopeDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	path := d.Id()
 
 	log.Printf("[DEBUG] Deleting OIDC Scope %s", path)

--- a/vault/resource_identity_oidc_scope_test.go
+++ b/vault/resource_identity_oidc_scope_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -74,7 +74,7 @@ resource "vault_identity_oidc_scope" "test" {
 }
 
 func testAccCheckOIDCScopeDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_identity_oidc_scope" {

--- a/vault/resource_identity_oidc_test.go
+++ b/vault/resource_identity_oidc_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -42,7 +42,7 @@ func TestAccIdentityOidc(t *testing.T) {
 }
 
 func testAccCheckIdentityOidcDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 	path := identityOidcPathTemplate
 
 	resp, err := client.Logical().Read(path)
@@ -73,7 +73,7 @@ func testAccIdentityOidcCheckAttrs() resource.TestCheckFunc {
 		}
 
 		path := identityOidcPathTemplate
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 		resp, err := client.Logical().Read(path)
 		if err != nil {
 			return fmt.Errorf("%q doesn't exist", path)

--- a/vault/resource_jwt_auth_backend.go
+++ b/vault/resource_jwt_auth_backend.go
@@ -10,6 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func jwtAuthBackendResource() *schema.Resource {
@@ -25,7 +27,6 @@ func jwtAuthBackendResource() *schema.Resource {
 		CustomizeDiff: jwtCustomizeDiff,
 
 		Schema: map[string]*schema.Schema{
-
 			"path": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -187,28 +188,29 @@ func jwtCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta interface{
 	return errors.New("exactly one of oidc_discovery_url, jwks_url or jwt_validation_pubkeys should be provided")
 }
 
-var (
-	// TODO: build this from the Resource Schema?
-	matchingJwtMountConfigOptions = []string{
-		"oidc_discovery_url",
-		"oidc_discovery_ca_pem",
-		"oidc_client_id",
-		"oidc_client_secret",
-		"oidc_response_mode",
-		"oidc_response_types",
-		"jwks_url",
-		"jwks_ca_pem",
-		"jwt_validation_pubkeys",
-		"bound_issuer",
-		"jwt_supported_algs",
-		"default_role",
-		"provider_config",
-		"namespace_in_state",
-	}
-)
+// TODO: build this from the Resource Schema?
+var matchingJwtMountConfigOptions = []string{
+	"oidc_discovery_url",
+	"oidc_discovery_ca_pem",
+	"oidc_client_id",
+	"oidc_client_secret",
+	"oidc_response_mode",
+	"oidc_response_types",
+	"jwks_url",
+	"jwks_ca_pem",
+	"jwt_validation_pubkeys",
+	"bound_issuer",
+	"jwt_supported_algs",
+	"default_role",
+	"provider_config",
+	"namespace_in_state",
+}
 
 func jwtAuthBackendWrite(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	authType := d.Get("type").(string)
 	path := getJwtPath(d)
@@ -221,7 +223,6 @@ func jwtAuthBackendWrite(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Writing auth %s to Vault", authType)
 
 	err := client.Sys().EnableAuthWithOptions(path, options)
-
 	if err != nil {
 		return fmt.Errorf("error writing to Vault: %s", err)
 	}
@@ -232,14 +233,16 @@ func jwtAuthBackendWrite(d *schema.ResourceData, meta interface{}) error {
 }
 
 func jwtAuthBackendDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := getJwtPath(d)
 
 	log.Printf("[DEBUG] Deleting auth %s from Vault", path)
 
 	err := client.Sys().DisableAuth(path)
-
 	if err != nil {
 		return fmt.Errorf("error disabling auth from Vault: %s", err)
 	}
@@ -248,7 +251,10 @@ func jwtAuthBackendDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func jwtAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := getJwtPath(d)
 	log.Printf("[DEBUG] Reading auth %s from Vault", path)
@@ -263,7 +269,6 @@ func jwtAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("path", path)
 
 	mount, err := getAuthMountIfPresent(client, path)
-
 	if err != nil {
 		return fmt.Errorf("unable to check auth backends in Vault for path %s: %s", path, err)
 	}
@@ -275,7 +280,6 @@ func jwtAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	config, err := client.Logical().Read(jwtConfigEndpoint(path))
-
 	if err != nil {
 		return fmt.Errorf("error reading from Vault: %s", err)
 	}
@@ -317,7 +321,6 @@ func jwtAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	return nil
-
 }
 
 func convertProviderConfigValues(input map[string]interface{}) (map[string]interface{}, error) {
@@ -345,7 +348,10 @@ func convertProviderConfigValues(input map[string]interface{}) (map[string]inter
 }
 
 func jwtAuthBackendUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := getJwtPath(d)
 	log.Printf("[DEBUG] Updating auth %s in Vault", path)

--- a/vault/resource_jwt_auth_backend_role.go
+++ b/vault/resource_jwt_auth_backend_role.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
@@ -147,7 +147,10 @@ func jwtAuthBackendRoleResource() *schema.Resource {
 }
 
 func jwtAuthBackendRoleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 
 	backend := d.Get("backend").(string)
 	role := d.Get("role_name").(string)
@@ -177,7 +180,10 @@ func jwtAuthBackendRoleCreate(ctx context.Context, d *schema.ResourceData, meta 
 }
 
 func jwtAuthBackendRoleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 	path := d.Id()
 
 	backend, err := jwtAuthBackendRoleBackendFromPath(path)
@@ -287,7 +293,10 @@ func jwtAuthBackendRoleRead(_ context.Context, d *schema.ResourceData, meta inte
 }
 
 func jwtAuthBackendRoleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 	path := d.Id()
 
 	log.Printf("[DEBUG] Updating JWT auth backend role %q", path)
@@ -316,7 +325,10 @@ func jwtAuthBackendRoleUpdate(ctx context.Context, d *schema.ResourceData, meta 
 }
 
 func jwtAuthBackendRoleDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 	path := d.Id()
 
 	log.Printf("[DEBUG] Deleting JWT auth backend role %q", path)

--- a/vault/resource_jwt_auth_backend_role_test.go
+++ b/vault/resource_jwt_auth_backend_role_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -491,7 +491,7 @@ func TestAccJWTAuthBackendRole_fullUpdate(t *testing.T) {
 }
 
 func testAccCheckJWTAuthBackendRoleDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_jwt_auth_backend_role" {

--- a/vault/resource_kmip_secret_backend.go
+++ b/vault/resource_kmip_secret_backend.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -38,7 +39,7 @@ func kmipSecretBackendResource() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				Description:  "Path where KMIP secret backend will be mounted",
-				ValidateFunc: validateNoTrailingLeadingSlashes,
+				ValidateFunc: validateNoLeadingTrailingSlashes,
 			},
 			"description": {
 				Type:        schema.TypeString,
@@ -108,7 +109,10 @@ func kmipSecretBackendResource() *schema.Resource {
 }
 
 func kmipSecretBackendCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	path := d.Get("path").(string)
 	defaultTLSClientTTL := fmt.Sprintf("%ds", d.Get("default_tls_client_ttl").(int))
 
@@ -130,7 +134,10 @@ func kmipSecretBackendCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func kmipSecretBackendUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	path := d.Id()
 
 	if !d.IsNewResource() && d.HasChange("path") {
@@ -212,7 +219,10 @@ func kmipSecretBackendUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func kmipSecretBackendRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 	log.Printf("[DEBUG] Reading KMIP config at %s/config", path)
@@ -238,7 +248,10 @@ func kmipSecretBackendRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func kmipSecretBackendDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	path := d.Id()
 	log.Printf("[DEBUG] Unmounting KMIP backend %q", path)
 

--- a/vault/resource_kmip_secret_backend_test.go
+++ b/vault/resource_kmip_secret_backend_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -137,7 +137,7 @@ func TestAccKMIPSecretBackend_remount(t *testing.T) {
 }
 
 func testAccKMIPSecretBackendCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	mounts, err := client.Sys().ListMounts()
 	if err != nil {

--- a/vault/resource_kmip_secret_role.go
+++ b/vault/resource_kmip_secret_role.go
@@ -5,7 +5,8 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 const (
@@ -60,7 +61,7 @@ func kmipSecretRoleResource() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				Description:  "Path where KMIP backend is mounted",
-				ValidateFunc: validateNoTrailingLeadingSlashes,
+				ValidateFunc: validateNoLeadingTrailingSlashes,
 			},
 			"scope": {
 				Type:        schema.TypeString,
@@ -178,7 +179,10 @@ func kmipSecretRoleResource() *schema.Resource {
 }
 
 func kmipSecretRoleCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	scope := d.Get("scope").(string)
 	role := d.Get("role").(string)
 
@@ -204,7 +208,10 @@ func kmipSecretRoleCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func kmipSecretRoleRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	rolePath := d.Id()
 	if rolePath == "" {
 		return fmt.Errorf("expected a path as ID, got empty string")
@@ -238,7 +245,10 @@ func kmipSecretRoleRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func kmipSecretRoleUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	rolePath := d.Id()
 
 	if d.HasChange("path") {
@@ -269,7 +279,10 @@ func kmipSecretRoleUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func kmipSecretRoleDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	rolePath := d.Id()
 
 	log.Printf("[DEBUG] Deleting KMIP role %s", rolePath)

--- a/vault/resource_kmip_secret_role_test.go
+++ b/vault/resource_kmip_secret_role_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -162,7 +162,7 @@ func TestAccKMIPSecretRole_remount(t *testing.T) {
 }
 
 func testAccKMIPSecretRoleCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	mounts, err := client.Sys().ListMounts()
 	if err != nil {

--- a/vault/resource_kmip_secret_scope.go
+++ b/vault/resource_kmip_secret_scope.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 var errKMIPScopeNotFound = errors.New("KMIP scope not found")
@@ -26,7 +28,7 @@ func kmipSecretScopeResource() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				Description:  "Path where KMIP backend is mounted",
-				ValidateFunc: validateNoTrailingLeadingSlashes,
+				ValidateFunc: validateNoLeadingTrailingSlashes,
 			},
 			"scope": {
 				Type:        schema.TypeString,
@@ -45,7 +47,10 @@ func kmipSecretScopeResource() *schema.Resource {
 }
 
 func kmipSecretScopeCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	scope := d.Get("scope").(string)
 	force := d.Get("force").(bool)
 
@@ -68,7 +73,10 @@ func kmipSecretScopeCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func kmipSecretScopeRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	scopeListPath := d.Get("path").(string) + "/scope"
 	scope := d.Get("scope").(string)
 
@@ -88,7 +96,10 @@ func kmipSecretScopeRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func kmipSecretScopeUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	scope := d.Get("scope").(string)
 
 	if d.HasChange("path") {
@@ -111,7 +122,10 @@ func kmipSecretScopeUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func kmipSecretScopeDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	scopePath := d.Id()
 
 	log.Printf("[DEBUG] Deleting KMIP scope %q", scopePath)

--- a/vault/resource_kmip_secret_scope_test.go
+++ b/vault/resource_kmip_secret_scope_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -54,7 +54,7 @@ func TestAccKMIPSecretScope_remount(t *testing.T) {
 }
 
 func testAccKMIPSecretScopeCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	mounts, err := client.Sys().ListMounts()
 	if err != nil {

--- a/vault/resource_kubernetes_auth_backend_config.go
+++ b/vault/resource_kubernetes_auth_backend_config.go
@@ -7,7 +7,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 var kubernetesAuthBackendConfigFromPathRegex = regexp.MustCompile("^auth/(.+)/config$")
@@ -85,7 +86,10 @@ func kubernetesAuthBackendConfigPath(backend string) string {
 }
 
 func kubernetesAuthBackendConfigCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 
@@ -152,7 +156,11 @@ func kubernetesAuthBackendConfigBackendFromPath(path string) (string, error) {
 }
 
 func kubernetesAuthBackendConfigRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	path := d.Id()
 
 	backend, err := kubernetesAuthBackendConfigBackendFromPath(path)
@@ -197,7 +205,11 @@ func kubernetesAuthBackendConfigRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func kubernetesAuthBackendConfigUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	path := d.Id()
 
 	log.Printf("[DEBUG] Updating Kubernetes auth backend config %q", path)
@@ -254,7 +266,10 @@ func kubernetesAuthBackendConfigDelete(d *schema.ResourceData, meta interface{})
 }
 
 func kubernetesAuthBackendConfigExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
 
 	path := d.Id()
 	log.Printf("[DEBUG] Checking if Kubernetes auth backend config %q exists", path)

--- a/vault/resource_kubernetes_auth_backend_config_test.go
+++ b/vault/resource_kubernetes_auth_backend_config_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -158,7 +158,7 @@ func TestAccKubernetesAuthBackendConfig_basic(t *testing.T) {
 }
 
 func testAccCheckKubernetesAuthBackendConfigDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_kubernetes_auth_backend_config" {
@@ -366,7 +366,7 @@ func TestAccKubernetesAuthBackendConfig_localCA(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					client := testProvider.Meta().(*api.Client)
+					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 					path := kubernetesAuthBackendConfigPath(backend)
 					if _, err := client.Logical().Write(path, map[string]interface{}{
 						"kubernetes_ca_cert": kubernetesCAcert,

--- a/vault/resource_kubernetes_auth_backend_role.go
+++ b/vault/resource_kubernetes_auth_backend_role.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
@@ -131,7 +131,10 @@ func kubernetesAuthBackendRoleBackendFromPath(path string) (string, error) {
 }
 
 func kubernetesAuthBackendRoleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 
 	backend := d.Get("backend").(string)
 	role := d.Get("role_name").(string)
@@ -154,7 +157,10 @@ func kubernetesAuthBackendRoleCreate(ctx context.Context, d *schema.ResourceData
 }
 
 func kubernetesAuthBackendRoleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 	path := d.Id()
 
 	backend, err := kubernetesAuthBackendRoleBackendFromPath(path)
@@ -205,7 +211,10 @@ func kubernetesAuthBackendRoleRead(_ context.Context, d *schema.ResourceData, me
 }
 
 func kubernetesAuthBackendRoleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 	path := d.Id()
 
 	log.Printf("[DEBUG] Updating Kubernetes auth backend role %q", path)
@@ -227,7 +236,10 @@ func kubernetesAuthBackendRoleUpdate(ctx context.Context, d *schema.ResourceData
 }
 
 func kubernetesAuthBackendRoleDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 	path := d.Id()
 
 	log.Printf("[DEBUG] Deleting Kubernetes auth backend role %q", path)

--- a/vault/resource_kubernetes_auth_backend_role_test.go
+++ b/vault/resource_kubernetes_auth_backend_role_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -433,7 +433,7 @@ func TestAccKubernetesAuthBackendRole_fullUpdate(t *testing.T) {
 }
 
 func testAccCheckKubernetesAuthBackendRoleDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_kubernetes_auth_backend_role" {

--- a/vault/resource_ldap_auth_backend.go
+++ b/vault/resource_ldap_auth_backend.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 const ldapAuthType string = "ldap"
@@ -175,7 +177,10 @@ func ldapAuthBackendConfigPath(path string) string {
 }
 
 func ldapAuthBackendWrite(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 
 	path := d.Get("path").(string)
 	options := &api.EnableAuthOptions{
@@ -197,7 +202,10 @@ func ldapAuthBackendWrite(ctx context.Context, d *schema.ResourceData, meta inte
 }
 
 func ldapAuthBackendUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 
 	path := ldapAuthBackendConfigPath(d.Id())
 	data := map[string]interface{}{}
@@ -299,7 +307,10 @@ func ldapAuthBackendUpdate(ctx context.Context, d *schema.ResourceData, meta int
 }
 
 func ldapAuthBackendRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 
 	path := d.Id()
 	auths, err := client.Sys().ListAuth()
@@ -365,7 +376,10 @@ func ldapAuthBackendRead(_ context.Context, d *schema.ResourceData, meta interfa
 }
 
 func ldapAuthBackendDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 	path := d.Id()
 
 	log.Printf("[DEBUG] Deleting LDAP auth backend %q", path)

--- a/vault/resource_ldap_auth_backend_group.go
+++ b/vault/resource_ldap_auth_backend_group.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/hashicorp/vault/api"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 var (
@@ -61,7 +61,10 @@ func ldapAuthBackendGroupResourcePath(backend, groupname string) string {
 }
 
 func ldapAuthBackendGroupResourceWrite(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 	groupname := d.Get("groupname").(string)
@@ -88,7 +91,11 @@ func ldapAuthBackendGroupResourceWrite(d *schema.ResourceData, meta interface{})
 }
 
 func ldapAuthBackendGroupResourceRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	path := d.Id()
 
 	backend, err := ldapAuthBackendGroupBackendFromPath(path)
@@ -122,11 +129,14 @@ func ldapAuthBackendGroupResourceRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("groupname", groupname)
 
 	return nil
-
 }
 
 func ldapAuthBackendGroupResourceDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	path := d.Id()
 
 	log.Printf("[DEBUG] Deleting LDAP group %q", path)
@@ -140,7 +150,11 @@ func ldapAuthBackendGroupResourceDelete(d *schema.ResourceData, meta interface{}
 }
 
 func ldapAuthBackendGroupResourceExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
+
 	path := d.Id()
 
 	log.Printf("[DEBUG] Checking if LDAP group %q exists", path)

--- a/vault/resource_ldap_auth_backend_group_test.go
+++ b/vault/resource_ldap_auth_backend_group_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 	"github.com/hashicorp/terraform-provider-vault/util"
 )
@@ -66,7 +66,7 @@ func TestLDAPAuthBackendGroup_basic(t *testing.T) {
 }
 
 func testLDAPAuthBackendGroupDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_ldap_auth_backend_group" {
@@ -100,7 +100,7 @@ func testLDAPAuthBackendGroupCheck_attrs(backend, groupname string) resource.Tes
 			return fmt.Errorf("expected id to be %q, got %q instead", endpoint, instanceState.ID)
 		}
 
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 		authMounts, err := client.Sys().ListAuth()
 		if err != nil {
 			return err

--- a/vault/resource_ldap_auth_backend_test.go
+++ b/vault/resource_ldap_auth_backend_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -102,7 +102,7 @@ func TestLDAPAuthBackend_tls(t *testing.T) {
 }
 
 func testLDAPAuthBackendDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_ldap_auth_backend" {
@@ -136,7 +136,7 @@ func testLDAPAuthBackendCheck_attrs(path string) resource.TestCheckFunc {
 			return fmt.Errorf("expected ID to be %q, got %q instead", endpoint, instanceState.ID)
 		}
 
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 		authMounts, err := client.Sys().ListAuth()
 		if err != nil {
 			return err

--- a/vault/resource_ldap_auth_backend_user.go
+++ b/vault/resource_ldap_auth_backend_user.go
@@ -7,8 +7,9 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
-	"github.com/hashicorp/vault/api"
 )
 
 var (
@@ -68,7 +69,10 @@ func ldapAuthBackendUserResourcePath(backend, username string) string {
 }
 
 func ldapAuthBackendUserResourceWrite(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 	username := d.Get("username").(string)
@@ -99,7 +103,11 @@ func ldapAuthBackendUserResourceWrite(d *schema.ResourceData, meta interface{}) 
 }
 
 func ldapAuthBackendUserResourceRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	path := d.Id()
 
 	backend, err := ldapAuthBackendUserBackendFromPath(path)
@@ -144,11 +152,14 @@ func ldapAuthBackendUserResourceRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("username", username)
 
 	return nil
-
 }
 
 func ldapAuthBackendUserResourceDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	path := d.Id()
 
 	log.Printf("[DEBUG] Deleting LDAP user %q", path)
@@ -162,7 +173,11 @@ func ldapAuthBackendUserResourceDelete(d *schema.ResourceData, meta interface{})
 }
 
 func ldapAuthBackendUserResourceExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
+
 	path := d.Id()
 
 	log.Printf("[DEBUG] Checking if LDAP user %q exists", path)

--- a/vault/resource_ldap_auth_backend_user_test.go
+++ b/vault/resource_ldap_auth_backend_user_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 	"github.com/hashicorp/terraform-provider-vault/util"
 )
@@ -132,7 +132,7 @@ func TestLDAPAuthBackendUser_oneGroup(t *testing.T) {
 }
 
 func testLDAPAuthBackendUserDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_ldap_auth_backend_user" {
@@ -161,7 +161,7 @@ func testLDAPAuthBackendUserCheck_groups(backend, username string, groups []stri
 			return fmt.Errorf("resource has no primary instance")
 		}
 
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 		resp, err := client.Logical().Read(instanceState.ID)
 		if err != nil {
 			return err
@@ -217,7 +217,7 @@ func testLDAPAuthBackendUserCheck_attrs(backend, username string) resource.TestC
 			return fmt.Errorf("expected ID to be %q, got %q instead", endpoint, instanceState.ID)
 		}
 
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 		authMounts, err := client.Sys().ListAuth()
 		if err != nil {
 			return err

--- a/vault/resource_mfa_duo.go
+++ b/vault/resource_mfa_duo.go
@@ -6,7 +6,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func mfaDuoResource() *schema.Resource {
@@ -63,7 +64,10 @@ func mfaDuoResource() *schema.Resource {
 }
 
 func mfaDuoWrite(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	name := d.Get("name").(string)
 
@@ -75,7 +79,6 @@ func mfaDuoWrite(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Creating mfaDuo %s in Vault", name)
 	_, err := client.Logical().Write(mfaDuoPath(name), data)
-
 	if err != nil {
 		return fmt.Errorf("error writing to Vault: %s", err)
 	}
@@ -84,14 +87,16 @@ func mfaDuoWrite(d *schema.ResourceData, meta interface{}) error {
 }
 
 func mfaDuoDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	name := d.Get("name").(string)
 
 	log.Printf("[DEBUG] Deleting mfaDuo %s from Vault", mfaDuoPath(name))
 
 	_, err := client.Logical().Delete(mfaDuoPath(name))
-
 	if err != nil {
 		return fmt.Errorf("error deleting from Vault: %s", err)
 	}
@@ -100,12 +105,14 @@ func mfaDuoDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func mfaDuoRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	name := d.Get("name").(string)
 
 	resp, err := client.Logical().Read(mfaDuoPath(name))
-
 	if err != nil {
 		return fmt.Errorf("error reading from Vault: %s", err)
 	}
@@ -152,7 +159,6 @@ func mfaDuoUpdateFields(d *schema.ResourceData, data map[string]interface{}) {
 	if v, ok := d.GetOk("push_info"); ok {
 		data["push_info"] = v.(string)
 	}
-
 }
 
 func mfaDuoPath(name string) string {

--- a/vault/resource_mfa_okta.go
+++ b/vault/resource_mfa_okta.go
@@ -6,7 +6,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func mfaOktaResource() *schema.Resource {
@@ -103,7 +104,10 @@ func mfaOktaRequestData(d *schema.ResourceData) map[string]interface{} {
 }
 
 func mfaOktaWrite(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	name := d.Get("name").(string)
 	path := mfaOktaPath(name)
 
@@ -119,7 +123,10 @@ func mfaOktaWrite(d *schema.ResourceData, meta interface{}) error {
 }
 
 func mfaOktaRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	path := mfaOktaPath(d.Id())
 
 	log.Printf("[DEBUG] Reading MFA Okta config %q", path)
@@ -148,7 +155,10 @@ func mfaOktaUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func mfaOktaDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	path := mfaOktaPath(d.Id())
 
 	log.Printf("[DEBUG] Deleting mfaOkta %s from Vault", path)

--- a/vault/resource_mfa_pingid.go
+++ b/vault/resource_mfa_pingid.go
@@ -6,7 +6,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func mfaPingIDResource() *schema.Resource {
@@ -113,7 +114,10 @@ func mfaPingIDRequestData(d *schema.ResourceData) map[string]interface{} {
 }
 
 func mfaPingIDWrite(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	name := d.Get("name").(string)
 	path := mfaPingIDPath(name)
 
@@ -129,7 +133,10 @@ func mfaPingIDWrite(d *schema.ResourceData, meta interface{}) error {
 }
 
 func mfaPingIDRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	path := mfaPingIDPath(d.Id())
 
 	log.Printf("[DEBUG] Reading MFA PingID config %q", path)
@@ -170,7 +177,10 @@ func mfaPingIDUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func mfaPingIDDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	path := mfaPingIDPath(d.Id())
 
 	log.Printf("[DEBUG] Deleting mfaPingID %s from Vault", path)

--- a/vault/resource_mfa_totp.go
+++ b/vault/resource_mfa_totp.go
@@ -6,7 +6,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func mfaTOTPResource() *schema.Resource {
@@ -111,7 +112,10 @@ func mfaTOTPRequestData(d *schema.ResourceData) map[string]interface{} {
 }
 
 func mfaTOTPWrite(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	name := d.Get("name").(string)
 	path := mfaTOTPPath(name)
 
@@ -127,7 +131,10 @@ func mfaTOTPWrite(d *schema.ResourceData, meta interface{}) error {
 }
 
 func mfaTOTPRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	name := d.Id()
 	path := mfaTOTPPath(name)
 
@@ -157,7 +164,10 @@ func mfaTOTPUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func mfaTOTPDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	path := mfaTOTPPath(d.Id())
 
 	log.Printf("[DEBUG] Deleting mfaTOTP %s from Vault", path)

--- a/vault/resource_mfa_totp_test.go
+++ b/vault/resource_mfa_totp_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -35,7 +35,7 @@ func TestMFATOTPBasic(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					client := testProvider.Meta().(*api.Client)
+					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 					resp, err := client.Logical().Read(mfaTOTPPath(path))
 					if err != nil {
 						t.Fatal(err)

--- a/vault/resource_mount.go
+++ b/vault/resource_mount.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 type schemaMap map[string]*schema.Schema
@@ -128,7 +130,10 @@ func MountResource() *schema.Resource {
 }
 
 func mountWrite(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, err := provider.GetClient(d, meta)
+	if err != nil {
+		return err
+	}
 
 	path := d.Get("path").(string)
 	if err := createMount(d, client, path, d.Get("type").(string)); err != nil {
@@ -171,7 +176,10 @@ func createMount(d *schema.ResourceData, client *api.Client, path string, mountT
 }
 
 func mountUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, err := provider.GetClient(d, meta)
+	if err != nil {
+		return err
+	}
 
 	config := api.MountConfigInput{
 		DefaultLeaseTTL: fmt.Sprintf("%ds", d.Get("default_lease_ttl_seconds")),
@@ -228,7 +236,10 @@ func mountUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func mountDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, err := provider.GetClient(d, meta)
+	if err != nil {
+		return err
+	}
 
 	path := d.Id()
 
@@ -246,7 +257,10 @@ func mountRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func readMount(d *schema.ResourceData, meta interface{}, excludeType bool) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 

--- a/vault/resource_mount_test.go
+++ b/vault/resource_mount_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -165,7 +166,6 @@ func TestResourceMount_KVV2(t *testing.T) {
 				max_lease_ttl_seconds = 36000
 			}`, path)
 	resource.Test(t, resource.TestCase{
-
 		Providers: testProviders,
 		PreCheck:  func() { testutil.TestAccPreCheck(t) },
 		Steps: []resource.TestStep{
@@ -664,7 +664,7 @@ resource "vault_mount" "test" {
 }
 
 func findMount(path string) (*api.MountOutput, error) {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	path = path + "/"
 

--- a/vault/resource_nomad_secret_backend.go
+++ b/vault/resource_nomad_secret_backend.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -106,7 +107,11 @@ func nomadSecretAccessBackendResource() *schema.Resource {
 }
 
 func createNomadAccessConfigResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	backend := d.Get("backend").(string)
 	description := d.Get("description").(string)
 	defaultTTL := d.Get("default_lease_ttl_seconds").(int)
@@ -181,7 +186,10 @@ func createNomadAccessConfigResource(d *schema.ResourceData, meta interface{}) e
 }
 
 func readNomadAccessConfigResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 	log.Printf("[DEBUG] Reading %q", path)
@@ -275,7 +283,11 @@ func readNomadAccessConfigResource(d *schema.ResourceData, meta interface{}) err
 func updateNomadAccessConfigResource(d *schema.ResourceData, meta interface{}) error {
 	backend := d.Id()
 
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	tune := api.MountConfigInput{}
 	data := map[string]interface{}{}
 
@@ -345,7 +357,11 @@ func updateNomadAccessConfigResource(d *schema.ResourceData, meta interface{}) e
 }
 
 func deleteNomadAccessConfigResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	vaultPath := d.Id()
 	log.Printf("[DEBUG] Unmounting Nomad backend %q", vaultPath)
 

--- a/vault/resource_nomad_secret_backend_test.go
+++ b/vault/resource_nomad_secret_backend_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -64,7 +64,7 @@ func TestAccNomadSecretBackend(t *testing.T) {
 }
 
 func testAccNomadSecretBackendCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	mounts, err := client.Sys().ListMounts()
 	if err != nil {

--- a/vault/resource_nomad_secret_role.go
+++ b/vault/resource_nomad_secret_role.go
@@ -7,8 +7,9 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
-	"github.com/hashicorp/vault/api"
 )
 
 var (
@@ -66,7 +67,11 @@ func nomadSecretBackendRoleResource() *schema.Resource {
 }
 
 func createNomadRoleResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	backend := d.Get("backend").(string)
 	role := d.Get("role").(string)
 	roleType := d.Get("type").(string)
@@ -113,7 +118,11 @@ func createNomadRoleResource(d *schema.ResourceData, meta interface{}) error {
 }
 
 func readNomadRoleResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	rolePath := d.Id()
 	log.Printf("[DEBUG] Reading %q", rolePath)
 
@@ -163,7 +172,11 @@ func readNomadRoleResource(d *schema.ResourceData, meta interface{}) error {
 }
 
 func updateNomadRoleResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	rolePath := d.Id()
 	roleType := d.Get("type").(string)
 	if roleType == "" {
@@ -201,7 +214,11 @@ func updateNomadRoleResource(d *schema.ResourceData, meta interface{}) error {
 }
 
 func deleteNomadRoleResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	rolePath := d.Id()
 	log.Printf("[DEBUG] Deleting %q", rolePath)
 

--- a/vault/resource_nomad_secret_role_test.go
+++ b/vault/resource_nomad_secret_role_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -86,7 +86,7 @@ func TestAccNomadSecretBackendRoleImport(t *testing.T) {
 }
 
 func testAccNomadSecretBackendRoleCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_nomad_secret_role" {

--- a/vault/resource_okta_auth_backend.go
+++ b/vault/resource_okta_auth_backend.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/vault/api"
 
 	"github.com/hashicorp/terraform-provider-vault/helper"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
@@ -244,7 +245,10 @@ func parseDurationSeconds(i interface{}) (string, error) {
 }
 
 func oktaAuthBackendWrite(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	authType := oktaAuthType
 	desc := d.Get("description").(string)
@@ -256,7 +260,6 @@ func oktaAuthBackendWrite(d *schema.ResourceData, meta interface{}) error {
 		Type:        authType,
 		Description: desc,
 	})
-
 	if err != nil {
 		return fmt.Errorf("error writing to Vault: %s", err)
 	}
@@ -267,14 +270,16 @@ func oktaAuthBackendWrite(d *schema.ResourceData, meta interface{}) error {
 }
 
 func oktaAuthBackendDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 
 	log.Printf("[DEBUG] Deleting auth %s from Vault", path)
 
 	err := client.Sys().DisableAuth(path)
-
 	if err != nil {
 		return fmt.Errorf("error disabling auth from Vault: %s", err)
 	}
@@ -283,17 +288,19 @@ func oktaAuthBackendDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func oktaAuthBackendExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	return isOktaAuthBackendPresent(meta.(*api.Client), d.Id())
+	return isOktaAuthBackendPresent(meta.(*provider.ProviderMeta).GetClient(), d.Id())
 }
 
 func oktaAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 	log.Printf("[DEBUG] Reading auth %s from Vault", path)
 
 	present, err := isOktaAuthBackendPresent(client, path)
-
 	if err != nil {
 		return fmt.Errorf("unable to check auth backends in Vault for path %s: %s", path, err)
 	}
@@ -385,7 +392,10 @@ func oktaReadAuthConfig(client *api.Client, path string, d *schema.ResourceData)
 }
 
 func oktaAuthBackendUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 	log.Printf("[DEBUG] Updating auth %s in Vault", path)
@@ -494,7 +504,6 @@ func oktaReadAllUsers(client *api.Client, path string) (*schema.Set, error) {
 }
 
 func oktaAuthUpdateGroups(d *schema.ResourceData, client *api.Client, path string, oldValue, newValue interface{}) error {
-
 	groupsToDelete := oldValue.(*schema.Set).Difference(newValue.(*schema.Set))
 	newGroups := newValue.(*schema.Set).Difference(oldValue.(*schema.Set))
 

--- a/vault/resource_okta_auth_backend_group.go
+++ b/vault/resource_okta_auth_backend_group.go
@@ -7,8 +7,9 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
-	"github.com/hashicorp/vault/api"
 )
 
 func oktaAuthBackendGroupResource() *schema.Resource {
@@ -68,7 +69,10 @@ func oktaAuthBackendGroupResource() *schema.Resource {
 }
 
 func oktaAuthBackendGroupWrite(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Get("path").(string)
 	groupName := d.Get("group_name").(string)
@@ -96,7 +100,11 @@ func oktaAuthBackendGroupWrite(d *schema.ResourceData, meta interface{}) error {
 }
 
 func oktaAuthBackendGroupRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	id := d.Id()
 
 	backend, err := oktaAuthBackendGroupPathFromID(id)
@@ -111,7 +119,6 @@ func oktaAuthBackendGroupRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading group %s from Okta auth backend %s", groupName, backend)
 
 	present, err := isOktaGroupPresent(client, backend, groupName)
-
 	if err != nil {
 		return fmt.Errorf("unable to read group %s from Vault: %s", groupName, err)
 	}
@@ -135,7 +142,10 @@ func oktaAuthBackendGroupRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func oktaAuthBackendGroupDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Get("path").(string)
 	group := d.Get("group_name").(string)
@@ -152,7 +162,11 @@ func oktaAuthBackendGroupDelete(d *schema.ResourceData, meta interface{}) error 
 }
 
 func oktaAuthBackendGroupExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
+
 	id := d.Id()
 
 	backend, err := oktaAuthBackendGroupPathFromID(id)
@@ -179,7 +193,7 @@ func oktaAuthBackendGroupID(path, groupName string) string {
 }
 
 func oktaAuthBackendGroupPathFromID(id string) (string, error) {
-	var parts = strings.SplitN(id, "/", 2)
+	parts := strings.SplitN(id, "/", 2)
 	if len(parts) != 2 {
 		return "", fmt.Errorf("Expected 2 parts in ID '%s'", id)
 	}
@@ -187,7 +201,7 @@ func oktaAuthBackendGroupPathFromID(id string) (string, error) {
 }
 
 func oktaAuthBackendGroupNameFromID(id string) (string, error) {
-	var parts = strings.SplitN(id, "/", 2)
+	parts := strings.SplitN(id, "/", 2)
 	if len(parts) != 2 {
 		return "", fmt.Errorf("Expected 2 parts in ID '%s'", id)
 	}

--- a/vault/resource_okta_auth_backend_group_test.go
+++ b/vault/resource_okta_auth_backend_group_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -111,7 +111,7 @@ func testAccOktaAuthBackendGroup_InitialCheck(s *terraform.State) error {
 
 func testAccOktaAuthBackendGroup_Destroyed(path, groupName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 		group, err := client.Logical().Read(fmt.Sprintf("/auth/%s/groups/%s", path, groupName))
 		if err != nil {

--- a/vault/resource_okta_auth_backend_test.go
+++ b/vault/resource_okta_auth_backend_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 	"github.com/hashicorp/terraform-provider-vault/util"
 )
@@ -203,7 +203,7 @@ func testAccOktaAuthBackend_InitialCheck(s *terraform.State) error {
 		return fmt.Errorf("id doesn't match path")
 	}
 
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	authMounts, err := client.Sys().ListAuth()
 	if err != nil {
@@ -251,7 +251,7 @@ func testAccOktaAuthBackend_InitialCheck(s *terraform.State) error {
 
 func testAccOktaAuthBackend_GroupsCheck(path, groupName string, expectedPolicies []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 		groupList, err := client.Logical().List(fmt.Sprintf("/auth/%s/groups", path))
 		if err != nil {
@@ -291,7 +291,7 @@ func testAccOktaAuthBackend_GroupsCheck(path, groupName string, expectedPolicies
 
 func testAccOktaAuthBackend_UsersCheck(path, userName string, expectedGroups, expectedPolicies []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 		userList, err := client.Logical().List(fmt.Sprintf("/auth/%s/users", path))
 		if err != nil {
@@ -354,7 +354,7 @@ func testAccOktaAuthBackend_UsersCheck(path, userName string, expectedGroups, ex
 
 func testAccOktaAuthBackend_Destroyed(path string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 		authMounts, err := client.Sys().ListAuth()
 		if err != nil {

--- a/vault/resource_okta_auth_backend_user.go
+++ b/vault/resource_okta_auth_backend_user.go
@@ -7,8 +7,9 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
-	"github.com/hashicorp/vault/api"
 )
 
 func oktaAuthBackendUserResource() *schema.Resource {
@@ -75,7 +76,10 @@ func oktaAuthBackendUserResource() *schema.Resource {
 }
 
 func oktaAuthBackendUserWrite(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	username := d.Get("username").(string)
 	path := d.Get("path").(string)
@@ -111,7 +115,10 @@ func oktaAuthBackendUserWrite(d *schema.ResourceData, meta interface{}) error {
 }
 
 func oktaAuthBackendUserRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Get("path").(string)
 	username := d.Get("username").(string)
@@ -119,7 +126,6 @@ func oktaAuthBackendUserRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Reading user %s from Okta auth backend %s", username, path)
 
 	present, err := isOktaUserPresent(client, path, username)
-
 	if err != nil {
 		return fmt.Errorf("unable to read user %s in Vault: %s", username, err)
 	}
@@ -142,7 +148,10 @@ func oktaAuthBackendUserRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func oktaAuthBackendUserDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Get("path").(string)
 	username := d.Get("username").(string)

--- a/vault/resource_okta_auth_backend_user_test.go
+++ b/vault/resource_okta_auth_backend_user_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -66,7 +66,7 @@ func testAccOktaAuthBackendUser_InitialCheck(s *terraform.State) error {
 
 func testAccOktaAuthBackendUser_Destroyed(path, userName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 		group, err := client.Logical().Read(fmt.Sprintf("/auth/%s/users/%s", path, userName))
 		if err != nil {

--- a/vault/resource_password_policy_test.go
+++ b/vault/resource_password_policy_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -62,7 +62,7 @@ func TestAccPasswordPolicy_import(t *testing.T) {
 }
 
 func testAccPasswordPolicyCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_password_policy" {
 			continue

--- a/vault/resource_pki_secret_backend_cert.go
+++ b/vault/resource_pki_secret_backend_cert.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
@@ -164,7 +164,10 @@ func pkiSecretBackendCertResource() *schema.Resource {
 }
 
 func pkiSecretBackendCertCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 	name := d.Get("name").(string)
@@ -281,7 +284,10 @@ func pkiSecretBackendCertRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	path := d.Get("backend").(string)
 	enabled, err := util.CheckMountEnabled(client, path)
 	if err != nil {
@@ -305,7 +311,10 @@ func pkiSecretBackendCertUpdate(d *schema.ResourceData, m interface{}) error {
 
 func pkiSecretBackendCertDelete(d *schema.ResourceData, meta interface{}) error {
 	if d.Get("revoke").(bool) {
-		client := meta.(*api.Client)
+		client, e := provider.GetClient(d, meta)
+		if e != nil {
+			return e
+		}
 
 		backend := d.Get("backend").(string)
 		path := strings.Trim(backend, "/") + "/revoke"

--- a/vault/resource_pki_secret_backend_cert_test.go
+++ b/vault/resource_pki_secret_backend_cert_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -82,7 +82,7 @@ func TestPkiSecretBackendCert_basic(t *testing.T) {
 }
 
 func testPkiSecretBackendCertDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	mounts, err := client.Sys().ListMounts()
 	if err != nil {
@@ -234,7 +234,7 @@ func TestPkiSecretBackendCert_renew(t *testing.T) {
 			{
 				// test unmounted backend
 				PreConfig: func() {
-					client := testProvider.Meta().(*api.Client)
+					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 					if err := client.Sys().Unmount(path); err != nil {
 						t.Fatal(err)
 					}
@@ -360,7 +360,7 @@ func testPKICertRevocation(path string, store *testPKICertStore) resource.TestCh
 			return fmt.Errorf("certificate in %#v is empty", store)
 		}
 
-		addr := testProvider.Meta().(*api.Client).Address()
+		addr := testProvider.Meta().(*provider.ProviderMeta).GetClient().Address()
 		url := fmt.Sprintf("%s/v1/%s/crl", addr, path)
 		c := cleanhttp.DefaultClient()
 		resp, err := c.Get(url)

--- a/vault/resource_pki_secret_backend_config_ca.go
+++ b/vault/resource_pki_secret_backend_config_ca.go
@@ -6,7 +6,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func pkiSecretBackendConfigCAResource() *schema.Resource {
@@ -34,7 +35,10 @@ func pkiSecretBackendConfigCAResource() *schema.Resource {
 }
 
 func pkiSecretBackendConfigCACreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 

--- a/vault/resource_pki_secret_backend_config_ca_test.go
+++ b/vault/resource_pki_secret_backend_config_ca_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -33,7 +33,7 @@ func TestPkiSecretBackendConfigCA_basic(t *testing.T) {
 }
 
 func testPkiSecretBackendConfigCADestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	mounts, err := client.Sys().ListMounts()
 	if err != nil {

--- a/vault/resource_pki_secret_backend_config_urls.go
+++ b/vault/resource_pki_secret_backend_config_urls.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
@@ -63,7 +63,10 @@ func pkiSecretBackendConfigUrlsResource() *schema.Resource {
 }
 
 func pkiSecretBackendConfigUrlsCreateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 
@@ -95,7 +98,10 @@ func pkiSecretBackendConfigUrlsCreateUpdate(d *schema.ResourceData, meta interfa
 }
 
 func pkiSecretBackendConfigUrlsRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 

--- a/vault/resource_pki_secret_backend_config_urls_test.go
+++ b/vault/resource_pki_secret_backend_config_urls_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -106,7 +106,7 @@ func testPkiSecretBackendConfigUrlsDestroy(s *terraform.State) error {
 func listPkiPaths(s *terraform.State) ([]string, error) {
 	var paths []string
 
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	mounts, err := client.Sys().ListMounts()
 	if err != nil {

--- a/vault/resource_pki_secret_backend_crl_config.go
+++ b/vault/resource_pki_secret_backend_crl_config.go
@@ -6,7 +6,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func pkiSecretBackendCrlConfigResource() *schema.Resource {
@@ -42,7 +43,10 @@ func pkiSecretBackendCrlConfigResource() *schema.Resource {
 }
 
 func pkiSecretBackendCrlConfigCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 	path := pkiSecretBackendCrlConfigPath(backend)
@@ -67,14 +71,16 @@ func pkiSecretBackendCrlConfigCreate(d *schema.ResourceData, meta interface{}) e
 }
 
 func pkiSecretBackendCrlConfigRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 	backend := pkiSecretBackendCrlConfigPath(path)
 
 	log.Printf("[DEBUG] Reading CRL config from PKI secret backend %q", backend)
 	config, err := client.Logical().Read(path)
-
 	if err != nil {
 		log.Printf("[WARN] Removing path %q its ID is invalid", path)
 		d.SetId("")
@@ -93,7 +99,10 @@ func pkiSecretBackendCrlConfigRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func pkiSecretBackendCrlConfigUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 	backend := pkiSecretBackendCrlConfigPath(path)
@@ -114,7 +123,6 @@ func pkiSecretBackendCrlConfigUpdate(d *schema.ResourceData, meta interface{}) e
 	log.Printf("[DEBUG] Updated CRL config on PKI secret backend %q", backend)
 
 	return pkiSecretBackendCrlConfigRead(d, meta)
-
 }
 
 func pkiSecretBackendCrlConfigDelete(d *schema.ResourceData, meta interface{}) error {

--- a/vault/resource_pki_secret_backend_crl_config_test.go
+++ b/vault/resource_pki_secret_backend_crl_config_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -34,7 +34,7 @@ func TestPkiSecretBackendCrlConfig_basic(t *testing.T) {
 }
 
 func testPkiSecretBackendCrlConfigDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	mounts, err := client.Sys().ListMounts()
 	if err != nil {

--- a/vault/resource_pki_secret_backend_intermediate_cert_request.go
+++ b/vault/resource_pki_secret_backend_intermediate_cert_request.go
@@ -2,11 +2,13 @@ package vault
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/hashicorp/vault/api"
 	"log"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func pkiSecretBackendIntermediateCertRequestResource() *schema.Resource {
@@ -171,7 +173,10 @@ func pkiSecretBackendIntermediateCertRequestResource() *schema.Resource {
 }
 
 func pkiSecretBackendIntermediateCertRequestCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 	intermediateType := d.Get("type").(string)

--- a/vault/resource_pki_secret_backend_intermediate_cert_request_test.go
+++ b/vault/resource_pki_secret_backend_intermediate_cert_request_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -38,7 +38,7 @@ func TestPkiSecretBackendIntermediateCertRequest_basic(t *testing.T) {
 }
 
 func testPkiSecretBackendIntermediateCertRequestDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	mounts, err := client.Sys().ListMounts()
 	if err != nil {

--- a/vault/resource_pki_secret_backend_intermediate_set_signed.go
+++ b/vault/resource_pki_secret_backend_intermediate_set_signed.go
@@ -6,7 +6,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func pkiSecretBackendIntermediateSetSignedResource() *schema.Resource {
@@ -33,7 +34,10 @@ func pkiSecretBackendIntermediateSetSignedResource() *schema.Resource {
 }
 
 func pkiSecretBackendIntermediateSetSignedCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 

--- a/vault/resource_pki_secret_backend_intermediate_set_signed_test.go
+++ b/vault/resource_pki_secret_backend_intermediate_set_signed_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -35,7 +35,7 @@ func TestPkiSecretBackendIntermediateSetSigned_basic(t *testing.T) {
 }
 
 func testPkiSecretBackendIntermediateSetSignedDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	mounts, err := client.Sys().ListMounts()
 	if err != nil {

--- a/vault/resource_pki_secret_backend_role.go
+++ b/vault/resource_pki_secret_backend_role.go
@@ -9,7 +9,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 var (
@@ -319,7 +320,10 @@ func pkiSecretBackendRoleResource() *schema.Resource {
 }
 
 func pkiSecretBackendRoleCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 	name := d.Get("name").(string)
@@ -429,7 +433,10 @@ func pkiSecretBackendRoleCreate(d *schema.ResourceData, meta interface{}) error 
 }
 
 func pkiSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 	backend, err := pkiSecretBackendRoleBackendFromPath(path)
@@ -539,7 +546,10 @@ func pkiSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func pkiSecretBackendRoleUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 	log.Printf("[DEBUG] Updating PKI secret backend role %q", path)
@@ -639,7 +649,10 @@ func pkiSecretBackendRoleUpdate(d *schema.ResourceData, meta interface{}) error 
 }
 
 func pkiSecretBackendRoleDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 	log.Printf("[DEBUG] Deleting role %q", path)
@@ -652,7 +665,10 @@ func pkiSecretBackendRoleDelete(d *schema.ResourceData, meta interface{}) error 
 }
 
 func pkiSecretBackendRoleExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
 
 	path := d.Id()
 	log.Printf("[DEBUG] Checking if role %q exists", path)

--- a/vault/resource_pki_secret_backend_role_test.go
+++ b/vault/resource_pki_secret_backend_role_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -248,7 +248,7 @@ resource "vault_pki_secret_backend_role" "test" {
 }
 
 func testPkiSecretBackendRoleCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_pki_secret_backend_role" {

--- a/vault/resource_pki_secret_backend_root_cert.go
+++ b/vault/resource_pki_secret_backend_root_cert.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/vault/api"
 	"github.com/hashicorp/vault/sdk/helper/certutil"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
@@ -42,7 +43,11 @@ func pkiSecretBackendRootCertResource() *schema.Resource {
 				return nil
 			}
 
-			client := meta.(*api.Client)
+			client, e := provider.GetClient(d, meta)
+			if e != nil {
+				return e
+			}
+
 			cert, err := getCACertificate(client, d.Get("backend").(string))
 			if err != nil {
 				return err
@@ -247,7 +252,10 @@ func pkiSecretBackendRootCertResource() *schema.Resource {
 }
 
 func pkiSecretBackendRootCertCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 	rootType := d.Get("type").(string)
@@ -374,7 +382,10 @@ func getCACertificate(client *api.Client, mount string) (*x509.Certificate, erro
 }
 
 func pkiSecretBackendRootCertDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 

--- a/vault/resource_pki_secret_backend_root_cert_test.go
+++ b/vault/resource_pki_secret_backend_root_cert_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -56,7 +56,7 @@ func TestPkiSecretBackendRootCertificate_basic(t *testing.T) {
 			{
 				// test unmounted backend
 				PreConfig: func() {
-					client := testProvider.Meta().(*api.Client)
+					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 					if err := client.Sys().Unmount(path); err != nil {
 						t.Fatal(err)
 					}
@@ -72,7 +72,7 @@ func TestPkiSecretBackendRootCertificate_basic(t *testing.T) {
 			{
 				// test out of band update to the root CA
 				PreConfig: func() {
-					client := testProvider.Meta().(*api.Client)
+					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 					_, err := client.Logical().Delete(fmt.Sprintf("%s/root", path))
 					if err != nil {
 						t.Fatal(err)
@@ -103,7 +103,7 @@ func TestPkiSecretBackendRootCertificate_basic(t *testing.T) {
 }
 
 func testPkiSecretBackendRootCertificateDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	mounts, err := client.Sys().ListMounts()
 	if err != nil {

--- a/vault/resource_pki_secret_backend_root_sign_intermediate.go
+++ b/vault/resource_pki_secret_backend_root_sign_intermediate.go
@@ -10,6 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func pkiSecretBackendRootSignIntermediateResource() *schema.Resource {
@@ -218,7 +220,10 @@ func pkiSecretBackendRootSignIntermediateResource() *schema.Resource {
 }
 
 func pkiSecretBackendRootSignIntermediateCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 

--- a/vault/resource_pki_secret_backend_root_sign_intermediate_test.go
+++ b/vault/resource_pki_secret_backend_root_sign_intermediate_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -299,7 +300,7 @@ func assertPKICAChain(res string) resource.TestCheckFunc {
 }
 
 func testPkiSecretBackendRootSignIntermediateDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	mounts, err := client.Sys().ListMounts()
 	if err != nil {

--- a/vault/resource_pki_secret_backend_sign.go
+++ b/vault/resource_pki_secret_backend_sign.go
@@ -7,7 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func pkiSecretBackendSignResource() *schema.Resource {
@@ -158,7 +159,10 @@ func pkiSecretBackendSignResource() *schema.Resource {
 }
 
 func pkiSecretBackendSignCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 	name := d.Get("name").(string)

--- a/vault/resource_pki_secret_backend_sign_test.go
+++ b/vault/resource_pki_secret_backend_sign_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -40,7 +40,7 @@ func TestPkiSecretBackendSign_basic(t *testing.T) {
 }
 
 func testPkiSecretBackendSignDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	mounts, err := client.Sys().ListMounts()
 	if err != nil {
@@ -207,7 +207,7 @@ func TestPkiSecretBackendSign_renew(t *testing.T) {
 			{
 				// test unmounted backend
 				PreConfig: func() {
-					client := testProvider.Meta().(*api.Client)
+					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 					if err := client.Sys().Unmount(path); err != nil {
 						t.Fatal(err)
 					}

--- a/vault/resource_policy.go
+++ b/vault/resource_policy.go
@@ -5,7 +5,8 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func policyResource() *schema.Resource {
@@ -36,14 +37,16 @@ func policyResource() *schema.Resource {
 }
 
 func policyWrite(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	name := d.Get("name").(string)
 	policy := d.Get("policy").(string)
 
 	log.Printf("[DEBUG] Writing policy %s to Vault", name)
 	err := client.Sys().PutPolicy(name, policy)
-
 	if err != nil {
 		return fmt.Errorf("error writing to Vault: %s", err)
 	}
@@ -54,7 +57,10 @@ func policyWrite(d *schema.ResourceData, meta interface{}) error {
 }
 
 func policyDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	name := d.Id()
 
@@ -69,12 +75,14 @@ func policyDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func policyRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	name := d.Id()
 
 	policy, err := client.Sys().GetPolicy(name)
-
 	if err != nil {
 		return fmt.Errorf("error reading from Vault: %s", err)
 	}

--- a/vault/resource_policy_test.go
+++ b/vault/resource_policy_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -65,7 +65,7 @@ func testResourcePolicy_initialCheck(expectedName string) resource.TestCheckFunc
 			return fmt.Errorf("unexpected policy name %q, expected %q", name, expectedName)
 		}
 
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 		policy, err := client.Sys().GetPolicy(name)
 		if err != nil {
 			return fmt.Errorf("error reading back policy: %s", err)
@@ -98,7 +98,7 @@ func testResourcePolicy_updateCheck(s *terraform.State) error {
 
 	name := instanceState.ID
 
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	if name != instanceState.Attributes["name"] {
 		return fmt.Errorf("id doesn't match name")

--- a/vault/resource_quota_lease_count.go
+++ b/vault/resource_quota_lease_count.go
@@ -6,7 +6,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func quotaLeaseCountPath(name string) string {
@@ -49,7 +50,10 @@ func quotaLeaseCountResource() *schema.Resource {
 }
 
 func quotaLeaseCountCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	name := d.Get("name").(string)
 	path := quotaLeaseCountPath(name)
@@ -72,7 +76,10 @@ func quotaLeaseCountCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func quotaLeaseCountRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	name := d.Id()
 	path := quotaLeaseCountPath(name)
@@ -102,7 +109,10 @@ func quotaLeaseCountRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func quotaLeaseCountUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	name := d.Id()
 	path := quotaLeaseCountPath(name)
@@ -124,7 +134,10 @@ func quotaLeaseCountUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func quotaLeaseCountDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	name := d.Id()
 	path := quotaLeaseCountPath(name)
@@ -140,7 +153,10 @@ func quotaLeaseCountDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func quotaLeaseCountExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
 
 	name := d.Id()
 	path := quotaLeaseCountPath(name)

--- a/vault/resource_quota_lease_count_test.go
+++ b/vault/resource_quota_lease_count_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -54,7 +54,7 @@ func TestQuotaLeaseCount(t *testing.T) {
 
 func testQuotaLeaseCountCheckDestroy(leaseCounts []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 		for _, name := range leaseCounts {
 			resp, err := client.Logical().Read(quotaLeaseCountPath(name))

--- a/vault/resource_quota_rate_limit.go
+++ b/vault/resource_quota_rate_limit.go
@@ -6,7 +6,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func quotaRateLimitPath(name string) string {
@@ -48,7 +49,10 @@ func quotaRateLimitResource() *schema.Resource {
 }
 
 func quotaRateLimitCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	name := d.Get("name").(string)
 	path := quotaRateLimitPath(name)
@@ -71,7 +75,10 @@ func quotaRateLimitCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func quotaRateLimitRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	name := d.Id()
 	path := quotaRateLimitPath(name)
@@ -101,7 +108,10 @@ func quotaRateLimitRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func quotaRateLimitUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	name := d.Id()
 	path := quotaRateLimitPath(name)
@@ -123,7 +133,10 @@ func quotaRateLimitUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func quotaRateLimitDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	name := d.Id()
 	path := quotaRateLimitPath(name)
@@ -139,7 +152,10 @@ func quotaRateLimitDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func quotaRateLimitExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
 
 	name := d.Id()
 	path := quotaRateLimitPath(name)

--- a/vault/resource_quota_rate_limit_test.go
+++ b/vault/resource_quota_rate_limit_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -61,7 +61,7 @@ func TestQuotaRateLimit(t *testing.T) {
 
 func testQuotaRateLimitCheckDestroy(rateLimits []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 		for _, name := range rateLimits {
 			resp, err := client.Logical().Read(quotaRateLimitPath(name))

--- a/vault/resource_rabbitmq_secret_backend.go
+++ b/vault/resource_rabbitmq_secret_backend.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func rabbitMQSecretBackendResource() *schema.Resource {
@@ -93,7 +95,10 @@ func rabbitMQSecretBackendResource() *schema.Resource {
 }
 
 func rabbitMQSecretBackendCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Get("path").(string)
 	description := d.Get("description").(string)
@@ -139,7 +144,10 @@ func rabbitMQSecretBackendCreate(d *schema.ResourceData, meta interface{}) error
 }
 
 func rabbitMQSecretBackendRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 
@@ -168,7 +176,10 @@ func rabbitMQSecretBackendRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func rabbitMQSecretBackendUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 	d.Partial(true)
@@ -205,7 +216,10 @@ func rabbitMQSecretBackendUpdate(d *schema.ResourceData, meta interface{}) error
 }
 
 func rabbitMQSecretBackendDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 	log.Printf("[DEBUG] Unmounting RabbitMQ backend %q", path)
@@ -218,7 +232,10 @@ func rabbitMQSecretBackendDelete(d *schema.ResourceData, meta interface{}) error
 }
 
 func rabbitMQSecretBackendExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
 
 	path := d.Id()
 	log.Printf("[DEBUG] Checking if RabbitMQ backend exists at %q", path)

--- a/vault/resource_rabbitmq_secret_backend_role.go
+++ b/vault/resource_rabbitmq_secret_backend_role.go
@@ -7,7 +7,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func rabbitMQSecretBackendRoleResource() *schema.Resource {
@@ -112,7 +113,10 @@ func rabbitMQSecretBackendRoleResource() *schema.Resource {
 }
 
 func rabbitMQSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 	name := d.Get("name").(string)
@@ -144,7 +148,10 @@ func rabbitMQSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) er
 }
 
 func rabbitMQSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 	pathPieces := strings.Split(path, "/")
@@ -184,7 +191,10 @@ func rabbitMQSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func rabbitMQSecretBackendRoleDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 	log.Printf("[DEBUG] Deleting role %q", path)
@@ -197,7 +207,10 @@ func rabbitMQSecretBackendRoleDelete(d *schema.ResourceData, meta interface{}) e
 }
 
 func rabbitMQSecretBackendRoleExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
 
 	path := d.Id()
 	log.Printf("[DEBUG] Checking if %q exists", path)

--- a/vault/resource_rabbitmq_secret_backend_role_test.go
+++ b/vault/resource_rabbitmq_secret_backend_role_test.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -152,7 +152,7 @@ func TestAccRabbitMQSecretBackendRole_topic(t *testing.T) {
 }
 
 func testAccRabbitMQSecretBackendRoleCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_rabbitmq_secret_backend_role" {

--- a/vault/resource_rabbitmq_secret_backend_test.go
+++ b/vault/resource_rabbitmq_secret_backend_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -89,7 +89,7 @@ func TestAccRabbitMQSecretBackend_template(t *testing.T) {
 }
 
 func testAccRabbitMQSecretBackendCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	mounts, err := client.Sys().ListMounts()
 	if err != nil {

--- a/vault/resource_raft_autopilot.go
+++ b/vault/resource_raft_autopilot.go
@@ -5,18 +5,21 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
-var autopilotPath = "sys/storage/raft/autopilot/configuration"
-var autopilotDefaults = map[string]interface{}{
-	"cleanup_dead_servers":               false,
-	"dead_server_last_contact_threshold": "24h0m0s",
-	"last_contact_threshold":             "10s",
-	"max_trailing_logs":                  1000,
-	"min_quorum":                         3,
-	"server_stabilization_time":          "10s",
-}
+var (
+	autopilotPath     = "sys/storage/raft/autopilot/configuration"
+	autopilotDefaults = map[string]interface{}{
+		"cleanup_dead_servers":               false,
+		"dead_server_last_contact_threshold": "24h0m0s",
+		"last_contact_threshold":             "10s",
+		"max_trailing_logs":                  1000,
+		"min_quorum":                         3,
+		"server_stabilization_time":          "10s",
+	}
+)
 
 func raftAutopilotConfigResource() *schema.Resource {
 	fields := map[string]*schema.Schema{
@@ -67,7 +70,10 @@ func raftAutopilotConfigResource() *schema.Resource {
 }
 
 func createOrUpdateAutopilotConfigResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	c := map[string]interface{}{
 		"cleanup_dead_servers":               d.Get("cleanup_dead_servers").(bool),
@@ -89,7 +95,10 @@ func createOrUpdateAutopilotConfigResource(d *schema.ResourceData, meta interfac
 }
 
 func readAutopilotConfigResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	log.Printf("[DEBUG] Reading %q", autopilotPath)
 
@@ -138,7 +147,10 @@ func readAutopilotConfigResource(d *schema.ResourceData, meta interface{}) error
 }
 
 func deleteAutopilotConfigResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	log.Print("[DEBUG] Resetting raft autopilot config")
 

--- a/vault/resource_raft_autopilot_test.go
+++ b/vault/resource_raft_autopilot_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -48,7 +48,7 @@ func TestAccRaftAutopilotConfig_basic(t *testing.T) {
 }
 
 func testAccRaftAutopilotConfigCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_raft_autopilot_config" {

--- a/vault/resource_raft_snapshot_agent_config.go
+++ b/vault/resource_raft_snapshot_agent_config.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
 )
 
 var (
@@ -280,7 +280,11 @@ func buildConfigFromResourceData(d *schema.ResourceData) (map[string]interface{}
 }
 
 func createOrUpdateSnapshotAgentConfigResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	name := d.Get("name").(string)
 	path := fmt.Sprintf(snapshotAutoPath, name)
 
@@ -300,7 +304,10 @@ func createOrUpdateSnapshotAgentConfigResource(d *schema.ResourceData, meta inte
 }
 
 func readSnapshotAgentConfigResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	name := d.Id()
 	configPath := fmt.Sprintf(snapshotAutoPath, name)
@@ -481,7 +488,11 @@ func readSnapshotAgentConfigResource(d *schema.ResourceData, meta interface{}) e
 }
 
 func deleteSnapshotAgentConfigResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	name := d.Id()
 	path := fmt.Sprintf(snapshotAutoPath, name)
 

--- a/vault/resource_raft_snapshot_agent_config_test.go
+++ b/vault/resource_raft_snapshot_agent_config_test.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 )
 
 func TestAccRaftSnapshotAgentConfig_basic(t *testing.T) {
@@ -127,7 +127,7 @@ func TestAccRaftSnapshotAgentConfig_import(t *testing.T) {
 }
 
 func testAccRaftSnapshotAgentConfigCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_raft_snapshot_agent_config" {

--- a/vault/resource_rgp_policy_test.go
+++ b/vault/resource_rgp_policy_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -40,7 +40,7 @@ func TestAccRoleGoverningPolicy(t *testing.T) {
 }
 
 func testAccRoleGoverningPolicyCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_rgp_policy" {
 			continue

--- a/vault/resource_ssh_secret_backend_ca.go
+++ b/vault/resource_ssh_secret_backend_ca.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func sshSecretBackendCAResource() *schema.Resource {
@@ -56,7 +58,11 @@ func sshSecretBackendCAResource() *schema.Resource {
 }
 
 func sshSecretBackendCACreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	backend := d.Get("backend").(string)
 
 	data := make(map[string]interface{})
@@ -82,7 +88,10 @@ func sshSecretBackendCACreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func sshSecretBackendCARead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Id()
 
@@ -116,7 +125,10 @@ func sshSecretBackendCARead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func sshSecretBackendCADelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Id()
 	log.Printf("[DEBUG] Deleting CA configuration for SSH backend %q", backend)

--- a/vault/resource_ssh_secret_backend_ca_test.go
+++ b/vault/resource_ssh_secret_backend_ca_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -65,7 +65,7 @@ func TestAccSSHSecretBackend_import(t *testing.T) {
 }
 
 func testAccCheckSSHSecretBackendCADestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_ssh_secret_backend_ca" {

--- a/vault/resource_ssh_secret_backend_role.go
+++ b/vault/resource_ssh_secret_backend_role.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
 	"golang.org/x/crypto/ssh"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 var (
@@ -190,7 +192,10 @@ func sshSecretBackendRoleResource() *schema.Resource {
 }
 
 func sshSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 	name := d.Get("name").(string)
@@ -311,7 +316,10 @@ func sshSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) error {
 }
 
 func sshSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 
@@ -441,7 +449,10 @@ func getSSHRoleKeyConfig(role *api.Secret) ([]map[string]interface{}, error) {
 }
 
 func sshSecretBackendRoleDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 	log.Printf("[DEBUG] Deleting role %q", path)
@@ -455,7 +466,10 @@ func sshSecretBackendRoleDelete(d *schema.ResourceData, meta interface{}) error 
 }
 
 func sshSecretBackendRoleExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
 
 	path := d.Id()
 	log.Printf("[DEBUG] Checking if %q exists", path)

--- a/vault/resource_ssh_secret_backend_role_test.go
+++ b/vault/resource_ssh_secret_backend_role_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -138,7 +138,7 @@ func TestAccSSHSecretBackendRoleOTP_basic(t *testing.T) {
 }
 
 func testAccSSHSecretBackendRoleCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_ssh_secret_backend_role" {

--- a/vault/resource_terraform_cloud_secret_backend.go
+++ b/vault/resource_terraform_cloud_secret_backend.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func terraformCloudSecretBackendResource() *schema.Resource {
@@ -75,7 +77,10 @@ func terraformCloudSecretBackendResource() *schema.Resource {
 }
 
 func terraformCloudSecretBackendCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 	address := d.Get("address").(string)
@@ -128,7 +133,10 @@ func terraformCloudSecretBackendCreate(d *schema.ResourceData, meta interface{})
 }
 
 func terraformCloudSecretBackendRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Id()
 	configPath := terraformCloudSecretBackendConfigPath(backend)
@@ -173,7 +181,10 @@ func terraformCloudSecretBackendRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func terraformCloudSecretBackendUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Id()
 	configPath := terraformCloudSecretBackendConfigPath(backend)
@@ -213,7 +224,10 @@ func terraformCloudSecretBackendUpdate(d *schema.ResourceData, meta interface{})
 }
 
 func terraformCloudSecretBackendDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Id()
 
@@ -227,7 +241,10 @@ func terraformCloudSecretBackendDelete(d *schema.ResourceData, meta interface{})
 }
 
 func terraformCloudSecretBackendExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
 
 	backend := d.Id()
 

--- a/vault/resource_terraform_cloud_secret_backend_test.go
+++ b/vault/resource_terraform_cloud_secret_backend_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -51,7 +51,7 @@ func TestTerraformCloudSecretBackend(t *testing.T) {
 }
 
 func testAccTerraformCloudSecretBackendCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	mounts, err := client.Sys().ListMounts()
 	if err != nil {

--- a/vault/resource_terraform_cloud_secret_creds.go
+++ b/vault/resource_terraform_cloud_secret_creds.go
@@ -6,7 +6,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func terraformCloudSecretCredsResource() *schema.Resource {
@@ -59,7 +60,11 @@ func terraformCloudSecretCredsResource() *schema.Resource {
 }
 
 func createTerraformCloudSecretCredsResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	backend := d.Get("backend").(string)
 	role := d.Get("role").(string)
 	path := fmt.Sprintf("%s/creds/%s", backend, role)
@@ -100,7 +105,11 @@ func createTerraformCloudSecretCredsResource(d *schema.ResourceData, meta interf
 }
 
 func deleteTerraformCloudSecretCredsResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	leaseId := d.Get("lease_id").(string)
 
 	if leaseId != "" {
@@ -126,7 +135,11 @@ func updateTerraformCloudSecretCredsResource(d *schema.ResourceData, meta interf
 }
 
 func readTerraformCloudSecretCredsResource(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	leaseId := d.Get("lease_id")
 
 	if leaseId != "" {

--- a/vault/resource_terraform_cloud_secret_creds_test.go
+++ b/vault/resource_terraform_cloud_secret_creds_test.go
@@ -6,11 +6,11 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -164,7 +164,7 @@ resource "vault_terraform_cloud_secret_creds" "token" {
 }
 
 func testAccResourceTerraformCloudSecretCredsCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_terraform_cloud_secret_creds" {

--- a/vault/resource_terraform_cloud_secret_role.go
+++ b/vault/resource_terraform_cloud_secret_role.go
@@ -7,7 +7,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 var (
@@ -79,7 +80,10 @@ func terraformCloudSecretRoleGetBackend(d *schema.ResourceData) string {
 }
 
 func terraformCloudSecretRoleWrite(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	name := d.Get("name").(string)
 
@@ -120,7 +124,10 @@ func terraformCloudSecretRoleWrite(d *schema.ResourceData, meta interface{}) err
 }
 
 func terraformCloudSecretRoleRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 	name, err := terraformCloudSecretRoleNameFromPath(path)
@@ -162,7 +169,10 @@ func terraformCloudSecretRoleRead(d *schema.ResourceData, meta interface{}) erro
 }
 
 func terraformCloudSecretRoleDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 
@@ -176,7 +186,10 @@ func terraformCloudSecretRoleDelete(d *schema.ResourceData, meta interface{}) er
 }
 
 func terraformCloudSecretRoleExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
 
 	path := d.Id()
 

--- a/vault/resource_terraform_cloud_secret_role_test.go
+++ b/vault/resource_terraform_cloud_secret_role_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -75,7 +75,7 @@ func TestTerraformCloudSecretRole(t *testing.T) {
 }
 
 func testAccTerraformCloudSecretRoleCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_terraform_cloud_secret_role" {

--- a/vault/resource_token.go
+++ b/vault/resource_token.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func tokenResource() *schema.Resource {
@@ -148,7 +150,11 @@ func tokenResource() *schema.Resource {
 }
 
 func tokenCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	var err error
 	var wrapped bool
 
@@ -259,7 +265,10 @@ func tokenCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func tokenRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	id := d.Get("client_token").(string)
 	accessor := d.Id()
@@ -350,7 +359,10 @@ func tokenUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func tokenDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	token := d.Id()
 
@@ -365,7 +377,11 @@ func tokenDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func tokenExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
+
 	accessor := d.Id()
 
 	log.Printf("[DEBUG] Checking if token accessor %q exists", accessor)

--- a/vault/resource_token_auth_backend_role.go
+++ b/vault/resource_token_auth_backend_role.go
@@ -9,7 +9,8 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 var tokenAuthBackendRoleNameFromPathRegex = regexp.MustCompile("^auth/token/roles/(.+)$")
@@ -130,7 +131,10 @@ func tokenAuthBackendRoleUpdateFields(d *schema.ResourceData, data map[string]in
 }
 
 func tokenAuthBackendRoleCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 
 	role := d.Get("role_name").(string)
 
@@ -154,7 +158,10 @@ func tokenAuthBackendRoleCreate(ctx context.Context, d *schema.ResourceData, met
 }
 
 func tokenAuthBackendRoleRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 	path := d.Id()
 
 	roleName, err := tokenAuthBackendRoleNameFromPath(path)
@@ -197,7 +204,10 @@ func tokenAuthBackendRoleRead(_ context.Context, d *schema.ResourceData, meta in
 }
 
 func tokenAuthBackendRoleUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 	path := d.Id()
 
 	log.Printf("[DEBUG] Updating Token auth backend role %q", path)
@@ -215,7 +225,10 @@ func tokenAuthBackendRoleUpdate(ctx context.Context, d *schema.ResourceData, met
 }
 
 func tokenAuthBackendRoleDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 	path := d.Id()
 
 	log.Printf("[DEBUG] Deleting Token auth backend role %q", path)

--- a/vault/resource_token_auth_backend_role_test.go
+++ b/vault/resource_token_auth_backend_role_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -133,7 +133,7 @@ func TestAccTokenAuthBackendRoleUpdate(t *testing.T) {
 }
 
 func testAccCheckTokenAuthBackendRoleDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_token_auth_backend_role" {
@@ -153,7 +153,7 @@ func testAccCheckTokenAuthBackendRoleDestroy(s *terraform.State) error {
 func testAccTokenAuthBackendRoleCheck_deleted(role string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		endpoint := "auth/token/roles"
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 		resp, err := client.Logical().List(endpoint)
 		if err != nil {
@@ -188,7 +188,7 @@ func testAccTokenAuthBackendRoleCheck_attrs(role string) resource.TestCheckFunc 
 			return fmt.Errorf("expected ID to be %q, got %q instead", "auth/token/roles/"+role, endpoint)
 		}
 
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 		resp, err := client.Logical().Read(endpoint)
 		if err != nil {
 			return fmt.Errorf("%q doesn't exist", endpoint)

--- a/vault/resource_token_test.go
+++ b/vault/resource_token_test.go
@@ -8,13 +8,13 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
 func testResourceTokenCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_token" {
@@ -310,7 +310,7 @@ func testResourceTokenLookup(n string) resource.TestCheckFunc {
 			return fmt.Errorf("No ID is set")
 		}
 
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 		_, err := client.Auth().Token().LookupAccessor(rs.Primary.ID)
 		if err != nil {
@@ -332,7 +332,7 @@ func testResourceTokenCheckExpireTime(n string) resource.TestCheckFunc {
 			return fmt.Errorf("No ID is set")
 		}
 
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 		token, err := client.Auth().Token().LookupAccessor(rs.Primary.ID)
 		if err != nil {
@@ -401,7 +401,7 @@ func testResourceTokenWaitRenewMinLeaseTime(n string) resource.TestCheckFunc {
 			return fmt.Errorf("No ID is set")
 		}
 
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 		token, err := client.Auth().Token().LookupAccessor(rs.Primary.ID)
 		if err != nil {

--- a/vault/resource_transit_cache_config.go
+++ b/vault/resource_transit_cache_config.go
@@ -6,7 +6,8 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func transitSecretBackendCacheConfig() *schema.Resource {
@@ -36,7 +37,11 @@ func transitSecretBackendCacheConfig() *schema.Resource {
 }
 
 func transitSecretBackendCacheConfigUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	size := d.Get("size").(int)
 
 	backend := d.Get("backend").(string) + "/cache-config"
@@ -65,7 +70,10 @@ func transitSecretBackendCacheConfigUpdate(d *schema.ResourceData, meta interfac
 }
 
 func transitSecretBackendCacheConfigRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Id()
 

--- a/vault/resource_transit_cache_config_test.go
+++ b/vault/resource_transit_cache_config_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -47,7 +47,7 @@ func TestAccTransitCacheConfig(t *testing.T) {
 }
 
 func testAccTransitCacheConfigCheckDestroyed(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_transit_secret_cache_config" {
@@ -78,7 +78,7 @@ func testAccTransitCacheConfigCheckApi(size int) resource.TestCheckFunc {
 
 		id := instanceState.ID
 
-		client := testProvider.Meta().(*api.Client)
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 		resp, err := client.Logical().Read(id)
 		if err != nil {
 			return err

--- a/vault/resource_transit_secret_backend_key.go
+++ b/vault/resource_transit_secret_backend_key.go
@@ -11,7 +11,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 var (
@@ -192,7 +193,10 @@ func transitSecretBackendKeyResource() *schema.Resource {
 }
 
 func transitSecretBackendKeyCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	backend := d.Get("backend").(string)
 	name := d.Get("name").(string)
@@ -249,7 +253,10 @@ func getTransitAutoRotatePeriod(d *schema.ResourceData) int {
 }
 
 func transitSecretBackendKeyRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 	backend, err := transitSecretBackendKeyBackendFromPath(path)
@@ -384,7 +391,11 @@ func transitSecretBackendKeyRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func transitSecretBackendKeyUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
 	path := d.Id()
 
 	log.Printf("[DEBUG] Updating transit secret backend key %q", path)
@@ -408,7 +419,10 @@ func transitSecretBackendKeyUpdate(d *schema.ResourceData, meta interface{}) err
 }
 
 func transitSecretBackendKeyDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	path := d.Id()
 	log.Printf("[DEBUG] Deleting key %q", path)
@@ -421,7 +435,10 @@ func transitSecretBackendKeyDelete(d *schema.ResourceData, meta interface{}) err
 }
 
 func transitSecretBackendKeyExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
 
 	path := d.Id()
 	log.Printf("[DEBUG] Checking if key %q exists", path)

--- a/vault/resource_transit_secret_backend_key_test.go
+++ b/vault/resource_transit_secret_backend_key_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -263,7 +263,7 @@ resource "vault_transit_secret_backend_key" "test" {
 }
 
 func testTransitSecretBackendKeyCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*api.Client)
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_transit_secret_backend_key" {

--- a/vault/sentinel.go
+++ b/vault/sentinel.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
-	"log"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func readSentinelPolicy(client *api.Client, policyType string, name string) (map[string]interface{}, error) {
@@ -73,7 +76,10 @@ func ValidateSentinelEnforcementLevel(v interface{}, k string) (ws []string, err
 }
 
 func sentinelPolicyDelete(policyType string, d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	name := d.Id()
 
@@ -88,12 +94,14 @@ func sentinelPolicyDelete(policyType string, d *schema.ResourceData, meta interf
 }
 
 func sentinelPolicyRead(policyType string, attributes []string, d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	name := d.Id()
 
 	policy, err := readSentinelPolicy(client, policyType, name)
-
 	if err != nil {
 		return fmt.Errorf("error reading from Vault: %s", err)
 	}
@@ -107,7 +115,10 @@ func sentinelPolicyRead(policyType string, attributes []string, d *schema.Resour
 }
 
 func sentinelPolicyWrite(policyType string, attributes []string, d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*api.Client)
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	name := d.Get("name").(string)
 
@@ -118,7 +129,6 @@ func sentinelPolicyWrite(policyType string, attributes []string, d *schema.Resou
 	}
 
 	err := PutSentinelPolicy(client, policyType, name, body)
-
 	if err != nil {
 		return fmt.Errorf("error writing to Vault: %s", err)
 	}

--- a/vault/validators_test.go
+++ b/vault/validators_test.go
@@ -1,40 +1,34 @@
 package vault
 
 import (
-	"regexp"
+	"fmt"
+	"reflect"
 	"testing"
 )
 
-func TestValidateNoTrailingSlash(t *testing.T) {
+func Test_validateNoTrailingSlash(t *testing.T) {
 	testCases := []struct {
 		val         string
-		expectedErr *regexp.Regexp
+		expectedErr []error
 	}{
 		{
 			val: "foo",
 		},
 		{
-			val:         "foo/",
-			expectedErr: regexp.MustCompile(`cannot write to a path ending in '/'`),
+			val: "foo/",
+			expectedErr: []error{
+				fmt.Errorf(`invalid value "foo/" for "test_property", contains leading/trailing "/"`),
+			},
 		},
 		{
 			val: "foo/bar",
 		},
 		{
-			val:         "foo/bar/",
-			expectedErr: regexp.MustCompile(`cannot write to a path ending in '/'`),
+			val: "foo/bar/",
+			expectedErr: []error{
+				fmt.Errorf(`invalid value "foo/bar/" for "test_property", contains leading/trailing "/"`),
+			},
 		},
-	}
-
-	matchErr := func(errs []error, r *regexp.Regexp) bool {
-		// err must match one provided
-		for _, err := range errs {
-			if r.MatchString(err.Error()) {
-				return true
-			}
-		}
-
-		return false
 	}
 
 	for i, tc := range testCases {
@@ -48,61 +42,78 @@ func TestValidateNoTrailingSlash(t *testing.T) {
 			t.Fatalf("expected test case %d to produce no errors, got %v", i, errs)
 		}
 
-		if !matchErr(errs, tc.expectedErr) {
+		if !reflect.DeepEqual(errs, tc.expectedErr) {
 			t.Fatalf("expected test case %d to produce error matching \"%s\", got %v", i, tc.expectedErr, errs)
 		}
 	}
 }
 
-func TestValidateNoTrailingLeadingSlashes(t *testing.T) {
-	testCases := []struct {
-		val         string
-		expectedErr *regexp.Regexp
+func Test_validateNoLeadingTrailingSlashes(t *testing.T) {
+	type args struct {
+		i interface{}
+		k string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantErr  bool
+		want     []string
+		wantErrs []error
 	}{
 		{
-			val: "foo",
+			name: "valid",
+			args: args{
+				i: "foo",
+				k: "bar",
+			},
 		},
 		{
-			val:         "foo/",
-			expectedErr: regexp.MustCompile(`cannot write to a path ending in '/'`),
+			name: "invalid-leading",
+			args: args{
+				i: "/foo",
+				k: "bar",
+			},
+			wantErr: true,
 		},
 		{
-			val: "foo/bar",
+			name: "invalid-trailing",
+			args: args{
+				i: "foo/",
+				k: "bar",
+			},
+			wantErr: true,
 		},
 		{
-			val:         "/foo/bar",
-			expectedErr: regexp.MustCompile(`cannot write to a path starting in '/'`),
-		},
-		{
-			val:         "/foo/bar/",
-			expectedErr: regexp.MustCompile(`cannot write to a path ending in '/'`),
+			name: "invalid-both",
+			args: args{
+				i: "/foo/",
+				k: "bar",
+			},
+			wantErr: true,
 		},
 	}
-
-	matchErr := func(errs []error, r *regexp.Regexp) bool {
-		// err must match one provided
-		for _, err := range errs {
-			if r.MatchString(err.Error()) {
-				return true
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, actualErrs := validateNoLeadingTrailingSlashes(tt.args.i, tt.args.k)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("validateNoLeadingTrailingSlashes() got = %v, want %v", got, tt.want)
 			}
-		}
 
-		return false
-	}
+			var expectedErrs []error
+			if tt.wantErr {
+				expectedErrs = []error{
+					fmt.Errorf(`invalid value %q for %q, contains leading/trailing %q`,
+						tt.args.i, tt.args.k, pathDelim),
+				}
+			}
 
-	for i, tc := range testCases {
-		_, errs := validateNoTrailingLeadingSlashes(tc.val, "test_property")
+			if tt.wantErr && actualErrs == nil {
+				t.Fatalf("expected errors %#v, actual %#v", expectedErrs, actualErrs)
+			}
 
-		if len(errs) == 0 && tc.expectedErr == nil {
-			continue
-		}
-
-		if len(errs) != 0 && tc.expectedErr == nil {
-			t.Fatalf("expected test case %d to produce no errors, got %v", i, errs)
-		}
-
-		if !matchErr(errs, tc.expectedErr) {
-			t.Fatalf("expected test case %d to produce error matching \"%s\", got %v", i, tc.expectedErr, errs)
-		}
+			if !reflect.DeepEqual(actualErrs, expectedErrs) {
+				t.Errorf("validateNoLeadingTrailingSlashes() actualErrs = %v, want %v", actualErrs, expectedErrs)
+			}
+		})
 	}
 }

--- a/website/docs/d/ad_access_credentials.html.md
+++ b/website/docs/d/ad_access_credentials.html.md
@@ -48,6 +48,11 @@ data "vault_ad_access_credentials" "creds" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace of the target resource.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+  *Available only for Vault Enterprise*.
+
 * `backend` - (Required) The path to the AD secret backend to
 read credentials from, with no leading or trailing `/`s.
 

--- a/website/docs/d/approle_auth_backend_role_id.md
+++ b/website/docs/d/approle_auth_backend_role_id.md
@@ -27,6 +27,11 @@ output "role-id" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace of the target resource.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+  *Available only for Vault Enterprise*.
+
 * `role_name` - (Required) The name of the role to retrieve the Role ID for.
 
 * `backend` - (Optional) The unique name for the AppRole backend the role to

--- a/website/docs/d/auth_backend.html.md
+++ b/website/docs/d/auth_backend.html.md
@@ -20,6 +20,11 @@ data "vault_auth_backend" "example" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace of the target resource.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+  *Available only for Vault Enterprise*.
+
 * `path` - (Required) The auth backend mount point.
 
 ## Attributes Reference

--- a/website/docs/d/aws_access_credentials.html.md
+++ b/website/docs/d/aws_access_credentials.html.md
@@ -60,6 +60,11 @@ provider "aws" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace of the target resource.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+  *Available only for Vault Enterprise*.
+
 * `backend` - (Required) The path to the AWS secret backend to
 read credentials from, with no leading or trailing `/`s.
 

--- a/website/docs/d/azure_access_credentials.html.md
+++ b/website/docs/d/azure_access_credentials.html.md
@@ -64,6 +64,11 @@ are required to be set for: `subscription_id`, `tenant_id`, `environment`.
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace of the target resource.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+  *Available only for Vault Enterprise*.
+
 * `backend` - (Required) The path to the Azure secret backend to
 read credentials from, with no leading or trailing `/`s.
 

--- a/website/docs/d/gcp_auth_backend_role.md
+++ b/website/docs/d/gcp_auth_backend_role.md
@@ -27,6 +27,11 @@ output "role-id" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace of the target resource.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+  *Available only for Vault Enterprise*.
+
 * `role_name` - (Required) The name of the role to retrieve the Role ID for.
 
 * `backend` - (Optional) The unique name for the GCP backend from which to fetch the role. Defaults to "gcp".

--- a/website/docs/d/generic_secret.html.md
+++ b/website/docs/d/generic_secret.html.md
@@ -64,6 +64,11 @@ data "template_file" "example_template" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace of the target resource.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+  *Available only for Vault Enterprise*.
+
 * `path` - (Required) The full logical path from which to request data.
 To read data from the "generic" secret backend mounted in Vault by
 default, this should be prefixed with `secret/`. Reading from other backends

--- a/website/docs/d/identity_entity.html.md
+++ b/website/docs/d/identity_entity.html.md
@@ -30,6 +30,11 @@ data "vault_identity_entity" "entity" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace of the target resource.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+  *Available only for Vault Enterprise*.
+
 * `entity_name` - (Optional) Name of the entity.
 
 * `entity_id` - (Optional) ID of the entity.

--- a/website/docs/d/identity_group.html.md
+++ b/website/docs/d/identity_group.html.md
@@ -30,6 +30,11 @@ data "vault_identity_group" "group" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace of the target resource.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+  *Available only for Vault Enterprise*.
+
 * `group_name` - (Optional) Name of the group.
 
 * `group_id` - (Optional) ID of the group.

--- a/website/docs/d/identity_oidc_client_creds.html.md
+++ b/website/docs/d/identity_oidc_client_creds.html.md
@@ -41,6 +41,11 @@ data "vault_identity_oidc_client_creds" "creds" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace of the target resource.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+  *Available only for Vault Enterprise*.
+
 * `name` - (Required) The name of the OIDC Client in Vault.
 
 

--- a/website/docs/d/identity_oidc_openid_config.html.md
+++ b/website/docs/d/identity_oidc_openid_config.html.md
@@ -56,6 +56,11 @@ data "vault_identity_oidc_openid_config" "config" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace of the target resource.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+  *Available only for Vault Enterprise*.
+
 * `name` - (Required) The name of the OIDC Provider in Vault.
 
 

--- a/website/docs/d/identity_oidc_public_keys.html.md
+++ b/website/docs/d/identity_oidc_public_keys.html.md
@@ -56,6 +56,11 @@ data "vault_identity_oidc_public_keys" "public_keys" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace of the target resource.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+  *Available only for Vault Enterprise*.
+
 * `name` - (Required) The name of the OIDC Provider in Vault.
 
 

--- a/website/docs/d/kubernetes_auth_backend_config.md
+++ b/website/docs/d/kubernetes_auth_backend_config.md
@@ -28,6 +28,11 @@ output "token_reviewer_jwt" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace of the target resource.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+  *Available only for Vault Enterprise*.
+
 * `backend` - (Optional) The unique name for the Kubernetes backend the config to
   retrieve Role attributes for resides in. Defaults to "kubernetes".
 

--- a/website/docs/d/kubernetes_auth_backend_role.md
+++ b/website/docs/d/kubernetes_auth_backend_role.md
@@ -29,6 +29,11 @@ output "policies" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace of the target resource.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+  *Available only for Vault Enterprise*.
+
 * `role_name` - (Required) The name of the role to retrieve the Role attributes for.
 
 * `backend` - (Optional) The unique name for the Kubernetes backend the role to

--- a/website/docs/d/nomad_access_token.html.md
+++ b/website/docs/d/nomad_access_token.html.md
@@ -48,6 +48,11 @@ data "vault_nomad_access_token" "token" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace of the target resource.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+  *Available only for Vault Enterprise*.
+
 * `backend` - (Required) The path to the Nomad secret backend to
 read credentials from, with no leading or trailing `/`s.
 

--- a/website/docs/d/transform_decode.html.md
+++ b/website/docs/d/transform_decode.html.md
@@ -43,6 +43,11 @@ data "vault_transform_decode_role" "test" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace of the target resource.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+  *Available only for Vault Enterprise*.
+
 * `path` - (Required) Path to where the back-end is mounted within Vault.
 * `batch_input` - (Optional) Specifies a list of items to be decoded in a single batch. If this parameter is set, the top-level parameters 'value', 'transformation' and 'tweak' will be ignored. Each batch item within the list can specify these parameters instead.
 * `batch_results` - (Optional) The result of decoding a batch.

--- a/website/docs/d/transform_encode.html.md
+++ b/website/docs/d/transform_encode.html.md
@@ -43,6 +43,11 @@ data "vault_transform_encode_role" "test" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace of the target resource.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+  *Available only for Vault Enterprise*.
+
 * `path` - (Required) Path to where the back-end is mounted within Vault.
 * `batch_input` - (Optional) Specifies a list of items to be encoded in a single batch. If this parameter is set, the parameters 'value', 'transformation' and 'tweak' will be ignored. Each batch item within the list can specify these parameters instead.
 * `batch_results` - (Optional) The result of encoding a batch.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -178,7 +178,9 @@ variables in order to keep credential information out of the configuration.
   for more information.*
 
 * `namespace` - (Optional) Set the namespace to use. May be set via the
-  `VAULT_NAMESPACE` environment variable. *Available only for Vault Enterprise*.
+  `VAULT_NAMESPACE` environment variable.
+  See [namespaces](https://www.vaultproject.io/docs/enterprise/namespaces) for more info.
+  *Available only for Vault Enterprise*.
 
 * `headers` - (Optional) A configuration block, described below, that provides headers
 to be sent along with all requests to the Vault server.  This block can be specified
@@ -192,7 +194,7 @@ The `auth_login` configuration block accepts the following arguments:
 
 * `namespace` - (Optional) The path to the namespace that has the mounted auth method.
   This defaults to the root namespace. Cannot contain any leading or trailing slashes.
-  *Available only for Vault Enterprise*
+  *Available only for Vault Enterprise*.
 
 * `method` - (Optional) When configured, will enable auth method specific operations.
   For example, when set to `aws`, the provider will automatically sign login requests

--- a/website/docs/r/ad_secret_backend.html.md
+++ b/website/docs/r/ad_secret_backend.html.md
@@ -35,6 +35,11 @@ resource "vault_ad_secret_backend" "config" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `backend` - (Optional) The unique path this backend should be mounted at. Must
 not begin or end with a `/`. Defaults to `ad`.
 

--- a/website/docs/r/ad_secret_backend_library.html.md
+++ b/website/docs/r/ad_secret_backend_library.html.md
@@ -45,6 +45,11 @@ resource "vault_ad_secret_library" "qa" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `backend` - (Required) The path the AD secret backend is mounted at,
   with no leading or trailing `/`s.
 

--- a/website/docs/r/ad_secret_role.html.md
+++ b/website/docs/r/ad_secret_role.html.md
@@ -42,6 +42,11 @@ resource "vault_ad_secret_role" "role" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `backend` - (Required) The path the AD secret backend is mounted at,
   with no leading or trailing `/`s.
 

--- a/website/docs/r/alicloud_auth_backend_role.md
+++ b/website/docs/r/alicloud_auth_backend_role.md
@@ -30,6 +30,11 @@ resource "vault_alicloud_auth_backend_role" "alicloud" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `role` - (Required; Forces new resource) Name of the role. Must correspond with the name of
   the role reflected in the arn.
 

--- a/website/docs/r/approle_auth_backend_login.html.md
+++ b/website/docs/r/approle_auth_backend_login.html.md
@@ -41,6 +41,11 @@ resource "vault_approle_auth_backend_login" "login" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `role_id` - (Required) The ID of the role to log in with.
 
 * `secret_id` - (Optional) The secret ID of the role to log in with. Required

--- a/website/docs/r/approle_auth_backend_role.html.md
+++ b/website/docs/r/approle_auth_backend_role.html.md
@@ -30,6 +30,11 @@ resource "vault_approle_auth_backend_role" "example" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `role_name` - (Required) The name of the role.
 
 * `role_id` - (Optional) The RoleID of this role. If not specified, one will be

--- a/website/docs/r/approle_auth_backend_role_secret_id.html.md
+++ b/website/docs/r/approle_auth_backend_role_secret_id.html.md
@@ -41,6 +41,11 @@ resource "vault_approle_auth_backend_role_secret_id" "id" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `role_name` - (Required) The name of the role to create the SecretID for.
 
 * `metadata` - (Optional) A JSON-encoded string containing metadata in

--- a/website/docs/r/audit.html.md
+++ b/website/docs/r/audit.html.md
@@ -40,6 +40,11 @@ resource "vault_audit" "test" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `type` - (Required) Type of the audit device, such as 'file'.
 
 * `path` - (optional) The path to mount the audit device. This defaults to the type.

--- a/website/docs/r/auth_backend.html.md
+++ b/website/docs/r/auth_backend.html.md
@@ -26,6 +26,11 @@ resource "vault_auth_backend" "example" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `type` - (Required) The name of the auth method type
 
 * `path` - (Optional) The path to mount the auth method — this defaults to the name of the type

--- a/website/docs/r/aws_auth_backend_cert.html.md
+++ b/website/docs/r/aws_auth_backend_cert.html.md
@@ -42,6 +42,11 @@ resource "vault_aws_auth_backend_cert" "cert" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `cert_name` - (Required) The name of the certificate.
 
 * `aws_public_cert` - (Required) The  Base64 encoded AWS Public key required to

--- a/website/docs/r/aws_auth_backend_client.html.md
+++ b/website/docs/r/aws_auth_backend_client.html.md
@@ -42,6 +42,11 @@ resource "vault_aws_auth_backend_client" "example" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `backend` - (Optional) The path the AWS auth backend being configured was
 	mounted at.  Defaults to `aws`.
 

--- a/website/docs/r/aws_auth_backend_identity_whitelist.html.md
+++ b/website/docs/r/aws_auth_backend_identity_whitelist.html.md
@@ -30,6 +30,11 @@ resource "vault_aws_auth_backend_identity_whitelist" "example" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `backend` - (Optional) The path of the AWS backend being configured.
 
 * `safety_buffer` - (Optional) The amount of extra time, in minutes, that must

--- a/website/docs/r/aws_auth_backend_login.html.md
+++ b/website/docs/r/aws_auth_backend_login.html.md
@@ -55,6 +55,11 @@ resource "vault_aws_auth_backend_login" "example" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `backend` - (Optional) The unique name of the AWS auth backend. Defaults to
   'aws'.
 

--- a/website/docs/r/aws_auth_backend_role.html.md
+++ b/website/docs/r/aws_auth_backend_role.html.md
@@ -43,6 +43,11 @@ resource "vault_aws_auth_backend_role" "example" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `role` - (Required) The name of the role.
 
 * `auth_type` - (Optional) The auth type permitted for this role. Valid choices

--- a/website/docs/r/aws_auth_backend_role_tag.html.md
+++ b/website/docs/r/aws_auth_backend_role_tag.html.md
@@ -40,6 +40,11 @@ resource "vault_aws_auth_backend_role_tag" "test" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `role` - (Required) The name of the AWS auth backend role to read
 role tags from, with no leading or trailing `/`s.
 

--- a/website/docs/r/aws_auth_backend_roletag_blacklist.html.md
+++ b/website/docs/r/aws_auth_backend_roletag_blacklist.html.md
@@ -27,6 +27,11 @@ resource "vault_aws_auth_backend_roletag_blacklist" "example" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `backend` - (Required) The path the AWS auth backend being configured was
 	mounted at.
 

--- a/website/docs/r/aws_auth_backend_sts_role.html.md
+++ b/website/docs/r/aws_auth_backend_sts_role.html.md
@@ -38,6 +38,11 @@ resource "vault_aws_auth_backend_sts_role" "role" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `account_id` - (Optional) The AWS account ID to configure the STS role for.
 
 * `sts_role` - (Optional) The STS role to assume when verifying requests made

--- a/website/docs/r/aws_secret_backend.html.md
+++ b/website/docs/r/aws_secret_backend.html.md
@@ -31,6 +31,11 @@ resource "vault_aws_secret_backend" "aws" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `access_key` - (Optional) The AWS Access Key ID this backend should use to
 issue new credentials. Vault uses the official AWS SDK to authenticate, and thus can also use standard AWS environment credentials, shared file credentials or IAM role/ECS task credentials.
 

--- a/website/docs/r/aws_secret_backend_role.html.md
+++ b/website/docs/r/aws_secret_backend_role.html.md
@@ -50,6 +50,11 @@ EOT
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `backend` - (Required) The path the AWS secret backend is mounted at,
   with no leading or trailing `/`s.
 

--- a/website/docs/r/azure_auth_backend_config.html.md
+++ b/website/docs/r/azure_auth_backend_config.html.md
@@ -44,6 +44,11 @@ resource "vault_azure_auth_backend_config" "example" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `tenant_id` - (Required) The tenant id for the Azure Active Directory
 	organization.
 

--- a/website/docs/r/azure_auth_backend_role.html.md
+++ b/website/docs/r/azure_auth_backend_role.html.md
@@ -36,6 +36,11 @@ resource "vault_azure_auth_backend_role" "example" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `role` - (Required) The name of the role.
 
 * `bound_service_principal_ids` - (Optional) If set, defines a constraint on the

--- a/website/docs/r/azure_secret_backend.html.md
+++ b/website/docs/r/azure_secret_backend.html.md
@@ -53,6 +53,11 @@ resource "vault_azure_secret_backend" "azure" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 - `subscription_id` (`string: <required>`) - The subscription id for the Azure Active Directory.
 
 - `use_microsoft_graph_api` (`bool: <optional>`) - Use the Microsoft Graph API introduced in `vault-1.9`. 

--- a/website/docs/r/azure_secret_backend_role.html.md
+++ b/website/docs/r/azure_secret_backend_role.html.md
@@ -54,6 +54,11 @@ resource "vault_azure_secret_backend_role" "existing_object_id" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `role` - (Required) Name of the Azure role
 * `backend` - Path to the mounted Azure auth backend
 * `azure_groups` - List of Azure groups to be assigned to the generated service principal.

--- a/website/docs/r/cert_auth_backend_role.html.md
+++ b/website/docs/r/cert_auth_backend_role.html.md
@@ -33,6 +33,11 @@ resource "vault_cert_auth_backend_role" "cert" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `name` - (Required) Name of the role
 
 * `certificate` - (Required) CA certificate used to validate client certificates

--- a/website/docs/r/consul_secret_backend.html.md
+++ b/website/docs/r/consul_secret_backend.html.md
@@ -33,6 +33,11 @@ resource "vault_consul_secret_backend" "test" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `token` - (Required) The Consul management token this backend should use to issue new tokens.
 
 ~> **Important** Because Vault does not support reading the configured

--- a/website/docs/r/consul_secret_backend_role.html.md
+++ b/website/docs/r/consul_secret_backend_role.html.md
@@ -35,6 +35,11 @@ resource "vault_consul_secret_backend_role" "example" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `backend` - (Optional) The unique name of an existing Consul secrets backend mount. Must not begin or end with a `/`. One of `path` or `backend` is required.
 
 * `name` - (Required) The name of the Consul secrets engine role to create.

--- a/website/docs/r/database_secret_backend_connection.md
+++ b/website/docs/r/database_secret_backend_connection.md
@@ -41,6 +41,11 @@ resource "vault_database_secret_backend_connection" "postgres" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `name` - (Required) A unique name to give the database connection.
 
 * `backend` - (Required) The unique name of the Vault mount to configure.

--- a/website/docs/r/database_secret_backend_role.md
+++ b/website/docs/r/database_secret_backend_role.md
@@ -48,6 +48,11 @@ resource "vault_database_secret_backend_role" "role" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `name` - (Required) A unique name to give the role.
 
 * `backend` - (Required) The unique name of the Vault mount to configure.

--- a/website/docs/r/database_secret_backend_static_role.md
+++ b/website/docs/r/database_secret_backend_static_role.md
@@ -44,6 +44,11 @@ resource "vault_database_secret_backend_static_role" "static_role" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `name` - (Required) A unique name to give the static role.
 
 * `backend` - (Required) The unique name of the Vault mount to configure.

--- a/website/docs/r/egp_policy.html.md
+++ b/website/docs/r/egp_policy.html.md
@@ -33,6 +33,11 @@ EOT
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `name` - (Required) The name of the policy
 
 * `paths` - (Required) List of paths to which the policy will be applied to

--- a/website/docs/r/gcp_auth_backend.html.md
+++ b/website/docs/r/gcp_auth_backend.html.md
@@ -22,6 +22,11 @@ resource "vault_gcp_auth_backend" "gcp" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `credentials` - A JSON string containing the contents of a GCP credentials file. If this value is empty, Vault will try to use Application Default Credentials from the machine on which the Vault server is running.
 
 * `path` - (Optional) The path to mount the auth method — this defaults to 'gcp'.

--- a/website/docs/r/gcp_auth_backend_role.html.md
+++ b/website/docs/r/gcp_auth_backend_role.html.md
@@ -31,6 +31,11 @@ resource "vault_gcp_auth_backend_role" "gcp" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `role` - (Required) Name of the GCP role
 
 * `type` - (Required) Type of GCP authentication role (either `gce` or `iam`)

--- a/website/docs/r/gcp_secret_backend.html.md
+++ b/website/docs/r/gcp_secret_backend.html.md
@@ -30,6 +30,11 @@ resource "vault_gcp_secret_backend" "gcp" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `credentials` - (Optional) The GCP service account credentials in JSON format.
 
 ~> **Important** Because Vault does not support reading the configured

--- a/website/docs/r/gcp_secret_roleset.html.md
+++ b/website/docs/r/gcp_secret_roleset.html.md
@@ -45,6 +45,11 @@ resource "vault_gcp_secret_roleset" "roleset" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `backend` - (Required, Forces new resource) Path where the GCP Secrets Engine is mounted
 
 * `roleset` - (Required, Forces new resource) Name of the Roleset to create

--- a/website/docs/r/gcp_secret_static_account.html.md
+++ b/website/docs/r/gcp_secret_static_account.html.md
@@ -48,6 +48,11 @@ resource "vault_gcp_secret_static_account" "static_account" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `backend` - (Required, Forces new resource) Path where the GCP Secrets Engine is mounted
 
 * `static_account` - (Required, Forces new resource) Name of the Static Account to create

--- a/website/docs/r/generic_endpoint.html.md
+++ b/website/docs/r/generic_endpoint.html.md
@@ -85,6 +85,11 @@ output "u1_id" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `path` - (Required) The full logical path at which to write the given
   data. Consult each backend's documentation to see which endpoints
   support the `PUT` methods and to determine whether they also support

--- a/website/docs/r/generic_secret.html.md
+++ b/website/docs/r/generic_secret.html.md
@@ -45,6 +45,11 @@ EOT
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `path` - (Required) The full logical path at which to write the given data.
   To write data into the "generic" secret backend mounted in Vault by default,
   this should be prefixed with `secret/`. Writing to other backends with this

--- a/website/docs/r/github_auth_backend.html.md
+++ b/website/docs/r/github_auth_backend.html.md
@@ -24,6 +24,11 @@ resource "vault_github_auth_backend" "example" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `path` - (Optional) Path where the auth backend is mounted. Defaults to `auth/github`
   if not specified.
 

--- a/website/docs/r/github_team.html.md
+++ b/website/docs/r/github_team.html.md
@@ -30,6 +30,11 @@ resource "vault_github_team" "tf_devs" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `backend` - (Required) Path where the github auth backend is mounted. Defaults to `github`
   if not specified.
 

--- a/website/docs/r/github_user.html.md
+++ b/website/docs/r/github_user.html.md
@@ -30,6 +30,11 @@ resource "vault_github_user" "tf_user" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `backend` - (Required) Path where the github auth backend is mounted. Defaults to `github`
   if not specified.
 

--- a/website/docs/r/identity_entity.html.md
+++ b/website/docs/r/identity_entity.html.md
@@ -33,6 +33,11 @@ resource "vault_identity_entity" "test" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `name` - (Required) Name of the identity entity to create.
 
 * `policies` - (Optional) A list of policies to apply to the entity.

--- a/website/docs/r/identity_entity_alias.html.md
+++ b/website/docs/r/identity_entity_alias.html.md
@@ -31,6 +31,11 @@ resource "vault_identity_entity_alias" "test" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `name` - (Required) Name of the alias. Name should be the identifier of the client in the authentication source. For example, if the alias belongs to userpass backend, the name should be a valid username within userpass backend. If alias belongs to GitHub, it should be the GitHub username.
 
 * `mount_accessor` - (Required) Accessor of the mount to which the alias should belong to.

--- a/website/docs/r/identity_entity_policies.html.md
+++ b/website/docs/r/identity_entity_policies.html.md
@@ -66,6 +66,11 @@ resource "vault_identity_entity_policies" "others" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `policies` - (Required) List of policies to assign to the entity
 
 * `entity_id` - (Required) Entity ID to assign policies to.

--- a/website/docs/r/identity_group.html.md
+++ b/website/docs/r/identity_group.html.md
@@ -77,6 +77,11 @@ resource "vault_identity_group" "Internal" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `name` - (Required, Forces new resource) Name of the identity group to create.
 
 * `type` - (Optional, Forces new resource) Type of the group, internal or external. Defaults to `internal`.

--- a/website/docs/r/identity_group_alias.html.md
+++ b/website/docs/r/identity_group_alias.html.md
@@ -37,6 +37,11 @@ resource "vault_identity_group_alias" "group-alias" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `name` - (Required, Forces new resource) Name of the group alias to create.
 
 * `mount_accessor` - (Required) Mount accessor of the authentication backend to which this alias belongs to.

--- a/website/docs/r/identity_group_member_entity_ids.html.md
+++ b/website/docs/r/identity_group_member_entity_ids.html.md
@@ -84,6 +84,11 @@ resource "vault_identity_group_member_entity_ids" "others" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `member_entity_ids` - (Required) List of member entities that belong to the group
 
 * `group_id` - (Required) Group ID to assign member entities to.

--- a/website/docs/r/identity_group_policies.html.md
+++ b/website/docs/r/identity_group_policies.html.md
@@ -78,6 +78,11 @@ resource "vault_identity_group_policies" "others" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `policies` - (Required) List of policies to assign to the group
 
 * `group_id` - (Required) Group ID to assign policies to.

--- a/website/docs/r/identity_oidc.html.md
+++ b/website/docs/r/identity_oidc.html.md
@@ -27,6 +27,11 @@ resource "vault_identity_oidc" "server" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `issuer` - (Optional) Issuer URL to be used in the iss claim of the token. If not set, Vault's
   `api_addr` will be used. The issuer is a case sensitive URL using the https scheme that contains
   scheme, host, and optionally, port number and path components, but no query or fragment

--- a/website/docs/r/identity_oidc_assignment.html.md
+++ b/website/docs/r/identity_oidc_assignment.html.md
@@ -40,6 +40,11 @@ resource "vault_identity_oidc_assignment" "default" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `name` - (Required) The name of the assignment.
 
 * `entity_ids` - (Optional) A set of Vault entity IDs.

--- a/website/docs/r/identity_oidc_client.html.md
+++ b/website/docs/r/identity_oidc_client.html.md
@@ -40,6 +40,11 @@ resource "vault_identity_oidc_client" "test" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `name` - (Required) The name of the client.
 
 * `key` - (Optional) A reference to a named key resource in Vault.

--- a/website/docs/r/identity_oidc_key.html.md
+++ b/website/docs/r/identity_oidc_key.html.md
@@ -49,6 +49,11 @@ resource "vault_identity_oidc_key_allowed_client_id" "role" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `name` - (Required; Forces new resource) Name of the OIDC Key to create.
 
 * `rotation_period` - (Optional) How often to generate a new signing key in number of seconds

--- a/website/docs/r/identity_oidc_key_allowed_client_id.html.md
+++ b/website/docs/r/identity_oidc_key_allowed_client_id.html.md
@@ -48,6 +48,11 @@ resource "vault_identity_oidc_key_allowed_client_id" "role" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `key_name` - (Required; Forces new resource) Name of the OIDC Key allow the Client ID.
 
 * `allowed_client_id` - (Required; Forces new resource) Client ID to allow usage with the OIDC named key

--- a/website/docs/r/identity_oidc_provider.html.md
+++ b/website/docs/r/identity_oidc_provider.html.md
@@ -69,6 +69,11 @@ resource "vault_identity_oidc_provider" "test" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `name` - (Required) The name of the provider.
 
 * `https_enabled` - (Optional) Set to true if the issuer endpoint uses HTTPS.

--- a/website/docs/r/identity_oidc_role.html.md
+++ b/website/docs/r/identity_oidc_role.html.md
@@ -78,6 +78,11 @@ resource "vault_identity_oidc_key_allowed_client_id" "role" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `name` - (Required; Forces new resource) Name of the OIDC Role to create.
 
 * `key` - (Required; Forces new resource) A configured named key, the key must already exist

--- a/website/docs/r/identity_oidc_scope.html.md
+++ b/website/docs/r/identity_oidc_scope.html.md
@@ -29,6 +29,11 @@ resource "vault_identity_oidc_scope" "groups" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `name` - (Required) The name of the scope. The `openid` scope name is reserved.
 
 * `template` - (Optional) The template string for the scope. This may be provided as escaped JSON or base64 encoded JSON.

--- a/website/docs/r/jwt_auth_backend.html.md
+++ b/website/docs/r/jwt_auth_backend.html.md
@@ -63,6 +63,11 @@ resource "vault_jwt_auth_backend" "gsuite" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `path` - (Required) Path to mount the JWT/OIDC auth backend
 
 * `type` - (Optional) Type of auth backend. Should be one of `jwt` or `oidc`. Default - `jwt`

--- a/website/docs/r/jwt_auth_backend_role.html.md
+++ b/website/docs/r/jwt_auth_backend_role.html.md
@@ -58,6 +58,11 @@ resource "vault_jwt_auth_backend_role" "example" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `role_name` - (Required) The name of the role.
 
 * `role_type` - (Optional) Type of role, either "oidc" (default) or "jwt".

--- a/website/docs/r/kmip_secret_backend.html.md
+++ b/website/docs/r/kmip_secret_backend.html.md
@@ -31,6 +31,11 @@ resource "vault_kmip_secret_backend" "default" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `path` - (Required) The unique path this backend should be mounted at. Must
   not begin or end with a `/`. Defaults to `kmip`.
 

--- a/website/docs/r/kmip_secret_role.html.md
+++ b/website/docs/r/kmip_secret_role.html.md
@@ -44,6 +44,11 @@ resource "vault_kmip_secret_role" "admin" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `path` - (Required) The unique path this backend should be mounted at. Must
   not begin or end with a `/`. Defaults to `kmip`.
 

--- a/website/docs/r/kmip_secret_scope.html.md
+++ b/website/docs/r/kmip_secret_scope.html.md
@@ -31,6 +31,11 @@ resource "vault_kmip_secret_scope" "dev" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `path` - (Required) The unique path this backend should be mounted at. Must
   not begin or end with a `/`. Defaults to `kmip`.
 

--- a/website/docs/r/kubernetes_auth_backend_config.md
+++ b/website/docs/r/kubernetes_auth_backend_config.md
@@ -33,6 +33,11 @@ resource "vault_kubernetes_auth_backend_config" "example" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `kubernetes_host` - (Required) Host must be a host string, a host:port pair, or a URL to the base of the Kubernetes API server.
 
 * `kubernetes_ca_cert` - (Optional) PEM encoded CA cert for use by the TLS client used to talk with the Kubernetes API.

--- a/website/docs/r/kubernetes_auth_backend_role.html.md
+++ b/website/docs/r/kubernetes_auth_backend_role.html.md
@@ -34,6 +34,11 @@ resource "vault_kubernetes_auth_backend_role" "example" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `role_name` - (Required) Name of the role.
 
 * `bound_service_account_names` - (Required) List of service account names able to access this role. If set to `["*"]` all names are allowed, both this and bound_service_account_namespaces can not be "*".

--- a/website/docs/r/ldap_auth_backend.html.md
+++ b/website/docs/r/ldap_auth_backend.html.md
@@ -29,6 +29,11 @@ resource "vault_ldap_auth_backend" "ldap" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `url` - (Required) The URL of the LDAP server
 
 * `starttls` - (Optional) Control use of TLS when conecting to LDAP

--- a/website/docs/r/ldap_auth_backend_group.html.md
+++ b/website/docs/r/ldap_auth_backend_group.html.md
@@ -35,6 +35,11 @@ resource "vault_ldap_auth_backend_group" "group" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `groupname` - (Required) The LDAP groupname
 
 * `policies` - (Optional) Policies which should be granted to members of the group

--- a/website/docs/r/ldap_auth_backend_user.html.md
+++ b/website/docs/r/ldap_auth_backend_user.html.md
@@ -35,6 +35,11 @@ resource "vault_ldap_auth_backend_user" "user" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `username` - (Required) The LDAP username
 
 * `policies` - (Optional) Policies which should be granted to user

--- a/website/docs/r/mfa_duo.html.md
+++ b/website/docs/r/mfa_duo.html.md
@@ -33,6 +33,11 @@ resource "vault_mfa_duo" "my_duo" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 - `name` `(string: <required>)` – Name of the MFA method.
 
 - `mount_accessor` `(string: <required>)` - The mount to tie this method to for use in automatic mappings. The mapping will use the Name field of Aliases associated with this mount as the username in the mapping.

--- a/website/docs/r/mfa_okta.html.md
+++ b/website/docs/r/mfa_okta.html.md
@@ -33,6 +33,11 @@ resource "vault_mfa_okta" "my_okta" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 - `name` `(string: <required>)` – Name of the MFA method.
 
 - `mount_accessor` `(string: <required>)` - The mount to tie this method to for use in automatic mappings. 

--- a/website/docs/r/mfa_pingid.html.md
+++ b/website/docs/r/mfa_pingid.html.md
@@ -34,6 +34,11 @@ resource "vault_mfa_pingid" "my_pingid" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 - `name` `(string: <required>)` – Name of the MFA method.
 
 - `mount_accessor` `(string: <required>)` - The mount to tie this method to for use in automatic mappings. 

--- a/website/docs/r/mfa_totp.html.md
+++ b/website/docs/r/mfa_totp.html.md
@@ -29,6 +29,11 @@ resource "vault_mfa_totp" "my_totp" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 - `name` `(string: <required>)` – Name of the MFA method.
 
 - `issuer` `(string: <required>)` - The name of the key's issuing organization.

--- a/website/docs/r/mount.html.md
+++ b/website/docs/r/mount.html.md
@@ -54,6 +54,11 @@ resource "vault_mount" "pki-example" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `path` - (Required) Where the secret backend will be mounted
 
 * `type` - (Required) Type of the backend, such as "aws"

--- a/website/docs/r/namespace.html.md
+++ b/website/docs/r/namespace.html.md
@@ -24,6 +24,11 @@ resource "vault_namespace" "ns1" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `path` - (Required) The path of the namespace. Must not have a trailing `/`
 
 ## Attributes Reference

--- a/website/docs/r/nomad_secret_backend.html.md
+++ b/website/docs/r/nomad_secret_backend.html.md
@@ -37,6 +37,11 @@ resource "vault_nomad_secret_backend" "config" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `backend` - (Optional) The unique path this backend should be mounted at. Must
 not begin or end with a `/`. Defaults to `nomad`.
 

--- a/website/docs/r/nomad_secret_role.html.md
+++ b/website/docs/r/nomad_secret_role.html.md
@@ -42,6 +42,11 @@ resource "vault_nomad_secret_role" "test" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `backend` - (Optional) The unique path this backend should be mounted at. Must
 not begin or end with a `/`. Defaults to `nomad`.
 

--- a/website/docs/r/okta_auth_backend.html.md
+++ b/website/docs/r/okta_auth_backend.html.md
@@ -35,6 +35,11 @@ resource "vault_okta_auth_backend" "example" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `path` - (Required) Path to mount the Okta auth backend
 
 * `description` - (Optional) The description of the auth backend

--- a/website/docs/r/okta_auth_backend_group.html.md
+++ b/website/docs/r/okta_auth_backend_group.html.md
@@ -30,6 +30,11 @@ resource "vault_okta_auth_backend_group" "foo" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `path` - (Required) The path where the Okta auth backend is mounted
 
 * `group_name` - (Required) Name of the group within the Okta

--- a/website/docs/r/okta_auth_backend_user.html.md
+++ b/website/docs/r/okta_auth_backend_user.html.md
@@ -30,6 +30,11 @@ resource "vault_okta_auth_backend_user" "foo" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `path` - (Required) The path where the Okta auth backend is mounted
 
 * `username` - (Required Optional) Name of the user within Okta

--- a/website/docs/r/password_policy.html.md
+++ b/website/docs/r/password_policy.html.md
@@ -31,6 +31,11 @@ resource "vault_password_policy" "alphanumeric" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `name` - (Required) The name of the password policy.
 
 * `policy` - (Required) String containing a password policy.

--- a/website/docs/r/pki_secret_backend_cert.html.md
+++ b/website/docs/r/pki_secret_backend_cert.html.md
@@ -34,6 +34,11 @@ resource "vault_pki_secret_backend_cert" "app" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `backend` - (Required) The PKI secret backend the resource belongs to.
 
 * `name` - (Required) Name of the role to create the certificate against

--- a/website/docs/r/pki_secret_backend_config_ca.html.md
+++ b/website/docs/r/pki_secret_backend_config_ca.html.md
@@ -82,6 +82,11 @@ EOT
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `backend` - (Required) The PKI secret backend the resource belongs to.
 
 * `pem_bundle` - (Required) The key and certificate PEM bundle

--- a/website/docs/r/pki_secret_backend_config_urls.html.md
+++ b/website/docs/r/pki_secret_backend_config_urls.html.md
@@ -33,6 +33,11 @@ resource "vault_pki_secret_backend_config_urls" "example" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `backend` - (Required) The path the PKI secret backend is mounted at, with no leading or trailing `/`s.
 
 * `issuing_certificates` - (Optional) Specifies the URL values for the Issuing Certificate field.

--- a/website/docs/r/pki_secret_backend_crl_config.html.md
+++ b/website/docs/r/pki_secret_backend_crl_config.html.md
@@ -31,6 +31,11 @@ resource "vault_pki_secret_backend_crl_config" "crl_config" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `backend` - (Required) The path the PKI secret backend is mounted at, with no leading or trailing `/`s.
 
 * `expiry` - (Optional) Specifies the time until expiration.

--- a/website/docs/r/pki_secret_backend_intermediate_cert_request.html.md
+++ b/website/docs/r/pki_secret_backend_intermediate_cert_request.html.md
@@ -32,6 +32,11 @@ resource "vault_pki_secret_backend_intermediate_cert_request" "test" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `backend` - (Required) The PKI secret backend the resource belongs to.
 
 * `type` - (Required) Type of intermediate to create. Must be either \"exported\" or \"internal\"

--- a/website/docs/r/pki_secret_backend_intermediate_set_signed.html.md
+++ b/website/docs/r/pki_secret_backend_intermediate_set_signed.html.md
@@ -82,6 +82,11 @@ resource "vault_pki_secret_backend_intermediate_set_signed" "example" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `backend` - (Required) The PKI secret backend the resource belongs to.
 
 * `certificate` - (Required) Specifies the PEM encoded certificate. May optionally append additional

--- a/website/docs/r/pki_secret_backend_role.html.md
+++ b/website/docs/r/pki_secret_backend_role.html.md
@@ -36,6 +36,11 @@ resource "vault_pki_secret_backend_role" "role" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `backend` - (Required) The path the PKI secret backend is mounted at, with no leading or trailing `/`s.
 
 * `name` - (Required) The name to identify this role within the backend. Must be unique within the backend.

--- a/website/docs/r/pki_secret_backend_root_cert.html.md
+++ b/website/docs/r/pki_secret_backend_root_cert.html.md
@@ -40,6 +40,11 @@ resource "vault_pki_secret_backend_root_cert" "test" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `backend` - (Required) The PKI secret backend the resource belongs to.
 
 * `type` - (Required) Type of intermediate to create. Must be either \"exported\" or \"internal\"

--- a/website/docs/r/pki_secret_backend_root_sign_intermediate.html.md
+++ b/website/docs/r/pki_secret_backend_root_sign_intermediate.html.md
@@ -28,6 +28,11 @@ resource "vault_pki_secret_backend_root_sign_intermediate" "root" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `backend` - (Required) The PKI secret backend the resource belongs to.
 
 * `csr` - (Required) The CSR

--- a/website/docs/r/pki_secret_backend_sign.html.md
+++ b/website/docs/r/pki_secret_backend_sign.html.md
@@ -61,6 +61,11 @@ EOT
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `backend` - (Required) The PKI secret backend the resource belongs to.
 
 * `name` - (Required) Name of the role to create the certificate against

--- a/website/docs/r/policy.html.md
+++ b/website/docs/r/policy.html.md
@@ -27,6 +27,11 @@ EOT
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `name` - (Required) The name of the policy
 
 * `policy` - (Required) String containing a Vault policy

--- a/website/docs/r/quota_lease_count.md
+++ b/website/docs/r/quota_lease_count.md
@@ -31,6 +31,11 @@ resource "vault_quota_lease_count" "global" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `name` - (Required) Name of the rate limit quota
 
 * `path` - (Optional) Path of the mount or namespace to apply the quota. A blank path configures a

--- a/website/docs/r/quota_rate_limit.md
+++ b/website/docs/r/quota_rate_limit.md
@@ -29,6 +29,11 @@ resource "vault_quota_rate_limit" "global" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `name` - (Required) Name of the rate limit quota
 
 * `path` - (Optional) Path of the mount or namespace to apply the quota. A blank path configures a

--- a/website/docs/r/rabbitmq_secret_backend.html.md
+++ b/website/docs/r/rabbitmq_secret_backend.html.md
@@ -32,6 +32,11 @@ resource "vault_rabbitmq_secret_backend" "rabbitmq" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `connection_uri` - (Required)  Specifies the RabbitMQ connection URI.
 
 * `username` - (Required) Specifies the RabbitMQ management administrator username.

--- a/website/docs/r/rabbitmq_secret_backend_role.html.md
+++ b/website/docs/r/rabbitmq_secret_backend_role.html.md
@@ -56,6 +56,11 @@ resource "vault_rabbitmq_secret_backend_role" "role" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `backend` - (Required) The path the RabbitMQ secret backend is mounted at,
 with no leading or trailing `/`s.
 

--- a/website/docs/r/raft_autopilot.html.md
+++ b/website/docs/r/raft_autopilot.html.md
@@ -30,6 +30,11 @@ resource "vault_raft_autopilot" "autopilot" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 - `cleanup_dead_servers` – (Optional) Specifies whether to remove dead server nodes
 periodically or when a new server joins. This requires that `min-quorum` is also set.
 

--- a/website/docs/r/raft_snapshot_agent_config.html.md
+++ b/website/docs/r/raft_snapshot_agent_config.html.md
@@ -64,6 +64,11 @@ resource "vault_raft_snapshot_agent_config" "s3_backups" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 - `name` `<required>` – Name of the configuration to modify.
 
 - `interval_seconds` `<required>` - Time (in seconds) between snapshots.

--- a/website/docs/r/rgp_policy.html.md
+++ b/website/docs/r/rgp_policy.html.md
@@ -31,6 +31,11 @@ EOT
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `name` - (Required) The name of the policy
 
 * `enforcement_level` - (Required) Enforcement level of Sentinel policy. Can be either `advisory` or `soft-mandatory` or `hard-mandatory`

--- a/website/docs/r/ssh_secret_backend_ca.html.md
+++ b/website/docs/r/ssh_secret_backend_ca.html.md
@@ -27,6 +27,11 @@ resource "vault_ssh_secret_backend_ca" "foo" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `backend` - (Optional) The path where the SSH secret backend is mounted. Defaults to 'ssh'
 
 * `generate_signing_key` - (Optional) Whether Vault should generate the signing key pair internally. Defaults to true

--- a/website/docs/r/ssh_secret_backend_role.html.md
+++ b/website/docs/r/ssh_secret_backend_role.html.md
@@ -39,6 +39,11 @@ resource "vault_ssh_secret_backend_role" "bar" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `name` - (Required) Specifies the name of the role to create.
 
 * `backend` - (Required) The path where the SSH secret backend is mounted.

--- a/website/docs/r/terraform_cloud_secret_backend.md
+++ b/website/docs/r/terraform_cloud_secret_backend.md
@@ -33,6 +33,11 @@ resource "vault_terraform_cloud_secret_backend" "test" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `token` - (Required) The Terraform Cloud management token this backend should 
   use to issue new tokens.
 

--- a/website/docs/r/terraform_cloud_secret_creds.html.md
+++ b/website/docs/r/terraform_cloud_secret_creds.html.md
@@ -45,6 +45,11 @@ resource "vault_terraform_cloud_secret_creds" "token" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `backend` - (Required) The path to the Terraform Cloud secret backend to
 read credentials from, with no leading or trailing `/`s.
 

--- a/website/docs/r/terraform_cloud_secret_role.html.md
+++ b/website/docs/r/terraform_cloud_secret_role.html.md
@@ -32,6 +32,11 @@ resource "vault_terraform_cloud_secret_role" "example" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `backend` - (Optional) The unique name of an existing Terraform Cloud secrets backend mount. Must not begin or end with a `/`.
 
 * `name` - (Required) The name of the Terraform Cloud secrets engine role to create.

--- a/website/docs/r/token.html.md
+++ b/website/docs/r/token.html.md
@@ -45,6 +45,11 @@ resource "vault_token" "example" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `role_name` - (Optional) The token role name
 
 * `policies` - (Optional) List of policies to attach to this token

--- a/website/docs/r/token_auth_backend_role.html.md
+++ b/website/docs/r/token_auth_backend_role.html.md
@@ -32,6 +32,11 @@ resource "vault_token_auth_backend_role" "example" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `role_name` - (Required) The name of the role.
 
 * `allowed_policies` (Optional) List of allowed policies for given role.

--- a/website/docs/r/transform_alphabet.html.md
+++ b/website/docs/r/transform_alphabet.html.md
@@ -31,6 +31,11 @@ resource "vault_transform_alphabet" "test" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `path` - (Required) Path to where the back-end is mounted within Vault.
 * `alphabet` - (Optional) A string of characters that contains the alphabet set.
 * `name` - (Required) The name of the alphabet.

--- a/website/docs/r/transform_role.html.md
+++ b/website/docs/r/transform_role.html.md
@@ -31,6 +31,11 @@ resource "vault_transform_role" "test" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `path` - (Required) Path to where the back-end is mounted within Vault.
 * `name` - (Required) The name of the role.
 * `transformations` - (Optional) A comma separated string or slice of transformations to use.

--- a/website/docs/r/transform_template.html.md
+++ b/website/docs/r/transform_template.html.md
@@ -54,6 +54,11 @@ resource "vault_transform_template" "test" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `path` - (Required) Path to where the back-end is mounted within Vault.
 * `alphabet` - (Optional) The alphabet to use for this template. This is only used during FPE transformations.
 * `name` - (Required) The name of the template.

--- a/website/docs/r/transform_transformation.html.md
+++ b/website/docs/r/transform_transformation.html.md
@@ -34,6 +34,11 @@ resource "vault_transform_transformation" "test" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `path` - (Required) Path to where the back-end is mounted within Vault.
 * `allowed_roles` - (Optional) The set of roles allowed to perform this transformation.
 * `masking_character` - (Optional) The character used to replace data when in masking mode

--- a/website/docs/r/transit_secret_backend_cache_config.html.md
+++ b/website/docs/r/transit_secret_backend_cache_config.html.md
@@ -31,6 +31,11 @@ resource "vault_transit_secret_cache_config" "cfg" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `backend` - (Required) The path the transit secret backend is mounted at, with no leading or trailing `/`s.
 
 * `size` - (Required) The number of cache entries. 0 means unlimited.

--- a/website/docs/r/transit_secret_backend_key.html.md
+++ b/website/docs/r/transit_secret_backend_key.html.md
@@ -31,6 +31,11 @@ resource "vault_transit_secret_backend_key" "key" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](../index.html#namespace).
+   *Available only for Vault Enterprise*.
+
 * `backend` - (Required) The path the transit secret backend is mounted at, with no leading or trailing `/`s.
 
 * `name` - (Required) The name to identify this key within the backend. Must be unique within the backend.


### PR DESCRIPTION
This change adds support for configuring namespaces at the resource or data source level.

All namespace directives are applied relative to the provider's configured namespace. This new approach allows for namespace'd resources to be created without having to pass a namespace specific provider, although that method is still fully supported.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
