### PR TITLE
vault_mfa_duo path and arguments fix

### DIFF
--- a/vault/provider.go
+++ b/vault/provider.go
@@ -556,8 +556,8 @@ var (
 		},
 		"vault_mfa_duo": {
 			Resource:       mfaDuoResource(),
-			PathInventory:  []string{"/sys/mfa/method/duo/{name}"},
-			EnterpriseOnly: true,
+			PathInventory:  []string{"/identity/mfa/method/duo/{id}"},
+			EnterpriseOnly: false,
 		},
 		"vault_mfa_okta": {
 			Resource:       mfaOktaResource(),

--- a/vault/resource_mfa_duo_test.go
+++ b/vault/resource_mfa_duo_test.go
@@ -4,51 +4,37 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
 func TestMFADuoBasic(t *testing.T) {
-	mfaDuoPath := acctest.RandomWithPrefix("mfa-duo")
+	mfaDuoConfig := fmt.Sprintf(`
+		resource "vault_mfa_duo" "test" {
+		secret_key            = "8C7THtrIigh2rPZQMbguugt8IUftWhMRCOBzbuyz"
+		integration_key       = "BIACEUEAXI20BNWTEYXT"
+		api_hostname          = "api-2b5c39f5.duosecurity.com"
+		username_format       = "user@example.com"
+		push_info             = "from=loginortal&domain=example.com"
+		}
+	`)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testutil.TestEntPreCheck(t) },
+		PreCheck:  func() { testutil.TestAccPreCheck(t) },
 		Providers: testProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testMFADuoConfig(mfaDuoPath),
+				Config: mfaDuoConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_mfa_duo.test", "name", mfaDuoPath),
 					resource.TestCheckResourceAttr("vault_mfa_duo.test", "secret_key", "8C7THtrIigh2rPZQMbguugt8IUftWhMRCOBzbuyz"),
 					resource.TestCheckResourceAttr("vault_mfa_duo.test", "integration_key", "BIACEUEAXI20BNWTEYXT"),
 					resource.TestCheckResourceAttr("vault_mfa_duo.test", "api_hostname", "api-2b5c39f5.duosecurity.com"),
 					resource.TestCheckResourceAttr("vault_mfa_duo.test", "username_format", "user@example.com"),
 					resource.TestCheckResourceAttr("vault_mfa_duo.test", "push_info", "from=loginortal&domain=example.com"),
+					resource.TestCheckResourceAttr("vault_mfa_duo.test", "use_passcode", "false"),
 				),
 			},
 		},
 	})
-}
-
-func testMFADuoConfig(path string) string {
-	userPassPath := acctest.RandomWithPrefix("userpass")
-
-	return fmt.Sprintf(`
-resource "vault_auth_backend" "userpass" {
-  type = "userpass"
-  path = %q
-}
-
-resource "vault_mfa_duo" "test" {
-  name                  = %q
-  mount_accessor        = vault_auth_backend.userpass.accessor
-  secret_key            = "8C7THtrIigh2rPZQMbguugt8IUftWhMRCOBzbuyz"
-  integration_key       = "BIACEUEAXI20BNWTEYXT"
-  api_hostname          = "api-2b5c39f5.duosecurity.com"
-  username_format       = "user@example.com"
-  push_info             = "from=loginortal&domain=example.com"
-}
-`, userPassPath, path)
 }

--- a/website/docs/r/mfa_duo.html.md
+++ b/website/docs/r/mfa_duo.html.md
@@ -8,21 +8,12 @@ description: |-
 
 # vault\_mfa-duo
 
-Provides a resource to manage [Duo MFA](https://www.vaultproject.io/docs/enterprise/mfa/mfa-duo.html).
-
-**Note** this feature is available only with Vault Enterprise.
+Provides a resource to manage [Duo MFA](https://www.vaultproject.io/api-docs/secret/identity/mfa/duo).
 
 ## Example Usage
 
 ```hcl
-resource "vault_auth_backend" "userpass" {
-  type = "userpass"
-  path = "userpass"
-}
-
 resource "vault_mfa_duo" "my_duo" {
-  name                  = "my_duo"
-  mount_accessor        = vault_auth_backend.userpass.accessor
   secret_key            = "8C7THtrIigh2rPZQMbguugt8IUftWhMRCOBzbuyz"
   integration_key       = "BIACEUEAXI20BNWTEYXT"
   api_hostname          = "api-2b5c39f5.duosecurity.com"
@@ -32,10 +23,6 @@ resource "vault_mfa_duo" "my_duo" {
 ## Argument Reference
 
 The following arguments are supported:
-
-- `name` `(string: <required>)` – Name of the MFA method.
-
-- `mount_accessor` `(string: <required>)` - The mount to tie this method to for use in automatic mappings. The mapping will use the Name field of Aliases associated with this mount as the username in the mapping.
 
 - `username_format` `(string)` - A format string for mapping Identity names to MFA method names. Values to substitute should be placed in `{{}}`. For example, `"{{alias.name}}@example.com"`. If blank, the Alias's Name field will be used as-is. Currently-supported mappings:
   - alias.name: The name returned by the mount configured via the `mount_accessor` parameter
@@ -51,11 +38,17 @@ The following arguments are supported:
 
 - `push_info` `(string)` - Push information for Duo.
 
+- `use_passcode` `(bool)` - If true, the user is reminded to use the passcode upon MFA validation.
+
+## Attributes Reference
+
+* `id` - ID of the Duo MFA method.
+
 ## Import
 
-Mounts can be imported using the `path`, e.g.
+Mounts can be imported using the `id`, e.g.
 
 ```
-$ terraform import vault_mfa_duo.my_duo my_duo
+$ terraform import vault_mfa_duo.my_duo "3856fb4d-3c91-dcaf-2401-68f446796bfb"
 ```
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #1468 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Updated vault_mfa_duo to support correct API endpoint and arguments in Vault OSS per [1.10 GA release](https://www.hashicorp.com/blog/login-mfa-support-added-to-vault-open-source-and-hcp-vault)
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestMFADuoBasic'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -v --run TestMFADuoBasic -timeout 30m ./...
?   	github.com/hashicorp/terraform-provider-vault	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/generate	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/codegen	0.115s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/generated	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode	0.390s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode	0.241s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet	0.560s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role	0.713s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template	0.839s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation	0.983s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/helper	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/internal/identity/entity	0.126s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/schema	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/testutil	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/util	0.214s [no tests to run]
=== RUN   TestMFADuoBasic
--- PASS: TestMFADuoBasic (2.24s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/vault	2.517s
...
```
