### PR TITLE
auth/gcp: adds custom_endpoint parameter to backend config

### DIFF
--- a/vault/resource_gcp_auth_backend.go
+++ b/vault/resource_gcp_auth_backend.go
@@ -242,7 +242,7 @@ func gcpAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 	if endpointsRaw, ok := resp.Data["custom_endpoint"]; ok {
 		endpoints, ok := endpointsRaw.(map[string]interface{})
 		if !ok {
-			return fmt.Errorf("custom_endpoint has unexpected type: %q", path)
+			return fmt.Errorf("custom_endpoint has unexpected type %T, path=%q", endpointsRaw, path)
 		}
 		if err := d.Set("custom_endpoint", []map[string]interface{}{endpoints}); err != nil {
 			return err

--- a/vault/resource_gcp_auth_backend.go
+++ b/vault/resource_gcp_auth_backend.go
@@ -180,13 +180,17 @@ func gcpAuthBackendUpdate(d *schema.ResourceData, meta interface{}) error {
 		data["credentials"] = v
 	}
 
-	if v, ok := d.GetOk("custom_endpoint"); ok {
+	epField := "custom_endpoint"
+	if d.HasChange(epField) {
 		endpoints := make(map[string]interface{})
-		for _, ep := range v.([]interface{}) {
-			for epKey, epVal := range ep.(map[string]interface{}) {
-				endpoints[epKey] = epVal
+		for epKey := range gcpAuthCustomEndpointSchema {
+			key := fmt.Sprintf("%s.%d.%s", epField, 0, epKey)
+			if d.HasChange(key) {
+				endpoints[epKey] = d.Get(key)
 			}
 		}
+		data["custom_endpoint"] = endpoints
+	}
 
 		data["custom_endpoint"] = endpoints
 	}

--- a/vault/resource_gcp_auth_backend.go
+++ b/vault/resource_gcp_auth_backend.go
@@ -73,6 +73,14 @@ func gcpAuthBackendResource() *schema.Resource {
 				Optional:    true,
 				Description: "Specifies if the auth method is local only",
 			},
+			"custom_endpoint": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: "Specifies overrides to service endpoints used when making API requests to GCP",
+			},
 		},
 	}
 }
@@ -143,7 +151,11 @@ func gcpAuthBackendUpdate(d *schema.ResourceData, meta interface{}) error {
 	data := map[string]interface{}{}
 
 	if v, ok := d.GetOk("credentials"); ok {
-		data["credentials"] = v.(string)
+		data["credentials"] = v
+	}
+
+	if v, ok := d.GetOk("custom_endpoint"); ok {
+		data["custom_endpoint"] = v
 	}
 
 	log.Printf("[DEBUG] Writing gcp config %q", path)
@@ -181,6 +193,7 @@ func gcpAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 		"project_id",
 		"client_email",
 		"local",
+		"custom_endpoint",
 	}
 
 	for _, param := range params {

--- a/vault/resource_gcp_auth_backend_test.go
+++ b/vault/resource_gcp_auth_backend_test.go
@@ -44,7 +44,7 @@ func TestGCPAuthBackend_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testGCPAuthBackendCheck_attrs(),
 					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
-						"custom_endpoint.%", "0"),
+						"custom_endpoint.#", "1"),
 					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
 						"custom_endpoint.0.%", "4"),
 					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",

--- a/vault/resource_gcp_auth_backend_test.go
+++ b/vault/resource_gcp_auth_backend_test.go
@@ -164,13 +164,13 @@ func testGCPAuthBackendCheck_attrs() resource.TestCheckFunc {
 func testGCPAuthBackendConfig_basic(path, credentials string) string {
 	return fmt.Sprintf(`
 variable "json_credentials" {
-  type = string
+  type    = string
   default = %q
 }
 
 resource "vault_gcp_auth_backend" "test" {
-  path                          = %q
-  credentials                   = var.json_credentials
+  path        = %q
+  credentials = var.json_credentials
 }
 `, credentials, path)
 }
@@ -178,13 +178,13 @@ resource "vault_gcp_auth_backend" "test" {
 func testGCPAuthBackendConfig_update(path, credentials string) string {
 	return fmt.Sprintf(`
 variable "json_credentials" {
-  type = string
+  type    = string
   default = %q
 }
 
 resource "vault_gcp_auth_backend" "test" {
-  path                          = %q
-  credentials                   = var.json_credentials
+  path        = %q
+  credentials = var.json_credentials
   custom_endpoint {
     api     = "www.googleapis.com"
     iam     = "iam.googleapis.com"
@@ -198,13 +198,13 @@ resource "vault_gcp_auth_backend" "test" {
 func testGCPAuthBackendConfig_update_partial(path, credentials string) string {
 	return fmt.Sprintf(`
 variable "json_credentials" {
-  type = string
+  type    = string
   default = %q
 }
 
 resource "vault_gcp_auth_backend" "test" {
-  path                          = %q
-  credentials                   = var.json_credentials
+  path        = %q
+  credentials = var.json_credentials
   custom_endpoint {
     crm     = "example.com:9200"
     compute = "compute.example.com"

--- a/vault/resource_gcp_auth_backend_test.go
+++ b/vault/resource_gcp_auth_backend_test.go
@@ -44,15 +44,35 @@ func TestGCPAuthBackend_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testGCPAuthBackendCheck_attrs(),
 					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
-						"custom_endpoint.%", "4"),
+						"custom_endpoint.%", "0"),
 					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
-						"custom_endpoint.api", "www.googleapis.com"),
+						"custom_endpoint.0.%", "4"),
 					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
-						"custom_endpoint.iam", "iam.googleapis.com"),
+						"custom_endpoint.0.api", "www.googleapis.com"),
 					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
-						"custom_endpoint.crm", "cloudresourcemanager.googleapis.com"),
+						"custom_endpoint.0.iam", "iam.googleapis.com"),
 					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
-						"custom_endpoint.compute", "compute.googleapis.com"),
+						"custom_endpoint.0.crm", "cloudresourcemanager.googleapis.com"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
+						"custom_endpoint.0.compute", "compute.googleapis.com"),
+				),
+			},
+			{
+				Config: testGCPAuthBackendConfig_update_partial(path, gcpJSONCredentials),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testGCPAuthBackendCheck_attrs(),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
+						"custom_endpoint.%", "0"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
+						"custom_endpoint.0.%", "4"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
+						"custom_endpoint.0.api", ""),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
+						"custom_endpoint.0.iam", ""),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
+						"custom_endpoint.0.crm", "example.com:9200"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
+						"custom_endpoint.0.compute", "compute.example.com"),
 				),
 			},
 		},
@@ -141,11 +161,29 @@ variable "json_credentials" {
 resource "vault_gcp_auth_backend" "test" {
   path                          = %q
   credentials                   = var.json_credentials
-  custom_endpoint = {
+  custom_endpoint {
     api     = "www.googleapis.com"
     iam     = "iam.googleapis.com"
     crm     = "cloudresourcemanager.googleapis.com"
     compute = "compute.googleapis.com"
+  }
+}
+`, credentials, path)
+}
+
+func testGCPAuthBackendConfig_update_partial(path, credentials string) string {
+	return fmt.Sprintf(`
+variable "json_credentials" {
+  type = string
+  default = %q
+}
+
+resource "vault_gcp_auth_backend" "test" {
+  path                          = %q
+  credentials                   = var.json_credentials
+  custom_endpoint {
+    crm     = "example.com:9200"
+    compute = "compute.example.com"
   }
 }
 `, credentials, path)

--- a/vault/resource_gcp_auth_backend_test.go
+++ b/vault/resource_gcp_auth_backend_test.go
@@ -62,7 +62,7 @@ func TestGCPAuthBackend_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testGCPAuthBackendCheck_attrs(),
 					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
-						"custom_endpoint.%", "0"),
+						"custom_endpoint.#", "1"),
 					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
 						"custom_endpoint.0.%", "4"),
 					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",

--- a/vault/resource_gcp_auth_backend_test.go
+++ b/vault/resource_gcp_auth_backend_test.go
@@ -75,6 +75,30 @@ func TestGCPAuthBackend_basic(t *testing.T) {
 						"custom_endpoint.0.compute", "compute.example.com"),
 				),
 			},
+			{
+				ResourceName:      "vault_gcp_auth_backend.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"credentials",
+				},
+			},
+			{
+				Config: testGCPAuthBackendConfig_basic(path, gcpJSONCredentials),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testGCPAuthBackendCheck_attrs(),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
+						"custom_endpoint.#", "0"),
+				),
+			},
+			{
+				ResourceName:      "vault_gcp_auth_backend.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"credentials",
+				},
+			},
 		},
 	})
 }

--- a/website/docs/r/gcp_auth_backend.html.md
+++ b/website/docs/r/gcp_auth_backend.html.md
@@ -30,6 +30,21 @@ The following arguments are supported:
 
 * `local` - (Optional) Specifies if the auth method is local only.
 
+* `custom_endpoint` - (Optional) Specifies overrides to
+  [service endpoints](https://cloud.google.com/apis/design/glossary#api_service_endpoint)
+  used when making API requests. This allows specific requests made during authentication
+  to target alternative service endpoints for use in [Private Google Access](https://cloud.google.com/vpc/docs/configure-private-google-access)
+  environments.
+
+  Overrides are set at the subdomain level using the following keys:
+  - `api` - Replaces the service endpoint used in API requests to `https://www.googleapis.com`.
+  - `iam` - Replaces the service endpoint used in API requests to `https://iam.googleapis.com`.
+  - `crm` - Replaces the service endpoint used in API requests to `https://cloudresourcemanager.googleapis.com`.
+  - `compute` - Replaces the service endpoint used in API requests to `https://compute.googleapis.com`.
+
+  The endpoint value provided for a given key has the form of `scheme://host:port`.
+  The `scheme://` and `:port` portions of the endpoint value are optional.
+
 For more details on the usage of each argument consult the [Vault GCP API documentation](https://www.vaultproject.io/api-docs/auth/gcp#configure).
 
 ## Attribute Reference

--- a/website/docs/r/gcp_auth_backend.html.md
+++ b/website/docs/r/gcp_auth_backend.html.md
@@ -13,8 +13,15 @@ Provides a resource to configure the [GCP auth backend within Vault](https://www
 ## Example Usage
 
 ```hcl
-resource "vault_gcp_auth_backend" "gcp" {
-    credentials  = file("vault-gcp-credentials.json")
+resource "vault_gcp_auth_backend" "gcp" { 
+  credentials  = file("vault-gcp-credentials.json")
+
+  custom_endpoint = {
+    api     = "www.googleapis.com"
+    iam     = "iam.googleapis.com"
+    crm     = "cloudresourcemanager.googleapis.com"
+    compute = "compute.googleapis.com"
+  }
 }
 ```
 
@@ -34,7 +41,7 @@ The following arguments are supported:
   [service endpoints](https://cloud.google.com/apis/design/glossary#api_service_endpoint)
   used when making API requests. This allows specific requests made during authentication
   to target alternative service endpoints for use in [Private Google Access](https://cloud.google.com/vpc/docs/configure-private-google-access)
-  environments.
+  environments. Requires Vault 1.11+.
 
   Overrides are set at the subdomain level using the following keys:
   - `api` - Replaces the service endpoint used in API requests to `https://www.googleapis.com`.

--- a/website/docs/r/jwt_auth_backend_role.html.md
+++ b/website/docs/r/jwt_auth_backend_role.html.md
@@ -72,6 +72,7 @@ The following arguments are supported:
 * `user_claim_json_pointer` - (Optional) Specifies if the `user_claim` value uses
   [JSON pointer](https://www.vaultproject.io/docs/auth/jwt#claim-specifications-and-json-pointer) 
   syntax for referencing claims. By default, the `user_claim` value will not use JSON pointer.
+  Requires Vault 1.11+.
 
 * `bound_subject` - (Optional) If set, requires that the `sub` claim matches
   this value.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes: N/A

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* `resource/vault_gcp_auth_backend`: Adds support for the `custom_endpoint` parameter on backend config (#1482)
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-count=1 -run=TestGCPAuth'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -count=1 -run=TestGCPAuth -timeout 30m ./...
=== RUN   TestGCPAuthBackend_pathRegex
=== RUN   TestGCPAuthBackend_pathRegex/no_nesting
=== RUN   TestGCPAuthBackend_pathRegex/nested
=== RUN   TestGCPAuthBackend_pathRegex/nested_with_double_'role'
--- PASS: TestGCPAuthBackend_pathRegex (0.00s)
    --- PASS: TestGCPAuthBackend_pathRegex/no_nesting (0.00s)
    --- PASS: TestGCPAuthBackend_pathRegex/nested (0.00s)
    --- PASS: TestGCPAuthBackend_pathRegex/nested_with_double_'role' (0.00s)
=== RUN   TestGCPAuthBackendRole_basic
=== RUN   TestGCPAuthBackendRole_basic/simple_backend_path
=== RUN   TestGCPAuthBackendRole_basic/nested_backend_path
--- PASS: TestGCPAuthBackendRole_basic (4.85s)
    --- PASS: TestGCPAuthBackendRole_basic/simple_backend_path (2.60s)
    --- PASS: TestGCPAuthBackendRole_basic/nested_backend_path (2.24s)
=== RUN   TestGCPAuthBackendRole_gce
--- PASS: TestGCPAuthBackendRole_gce (1.13s)
=== RUN   TestGCPAuthBackend_basic
--- PASS: TestGCPAuthBackend_basic (1.89s)
=== RUN   TestGCPAuthBackend_import
--- PASS: TestGCPAuthBackend_import (1.32s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     10.082s
```
