### PR TITLE
Update all tests to use testutil.AssertVaultState

### DIFF
--- a/internal/identity/entity/entity.go
+++ b/internal/identity/entity/entity.go
@@ -12,6 +12,7 @@ const (
 	RootEntityIDPath = RootEntityPath + "/id"
 	RootAliasPath    = RootEntityPath + "-alias"
 	RootAliasIDPath  = RootAliasPath + "/id"
+	LookupPath       = "identity/lookup/entity"
 )
 
 // Entity represents a Vault identity entity

--- a/internal/identity/group/group.go
+++ b/internal/identity/group/group.go
@@ -1,0 +1,5 @@
+package group
+
+const (
+	LookupPath = "identity/lookup/group"
+)

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -239,9 +239,12 @@ func NewProviderMeta(d *schema.ResourceData) (interface{}, error) {
 // namespace. The value for the namespace is resolved from *schema.ResourceData,
 // *schema.ResourceDiff, or *terraform.InstanceState.
 func GetClient(i interface{}, meta interface{}) (*api.Client, error) {
-	p, ok := meta.(*ProviderMeta)
-	if p == nil || !ok {
-		return nil, fmt.Errorf("meta argument must be a ProviderMeta")
+	var p *ProviderMeta
+	switch v := meta.(type) {
+	case *ProviderMeta:
+		p = v
+	default:
+		return nil, fmt.Errorf("meta argument must be a %T, not %T", p, meta)
 	}
 
 	var ns string

--- a/internal/provider/meta_test.go
+++ b/internal/provider/meta_test.go
@@ -212,7 +212,7 @@ func TestGetClient(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		meta      *ProviderMeta
+		meta      interface{}
 		ifcNS     string
 		envNS     string
 		want      string
@@ -294,13 +294,14 @@ func TestGetClient(t *testing.T) {
 			name:      "error-not-provider-meta",
 			meta:      nil,
 			wantErr:   true,
-			expectErr: fmt.Errorf("meta argument must be a ProviderMeta"),
+			expectErr: fmt.Errorf("meta argument must be a *provider.ProviderMeta, not <nil>"),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.meta != nil {
-				tt.meta.resourceData = schema.TestResourceDataRaw(t,
+				m := tt.meta.(*ProviderMeta)
+				m.resourceData = schema.TestResourceDataRaw(t,
 					map[string]*schema.Schema{
 						consts.FieldNamespace: {
 							Type:     schema.TypeString,
@@ -309,6 +310,7 @@ func TestGetClient(t *testing.T) {
 					},
 					map[string]interface{}{},
 				)
+				tt.meta = m
 			}
 
 			var i interface{}

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"os"
 	"reflect"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/coreos/pkg/multierror"
@@ -119,9 +121,12 @@ func GetTestAzureConf(t *testing.T) *AzureTestConf {
 }
 
 func GetTestGCPCreds(t *testing.T) (string, string) {
-	v := SkipTestEnvUnset(t, "GOOGLE_CREDENTIALS", "GOOGLE_PROJECT")
+	// v := SkipTestEnvUnset(t, "GOOGLE_CREDENTIALS", "GOOGLE_PROJECT")
+	v := SkipTestEnvUnset(t, "GOOGLE_CREDENTIALS")
 
-	maybeCreds, project := v[0], v[1]
+	var project string
+	// maybeCreds, project := v[0], v[1]
+	maybeCreds := v[0]
 	maybeFilename := maybeCreds
 	if maybeCreds[0] == '~' {
 		var err error
@@ -131,12 +136,24 @@ func GetTestGCPCreds(t *testing.T) (string, string) {
 		}
 	}
 
-	if _, err := os.Stat(maybeFilename); err == nil {
+	if _, err := os.Lstat(maybeFilename); err == nil {
 		contents, err := ioutil.ReadFile(maybeFilename)
 		if err != nil {
 			t.Fatal("Error reading GOOGLE_CREDENTIALS: " + err.Error())
 		}
 		maybeCreds = string(contents)
+
+	}
+	if _, ok := os.LookupEnv("GOOGLE_PROJECT"); !ok {
+		// attempt to get the project ID from the creds JSON
+		var i map[string]interface{}
+		if err := json.Unmarshal([]byte(maybeCreds), &i); err == nil {
+			if v, ok := i["project_id"]; ok {
+				project = v.(string)
+			}
+		}
+	} else {
+		project = SkipTestEnvSet(t, "GOOGLE_PROJECT")[0]
 	}
 
 	return maybeCreds, project
@@ -328,4 +345,252 @@ func GetDynamicTCPListeners(host string, count int) ([]net.Listener, func() erro
 	}
 
 	return listeners, closer, nil
+}
+
+// VaultStateTest for validating a resource's state to what is configured in Vault.
+type VaultStateTest struct {
+	// ResourceName fully qualified resource name
+	ResourceName string
+	// StateAttr for the resource
+	StateAttr string
+	// VaultAttr from api.Secret.Data
+	VaultAttr string
+	// IsSubset check when checking equality of []interface{} state value
+	IsSubset bool
+	// AsSet evaluation
+	AsSet bool
+	// TransformVaultValue function for
+	TransformVaultValue TransformVaultValue
+}
+
+func (v *VaultStateTest) String() string {
+	return fmt.Sprintf(`"%s.%s"" (vault attr: %q)`, v.ResourceName, v.StateAttr, v.VaultAttr)
+}
+
+// TransformVaultValue function to be used for a value from vault into a form that can be ccmpared to a value from
+// from the TF state.
+type TransformVaultValue func(st *VaultStateTest, resp *api.Secret) (interface{}, error)
+
+func SplitVaultValueString(st *VaultStateTest, resp *api.Secret) (interface{}, error) {
+	v, ok := resp.Data[st.VaultAttr]
+	if !ok {
+		return nil, fmt.Errorf("expected vault attribute %q, not found", st.VaultAttr)
+	}
+
+	result := []interface{}{}
+	if v.(string) == "" {
+		return result, nil
+	}
+
+	for _, s := range strings.Split(v.(string), ",") {
+		result = append(result, s)
+	}
+
+	return result, nil
+}
+
+func AssertVaultState(client *api.Client, s *terraform.State, path string, tests ...*VaultStateTest) error {
+	resp, err := client.Logical().Read(path)
+	if resp == nil {
+		return fmt.Errorf("%q doesn't exist", path)
+	}
+	if err != nil {
+		return fmt.Errorf("error reading path %q, err=%w", path, err)
+	}
+
+	return assertVaultState(resp, s, path, tests...)
+}
+
+func AssertVaultStateFromResp(resp *api.Secret, s *terraform.State, path string, tests ...*VaultStateTest) error {
+	return assertVaultState(resp, s, path, tests...)
+}
+
+func assertVaultState(resp *api.Secret, tfs *terraform.State, path string, tests ...*VaultStateTest) error {
+	for _, st := range tests {
+		rs, err := GetResourceFromRootModule(tfs, st.ResourceName)
+		if err != nil {
+			return err
+		}
+		attrs := rs.Primary.Attributes
+
+		var s string
+		var inState bool
+		for _, suffix := range []string{"", ".#"} {
+			s, inState = attrs[st.StateAttr+suffix]
+			if inState {
+				break
+			}
+		}
+
+		v, inVault := resp.Data[st.VaultAttr]
+		if v == nil && (s == "" || s == "0") {
+			continue
+		}
+
+		if !inVault && inState {
+			return fmt.Errorf("expected vault attribute %q, not found", st.VaultAttr)
+		}
+
+		if st.TransformVaultValue != nil {
+			i, err := st.TransformVaultValue(st, resp)
+			if err != nil {
+				return err
+			}
+			v = i
+		}
+
+		errFmt := fmt.Sprintf("expected %s (%%s in state) of %q to be %%#v, got %%#v",
+			st.VaultAttr, path)
+
+		switch v := v.(type) {
+		case json.Number:
+			actual, err := v.Int64()
+			if err != nil {
+				return fmt.Errorf("expected API field %s to be an int, was %T", st.VaultAttr, v)
+			}
+
+			expected, err := strconv.ParseInt(s, 10, 64)
+			if err != nil {
+				return fmt.Errorf("expected state field %s to be a %T, was %T", st.StateAttr, v, s)
+			}
+
+			if actual != expected {
+				return fmt.Errorf(errFmt, st.StateAttr, expected, actual)
+			}
+		case bool:
+			actual := v
+			if s != "" {
+				expected, err := strconv.ParseBool(s)
+				if err != nil {
+					return fmt.Errorf("expected state field %s to be a %T, was %T", st.StateAttr, v, s)
+				}
+
+				if actual != expected {
+					return fmt.Errorf(errFmt, st.StateAttr, expected, actual)
+				}
+			}
+		case []interface{}:
+			if !inState && st.IsSubset || len(v) == 0 {
+				// although not strictly a subset since the state value is not a member of Vault's
+				// we consider this to be valid  in lieu of a better option.
+				// Usually this means that another resource was responsible for setting the value in Vault.
+				return nil
+			}
+
+			c, err := strconv.ParseInt(attrs[st.StateAttr+".#"], 10, 0)
+			if err != nil {
+				return err
+			}
+
+			actual := v
+			expected := []interface{}{}
+			for i := 0; i < int(c); i++ {
+				if v, ok := attrs[fmt.Sprintf("%s.%d", st.StateAttr, i)]; ok {
+					expected = append(expected, v)
+				}
+			}
+
+			if st.IsSubset {
+				if len(expected) > len(actual) {
+					return fmt.Errorf(errFmt, st.StateAttr, expected, actual)
+				}
+
+				var count int
+				for _, v := range expected {
+					for _, a := range actual {
+						if reflect.DeepEqual(v, a) {
+							count++
+						}
+					}
+				}
+				if len(expected) != count {
+					return fmt.Errorf(errFmt, st.StateAttr, expected, actual)
+				}
+			} else if st.AsSet {
+				if len(expected) != len(actual) {
+					return fmt.Errorf(errFmt, st.StateAttr, expected, actual)
+				}
+
+				union := make(map[interface{}]bool)
+				for _, v := range append(expected, actual...) {
+					union[v] = true
+				}
+
+				if len(union) != len(expected) {
+					return fmt.Errorf(errFmt, st.StateAttr, expected, actual)
+				}
+			} else {
+				if !reflect.DeepEqual(expected, actual) {
+					return fmt.Errorf(errFmt, st.StateAttr, expected, actual)
+				}
+			}
+		case []map[string]interface{}:
+			var expected []map[string]interface{}
+			c, err := strconv.ParseInt(attrs[st.StateAttr+".#"], 10, 0)
+			if err != nil {
+				return err
+			}
+
+			for i := 0; i < int(c); i++ {
+				prefix := fmt.Sprintf("%s.%d", st.StateAttr, i)
+				keys := map[string]bool{}
+				for attr := range attrs {
+					if strings.HasPrefix(attr, prefix) {
+						parts := strings.Split(attr, ".")
+						if len(parts) < 3 {
+							continue
+						}
+
+						switch parts[2] {
+						case "#", "%":
+							continue
+						}
+
+						keys[parts[2]] = true
+					}
+				}
+
+				// schema.Resource recursion is not supported.
+				m := make(map[string]interface{}, len(keys))
+				for key := range keys {
+					p := prefix + "." + key
+					if val, ok := attrs[p+".#"]; ok {
+						c, err := strconv.ParseInt(val, 10, 64)
+						if err != nil {
+							return err
+						}
+						vals := make([]interface{}, c)
+						for i := 0; i < int(c); i++ {
+							vals[i] = attrs[fmt.Sprintf("%s.%d", p, i)]
+						}
+						m[key] = vals
+
+					} else {
+						m[key] = attrs[p]
+					}
+				}
+
+				expected = append(expected, m)
+			}
+			if !reflect.DeepEqual(expected, v) {
+				return fmt.Errorf(errFmt, st.StateAttr, expected, v)
+			}
+		case string:
+			if v != s {
+				return fmt.Errorf(errFmt, st.StateAttr, s, v)
+			}
+		default:
+			return fmt.Errorf("got unsupported type %T from vault for %s", v, st)
+		}
+	}
+
+	return nil
+}
+
+func GetResourceFromRootModule(s *terraform.State, resourceName string) (*terraform.ResourceState, error) {
+	if rs, ok := s.RootModule().Resources[resourceName]; ok {
+		return rs, nil
+	}
+
+	return nil, fmt.Errorf("expected resource %q, not found in state", resourceName)
 }

--- a/testutil/testutil_test.go
+++ b/testutil/testutil_test.go
@@ -1,0 +1,277 @@
+package testutil
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/vault/api"
+)
+
+func Test_assertVaultState(t *testing.T) {
+	resourceName := "resource.test"
+	tests := []struct {
+		name    string
+		resp    *api.Secret
+		tfs     *terraform.State
+		path    string
+		tests   []*VaultStateTest
+		wantErr bool
+	}{
+		{
+			name: "string",
+			resp: &api.Secret{
+				Data: map[string]interface{}{
+					"attr1": "value1",
+				},
+			},
+			tfs: &terraform.State{
+				Version: 0,
+				Modules: []*terraform.ModuleState{
+					{
+						Path: []string{"root"},
+						Resources: map[string]*terraform.ResourceState{
+							resourceName: {
+								Type:         "",
+								Dependencies: nil,
+								Primary: &terraform.InstanceState{
+									ID: "",
+									Attributes: map[string]string{
+										"attr1": "value1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			path: "string",
+			tests: []*VaultStateTest{
+				{
+					ResourceName: resourceName,
+					StateAttr:    "attr1",
+					VaultAttr:    "attr1",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "bool",
+			resp: &api.Secret{
+				Data: map[string]interface{}{
+					"attr1": true,
+				},
+			},
+			tfs: &terraform.State{
+				Version: 0,
+				Modules: []*terraform.ModuleState{
+					{
+						Path: []string{"root"},
+						Resources: map[string]*terraform.ResourceState{
+							resourceName: {
+								Type:         "",
+								Dependencies: nil,
+								Primary: &terraform.InstanceState{
+									ID: "",
+									Attributes: map[string]string{
+										"attr1": "true",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			path: "bool",
+			tests: []*VaultStateTest{
+				{
+					ResourceName: resourceName,
+					StateAttr:    "attr1",
+					VaultAttr:    "attr1",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "slice-ordered",
+			resp: &api.Secret{
+				Data: map[string]interface{}{
+					"attr1": []interface{}{
+						"val1",
+						"val2",
+					},
+				},
+			},
+			tfs: &terraform.State{
+				Version: 0,
+				Modules: []*terraform.ModuleState{
+					{
+						Path: []string{"root"},
+						Resources: map[string]*terraform.ResourceState{
+							resourceName: {
+								Type:         "",
+								Dependencies: nil,
+								Primary: &terraform.InstanceState{
+									ID: "",
+									Attributes: map[string]string{
+										"attr1.#": "2",
+										"attr1.0": "val1",
+										"attr1.1": "val2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			path: "slice-ordered",
+			tests: []*VaultStateTest{
+				{
+					ResourceName: resourceName,
+					StateAttr:    "attr1",
+					VaultAttr:    "attr1",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "slice-set-cmp",
+			resp: &api.Secret{
+				Data: map[string]interface{}{
+					"attr1": []interface{}{
+						"val1",
+						"val2",
+						"val3",
+					},
+				},
+			},
+			tfs: &terraform.State{
+				Version: 0,
+				Modules: []*terraform.ModuleState{
+					{
+						Path: []string{"root"},
+						Resources: map[string]*terraform.ResourceState{
+							resourceName: {
+								Type:         "",
+								Dependencies: nil,
+								Primary: &terraform.InstanceState{
+									ID: "",
+									Attributes: map[string]string{
+										"attr1.#": "3",
+										"attr1.0": "val2",
+										"attr1.1": "val1",
+										"attr1.2": "val3",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			path: "slice-set-cmp",
+			tests: []*VaultStateTest{
+				{
+					ResourceName: resourceName,
+					StateAttr:    "attr1",
+					VaultAttr:    "attr1",
+					AsSet:        true,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "slice-subset-cmp",
+			resp: &api.Secret{
+				Data: map[string]interface{}{
+					"attr1": []interface{}{
+						"val1",
+						"val2",
+						"val3",
+					},
+				},
+			},
+			tfs: &terraform.State{
+				Version: 0,
+				Modules: []*terraform.ModuleState{
+					{
+						Path: []string{"root"},
+						Resources: map[string]*terraform.ResourceState{
+							resourceName: {
+								Type:         "",
+								Dependencies: nil,
+								Primary: &terraform.InstanceState{
+									ID: "",
+									Attributes: map[string]string{
+										"attr1.#": "1",
+										"attr1.1": "val1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			path: "slice-set-cmp",
+			tests: []*VaultStateTest{
+				{
+					ResourceName: resourceName,
+					StateAttr:    "attr1",
+					VaultAttr:    "attr1",
+					IsSubset:     true,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "slice-superset-error",
+			resp: &api.Secret{
+				Data: map[string]interface{}{
+					"attr1": []interface{}{
+						"val1",
+					},
+				},
+			},
+			tfs: &terraform.State{
+				Version: 0,
+				Modules: []*terraform.ModuleState{
+					{
+						Path: []string{"root"},
+						Resources: map[string]*terraform.ResourceState{
+							resourceName: {
+								Type:         "",
+								Dependencies: nil,
+								Primary: &terraform.InstanceState{
+									ID: "",
+									Attributes: map[string]string{
+										"attr1.#": "3",
+										"attr1.1": "val1",
+										"attr1.2": "val2",
+										"attr1.3": "val3",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			path: "slice-set-cmp",
+			tests: []*VaultStateTest{
+				{
+					ResourceName: resourceName,
+					StateAttr:    "attr1",
+					VaultAttr:    "attr1",
+					IsSubset:     true,
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		// tfs := terraform.NewState()
+		// tfs.Modules = tt.tfs.Modules
+		t.Run(tt.name, func(t *testing.T) {
+			if err := assertVaultState(tt.resp, tt.tfs, tt.path, tt.tests...); (err != nil) != tt.wantErr {
+				t.Errorf("assertVaultState() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/vault/data_identity_entity.go
+++ b/vault/data_identity_entity.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/identity/entity"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
@@ -196,9 +197,9 @@ func identityEntityDataSource() *schema.Resource {
 
 func identityEntityLookup(client *api.Client, data map[string]interface{}) (*api.Secret, error) {
 	log.Print("[DEBUG] Looking up IdentityEntity")
-	resp, err := client.Logical().Write("identity/lookup/entity", data)
+	resp, err := client.Logical().Write(entity.LookupPath, data)
 	if err != nil {
-		return nil, fmt.Errorf("Error reading Identity Entity '%v': %s", data, err)
+		return nil, fmt.Errorf("Error reading Identity Entity '%v': %w", data, err)
 	}
 
 	if resp == nil {

--- a/vault/data_identity_entity_test.go
+++ b/vault/data_identity_entity_test.go
@@ -1,16 +1,14 @@
 package vault
 
 import (
-	"encoding/json"
 	"fmt"
-	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/identity/entity"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
@@ -18,6 +16,7 @@ import (
 func TestDataSourceIdentityEntityName(t *testing.T) {
 	entity := acctest.RandomWithPrefix("test-entity")
 
+	resourceName := "data.vault_identity_entity.entity"
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
 		PreCheck:  func() { testutil.TestAccPreCheck(t) },
@@ -25,10 +24,10 @@ func TestDataSourceIdentityEntityName(t *testing.T) {
 			{
 				Config: testDataSourceIdentityEntity_configName(entity),
 				Check: resource.ComposeTestCheckFunc(
-					testDataSourceIdentityEntity_check(),
-					resource.TestCheckResourceAttr("data.vault_identity_entity.entity", "entity_name", entity),
-					resource.TestCheckResourceAttr("data.vault_identity_entity.entity", "policies.#", "1"),
-					resource.TestCheckResourceAttr("data.vault_identity_entity.entity", "metadata.version", "1"),
+					testDataSourceIdentityEntity_check(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "entity_name", entity),
+					resource.TestCheckResourceAttr(resourceName, "policies.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.version", "1"),
 				),
 			},
 		},
@@ -38,6 +37,7 @@ func TestDataSourceIdentityEntityName(t *testing.T) {
 func TestDataSourceIdentityEntityAlias(t *testing.T) {
 	entity := acctest.RandomWithPrefix("test-entity")
 
+	resourceName := "data.vault_identity_entity.entity"
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
 		PreCheck:  func() { testutil.TestAccPreCheck(t) },
@@ -45,124 +45,53 @@ func TestDataSourceIdentityEntityAlias(t *testing.T) {
 			{
 				Config: testDataSourceIdentityEntity_configAlias(entity),
 				Check: resource.ComposeTestCheckFunc(
-					testDataSourceIdentityEntity_check(),
-					resource.TestCheckResourceAttr("data.vault_identity_entity.entity", "entity_name", entity),
-					resource.TestCheckResourceAttr("data.vault_identity_entity.entity", "policies.#", "1"),
-					resource.TestCheckResourceAttr("data.vault_identity_entity.entity", "metadata.version", "1"),
-					resource.TestCheckResourceAttr("data.vault_identity_entity.entity", "aliases.#", "1"),
+					testDataSourceIdentityEntity_check(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "entity_name", entity),
+					resource.TestCheckResourceAttr(resourceName, "policies.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.version", "1"),
+					resource.TestCheckResourceAttr(resourceName, "aliases.#", "1"),
 				),
 			},
 		},
 	})
 }
 
-func testDataSourceIdentityEntity_check() resource.TestCheckFunc {
+func testDataSourceIdentityEntity_check(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		resourceState := s.Modules[0].Resources["data.vault_identity_entity.entity"]
-		if resourceState == nil {
-			return fmt.Errorf("resource not found in state")
-		}
-
-		instanceState := resourceState.Primary
-		if instanceState == nil {
-			return fmt.Errorf("resource not found in state")
-		}
-
-		id := instanceState.ID
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
-		resp, err := identityEntityLookup(client, map[string]interface{}{"id": id})
+		rs, err := testutil.GetResourceFromRootModule(s, resourceName)
 		if err != nil {
 			return err
 		}
 
-		attrs := map[string]string{
-			"id":          "id",
-			"entity_id":   "id",
-			"entity_name": "name",
-		}
-		for _, k := range identityEntityFields {
-			attrs[k] = k
+		client, err := provider.GetClient(rs.Primary, testProvider.Meta())
+		if err != nil {
+			return err
 		}
 
-		for stateAttr, apiAttr := range attrs {
-			if resp.Data[apiAttr] == nil && instanceState.Attributes[stateAttr] == "" {
-				continue
-			}
-			var match bool
-			switch resp.Data[apiAttr].(type) {
-			case json.Number:
-				apiData, err := resp.Data[apiAttr].(json.Number).Int64()
-				if err != nil {
-					return fmt.Errorf("expected API field %s to be an int, was %q", apiAttr, resp.Data[apiAttr])
-				}
-				stateData, err := strconv.ParseInt(instanceState.Attributes[stateAttr], 10, 64)
-				if err != nil {
-					return fmt.Errorf("expected state field %s to be an int, was %q", stateAttr, instanceState.Attributes[stateAttr])
-				}
-				match = apiData == stateData
-			case bool:
-				if _, ok := resp.Data[apiAttr]; !ok && instanceState.Attributes[stateAttr] == "" {
-					match = true
-				} else {
-					stateData, err := strconv.ParseBool(instanceState.Attributes[stateAttr])
-					if err != nil {
-						return fmt.Errorf("expected state field %s to be a bool, was %q", stateAttr, instanceState.Attributes[stateAttr])
-					}
-					match = resp.Data[apiAttr] == stateData
-				}
-			case map[string]interface{}:
-				apiData := resp.Data[apiAttr].(map[string]interface{})
-				for k, v := range apiData {
-					stateKey := stateAttr + "." + k
-					stateData := instanceState.Attributes[stateKey]
-					if stateData != v {
-						return fmt.Errorf("Expected %s of %s (%s in state) to be %s, but got %s", k, apiAttr, stateKey, v, stateData)
-					}
-				}
-				match = true
-
-			case []interface{}:
-				apiData := resp.Data[apiAttr].([]interface{})
-				length := instanceState.Attributes[stateAttr+".#"]
-				if length == "" {
-					if len(resp.Data[apiAttr].([]interface{})) != 0 {
-						return fmt.Errorf("expected state field %s to have %d entries, had 0", stateAttr, len(apiData))
-					}
-					match = true
-				} else {
-					count, err := strconv.Atoi(length)
-					if err != nil {
-						return fmt.Errorf("expected %s.# to be a number, got %q", stateAttr, instanceState.Attributes[stateAttr+".#"])
-					}
-					if count != len(apiData) {
-						return fmt.Errorf("expected %s to have %d entries in state, has %d", stateAttr, len(apiData), count)
-					}
-
-					for i := 0; i < count; i++ {
-						found := false
-						for stateKey, stateValue := range instanceState.Attributes {
-							if strings.HasPrefix(stateKey, stateAttr) {
-								if apiData[i] == stateValue {
-									found = true
-									break
-								}
-							}
-						}
-						if !found {
-							return fmt.Errorf("Expected item %d of %s (%s in state) of %q to be in state but wasn't", i, apiAttr, stateAttr, apiData[i])
-						}
-					}
-					match = true
-				}
-			default:
-				match = resp.Data[apiAttr] == instanceState.Attributes[stateAttr]
-			}
-			if !match {
-				return fmt.Errorf("expected %s (%s in state) to be %q, got %q", apiAttr, stateAttr, instanceState.Attributes[stateAttr], resp.Data[apiAttr])
-			}
+		resp, err := identityEntityLookup(client, map[string]interface{}{"id": rs.Primary.ID})
+		if err != nil {
+			return err
 		}
-		return nil
+
+		tAttrs := []*testutil.VaultStateTest{
+			{
+				ResourceName: resourceName,
+				StateAttr:    "id",
+				VaultAttr:    "id",
+			},
+			{
+				ResourceName: resourceName,
+				StateAttr:    "entity_id",
+				VaultAttr:    "id",
+			},
+			{
+				ResourceName: resourceName,
+				StateAttr:    "entity_name",
+				VaultAttr:    "name",
+			},
+		}
+
+		return testutil.AssertVaultStateFromResp(resp, s, entity.LookupPath, tAttrs...)
 	}
 }
 

--- a/vault/data_identity_group.go
+++ b/vault/data_identity_group.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/identity/group"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
@@ -171,7 +172,7 @@ func identityGroupDataSource() *schema.Resource {
 
 func identityGroupLookup(client *api.Client, data map[string]interface{}) (*api.Secret, error) {
 	log.Print("[DEBUG] Looking up IdentityGroup")
-	resp, err := client.Logical().Write("identity/lookup/group", data)
+	resp, err := client.Logical().Write(group.LookupPath, data)
 	if err != nil {
 		return nil, fmt.Errorf("Error reading Identity Group '%v': %s", data, err)
 	}

--- a/vault/data_identity_group_test.go
+++ b/vault/data_identity_group_test.go
@@ -1,16 +1,14 @@
 package vault
 
 import (
-	"encoding/json"
 	"fmt"
-	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/identity/group"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
@@ -56,113 +54,42 @@ func TestDataSourceIdentityGroupAlias(t *testing.T) {
 	})
 }
 
-func testDataSourceIdentityGroup_check(resource string) resource.TestCheckFunc {
+func testDataSourceIdentityGroup_check(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		resourceState := s.Modules[0].Resources[resource]
-		if resourceState == nil {
-			return fmt.Errorf("resource not found in state")
-		}
-
-		instanceState := resourceState.Primary
-		if instanceState == nil {
-			return fmt.Errorf("resource not found in state")
-		}
-
-		id := instanceState.ID
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
-		resp, err := identityGroupLookup(client, map[string]interface{}{"id": id})
+		rs, err := testutil.GetResourceFromRootModule(s, resourceName)
 		if err != nil {
 			return err
 		}
 
-		attrs := map[string]string{
-			"id":         "id",
-			"group_id":   "id",
-			"group_name": "name",
-		}
-		for _, k := range identityGroupFields {
-			attrs[k] = k
+		client, err := provider.GetClient(rs.Primary, testProvider.Meta())
+		if err != nil {
+			return err
 		}
 
-		for stateAttr, apiAttr := range attrs {
-			if resp.Data[apiAttr] == nil && instanceState.Attributes[stateAttr] == "" {
-				continue
-			}
-			var match bool
-			switch resp.Data[apiAttr].(type) {
-			case json.Number:
-				apiData, err := resp.Data[apiAttr].(json.Number).Int64()
-				if err != nil {
-					return fmt.Errorf("expected API field %s to be an int, was %q", apiAttr, resp.Data[apiAttr])
-				}
-				stateData, err := strconv.ParseInt(instanceState.Attributes[stateAttr], 10, 64)
-				if err != nil {
-					return fmt.Errorf("expected state field %s to be an int, was %q", stateAttr, instanceState.Attributes[stateAttr])
-				}
-				match = apiData == stateData
-			case bool:
-				if _, ok := resp.Data[apiAttr]; !ok && instanceState.Attributes[stateAttr] == "" {
-					match = true
-				} else {
-					stateData, err := strconv.ParseBool(instanceState.Attributes[stateAttr])
-					if err != nil {
-						return fmt.Errorf("expected state field %s to be a bool, was %q", stateAttr, instanceState.Attributes[stateAttr])
-					}
-					match = resp.Data[apiAttr] == stateData
-				}
-			case map[string]interface{}:
-				apiData := resp.Data[apiAttr].(map[string]interface{})
-				for k, v := range apiData {
-					stateKey := stateAttr + "." + k
-					stateData := instanceState.Attributes[stateKey]
-					if stateData != v {
-						return fmt.Errorf("Expected %s of %s (%s in state) to be %s, but got %s", k, apiAttr, stateKey, v, stateData)
-					}
-				}
-				match = true
-
-			case []interface{}:
-				apiData := resp.Data[apiAttr].([]interface{})
-				length := instanceState.Attributes[stateAttr+".#"]
-				if length == "" {
-					if len(resp.Data[apiAttr].([]interface{})) != 0 {
-						return fmt.Errorf("expected state field %s to have %d entries, had 0", stateAttr, len(apiData))
-					}
-					match = true
-				} else {
-					count, err := strconv.Atoi(length)
-					if err != nil {
-						return fmt.Errorf("expected %s.# to be a number, got %q", stateAttr, instanceState.Attributes[stateAttr+".#"])
-					}
-					if count != len(apiData) {
-						return fmt.Errorf("expected %s to have %d entries in state, has %d", stateAttr, len(apiData), count)
-					}
-
-					for i := 0; i < count; i++ {
-						found := false
-						for stateKey, stateValue := range instanceState.Attributes {
-							if strings.HasPrefix(stateKey, stateAttr) {
-								if apiData[i] == stateValue {
-									found = true
-									break
-								}
-							}
-						}
-						if !found {
-							return fmt.Errorf("Expected item %d of %s (%s in state) of %q to be in state but wasn't", i, apiAttr, stateAttr, apiData[i])
-						}
-					}
-					match = true
-				}
-			default:
-				match = resp.Data[apiAttr] == instanceState.Attributes[stateAttr]
-			}
-			if !match {
-				return fmt.Errorf("expected %s (%s in state) to be %q, got %q", apiAttr, stateAttr, instanceState.Attributes[stateAttr], resp.Data[apiAttr])
-			}
+		resp, err := identityGroupLookup(client, map[string]interface{}{"id": rs.Primary.ID})
+		if err != nil {
+			return err
 		}
-		return nil
+
+		tAttrs := []*testutil.VaultStateTest{
+			{
+				ResourceName: resourceName,
+				StateAttr:    "id",
+				VaultAttr:    "id",
+			},
+			{
+				ResourceName: resourceName,
+				StateAttr:    "group_id",
+				VaultAttr:    "id",
+			},
+			{
+				ResourceName: resourceName,
+				StateAttr:    "group_name",
+				VaultAttr:    "name",
+			},
+		}
+
+		return testutil.AssertVaultStateFromResp(resp, s, group.LookupPath, tAttrs...)
 	}
 }
 

--- a/vault/data_source_gcp_auth_backend_role_test.go
+++ b/vault/data_source_gcp_auth_backend_role_test.go
@@ -61,6 +61,7 @@ func TestAccGCPAuthBackendRoleDataSource_gce(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-test-gcp-role")
 	projectId := acctest.RandomWithPrefix("tf-test-gcp-project-id")
 
+	resourceName := "vault_gcp_auth_backend_role.test"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
@@ -69,24 +70,18 @@ func TestAccGCPAuthBackendRoleDataSource_gce(t *testing.T) {
 			{
 				Config: testGCPAuthBackendRoleConfig_gce(backend, name, projectId),
 				Check: resource.ComposeTestCheckFunc(
-					testGCPAuthBackendRoleCheck_attrs(backend, name),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend_role.test",
-						"bound_labels.#", "2"),
+					testGCPAuthBackendRoleCheck_attrs(resourceName, backend, name),
+					resource.TestCheckResourceAttr(resourceName, "bound_labels.#", "2"),
 				),
 			},
 			{
 				Config: testAccGCPAuthBackendRoleDataSourceConfig_gce(backend, name, projectId),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.vault_gcp_auth_backend_role.gcp_role",
-						"backend", backend),
-					resource.TestCheckResourceAttr("data.vault_gcp_auth_backend_role.gcp_role",
-						"role_name", name),
-					resource.TestCheckResourceAttr("data.vault_gcp_auth_backend_role.gcp_role",
-						"type", "gce"),
-					resource.TestCheckResourceAttrSet("data.vault_gcp_auth_backend_role.gcp_role",
-						"role_id"),
-					resource.TestCheckResourceAttr("data.vault_gcp_auth_backend_role.gcp_role",
-						"bound_labels.#", "2"),
+					resource.TestCheckResourceAttr("data.vault_gcp_auth_backend_role.gcp_role", "backend", backend),
+					resource.TestCheckResourceAttr("data.vault_gcp_auth_backend_role.gcp_role", "role_name", name),
+					resource.TestCheckResourceAttr("data.vault_gcp_auth_backend_role.gcp_role", "type", "gce"),
+					resource.TestCheckResourceAttrSet("data.vault_gcp_auth_backend_role.gcp_role", "role_id"),
+					resource.TestCheckResourceAttr("data.vault_gcp_auth_backend_role.gcp_role", "bound_labels.#", "2"),
 				),
 			},
 		},

--- a/vault/resource_auth_backend_test.go
+++ b/vault/resource_auth_backend_test.go
@@ -160,51 +160,6 @@ func testResourceAuth_initialCheck(expectedPath string) resource.TestCheckFunc {
 	}
 }
 
-func testResourceAuth_updateCheck(s *terraform.State) error {
-	resourceState := s.Modules[0].Resources["vault_auth_backend.test"]
-	if resourceState == nil {
-		return fmt.Errorf("resource not found in state")
-	}
-
-	instanceState := resourceState.Primary
-	if instanceState == nil {
-		return fmt.Errorf("resource has no primary instance")
-	}
-
-	name := instanceState.ID
-
-	if name != instanceState.Attributes["type"] {
-		return fmt.Errorf("id doesn't match name")
-	}
-
-	if name != "ldap" {
-		return fmt.Errorf("unexpected auth name")
-	}
-
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-	auths, err := client.Sys().ListAuth()
-	if err != nil {
-		return fmt.Errorf("error reading back auth: %s", err)
-	}
-
-	found := false
-	for _, auth := range auths {
-		if auth.Type == name {
-			found = true
-			if wanted := instanceState.Attributes["accessor"]; auth.Accessor != wanted {
-				return fmt.Errorf("accessor is %v; wanted %v", auth.Accessor, wanted)
-			}
-			break
-		}
-	}
-
-	if !found {
-		return fmt.Errorf("could not find auth backend %s in %+v", name, auths)
-	}
-
-	return nil
-}
-
 func TestResourceAuthTune(t *testing.T) {
 	backend := acctest.RandomWithPrefix("github")
 	resName := "vault_auth_backend.test"

--- a/vault/resource_aws_auth_backend_login_test.go
+++ b/vault/resource_aws_auth_backend_login_test.go
@@ -183,7 +183,6 @@ resource "vault_aws_auth_backend_role" "test" {
   role = "%s"
   auth_type = "iam"
   bound_iam_principal_arns = ["%s"]
-  policies = ["default"]
   depends_on = ["vault_aws_auth_backend_client.test"]
 }
 
@@ -215,7 +214,6 @@ resource "vault_aws_auth_backend_role" "test" {
   backend = vault_auth_backend.aws.path
   role = "%s"
   auth_type = "ec2"
-  policies = ["default"]
   bound_ami_ids = ["%s"]
   bound_account_ids = ["%s"]
   bound_iam_instance_profile_arns = ["%s"]
@@ -249,7 +247,6 @@ resource "vault_aws_auth_backend_role" "test" {
   backend = vault_auth_backend.aws.path
   role = "%s"
   auth_type = "ec2"
-  policies = ["default"]
   bound_ami_ids = ["%s"]
   bound_account_ids = ["%s"]
   bound_iam_instance_profile_arns = ["%s"]

--- a/vault/resource_aws_auth_backend_role_test.go
+++ b/vault/resource_aws_auth_backend_role_test.go
@@ -1,10 +1,7 @@
 package vault
 
 import (
-	"encoding/json"
 	"fmt"
-	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -18,6 +15,8 @@ import (
 func TestAccAWSAuthBackendRole_importInferred(t *testing.T) {
 	backend := acctest.RandomWithPrefix("aws")
 	role := acctest.RandomWithPrefix("test-role")
+
+	resourceName := "vault_aws_auth_backend_role.role"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
@@ -25,10 +24,10 @@ func TestAccAWSAuthBackendRole_importInferred(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSAuthBackendRoleConfig_inferred(backend, role),
-				Check:  testAccAWSAuthBackendRoleCheck_attrs(backend, role),
+				Check:  testAccAWSAuthBackendRoleCheck_attrs(resourceName, backend, role),
 			},
 			{
-				ResourceName:      "vault_aws_auth_backend_role.role",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
@@ -45,6 +44,8 @@ func TestAccAWSAuthBackendRole_importInferred(t *testing.T) {
 func TestAccAWSAuthBackendRole_importEC2(t *testing.T) {
 	backend := acctest.RandomWithPrefix("aws")
 	role := acctest.RandomWithPrefix("test-role")
+
+	resourceName := "vault_aws_auth_backend_role.role"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
@@ -52,10 +53,10 @@ func TestAccAWSAuthBackendRole_importEC2(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSAuthBackendRoleConfig_ec2(backend, role),
-				Check:  testAccAWSAuthBackendRoleCheck_attrs(backend, role),
+				Check:  testAccAWSAuthBackendRoleCheck_attrs(resourceName, backend, role),
 			},
 			{
-				ResourceName:      "vault_aws_auth_backend_role.role",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -66,6 +67,8 @@ func TestAccAWSAuthBackendRole_importEC2(t *testing.T) {
 func TestAccAWSAuthBackendRole_importIAM(t *testing.T) {
 	backend := acctest.RandomWithPrefix("aws")
 	role := acctest.RandomWithPrefix("test-role")
+
+	resourceName := "vault_aws_auth_backend_role.role"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
@@ -73,10 +76,10 @@ func TestAccAWSAuthBackendRole_importIAM(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSAuthBackendRoleConfig_iam(backend, role),
-				Check:  testAccAWSAuthBackendRoleCheck_attrs(backend, role),
+				Check:  testAccAWSAuthBackendRoleCheck_attrs(resourceName, backend, role),
 			},
 			{
-				ResourceName:      "vault_aws_auth_backend_role.role",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -88,6 +91,7 @@ func TestAccAWSAuthBackendRole_inferred(t *testing.T) {
 	backend := acctest.RandomWithPrefix("aws")
 	role := acctest.RandomWithPrefix("test-role")
 
+	resourceName := "vault_aws_auth_backend_role.role"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
@@ -95,7 +99,7 @@ func TestAccAWSAuthBackendRole_inferred(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSAuthBackendRoleConfig_inferred(backend, role),
-				Check:  testAccAWSAuthBackendRoleCheck_attrs(backend, role),
+				Check:  testAccAWSAuthBackendRoleCheck_attrs(resourceName, backend, role),
 			},
 		},
 	})
@@ -105,6 +109,7 @@ func TestAccAWSAuthBackendRole_ec2(t *testing.T) {
 	backend := acctest.RandomWithPrefix("aws")
 	role := acctest.RandomWithPrefix("test-role")
 
+	resourceName := "vault_aws_auth_backend_role.role"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
@@ -112,7 +117,7 @@ func TestAccAWSAuthBackendRole_ec2(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSAuthBackendRoleConfig_ec2(backend, role),
-				Check:  testAccAWSAuthBackendRoleCheck_attrs(backend, role),
+				Check:  testAccAWSAuthBackendRoleCheck_attrs(resourceName, backend, role),
 			},
 		},
 	})
@@ -122,6 +127,7 @@ func TestAccAWSAuthBackendRole_iam(t *testing.T) {
 	backend := acctest.RandomWithPrefix("aws")
 	role := acctest.RandomWithPrefix("test-role")
 
+	resourceName := "vault_aws_auth_backend_role.role"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
@@ -129,7 +135,7 @@ func TestAccAWSAuthBackendRole_iam(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSAuthBackendRoleConfig_iam(backend, role),
-				Check:  testAccAWSAuthBackendRoleCheck_attrs(backend, role),
+				Check:  testAccAWSAuthBackendRoleCheck_attrs(resourceName, backend, role),
 			},
 		},
 	})
@@ -139,6 +145,7 @@ func TestAccAWSAuthBackendRole_iam_resolve_aws_unique_ids(t *testing.T) {
 	backend := acctest.RandomWithPrefix("aws")
 	role := acctest.RandomWithPrefix("test-role")
 
+	resourceName := "vault_aws_auth_backend_role.role"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
@@ -146,7 +153,7 @@ func TestAccAWSAuthBackendRole_iam_resolve_aws_unique_ids(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSAuthBackendRoleConfig_iam_resolve_aws_unique_ids(backend, role),
-				Check:  testAccAWSAuthBackendRoleCheck_attrs(backend, role),
+				Check:  testAccAWSAuthBackendRoleCheck_attrs(resourceName, backend, role),
 			},
 		},
 	})
@@ -156,6 +163,7 @@ func TestAccAWSAuthBackendRole_iamUpdate(t *testing.T) {
 	backend := acctest.RandomWithPrefix("aws")
 	role := acctest.RandomWithPrefix("test-role")
 
+	resourceName := "vault_aws_auth_backend_role.role"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
@@ -163,46 +171,35 @@ func TestAccAWSAuthBackendRole_iamUpdate(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSAuthBackendRoleConfig_iam(backend, role),
-				Check:  testAccAWSAuthBackendRoleCheck_attrs(backend, role),
+				Check:  testAccAWSAuthBackendRoleCheck_attrs(resourceName, backend, role),
 			},
 			{
 				Config: testAccAWSAuthBackendRoleConfig_iamUpdate(backend, role),
 				Check: resource.ComposeTestCheckFunc(
-					testAccAWSAuthBackendRoleCheck_attrs(backend, role),
-					resource.TestCheckResourceAttr("vault_aws_auth_backend_role.role",
-						"bound_iam_principal_arns.#", "1"),
-					resource.TestCheckResourceAttr("vault_aws_auth_backend_role.role",
-						"bound_iam_principal_arns.0", "arn:aws:iam::123456789012:role/MyRole/*"),
-					resource.TestCheckResourceAttr("vault_aws_auth_backend_role.role",
-						"token_ttl", "30"),
-					resource.TestCheckResourceAttr("vault_aws_auth_backend_role.role",
-						"token_max_ttl", "60"),
-					resource.TestCheckResourceAttr("vault_aws_auth_backend_role.role",
-						"token_policies.#", "2"),
-					resource.TestCheckResourceAttr("vault_aws_auth_backend_role.role",
-						"token_policies.0", "default"),
-					resource.TestCheckResourceAttr("vault_aws_auth_backend_role.role",
-						"token_policies.1", "dev"),
+					testAccAWSAuthBackendRoleCheck_attrs(resourceName, backend, role),
+					resource.TestCheckResourceAttr(resourceName, "bound_iam_principal_arns.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "bound_iam_principal_arns.0", "arn:aws:iam::123456789012:role/MyRole/*"),
+					resource.TestCheckResourceAttr(resourceName, "token_ttl", "30"),
+					resource.TestCheckResourceAttr(resourceName, "token_max_ttl", "60"),
+					resource.TestCheckResourceAttr(resourceName, "token_policies.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "token_policies.0", "default"),
+					resource.TestCheckResourceAttr(resourceName, "token_policies.1", "dev"),
 				),
 			},
 			{
 				Config: testAccAWSAuthBackendRoleConfig_DeletePolicies(backend, role),
 				Check: resource.ComposeTestCheckFunc(
-					testAccAWSAuthBackendRoleCheck_attrs(backend, role),
-					resource.TestCheckResourceAttr("vault_aws_auth_backend_role.role",
-						"token_policies.#", "0"),
+					testAccAWSAuthBackendRoleCheck_attrs(resourceName, backend, role),
+					resource.TestCheckResourceAttr(resourceName, "token_policies.#", "0"),
 				),
 			},
 			{
 				Config: testAccAWSAuthBackendRoleConfig_Unset(backend, role),
 				Check: resource.ComposeTestCheckFunc(
-					testAccAWSAuthBackendRoleCheck_attrs(backend, role),
-					resource.TestCheckResourceAttr("vault_aws_auth_backend_role.role",
-						"token_policies.#", "0"),
-					resource.TestCheckResourceAttr("vault_aws_auth_backend_role.role",
-						"token_ttl", "0"),
-					resource.TestCheckResourceAttr("vault_aws_auth_backend_role.role",
-						"token_max_ttl", "0"),
+					testAccAWSAuthBackendRoleCheck_attrs(resourceName, backend, role),
+					resource.TestCheckResourceAttr(resourceName, "token_policies.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "token_ttl", "0"),
+					resource.TestCheckResourceAttr(resourceName, "token_max_ttl", "0"),
 				),
 			},
 		},
@@ -227,142 +224,65 @@ func testAccCheckAWSAuthBackendRoleDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccAWSAuthBackendRoleCheck_attrs(backend, role string) resource.TestCheckFunc {
+func testAccAWSAuthBackendRoleCheck_attrs(resourceName, backend, role string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		resourceState := s.Modules[0].Resources["vault_aws_auth_backend_role.role"]
-		if resourceState == nil {
-			return fmt.Errorf("resource not found in state")
-		}
-
-		instanceState := resourceState.Primary
-		if instanceState == nil {
-			return fmt.Errorf("resource not found in state")
-		}
-
-		endpoint := instanceState.ID
-
-		if endpoint != "auth/"+backend+"/role/"+role {
-			return fmt.Errorf("expected ID to be %q, got %q instead", "auth/"+backend+"/role/"+role, endpoint)
-		}
-
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-		resp, err := client.Logical().Read(endpoint)
+		rs, err := testutil.GetResourceFromRootModule(s, resourceName)
 		if err != nil {
-			return fmt.Errorf("%q doesn't exist", endpoint)
+			return err
 		}
 
-		attrs := []*fieldNames{
-			{NameInVault: "auth_type", NameInProvider: "auth_type"},
-			{NameInVault: "bound_ami_id", NameInProvider: "bound_ami_ids", PreviousNameInProvider: "bound_ami_id"},
-			{NameInVault: "bound_account_id", NameInProvider: "bound_account_ids", PreviousNameInProvider: "bound_account_id"},
-			{NameInVault: "bound_region", NameInProvider: "bound_regions", PreviousNameInProvider: "bound_region"},
-			{NameInVault: "bound_vpc_id", NameInProvider: "bound_vpc_ids", PreviousNameInProvider: "bound_vpc_id"},
-			{NameInVault: "bound_subnet_id", NameInProvider: "bound_subnet_ids", PreviousNameInProvider: "bound_subnet_id"},
-			{NameInVault: "bound_iam_role_arn", NameInProvider: "bound_iam_role_arns", PreviousNameInProvider: "bound_iam_role_arn"},
-			{NameInVault: "bound_iam_instance_profile_arn", NameInProvider: "bound_iam_instance_profile_arns", PreviousNameInProvider: "bound_iam_instance_profile_arn"},
-			{NameInVault: "bound_ec2_instance_id", NameInProvider: "bound_ec2_instance_ids", PreviousNameInProvider: "bound_ec2_instance_id"},
-			{NameInVault: "role_tag", NameInProvider: "role_tag"},
-			{NameInVault: "role_id", NameInProvider: "role_id"},
-			{NameInVault: "bound_iam_principal_arn", NameInProvider: "bound_iam_principal_arns", PreviousNameInProvider: "bound_iam_principal_arn"},
-			{NameInVault: "inferred_entity_type", NameInProvider: "inferred_entity_type"},
-			{NameInVault: "inferred_aws_region", NameInProvider: "inferred_aws_region"},
-			{NameInVault: "resolve_aws_unique_ids", NameInProvider: "resolve_aws_unique_ids"},
-			{NameInVault: "token_ttl", NameInProvider: "token_ttl"},
-			{NameInVault: "token_max_ttl", NameInProvider: "token_max_ttl"},
-			{NameInVault: "token_period", NameInProvider: "token_period"},
-			{NameInVault: "token_policies", NameInProvider: "token_policies"},
-			{NameInVault: "allow_instance_migration", NameInProvider: "allow_instance_migration"},
-			{NameInVault: "disallow_reauthentication", NameInProvider: "disallow_reauthentication"},
-		}
-		for _, attr := range attrs {
+		path := rs.Primary.ID
 
-			providerValIsArray := true
-			stateAttr := ""
-			if _, ok := instanceState.Attributes[attr.NameInProvider]; ok {
-				providerValIsArray = false
-				stateAttr = attr.NameInProvider
-			} else if _, ok := instanceState.Attributes[attr.PreviousNameInProvider]; ok {
-				providerValIsArray = false
-				stateAttr = attr.PreviousNameInProvider
-			} else if _, ok := instanceState.Attributes[attr.NameInProvider+".#"]; ok {
-				stateAttr = attr.NameInProvider
-			} else if _, ok := instanceState.Attributes[attr.PreviousNameInProvider+".#"]; ok {
-				stateAttr = attr.PreviousNameInProvider
-			}
-			stateAttrVal := instanceState.Attributes[stateAttr]
-
-			if resp.Data[attr.NameInVault] == nil && stateAttrVal == "" {
-				continue
-			}
-			var match bool
-			switch vaultRespVal := resp.Data[attr.NameInVault].(type) {
-			case json.Number:
-				apiData, err := vaultRespVal.Int64()
-				if err != nil {
-					return fmt.Errorf("expected API field %s to be an int, was %q", attr.NameInVault, resp.Data[attr.NameInVault])
-				}
-				stateData, err := strconv.ParseInt(stateAttrVal, 10, 64)
-				if err != nil {
-					return fmt.Errorf("expected state field %s to be an int, was %q", stateAttr, stateAttrVal)
-				}
-				match = apiData == stateData
-			case bool:
-				if _, ok := resp.Data[attr.NameInVault]; !ok && stateAttrVal == "" {
-					match = true
-				} else {
-					stateData, err := strconv.ParseBool(stateAttrVal)
-					if err != nil {
-						return fmt.Errorf("expected state field %s to be a bool, was %q", stateAttr, stateAttrVal)
-					}
-					match = vaultRespVal == stateData
-				}
-			case []interface{}:
-				length := instanceState.Attributes[stateAttr+".#"]
-				if !providerValIsArray {
-					if len(vaultRespVal) != 1 {
-						return fmt.Errorf("expected one response value but received %s", vaultRespVal)
-					}
-					if vaultRespVal[0] != stateAttrVal {
-						return fmt.Errorf("expected %s but received %s", stateAttrVal, vaultRespVal[0])
-					}
-					match = true
-				} else if length == "" {
-					if len(vaultRespVal) != 0 {
-						return fmt.Errorf("expected state field %s to have %d entries, had 0", stateAttr, len(vaultRespVal))
-					}
-					match = true
-				} else {
-					count, err := strconv.Atoi(length)
-					if err != nil {
-						return fmt.Errorf("expected %s.# to be a number, got %q", stateAttr, instanceState.Attributes[stateAttr+".#"])
-					}
-					if count != len(vaultRespVal) {
-						return fmt.Errorf("expected %s to have %d entries in state, has %d", stateAttr, len(vaultRespVal), count)
-					}
-					for i := 0; i < count; i++ {
-						found := false
-						for stateKey, stateValue := range instanceState.Attributes {
-							if strings.HasPrefix(stateKey, stateAttr) {
-								if vaultRespVal[i] == stateValue {
-									found = true
-									break
-								}
-							}
-						}
-						if !found {
-							return fmt.Errorf("Expected item %d of %s (%s in state) of %q to be in state but wasn't", i, attr.NameInVault, stateAttr, vaultRespVal[i])
-						}
-					}
-					match = true
-				}
-			default:
-				match = resp.Data[attr.NameInVault] == stateAttrVal
-			}
-			if !match {
-				return fmt.Errorf("expected %s (%s in state) of %q to be %q, got %q", attr.NameInVault, stateAttr, endpoint, stateAttrVal, resp.Data[attr.NameInVault])
-			}
+		expectedPath := "auth/" + backend + "/role/" + role
+		if path != expectedPath {
+			return fmt.Errorf("expected ID to be %q, got %q instead", expectedPath, path)
 		}
-		return nil
+
+		client, err := provider.GetClient(rs.Primary, testProvider.Meta())
+		if err != nil {
+			return err
+		}
+
+		attrs := map[string]string{
+			"auth_type":                       "auth_type",
+			"bound_ami_ids":                   "bound_ami_id",
+			"bound_account_ids":               "bound_account_id",
+			"bound_regions":                   "bound_region",
+			"bound_vpc_ids":                   "bound_vpc_id",
+			"bound_subnet_ids":                "bound_subnet_id",
+			"bound_iam_role_arns":             "bound_iam_role_arn",
+			"bound_iam_instance_profile_arns": "bound_iam_instance_profile_arn",
+			"bound_ec2_instance_ids":          "bound_ec2_instance_id",
+			"role_tag":                        "role_tag",
+			"role_id":                         "role_id",
+			"bound_iam_principal_arns":        "bound_iam_principal_arn",
+			"inferred_entity_type":            "inferred_entity_type",
+			"inferred_aws_region":             "inferred_aws_region",
+			"resolve_aws_unique_ids":          "resolve_aws_unique_ids",
+			"token_ttl":                       "token_ttl",
+			"token_max_ttl":                   "token_max_ttl",
+			"token_period":                    "token_period",
+			"token_policies":                  "token_policies",
+			"allow_instance_migration":        "allow_instance_migration",
+			"disallow_reauthentication":       "disallow_reauthentication",
+		}
+
+		tAttrs := []*testutil.VaultStateTest{}
+		for k, v := range attrs {
+			ta := &testutil.VaultStateTest{
+				ResourceName: resourceName,
+				StateAttr:    k,
+				VaultAttr:    v,
+			}
+			switch k {
+			case "token_policies":
+				ta.AsSet = true
+			}
+
+			tAttrs = append(tAttrs, ta)
+		}
+
+		return testutil.AssertVaultState(client, s, path, tAttrs...)
 	}
 }
 

--- a/vault/resource_azure_auth_backend_role.go
+++ b/vault/resource_azure_auth_backend_role.go
@@ -216,30 +216,12 @@ func azureAuthBackendRoleRead(_ context.Context, d *schema.ResourceData, meta in
 
 	d.Set("backend", backend)
 	d.Set("role", role)
-
-	if _, ok := d.GetOk("bound_service_principal_ids"); ok {
-		d.Set("bound_service_principal_ids", resp.Data["bound_service_principal_ids"])
-	}
-
-	if _, ok := d.GetOk("bound_group_ids"); ok {
-		d.Set("bound_group_ids", resp.Data["bound_group_ids"])
-	}
-
-	if _, ok := d.GetOk("bound_locations"); ok {
-		d.Set("bound_locations", resp.Data["bound_locations"])
-	}
-
-	if _, ok := d.GetOk("bound_subscription_ids"); ok {
-		d.Set("bound_subscription_ids", resp.Data["bound_subscription_ids"])
-	}
-
-	if _, ok := d.GetOk("bound_resource_groups"); ok {
-		d.Set("bound_resource_groups", resp.Data["bound_resource_groups"])
-	}
-
-	if _, ok := d.GetOk("bound_scale_sets"); ok {
-		d.Set("bound_scale_sets", resp.Data["bound_scale_sets"])
-	}
+	d.Set("bound_service_principal_ids", resp.Data["bound_service_principal_ids"])
+	d.Set("bound_group_ids", resp.Data["bound_group_ids"])
+	d.Set("bound_locations", resp.Data["bound_locations"])
+	d.Set("bound_subscription_ids", resp.Data["bound_subscription_ids"])
+	d.Set("bound_resource_groups", resp.Data["bound_resource_groups"])
+	d.Set("bound_scale_sets", resp.Data["bound_scale_sets"])
 
 	diags := checkCIDRs(d, TokenFieldBoundCIDRs)
 

--- a/vault/resource_azure_auth_backend_role_test.go
+++ b/vault/resource_azure_auth_backend_role_test.go
@@ -1,9 +1,7 @@
 package vault
 
 import (
-	"encoding/json"
 	"fmt"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -19,6 +17,7 @@ func TestAzureAuthBackendRole_basic(t *testing.T) {
 	backend := acctest.RandomWithPrefix("tf-test-azure-backend")
 	name := acctest.RandomWithPrefix("tf-test-azure-role")
 
+	resourceName := "vault_azure_auth_backend_role.test"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
@@ -26,7 +25,7 @@ func TestAzureAuthBackendRole_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAzureAuthBackendRoleConfig_basic(backend, name),
-				Check:  testAzureAuthBackendRoleCheck_attrs(backend, name),
+				Check:  testAzureAuthBackendRoleCheck_attrs(resourceName, backend, name),
 			},
 		},
 	})
@@ -36,6 +35,7 @@ func TestAzureAuthBackendRole(t *testing.T) {
 	backend := acctest.RandomWithPrefix("tf-test-azure-backend")
 	name := acctest.RandomWithPrefix("tf-test-azure-role")
 
+	resourceName := "vault_azure_auth_backend_role.test"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
@@ -44,25 +44,19 @@ func TestAzureAuthBackendRole(t *testing.T) {
 			{
 				Config: testAzureAuthBackendRoleConfig(backend, name),
 				Check: resource.ComposeTestCheckFunc(
-					testAzureAuthBackendRoleCheck_attrs(backend, name),
-					resource.TestCheckResourceAttr("vault_azure_auth_backend_role.test",
-						"token_ttl", "300"),
-					resource.TestCheckResourceAttr("vault_azure_auth_backend_role.test",
-						"token_max_ttl", "600"),
-					resource.TestCheckResourceAttr("vault_azure_auth_backend_role.test",
-						"token_policies.#", "2"),
+					testAzureAuthBackendRoleCheck_attrs(resourceName, backend, name),
+					resource.TestCheckResourceAttr(resourceName, "token_ttl", "300"),
+					resource.TestCheckResourceAttr(resourceName, "token_max_ttl", "600"),
+					resource.TestCheckResourceAttr(resourceName, "token_policies.#", "2"),
 				),
 			},
 			{
 				Config: testAzureAuthBackendRoleUnset(backend, name),
 				Check: resource.ComposeTestCheckFunc(
-					testAzureAuthBackendRoleCheck_attrs(backend, name),
-					resource.TestCheckResourceAttr("vault_azure_auth_backend_role.test",
-						"token_ttl", "0"),
-					resource.TestCheckResourceAttr("vault_azure_auth_backend_role.test",
-						"token_max_ttl", "0"),
-					resource.TestCheckResourceAttr("vault_azure_auth_backend_role.test",
-						"token_policies.#", "0"),
+					testAzureAuthBackendRoleCheck_attrs(resourceName, backend, name),
+					resource.TestCheckResourceAttr(resourceName, "token_ttl", "0"),
+					resource.TestCheckResourceAttr(resourceName, "token_max_ttl", "0"),
+					resource.TestCheckResourceAttr(resourceName, "token_policies.#", "0"),
 				),
 			},
 		},
@@ -87,24 +81,25 @@ func testAzureAuthBackendRoleDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAzureAuthBackendRoleCheck_attrs(backend, name string) resource.TestCheckFunc {
+func testAzureAuthBackendRoleCheck_attrs(resourceName, backend, name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		resourceState := s.Modules[0].Resources["vault_azure_auth_backend_role.test"]
-		if resourceState == nil {
-			return fmt.Errorf("resource not found in state")
+		rs, err := testutil.GetResourceFromRootModule(s, resourceName)
+		if err != nil {
+			return err
 		}
 
-		instanceState := resourceState.Primary
-		if instanceState == nil {
-			return fmt.Errorf("resource has no primary instance")
+		client, err := provider.GetClient(rs.Primary, testProvider.Meta())
+		if err != nil {
+			return err
 		}
+
+		path := rs.Primary.ID
 
 		endpoint := "auth/" + strings.Trim(backend, "/") + "/role/" + name
-		if endpoint != instanceState.ID {
-			return fmt.Errorf("expected ID to be %q, got %q instead", endpoint, instanceState.ID)
+		if endpoint != path {
+			return fmt.Errorf("expected ID to be %q, got %q instead", endpoint, path)
 		}
 
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 		authMounts, err := client.Sys().ListAuth()
 		if err != nil {
 			return err
@@ -118,18 +113,7 @@ func testAzureAuthBackendRoleCheck_attrs(backend, name string) resource.TestChec
 		if "azure" != authMount.Type {
 			return fmt.Errorf("incorrect mount type: %s", authMount.Type)
 		}
-
-		resp, err := client.Logical().Read(instanceState.ID)
-		if err != nil {
-			return err
-		}
-
 		attrs := map[string]string{
-			"type":                        "role_type",
-			"token_ttl":                   "token_ttl",
-			"token_max_ttl":               "token_max_ttl",
-			"token_period":                "token_period",
-			"token_policies":              "token_policies",
 			"bound_service_principal_ids": "bound_service_principal_ids",
 			"bound_group_ids":             "bound_group_ids",
 			"bound_locations":             "bound_locations",
@@ -138,76 +122,26 @@ func testAzureAuthBackendRoleCheck_attrs(backend, name string) resource.TestChec
 			"bound_scale_sets":            "bound_scale_sets",
 		}
 
-		for stateAttr, apiAttr := range attrs {
-			if resp.Data[apiAttr] == nil && instanceState.Attributes[stateAttr] == "" {
-				continue
-			}
-			var match bool
-			switch resp.Data[apiAttr].(type) {
-			case json.Number:
-				apiData, err := resp.Data[apiAttr].(json.Number).Int64()
-				if err != nil {
-					return fmt.Errorf("Expected API field %s to be an int, was %q", apiAttr, resp.Data[apiAttr])
-				}
-				stateData, err := strconv.ParseInt(instanceState.Attributes[stateAttr], 10, 64)
-				if err != nil {
-					return fmt.Errorf("Expected state field %s to be an int, was %q", stateAttr, instanceState.Attributes[stateAttr])
-				}
-				match = apiData == stateData
-			case bool:
-				if _, ok := resp.Data[apiAttr]; !ok && instanceState.Attributes[stateAttr] == "" {
-					match = true
-				} else {
-					stateData, err := strconv.ParseBool(instanceState.Attributes[stateAttr])
-					if err != nil {
-						return fmt.Errorf("Expected state field %s to be a bool, was %q", stateAttr, instanceState.Attributes[stateAttr])
-					}
-					match = resp.Data[apiAttr] == stateData
-				}
-
-			case []interface{}:
-				apiData := resp.Data[apiAttr].([]interface{})
-				length := instanceState.Attributes[stateAttr+".#"]
-				if length == "" {
-					if len(resp.Data[apiAttr].([]interface{})) != 0 {
-						return fmt.Errorf("Expected state field %s to have %d entries, had 0", stateAttr, len(apiData))
-					}
-					match = true
-				} else {
-					count, err := strconv.Atoi(length)
-					if err != nil {
-						return fmt.Errorf("Expected %s.# to be a number, got %q", stateAttr, instanceState.Attributes[stateAttr+".#"])
-					}
-					if count != len(apiData) {
-						return fmt.Errorf("Expected %s to have %d entries in state, has %d", stateAttr, len(apiData), count)
-					}
-
-					for i := 0; i < count; i++ {
-						found := false
-						for stateKey, stateValue := range instanceState.Attributes {
-							if strings.HasPrefix(stateKey, stateAttr) {
-								if apiData[i] == stateValue {
-									found = true
-								}
-							}
-						}
-						if !found {
-							return fmt.Errorf("Expected item %d of %s (%s in state) of %q to be in state but wasn't", i, apiAttr, stateAttr, endpoint)
-						}
-					}
-					match = true
-				}
-			default:
-				match = resp.Data[apiAttr] == instanceState.Attributes[stateAttr]
-
-			}
-			if !match {
-				return fmt.Errorf("Expected %s (%s in state) of %q to be %q, got %q", apiAttr, stateAttr, endpoint, instanceState.Attributes[stateAttr], resp.Data[apiAttr])
-			}
-
+		for _, v := range commonTokenFields {
+			attrs[v] = v
 		}
 
-		return nil
+		tAttrs := []*testutil.VaultStateTest{}
+		for k, v := range attrs {
+			ta := &testutil.VaultStateTest{
+				ResourceName: resourceName,
+				StateAttr:    k,
+				VaultAttr:    v,
+			}
+			switch k {
+			case TokenFieldPolicies:
+				ta.AsSet = true
+			}
+
+			tAttrs = append(tAttrs, ta)
+		}
+
+		return testutil.AssertVaultState(client, s, path, tAttrs...)
 	}
 }
 

--- a/vault/resource_gcp_auth_backend_role_test.go
+++ b/vault/resource_gcp_auth_backend_role_test.go
@@ -1,15 +1,14 @@
 package vault
 
 import (
-	"encoding/json"
 	"fmt"
-	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/vault/api"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
@@ -74,6 +73,7 @@ func testGCPAuthBackendRole_basic(t *testing.T, backend string) {
 	serviceAccount := acctest.RandomWithPrefix("tf-test-gcp-service-account")
 	projectId := acctest.RandomWithPrefix("tf-test-gcp-project-id")
 
+	resourceName := "vault_gcp_auth_backend_role.test"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
@@ -82,29 +82,23 @@ func testGCPAuthBackendRole_basic(t *testing.T, backend string) {
 			{
 				Config: testGCPAuthBackendRoleConfig_basic(backend, name, serviceAccount, projectId),
 				Check: resource.ComposeTestCheckFunc(
-					testGCPAuthBackendRoleCheck_attrs(backend, name),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend_role.test",
-						"token_ttl", "300"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend_role.test",
-						"token_max_ttl", "600"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend_role.test",
-						"token_policies.#", "2"),
+					testGCPAuthBackendRoleCheck_attrs(resourceName, backend, name),
+					resource.TestCheckResourceAttr(resourceName, "token_ttl", "300"),
+					resource.TestCheckResourceAttr(resourceName, "token_max_ttl", "600"),
+					resource.TestCheckResourceAttr(resourceName, "token_policies.#", "2"),
 				),
 			},
 			{
 				Config: testGCPAuthBackendRoleConfig_unset(backend, name, serviceAccount, projectId),
 				Check: resource.ComposeTestCheckFunc(
-					testGCPAuthBackendRoleCheck_attrs(backend, name),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend_role.test",
-						"token_ttl", "0"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend_role.test",
-						"token_max_ttl", "0"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend_role.test",
-						"token_policies.#", "0"),
+					testGCPAuthBackendRoleCheck_attrs(resourceName, backend, name),
+					resource.TestCheckResourceAttr(resourceName, "token_ttl", "0"),
+					resource.TestCheckResourceAttr(resourceName, "token_max_ttl", "0"),
+					resource.TestCheckResourceAttr(resourceName, "token_policies.#", "0"),
 				),
 			},
 			{
-				ResourceName:      "vault_gcp_auth_backend_role.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -117,6 +111,7 @@ func TestGCPAuthBackendRole_gce(t *testing.T) {
 	name := acctest.RandomWithPrefix("tf-test-gcp-role")
 	projectId := acctest.RandomWithPrefix("tf-test-gcp-project-id")
 
+	resourceName := "vault_gcp_auth_backend_role.test"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
@@ -125,9 +120,8 @@ func TestGCPAuthBackendRole_gce(t *testing.T) {
 			{
 				Config: testGCPAuthBackendRoleConfig_gce(backend, name, projectId),
 				Check: resource.ComposeTestCheckFunc(
-					testGCPAuthBackendRoleCheck_attrs(backend, name),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend_role.test",
-						"bound_labels.#", "2"),
+					testGCPAuthBackendRoleCheck_attrs(resourceName, backend, name),
+					resource.TestCheckResourceAttr(resourceName, "bound_labels.#", "2"),
 				),
 			},
 		},
@@ -152,24 +146,25 @@ func testGCPAuthBackendRoleDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testGCPAuthBackendRoleCheck_attrs(backend, name string) resource.TestCheckFunc {
+func testGCPAuthBackendRoleCheck_attrs(resourceName, backend, name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		resourceState := s.Modules[0].Resources["vault_gcp_auth_backend_role.test"]
-		if resourceState == nil {
-			return fmt.Errorf("resource not found in state")
+		rs, err := testutil.GetResourceFromRootModule(s, resourceName)
+		if err != nil {
+			return err
 		}
 
-		instanceState := resourceState.Primary
-		if instanceState == nil {
-			return fmt.Errorf("resource has no primary instance")
+		client, err := provider.GetClient(rs.Primary, testProvider.Meta())
+		if err != nil {
+			return err
 		}
+
+		path := rs.Primary.ID
 
 		endpoint := "auth/" + strings.Trim(backend, "/") + "/role/" + name
-		if endpoint != instanceState.ID {
-			return fmt.Errorf("expected ID to be %q, got %q instead", endpoint, instanceState.ID)
+		if endpoint != path {
+			return fmt.Errorf("expected ID to be %q, got %q instead", endpoint, path)
 		}
 
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 		authMounts, err := client.Sys().ListAuth()
 		if err != nil {
 			return err
@@ -179,23 +174,13 @@ func testGCPAuthBackendRoleCheck_attrs(backend, name string) resource.TestCheckF
 		if authMount == nil {
 			return fmt.Errorf("auth mount %s not present", backend)
 		}
-
 		if "gcp" != authMount.Type {
 			return fmt.Errorf("incorrect mount type: %s", authMount.Type)
-		}
-
-		resp, err := client.Logical().Read(instanceState.ID)
-		if err != nil {
-			return err
 		}
 
 		attrs := map[string]string{
 			"type":                   "type",
 			"bound_projects":         "bound_projects",
-			"token_ttl":              "token_ttl",
-			"token_max_ttl":          "token_max_ttl",
-			"token_period":           "token_period",
-			"token_policies":         "token_policies",
 			"bound_service_accounts": "bound_service_accounts",
 			"bound_regions":          "bound_regions",
 			"bound_zones":            "bound_zones",
@@ -203,117 +188,42 @@ func testGCPAuthBackendRoleCheck_attrs(backend, name string) resource.TestCheckF
 			"add_group_aliases":      "add_group_aliases",
 		}
 
-		for stateAttr, apiAttr := range attrs {
-			if resp.Data[apiAttr] == nil && instanceState.Attributes[stateAttr] == "" {
-				continue
-			}
-			var match bool
-			switch resp.Data[apiAttr].(type) {
-			case json.Number:
-				apiData, err := resp.Data[apiAttr].(json.Number).Int64()
-				if err != nil {
-					return fmt.Errorf("Expected API field %s to be an int, was %q", apiAttr, resp.Data[apiAttr])
-				}
-				stateData, err := strconv.ParseInt(instanceState.Attributes[stateAttr], 10, 64)
-				if err != nil {
-					return fmt.Errorf("Expected state field %s to be an int, was %q", stateAttr, instanceState.Attributes[stateAttr])
-				}
-				match = apiData == stateData
-			case bool:
-				if _, ok := resp.Data[apiAttr]; !ok && instanceState.Attributes[stateAttr] == "" {
-					match = true
-				} else {
-					stateData, err := strconv.ParseBool(instanceState.Attributes[stateAttr])
-					if err != nil {
-						return fmt.Errorf("Expected state field %s to be a bool, was %q", stateAttr, instanceState.Attributes[stateAttr])
-					}
-					match = resp.Data[apiAttr] == stateData
-				}
-			case map[string]interface{}:
-				apiData := resp.Data[apiAttr].(map[string]interface{})
-				length := instanceState.Attributes[stateAttr+".#"]
-				if length == "" {
-					if len(resp.Data[apiAttr].(map[string]interface{})) != 0 {
-						return fmt.Errorf("Expected state field %s to have %d entries, had 0", stateAttr, len(apiData))
-					}
-					match = true
-				} else {
-					count, err := strconv.Atoi(length)
-					if err != nil {
-						return fmt.Errorf("Expected %s.# to be a number, got %q", stateAttr, instanceState.Attributes[stateAttr+".#"])
-					}
-					if count != len(apiData) {
-						return fmt.Errorf("Expected %s to have %d entries in state, has %d", stateAttr, len(apiData), count)
-					}
-
-					for respKey, respValue := range apiData {
-						found := false
-						for stateKey, stateValue := range instanceState.Attributes {
-							if strings.HasPrefix(stateKey, stateAttr) {
-								val := respValue
-
-								// We send a list to Vault and it returns a map. To ensure
-								// the response from Vault and the state file are equal,
-								// we need to prepare a string "key:value" for comparison.
-								if apiAttr == "bound_labels" {
-									val = fmt.Sprintf("%s:%s", respKey, respValue)
-								}
-
-								if val == stateValue {
-									found = true
-								}
-							}
-						}
-						if !found {
-							return fmt.Errorf("Expected item %s of %s (%s in state) of %q to be in state but wasn't", respKey, apiAttr, stateAttr, endpoint)
-						}
-					}
-					match = true
-				}
-
-			case []interface{}:
-				apiData := resp.Data[apiAttr].([]interface{})
-				length := instanceState.Attributes[stateAttr+".#"]
-				if length == "" {
-					if len(resp.Data[apiAttr].([]interface{})) != 0 {
-						return fmt.Errorf("Expected state field %s to have %d entries, had 0", stateAttr, len(apiData))
-					}
-					match = true
-				} else {
-					count, err := strconv.Atoi(length)
-					if err != nil {
-						return fmt.Errorf("Expected %s.# to be a number, got %q", stateAttr, instanceState.Attributes[stateAttr+".#"])
-					}
-					if count != len(apiData) {
-						return fmt.Errorf("Expected %s to have %d entries in state, has %d", stateAttr, len(apiData), count)
-					}
-
-					for i := 0; i < count; i++ {
-						found := false
-						for stateKey, stateValue := range instanceState.Attributes {
-							if strings.HasPrefix(stateKey, stateAttr) {
-								if apiData[i] == stateValue {
-									found = true
-								}
-							}
-						}
-						if !found {
-							return fmt.Errorf("Expected item %d of %s (%s in state) of %q to be in state but wasn't", i, apiAttr, stateAttr, endpoint)
-						}
-					}
-					match = true
-				}
-			default:
-				match = resp.Data[apiAttr] == instanceState.Attributes[stateAttr]
-
-			}
-			if !match {
-				return fmt.Errorf("Expected %s (%s in state) of %q to be %q, got %q", apiAttr, stateAttr, endpoint, instanceState.Attributes[stateAttr], resp.Data[apiAttr])
-			}
-
+		for _, v := range commonTokenFields {
+			attrs[v] = v
 		}
 
-		return nil
+		tAttrs := []*testutil.VaultStateTest{}
+		for k, v := range attrs {
+			ta := &testutil.VaultStateTest{
+				ResourceName: resourceName,
+				StateAttr:    k,
+				VaultAttr:    v,
+			}
+			switch k {
+			case TokenFieldPolicies:
+				ta.AsSet = true
+			case "bound_labels":
+				ta.AsSet = true
+				ta.TransformVaultValue = func(st *testutil.VaultStateTest, resp *api.Secret) (interface{}, error) {
+					// converts a map[string]interface{} to a slice of 'k:v' delimited strings.
+					result := []interface{}{}
+					v, ok := resp.Data[st.VaultAttr]
+					if !ok {
+						return nil, fmt.Errorf("no value for %s", st)
+					}
+
+					for k, v := range v.(map[string]interface{}) {
+						result = append(result, fmt.Sprintf("%s:%s", k, v))
+					}
+
+					return result, nil
+				}
+			}
+
+			tAttrs = append(tAttrs, ta)
+		}
+
+		return testutil.AssertVaultState(client, s, path, tAttrs...)
 	}
 }
 

--- a/vault/resource_gcp_secret_roleset_test.go
+++ b/vault/resource_gcp_secret_roleset_test.go
@@ -1,17 +1,13 @@
 package vault
 
 import (
-	"encoding/json"
 	"fmt"
-	"log"
-	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/vault/api"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
@@ -25,105 +21,96 @@ func TestGCPSecretRoleset(t *testing.T) {
 	roleset := acctest.RandomWithPrefix("tf-test")
 	credentials, project := testutil.GetTestGCPCreds(t)
 
-	serviceAccountEmail := ""
+	projectBaseURI := "//cloudresourcemanager.googleapis.com/projects/"
 
 	initialRole := "roles/viewer"
-	initialConfig, initialHash := testGCPSecretRoleset_access_token(backend, roleset, credentials, project, initialRole)
-
 	updatedRole := "roles/browser"
-	updatedConfig, updatedHash := testGCPSecretRoleset_access_token(backend, roleset, credentials, project, updatedRole)
 
-	keyConfig, keyHash := testGCPSecretRoleset_service_account_key(backend, roleset, credentials, project, updatedRole)
-
+	resourceNameBackend := "vault_gcp_secret_backend.test"
+	resourceName := "vault_gcp_secret_roleset.test"
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		CheckDestroy: testGCPSecretRolesetDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: initialConfig,
+				Config: testGCPSecretRolesetConfig(backend, roleset, credentials, project, initialRole),
 				Check: resource.ComposeTestCheckFunc(
-					testGCPSecretRoleset_attrs(backend, roleset),
-					testGCPSecretRoleset_serviceAccountEmail(&serviceAccountEmail, false),
-					resource.TestCheckResourceAttr("vault_gcp_secret_backend.test", "path", backend),
-					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", "roleset", roleset),
-					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", "secret_type", "access_token"),
-					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", "project", project),
-					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", "token_scopes.#", "1"),
-					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", "token_scopes.0", "https://www.googleapis.com/auth/cloud-platform"),
-					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", "binding.#", "1"),
-					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", fmt.Sprintf("binding.%d.resource", initialHash), fmt.Sprintf("//cloudresourcemanager.googleapis.com/projects/%s", project)),
-					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", fmt.Sprintf("binding.%d.roles.#", initialHash), "1"),
-					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", fmt.Sprintf("binding.%d.roles.0", initialHash), initialRole),
+					resource.TestCheckResourceAttr(resourceNameBackend, "path", backend),
+					resource.TestCheckResourceAttrSet(resourceName, "service_account_email"),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "roleset", roleset),
+					resource.TestCheckResourceAttr(resourceName, "secret_type", "access_token"),
+					resource.TestCheckResourceAttr(resourceName, "project", project),
+					resource.TestCheckResourceAttr(resourceName, "token_scopes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "token_scopes.0", "https://www.googleapis.com/auth/cloud-platform"),
+					resource.TestCheckResourceAttr(resourceName, "binding.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "binding.0.resource", projectBaseURI+project),
+					resource.TestCheckResourceAttr(resourceName, "binding.0.roles.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "binding.0.roles.0", initialRole),
+					testGCPSecretRolesetAttrs(resourceName, backend, roleset),
 				),
 			},
 			{
-				ResourceName:            "vault_gcp_secret_roleset.test",
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{},
 			},
 			{
-				Config: updatedConfig,
+				Config: testGCPSecretRolesetConfig(backend, roleset, credentials, project, updatedRole),
 				Check: resource.ComposeTestCheckFunc(
-					testGCPSecretRoleset_attrs(backend, roleset),
-					testGCPSecretRoleset_serviceAccountEmail(&serviceAccountEmail, true),
-					resource.TestCheckResourceAttr("vault_gcp_secret_backend.test", "path", backend),
-					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", "roleset", roleset),
-					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", "secret_type", "access_token"),
-					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", "project", project),
-					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", "token_scopes.#", "1"),
-					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", "token_scopes.0", "https://www.googleapis.com/auth/cloud-platform"),
-					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", "binding.#", "1"),
-					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", fmt.Sprintf("binding.%d.resource", updatedHash), fmt.Sprintf("//cloudresourcemanager.googleapis.com/projects/%s", project)),
-					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", fmt.Sprintf("binding.%d.roles.#", updatedHash), "1"),
-					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", fmt.Sprintf("binding.%d.roles.0", updatedHash), updatedRole),
+					resource.TestCheckResourceAttr(resourceNameBackend, "path", backend),
+					resource.TestCheckResourceAttrSet(resourceName, "service_account_email"),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "roleset", roleset),
+					resource.TestCheckResourceAttr(resourceName, "secret_type", "access_token"),
+					resource.TestCheckResourceAttr(resourceName, "project", project),
+					resource.TestCheckResourceAttr(resourceName, "token_scopes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "token_scopes.0", "https://www.googleapis.com/auth/cloud-platform"),
+					resource.TestCheckResourceAttr(resourceName, "binding.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "binding.0.resource", projectBaseURI+project),
+					resource.TestCheckResourceAttr(resourceName, "binding.0.roles.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "binding.0.roles.0", updatedRole),
+					testGCPSecretRolesetAttrs(resourceName, backend, roleset),
 				),
 			},
 			{
-				Config: keyConfig,
+				Config: testGCPSecretRolesetServiceAccountKey(backend, roleset, credentials, project, updatedRole),
 				Check: resource.ComposeTestCheckFunc(
-					testGCPSecretRoleset_attrs(backend, roleset),
-					testGCPSecretRoleset_serviceAccountEmail(&serviceAccountEmail, true),
-					resource.TestCheckResourceAttr("vault_gcp_secret_backend.test", "path", backend),
-					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", "roleset", roleset),
-					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", "secret_type", "service_account_key"),
-					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", "project", project),
-					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", "binding.#", "1"),
-					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", fmt.Sprintf("binding.%d.resource", keyHash), fmt.Sprintf("//cloudresourcemanager.googleapis.com/projects/%s", project)),
-					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", fmt.Sprintf("binding.%d.roles.#", keyHash), "1"),
-					resource.TestCheckResourceAttr("vault_gcp_secret_roleset.test", fmt.Sprintf("binding.%d.roles.0", keyHash), updatedRole),
+					resource.TestCheckResourceAttr(resourceNameBackend, "path", backend),
+					resource.TestCheckResourceAttrSet(resourceName, "service_account_email"),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "roleset", roleset),
+					resource.TestCheckResourceAttr(resourceName, "secret_type", "service_account_key"),
+					resource.TestCheckResourceAttr(resourceName, "project", project),
+					resource.TestCheckResourceAttr(resourceName, "binding.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "binding.0.resource", projectBaseURI+project),
+					resource.TestCheckResourceAttr(resourceName, "binding.0.roles.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "binding.0.roles.0", updatedRole),
+					testGCPSecretRolesetAttrs(resourceName, backend, roleset, "token_scopes"),
 				),
 			},
 		},
 	})
 }
 
-func testGCPSecretRoleset_attrs(backend, roleset string) resource.TestCheckFunc {
+func testGCPSecretRolesetAttrs(resourceName, backend, roleset string, ignoreFields ...string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		resourceState := s.Modules[0].Resources["vault_gcp_secret_roleset.test"]
-		if resourceState == nil {
-			return fmt.Errorf("resource not found in state")
-		}
-
-		instanceState := resourceState.Primary
-		if instanceState == nil {
-			return fmt.Errorf("resource not found in state")
-		}
-
-		endpoint := instanceState.ID
-
-		if endpoint != backend+"/roleset/"+roleset {
-			return fmt.Errorf("expected ID to be %q, got %q instead", backend+"/roleset/"+roleset, endpoint)
-		}
-
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-		resp, err := client.Logical().Read(endpoint)
+		rs, err := testutil.GetResourceFromRootModule(s, resourceName)
 		if err != nil {
-			return fmt.Errorf("%q doesn't exist", endpoint)
+			return err
+		}
+
+		client, err := provider.GetClient(rs.Primary, testProvider.Meta())
+		if err != nil {
+			return err
+		}
+
+		path := rs.Primary.ID
+
+		if path != backend+"/roleset/"+roleset {
+			return fmt.Errorf("expected ID to be %q, got %q instead", backend+"/roleset/"+roleset, path)
 		}
 
 		attrs := map[string]string{
@@ -132,160 +119,52 @@ func testGCPSecretRoleset_attrs(backend, roleset string) resource.TestCheckFunc 
 			"token_scopes":          "token_scopes",
 			"service_account_email": "service_account_email",
 		}
-		for stateAttr, apiAttr := range attrs {
-			if resp.Data[apiAttr] == nil && instanceState.Attributes[stateAttr] == "" {
+
+		tAttrs := []*testutil.VaultStateTest{}
+		for k, v := range attrs {
+			var skip bool
+			for _, f := range ignoreFields {
+				if k == f {
+					skip = true
+					break
+				}
+			}
+			if skip {
 				continue
 			}
-			var match bool
-			switch resp.Data[apiAttr].(type) {
-			case json.Number:
-				apiData, err := resp.Data[apiAttr].(json.Number).Int64()
-				if err != nil {
-					return fmt.Errorf("expected API field %s to be an int, was %q", apiAttr, resp.Data[apiAttr])
-				}
-				stateData, err := strconv.ParseInt(instanceState.Attributes[stateAttr], 10, 64)
-				if err != nil {
-					return fmt.Errorf("expected state field %s to be an int, was %q", stateAttr, instanceState.Attributes[stateAttr])
-				}
-				match = apiData == stateData
-			case bool:
-				if _, ok := resp.Data[apiAttr]; !ok && instanceState.Attributes[stateAttr] == "" {
-					match = true
-				} else {
-					stateData, err := strconv.ParseBool(instanceState.Attributes[stateAttr])
-					if err != nil {
-						return fmt.Errorf("expected state field %s to be a bool, was %q", stateAttr, instanceState.Attributes[stateAttr])
-					}
-					match = resp.Data[apiAttr] == stateData
-				}
-			case []interface{}:
-				apiData := resp.Data[apiAttr].([]interface{})
-				length := instanceState.Attributes[stateAttr+".#"]
-				if length == "" {
-					if len(resp.Data[apiAttr].([]interface{})) != 0 {
-						return fmt.Errorf("expected state field %s to have %d entries, had 0", stateAttr, len(apiData))
-					}
-					match = true
-				} else {
-					count, err := strconv.Atoi(length)
-					if err != nil {
-						return fmt.Errorf("expected %s.# to be a number, got %q", stateAttr, instanceState.Attributes[stateAttr+".#"])
-					}
-					if count != len(apiData) {
-						return fmt.Errorf("expected %s to have %d entries in state, has %d", stateAttr, len(apiData), count)
+			ta := &testutil.VaultStateTest{
+				ResourceName: resourceName,
+				StateAttr:    k,
+				VaultAttr:    v,
+			}
+
+			tAttrs = append(tAttrs, ta)
+		}
+
+		tAttrs = append(tAttrs,
+			&testutil.VaultStateTest{
+				ResourceName: resourceName,
+				StateAttr:    "binding",
+				VaultAttr:    "bindings",
+				TransformVaultValue: func(st *testutil.VaultStateTest, resp *api.Secret) (interface{}, error) {
+					result := []map[string]interface{}{}
+					v, ok := resp.Data[st.VaultAttr]
+					if !ok {
+						return nil, fmt.Errorf("no value for %s", st)
 					}
 
-					for i := 0; i < count; i++ {
-						found := false
-						for stateKey, stateValue := range instanceState.Attributes {
-							if strings.HasPrefix(stateKey, stateAttr) {
-								if apiData[i] == stateValue {
-									found = true
-								}
-							}
-						}
-						if !found {
-							return fmt.Errorf("Expected item %d of %s (%s in state) of %q to be in state but wasn't", i, apiAttr, stateAttr, apiData[i])
-						}
+					for k, v := range v.(map[string]interface{}) {
+						result = append(result, map[string]interface{}{
+							"resource": k,
+							"roles":    v,
+						})
 					}
-					match = true
-				}
-			default:
-				match = resp.Data[apiAttr] == instanceState.Attributes[stateAttr]
-			}
-			if !match {
-				return fmt.Errorf("expected %s (%s in state) of %q to be %q, got %q", apiAttr, stateAttr, endpoint, instanceState.Attributes[stateAttr], resp.Data[apiAttr])
-			}
-		}
+					return result, nil
+				},
+			},
+		)
 
-		roleHashFunction := schema.HashSchema(&schema.Schema{
-			Type: schema.TypeString,
-		})
-
-		// Bindings need to be tested separately
-		remoteBindings := resp.Data["bindings"] // map[string]interface {}
-		if remoteBindings == nil {
-			return fmt.Errorf("cannot find bindings from Vault")
-		}
-		localBindingsLengthRaw := instanceState.Attributes["binding.#"]
-		if localBindingsLengthRaw == "" {
-			return fmt.Errorf("cannot find bindings from state")
-		}
-		localBindingsLength, err := strconv.Atoi(localBindingsLengthRaw)
-		if err != nil {
-			return fmt.Errorf("expected binding.# to be a number, got %q", localBindingsLengthRaw)
-		}
-		remoteLength := len(remoteBindings.(map[string]interface{}))
-		if localBindingsLength != remoteLength {
-			return fmt.Errorf("expected %s to have %d entries in state, has %d", "binding", remoteLength, localBindingsLength)
-		}
-
-		flattenedBindings := gcpSecretFlattenBinding(remoteBindings).(*schema.Set)
-		for _, remoteBinding := range flattenedBindings.List() {
-			bindingHash := strconv.Itoa(gcpSecretBindingHash(remoteBinding))
-
-			remoteResource := remoteBinding.(map[string]interface{})["resource"].(string)
-			localResource := instanceState.Attributes["binding."+bindingHash+".resource"]
-			if localResource == "" {
-				return fmt.Errorf("expected to find binding for resource %s in state, but didn't", remoteResource)
-			}
-			if localResource != remoteResource {
-				return fmt.Errorf("expected to find binding for resource %s in state, but found %s instead", remoteResource, localResource)
-			}
-
-			// Check Roles
-			remoteRoles := remoteBinding.(map[string]interface{})["roles"].(*schema.Set)
-			localRolesCountRaw := instanceState.Attributes["binding."+bindingHash+".roles.#"]
-			if localRolesCountRaw == "" {
-				return fmt.Errorf("cannot find role counts for the binding for resource %s", remoteResource)
-			}
-			localRolesCount, err := strconv.Atoi(localRolesCountRaw)
-			if err != nil {
-				return fmt.Errorf("expected binding.%s.roles.# to be a number, got %q", remoteResource, localRolesCountRaw)
-			}
-			if remoteRoles.Len() != localRolesCount {
-				return fmt.Errorf("expected %d roles for binding for resource %s but got %d instead", remoteRoles.Len(), remoteResource, localRolesCount)
-			}
-
-			for _, remoteRole := range remoteRoles.List() {
-				roleHash := strconv.Itoa(roleHashFunction(remoteRole.(string)))
-				log.Printf("[DEBUG] Path to look for %s for %s", "binding."+bindingHash+".roles."+roleHash, remoteRole.(string))
-				localRole := instanceState.Attributes["binding."+bindingHash+".roles."+roleHash]
-				if localRole == "" {
-					return fmt.Errorf("expected to find role %s for binding for resource %s in state, but didn't", remoteRole.(string), remoteResource)
-				}
-
-				if localRole != remoteRole.(string) {
-					return fmt.Errorf("expected to find role %s for binding for resource %s in state, but found %s instead", remoteRole.(string), remoteResource, localRole)
-				}
-			}
-		}
-		return nil
-	}
-}
-
-func testGCPSecretRoleset_serviceAccountEmail(serviceAccountEmail *string, checkDifferent bool) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		resourceState := s.Modules[0].Resources["vault_gcp_secret_roleset.test"]
-		if resourceState == nil {
-			return fmt.Errorf("resource not found in state")
-		}
-
-		instanceState := resourceState.Primary
-		if instanceState == nil {
-			return fmt.Errorf("resource not found in state")
-		}
-
-		newEmail := instanceState.Attributes["service_account_email"]
-
-		if checkDifferent {
-			if newEmail == *serviceAccountEmail {
-				return fmt.Errorf("expected service account email to change but did not")
-			}
-		}
-
-		*serviceAccountEmail = newEmail
-		return nil
+		return testutil.AssertVaultState(client, s, path, tAttrs...)
 	}
 }
 
@@ -307,10 +186,9 @@ func testGCPSecretRolesetDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testGCPSecretRoleset_access_token(backend, roleset, credentials, project, role string) (string, int) {
-	resource := fmt.Sprintf("//cloudresourcemanager.googleapis.com/projects/%s", project)
-
-	terraform := fmt.Sprintf(`
+func testGCPSecretRolesetConfig(backend, roleSet, credentials, project, role string) string {
+	projectURI := fmt.Sprintf("//cloudresourcemanager.googleapis.com/projects/%s", project)
+	config := fmt.Sprintf(`
 resource "vault_gcp_secret_backend" "test" {
   path = "%s"
   credentials = <<CREDS
@@ -330,21 +208,14 @@ resource "vault_gcp_secret_roleset" "test" {
     roles = ["%s"]
   }
 }
-`, backend, credentials, roleset, project, resource, role)
+`, backend, credentials, roleSet, project, projectURI, role)
 
-	// Hash the set of bindings
-	binding := make(map[string]interface{})
-	roles := []interface{}{role}
-	binding["resource"] = resource
-	binding["roles"] = schema.NewSet(schema.HashString, roles)
-
-	return terraform, gcpSecretBindingHash(binding)
+	return config
 }
 
-func testGCPSecretRoleset_service_account_key(backend, roleset, credentials, project, role string) (string, int) {
-	resource := fmt.Sprintf("//cloudresourcemanager.googleapis.com/projects/%s", project)
-
-	terraform := fmt.Sprintf(`
+func testGCPSecretRolesetServiceAccountKey(backend, roleset, credentials, project, role string) string {
+	projectURI := fmt.Sprintf("//cloudresourcemanager.googleapis.com/projects/%s", project)
+	config := fmt.Sprintf(`
 resource "vault_gcp_secret_backend" "test" {
   path = "%s"
   credentials = <<CREDS
@@ -363,13 +234,7 @@ resource "vault_gcp_secret_roleset" "test" {
     roles = ["%s"]
   }
 }
-`, backend, credentials, roleset, project, resource, role)
+`, backend, credentials, roleset, project, projectURI, role)
 
-	// Hash the set of bindings
-	binding := make(map[string]interface{})
-	roles := []interface{}{role}
-	binding["resource"] = resource
-	binding["roles"] = schema.NewSet(schema.HashString, roles)
-
-	return terraform, gcpSecretBindingHash(binding)
+	return config
 }

--- a/vault/resource_gcp_secret_static_account_test.go
+++ b/vault/resource_gcp_secret_static_account_test.go
@@ -1,16 +1,11 @@
 package vault
 
 import (
-	"encoding/json"
 	"fmt"
-	"log"
-	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"golang.org/x/oauth2/google"
 
@@ -26,6 +21,8 @@ func TestGCPSecretStaticAccount(t *testing.T) {
 	staticAccount := acctest.RandomWithPrefix("tf-test")
 	credentials, project := testutil.GetTestGCPCreds(t)
 
+	projectBaseURI := "//cloudresourcemanager.googleapis.com/projects/"
+
 	// We will use the provided key as the static account
 	conf, err := google.JWTConfigFromJSON([]byte(credentials), "https://www.googleapis.com/auth/cloud-platform")
 	if err != nil {
@@ -36,13 +33,15 @@ func TestGCPSecretStaticAccount(t *testing.T) {
 	noBindings := testGCPSecretStaticAccount_accessToken(backend, staticAccount, credentials, serviceAccountEmail, project)
 
 	initialRole := "roles/viewer"
-	initialConfig, initialHash := testGCPSecretStaticAccount_accessTokenBinding(backend, staticAccount, credentials, serviceAccountEmail, project, initialRole)
+	initialConfig := testGCPSecretStaticAccount_accessTokenBinding(backend, staticAccount, credentials, serviceAccountEmail, project, initialRole)
 
 	updatedRole := "roles/browser"
-	updatedConfig, updatedHash := testGCPSecretStaticAccount_accessTokenBinding(backend, staticAccount, credentials, serviceAccountEmail, project, updatedRole)
+	updatedConfig := testGCPSecretStaticAccount_accessTokenBinding(backend, staticAccount, credentials, serviceAccountEmail, project, updatedRole)
 
-	keyConfig, keyHash := testGCPSecretStaticAccount_serviceAccountKey(backend, staticAccount, credentials, serviceAccountEmail, project, updatedRole)
+	keyConfig := testGCPSecretStaticAccount_serviceAccountKey(backend, staticAccount, credentials, serviceAccountEmail, project, updatedRole)
 
+	resourceNameBackend := "vault_gcp_secret_backend.test"
+	resourceName := "vault_gcp_secret_static_account.test"
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
@@ -51,38 +50,37 @@ func TestGCPSecretStaticAccount(t *testing.T) {
 			{
 				Config: noBindings,
 				Check: resource.ComposeTestCheckFunc(
-					testGCPSecretStaticAccount_attrs(backend, staticAccount),
-					resource.TestCheckResourceAttr("vault_gcp_secret_backend.test", "path", backend),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", "static_account", staticAccount),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", "secret_type", "access_token"),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", "service_account_email", serviceAccountEmail),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", "service_account_project", project),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", "token_scopes.#", "1"),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", "token_scopes.0", "https://www.googleapis.com/auth/cloud-platform"),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", "binding.#", "0"),
+					resource.TestCheckResourceAttr(resourceNameBackend, "path", backend),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "static_account", staticAccount),
+					resource.TestCheckResourceAttr(resourceName, "secret_type", "access_token"),
+					resource.TestCheckResourceAttr(resourceName, "service_account_email", serviceAccountEmail),
+					resource.TestCheckResourceAttr(resourceName, "service_account_project", project),
+					resource.TestCheckResourceAttr(resourceName, "token_scopes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "token_scopes.0", "https://www.googleapis.com/auth/cloud-platform"),
+					testGCPSecretStaticAccountAttrs(resourceName, backend, staticAccount),
 				),
 			},
 			{
 				Config: initialConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testGCPSecretStaticAccount_attrs(backend, staticAccount),
-					resource.TestCheckResourceAttr("vault_gcp_secret_backend.test", "path", backend),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", "static_account", staticAccount),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", "secret_type", "access_token"),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", "service_account_email", serviceAccountEmail),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", "service_account_project", project),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", "token_scopes.#", "1"),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", "token_scopes.0", "https://www.googleapis.com/auth/cloud-platform"),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", "binding.#", "1"),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", fmt.Sprintf("binding.%d.resource", initialHash), fmt.Sprintf("//cloudresourcemanager.googleapis.com/projects/%s", project)),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", fmt.Sprintf("binding.%d.roles.#", initialHash), "1"),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", fmt.Sprintf("binding.%d.roles.0", initialHash), initialRole),
+					resource.TestCheckResourceAttr(resourceNameBackend, "path", backend),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "static_account", staticAccount),
+					resource.TestCheckResourceAttr(resourceName, "secret_type", "access_token"),
+					resource.TestCheckResourceAttr(resourceName, "service_account_email", serviceAccountEmail),
+					resource.TestCheckResourceAttr(resourceName, "service_account_project", project),
+					resource.TestCheckResourceAttr(resourceName, "token_scopes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "token_scopes.0", "https://www.googleapis.com/auth/cloud-platform"),
+					resource.TestCheckResourceAttr(resourceName, "binding.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "binding.0.resource", projectBaseURI+project),
+					resource.TestCheckResourceAttr(resourceName, "binding.0.roles.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "binding.0.roles.0", initialRole),
+					testGCPSecretStaticAccountAttrs(resourceName, backend, staticAccount),
 				),
 			},
 			{
-				ResourceName:            "vault_gcp_secret_static_account.test",
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{},
@@ -90,63 +88,58 @@ func TestGCPSecretStaticAccount(t *testing.T) {
 			{
 				Config: updatedConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testGCPSecretStaticAccount_attrs(backend, staticAccount),
-					resource.TestCheckResourceAttr("vault_gcp_secret_backend.test", "path", backend),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", "static_account", staticAccount),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", "secret_type", "access_token"),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", "service_account_email", serviceAccountEmail),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", "service_account_project", project),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", "token_scopes.#", "1"),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", "token_scopes.0", "https://www.googleapis.com/auth/cloud-platform"),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", "binding.#", "1"),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", fmt.Sprintf("binding.%d.resource", updatedHash), fmt.Sprintf("//cloudresourcemanager.googleapis.com/projects/%s", project)),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", fmt.Sprintf("binding.%d.roles.#", updatedHash), "1"),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", fmt.Sprintf("binding.%d.roles.0", updatedHash), updatedRole),
+					resource.TestCheckResourceAttr(resourceNameBackend, "path", backend),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "static_account", staticAccount),
+					resource.TestCheckResourceAttr(resourceName, "secret_type", "access_token"),
+					resource.TestCheckResourceAttr(resourceName, "service_account_email", serviceAccountEmail),
+					resource.TestCheckResourceAttr(resourceName, "service_account_project", project),
+					resource.TestCheckResourceAttr(resourceName, "token_scopes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "token_scopes.0", "https://www.googleapis.com/auth/cloud-platform"),
+					resource.TestCheckResourceAttr(resourceName, "binding.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "binding.0.resource", fmt.Sprintf("//cloudresourcemanager.googleapis.com/projects/%s", project)),
+					resource.TestCheckResourceAttr(resourceName, "binding.0.roles.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "binding.0.roles.0", updatedRole),
+					testGCPSecretStaticAccountAttrs(resourceName, backend, staticAccount),
 				),
 			},
 			{
 				Config: keyConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testGCPSecretStaticAccount_attrs(backend, staticAccount),
-					resource.TestCheckResourceAttr("vault_gcp_secret_backend.test", "path", backend),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", "static_account", staticAccount),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", "secret_type", "service_account_key"),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", "service_account_email", serviceAccountEmail),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", "service_account_project", project),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", "binding.#", "1"),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", fmt.Sprintf("binding.%d.resource", keyHash), fmt.Sprintf("//cloudresourcemanager.googleapis.com/projects/%s", project)),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", fmt.Sprintf("binding.%d.roles.#", keyHash), "1"),
-					resource.TestCheckResourceAttr("vault_gcp_secret_static_account.test", fmt.Sprintf("binding.%d.roles.0", keyHash), updatedRole),
+					resource.TestCheckResourceAttr(resourceNameBackend, "path", backend),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "static_account", staticAccount),
+					resource.TestCheckResourceAttr(resourceName, "secret_type", "service_account_key"),
+					resource.TestCheckResourceAttr(resourceName, "service_account_email", serviceAccountEmail),
+					resource.TestCheckResourceAttr(resourceName, "service_account_project", project),
+					resource.TestCheckResourceAttr(resourceName, "binding.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "binding.0.resource", projectBaseURI+project),
+					resource.TestCheckResourceAttr(resourceName, "binding.0.roles.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "binding.0.roles.0", updatedRole),
+					testGCPSecretStaticAccountAttrs(resourceName, backend, staticAccount, "token_scopes"),
 				),
 			},
 		},
 	})
 }
 
-func testGCPSecretStaticAccount_attrs(backend, staticAccount string) resource.TestCheckFunc {
+func testGCPSecretStaticAccountAttrs(resourceName, backend, staticAccount string, ignoreFields ...string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		resourceState := s.Modules[0].Resources["vault_gcp_secret_static_account.test"]
-		if resourceState == nil {
-			return fmt.Errorf("resource not found in state")
-		}
-
-		instanceState := resourceState.Primary
-		if instanceState == nil {
-			return fmt.Errorf("resource not found in state")
-		}
-
-		endpoint := instanceState.ID
-
-		if endpoint != backend+"/static-account/"+staticAccount {
-			return fmt.Errorf("expected ID to be %q, got %q instead", backend+"/static-account/"+staticAccount, endpoint)
-		}
-
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-		resp, err := client.Logical().Read(endpoint)
+		rs, err := testutil.GetResourceFromRootModule(s, resourceName)
 		if err != nil {
-			return fmt.Errorf("%q doesn't exist", endpoint)
+			return err
+		}
+
+		client, err := provider.GetClient(rs.Primary, testProvider.Meta())
+		if err != nil {
+			return err
+		}
+
+		path := rs.Primary.ID
+
+		expectedPath := backend + "/static-account/" + staticAccount
+		if path != expectedPath {
+			return fmt.Errorf("expected ID to be %q, got %q instead", expectedPath, path)
 		}
 
 		attrs := map[string]string{
@@ -155,138 +148,29 @@ func testGCPSecretStaticAccount_attrs(backend, staticAccount string) resource.Te
 			"token_scopes":            "token_scopes",
 			"service_account_email":   "service_account_email",
 		}
-		for stateAttr, apiAttr := range attrs {
-			if resp.Data[apiAttr] == nil && instanceState.Attributes[stateAttr] == "" {
+
+		tAttrs := []*testutil.VaultStateTest{}
+		for k, v := range attrs {
+			var skip bool
+			for _, f := range ignoreFields {
+				if k == f {
+					skip = true
+					break
+				}
+			}
+			if skip {
 				continue
 			}
-			var match bool
-			switch resp.Data[apiAttr].(type) {
-			case json.Number:
-				apiData, err := resp.Data[apiAttr].(json.Number).Int64()
-				if err != nil {
-					return fmt.Errorf("expected API field %s to be an int, was %q", apiAttr, resp.Data[apiAttr])
-				}
-				stateData, err := strconv.ParseInt(instanceState.Attributes[stateAttr], 10, 64)
-				if err != nil {
-					return fmt.Errorf("expected state field %s to be an int, was %q", stateAttr, instanceState.Attributes[stateAttr])
-				}
-				match = apiData == stateData
-			case bool:
-				if _, ok := resp.Data[apiAttr]; !ok && instanceState.Attributes[stateAttr] == "" {
-					match = true
-				} else {
-					stateData, err := strconv.ParseBool(instanceState.Attributes[stateAttr])
-					if err != nil {
-						return fmt.Errorf("expected state field %s to be a bool, was %q", stateAttr, instanceState.Attributes[stateAttr])
-					}
-					match = resp.Data[apiAttr] == stateData
-				}
-			case []interface{}:
-				apiData := resp.Data[apiAttr].([]interface{})
-				length := instanceState.Attributes[stateAttr+".#"]
-				if length == "" {
-					if len(resp.Data[apiAttr].([]interface{})) != 0 {
-						return fmt.Errorf("expected state field %s to have %d entries, had 0", stateAttr, len(apiData))
-					}
-					match = true
-				} else {
-					count, err := strconv.Atoi(length)
-					if err != nil {
-						return fmt.Errorf("expected %s.# to be a number, got %q", stateAttr, instanceState.Attributes[stateAttr+".#"])
-					}
-					if count != len(apiData) {
-						return fmt.Errorf("expected %s to have %d entries in state, has %d", stateAttr, len(apiData), count)
-					}
+			ta := &testutil.VaultStateTest{
+				ResourceName: resourceName,
+				StateAttr:    k,
+				VaultAttr:    v,
+			}
 
-					for i := 0; i < count; i++ {
-						found := false
-						for stateKey, stateValue := range instanceState.Attributes {
-							if strings.HasPrefix(stateKey, stateAttr) {
-								if apiData[i] == stateValue {
-									found = true
-								}
-							}
-						}
-						if !found {
-							return fmt.Errorf("Expected item %d of %s (%s in state) of %q to be in state but wasn't", i, apiAttr, stateAttr, apiData[i])
-						}
-					}
-					match = true
-				}
-			default:
-				match = resp.Data[apiAttr] == instanceState.Attributes[stateAttr]
-			}
-			if !match {
-				return fmt.Errorf("expected %s (%s in state) of %q to be %q, got %q", apiAttr, stateAttr, endpoint, instanceState.Attributes[stateAttr], resp.Data[apiAttr])
-			}
+			tAttrs = append(tAttrs, ta)
 		}
 
-		roleHashFunction := schema.HashSchema(&schema.Schema{
-			Type: schema.TypeString,
-		})
-
-		// Bindings need to be tested separately
-		remoteBindings := resp.Data["bindings"] // map[string]interface {}
-		localBindingsLengthRaw := instanceState.Attributes["binding.#"]
-		if localBindingsLengthRaw == "" {
-			return fmt.Errorf("cannot find bindings from state")
-		}
-		localBindingsLength, err := strconv.Atoi(localBindingsLengthRaw)
-		if err != nil {
-			return fmt.Errorf("expected binding.# to be a number, got %q", localBindingsLengthRaw)
-		}
-
-		var remoteLength int
-		if remoteBindings == nil {
-			remoteLength = 0
-		} else {
-			remoteLength = len(remoteBindings.(map[string]interface{}))
-		}
-		if localBindingsLength != remoteLength {
-			return fmt.Errorf("expected %s to have %d entries in state, has %d", "binding", remoteLength, localBindingsLength)
-		}
-
-		flattenedBindings := gcpSecretFlattenBinding(remoteBindings).(*schema.Set)
-		for _, remoteBinding := range flattenedBindings.List() {
-			bindingHash := strconv.Itoa(gcpSecretBindingHash(remoteBinding))
-
-			remoteResource := remoteBinding.(map[string]interface{})["resource"].(string)
-			localResource := instanceState.Attributes["binding."+bindingHash+".resource"]
-			if localResource == "" {
-				return fmt.Errorf("expected to find binding for resource %s in state, but didn't", remoteResource)
-			}
-			if localResource != remoteResource {
-				return fmt.Errorf("expected to find binding for resource %s in state, but found %s instead", remoteResource, localResource)
-			}
-
-			// Check Roles
-			remoteRoles := remoteBinding.(map[string]interface{})["roles"].(*schema.Set)
-			localRolesCountRaw := instanceState.Attributes["binding."+bindingHash+".roles.#"]
-			if localRolesCountRaw == "" {
-				return fmt.Errorf("cannot find role counts for the binding for resource %s", remoteResource)
-			}
-			localRolesCount, err := strconv.Atoi(localRolesCountRaw)
-			if err != nil {
-				return fmt.Errorf("expected binding.%s.roles.# to be a number, got %q", remoteResource, localRolesCountRaw)
-			}
-			if remoteRoles.Len() != localRolesCount {
-				return fmt.Errorf("expected %d roles for binding for resource %s but got %d instead", remoteRoles.Len(), remoteResource, localRolesCount)
-			}
-
-			for _, remoteRole := range remoteRoles.List() {
-				roleHash := strconv.Itoa(roleHashFunction(remoteRole.(string)))
-				log.Printf("[DEBUG] Path to look for %s for %s", "binding."+bindingHash+".roles."+roleHash, remoteRole.(string))
-				localRole := instanceState.Attributes["binding."+bindingHash+".roles."+roleHash]
-				if localRole == "" {
-					return fmt.Errorf("expected to find role %s for binding for resource %s in state, but didn't", remoteRole.(string), remoteResource)
-				}
-
-				if localRole != remoteRole.(string) {
-					return fmt.Errorf("expected to find role %s for binding for resource %s in state, but found %s instead", remoteRole.(string), remoteResource, localRole)
-				}
-			}
-		}
-		return nil
+		return testutil.AssertVaultState(client, s, path, tAttrs...)
 	}
 }
 
@@ -328,10 +212,9 @@ resource "vault_gcp_secret_static_account" "test" {
 `, backend, credentials, staticAccount, serviceAccountEmail)
 }
 
-func testGCPSecretStaticAccount_accessTokenBinding(backend, staticAccount, credentials, serviceAccountEmail, project, role string) (string, int) {
-	resource := fmt.Sprintf("//cloudresourcemanager.googleapis.com/projects/%s", project)
-
-	terraform := fmt.Sprintf(`
+func testGCPSecretStaticAccount_accessTokenBinding(backend, staticAccount, credentials, serviceAccountEmail, project, role string) string {
+	projectURI := fmt.Sprintf("//cloudresourcemanager.googleapis.com/projects/%s", project)
+	config := fmt.Sprintf(`
 resource "vault_gcp_secret_backend" "test" {
   path = "%s"
   credentials = <<CREDS
@@ -352,21 +235,15 @@ resource "vault_gcp_secret_static_account" "test" {
     roles = ["%s"]
   }
 }
-`, backend, credentials, staticAccount, serviceAccountEmail, resource, role)
+`, backend, credentials, staticAccount, serviceAccountEmail, projectURI, role)
 
-	// Hash the set of bindings
-	binding := make(map[string]interface{})
-	roles := []interface{}{role}
-	binding["resource"] = resource
-	binding["roles"] = schema.NewSet(schema.HashString, roles)
-
-	return terraform, gcpSecretBindingHash(binding)
+	return config
 }
 
-func testGCPSecretStaticAccount_serviceAccountKey(backend, staticAccount, credentials, serviceAccountEmail, project, role string) (string, int) {
-	resource := fmt.Sprintf("//cloudresourcemanager.googleapis.com/projects/%s", project)
+func testGCPSecretStaticAccount_serviceAccountKey(backend, staticAccount, credentials, serviceAccountEmail, project, role string) string {
+	projectURI := fmt.Sprintf("//cloudresourcemanager.googleapis.com/projects/%s", project)
 
-	terraform := fmt.Sprintf(`
+	config := fmt.Sprintf(`
 resource "vault_gcp_secret_backend" "test" {
   path = "%s"
   credentials = <<CREDS
@@ -387,13 +264,7 @@ resource "vault_gcp_secret_static_account" "test" {
     roles = ["%s"]
   }
 }
-`, backend, credentials, staticAccount, serviceAccountEmail, resource, role)
+`, backend, credentials, staticAccount, serviceAccountEmail, projectURI, role)
 
-	// Hash the set of bindings
-	binding := make(map[string]interface{})
-	roles := []interface{}{role}
-	binding["resource"] = resource
-	binding["roles"] = schema.NewSet(schema.HashString, roles)
-
-	return terraform, gcpSecretBindingHash(binding)
+	return config
 }

--- a/vault/resource_identity_entity_policies_test.go
+++ b/vault/resource_identity_entity_policies_test.go
@@ -1,10 +1,8 @@
 package vault
 
 import (
-	"encoding/json"
 	"fmt"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -109,98 +107,38 @@ func testAccCheckidentityEntityPoliciesDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccIdentityEntityPoliciesCheckAttrs(resource string) resource.TestCheckFunc {
+func testAccIdentityEntityPoliciesCheckAttrs(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		resourceState := s.Modules[0].Resources[resource]
-		if resourceState == nil {
-			return fmt.Errorf("resource not found in state")
-		}
-
-		instanceState := resourceState.Primary
-		if instanceState == nil {
-			return fmt.Errorf("resource not found in state")
-		}
-
-		id := instanceState.ID
-
-		path := entity.JoinEntityID(id)
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-		resp, err := client.Logical().Read(path)
+		rs, err := testutil.GetResourceFromRootModule(s, resourceName)
 		if err != nil {
-			return fmt.Errorf("%q doesn't exist", path)
+			return err
 		}
+
+		client, err := provider.GetClient(rs.Primary, testProvider.Meta())
+		if err != nil {
+			return err
+		}
+
+		path := entity.JoinEntityID(rs.Primary.ID)
 
 		attrs := map[string]string{
 			"entity_id":   "id",
 			"entity_name": "name",
 			"policies":    "policies",
 		}
-		for stateAttr, apiAttr := range attrs {
-			if resp.Data[apiAttr] == nil && instanceState.Attributes[stateAttr] == "" {
-				continue
-			}
-			var match bool
-			switch resp.Data[apiAttr].(type) {
-			case json.Number:
-				apiData, err := resp.Data[apiAttr].(json.Number).Int64()
-				if err != nil {
-					return fmt.Errorf("expected API field %s to be an int, was %q", apiAttr, resp.Data[apiAttr])
-				}
-				stateData, err := strconv.ParseInt(instanceState.Attributes[stateAttr], 10, 64)
-				if err != nil {
-					return fmt.Errorf("expected state field %s to be an int, was %q", stateAttr, instanceState.Attributes[stateAttr])
-				}
-				match = apiData == stateData
-			case bool:
-				if _, ok := resp.Data[apiAttr]; !ok && instanceState.Attributes[stateAttr] == "" {
-					match = true
-				} else {
-					stateData, err := strconv.ParseBool(instanceState.Attributes[stateAttr])
-					if err != nil {
-						return fmt.Errorf("expected state field %s to be a bool, was %q", stateAttr, instanceState.Attributes[stateAttr])
-					}
-					match = resp.Data[apiAttr] == stateData
-				}
-			case []interface{}:
-				apiData := resp.Data[apiAttr].([]interface{})
-				length := instanceState.Attributes[stateAttr+".#"]
-				if length == "" {
-					if len(resp.Data[apiAttr].([]interface{})) != 0 {
-						return fmt.Errorf("expected state field %s to have %d entries, had 0", stateAttr, len(apiData))
-					}
-					match = true
-				} else {
-					count, err := strconv.Atoi(length)
-					if err != nil {
-						return fmt.Errorf("expected %s.# to be a number, got %q", stateAttr, instanceState.Attributes[stateAttr+".#"])
-					}
-					if count != len(apiData) {
-						return fmt.Errorf("expected %s to have %d entries in state, has %d", stateAttr, len(apiData), count)
-					}
 
-					for i := 0; i < count; i++ {
-						found := false
-						for stateKey, stateValue := range instanceState.Attributes {
-							if strings.HasPrefix(stateKey, stateAttr) {
-								if apiData[i] == stateValue {
-									found = true
-								}
-							}
-						}
-						if !found {
-							return fmt.Errorf("Expected item %d of %s (%s in state) of %q to be in state but wasn't", i, apiAttr, stateAttr, apiData[i])
-						}
-					}
-					match = true
-				}
-			default:
-				match = resp.Data[apiAttr] == instanceState.Attributes[stateAttr]
+		tAttrs := []*testutil.VaultStateTest{}
+		for k, v := range attrs {
+			ta := &testutil.VaultStateTest{
+				ResourceName: resourceName,
+				StateAttr:    k,
+				VaultAttr:    v,
 			}
-			if !match {
-				return fmt.Errorf("expected %s (%s in state) of %q to be %q, got %q", apiAttr, stateAttr, path, instanceState.Attributes[stateAttr], resp.Data[apiAttr])
-			}
+
+			tAttrs = append(tAttrs, ta)
 		}
-		return nil
+
+		return testutil.AssertVaultState(client, s, path, tAttrs...)
 	}
 }
 

--- a/vault/resource_identity_entity_test.go
+++ b/vault/resource_identity_entity_test.go
@@ -138,26 +138,31 @@ func testAccCheckIdentityEntityDestroy(s *terraform.State) error {
 
 func testAccIdentityEntityCheckAttrs(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, err := testGetResourceFromRootModule(s, resourceName)
+		rs, err := testutil.GetResourceFromRootModule(s, resourceName)
+		if err != nil {
+			return err
+		}
+
+		client, err := provider.GetClient(rs.Primary, testProvider.Meta())
 		if err != nil {
 			return err
 		}
 
 		path := entity.JoinEntityID(rs.Primary.ID)
-		tAttrs := []*vaultStateTest{
+		tAttrs := []*testutil.VaultStateTest{
 			{
-				rs:        resourceName,
-				stateAttr: "name",
-				vaultAttr: "name",
+				ResourceName: resourceName,
+				StateAttr:    "name",
+				VaultAttr:    "name",
 			},
 			{
-				rs:        resourceName,
-				stateAttr: "policies",
-				vaultAttr: "policies",
+				ResourceName: resourceName,
+				StateAttr:    "policies",
+				VaultAttr:    "policies",
 			},
 		}
 
-		return assertVaultState(s, path, tAttrs...)
+		return testutil.AssertVaultState(client, s, path, tAttrs...)
 	}
 }
 

--- a/vault/resource_identity_group_member_entity_ids_test.go
+++ b/vault/resource_identity_group_member_entity_ids_test.go
@@ -1,9 +1,7 @@
 package vault
 
 import (
-	"encoding/json"
 	"fmt"
-	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -390,112 +388,16 @@ func testAccCheckidentityGroupMemberEntityIdsDestroy(s *terraform.State) error {
 	return nil
 }
 
-// vaultStateTest
-type vaultStateTest struct {
-	// rs fully qualified resource name
-	rs        string
-	stateAttr string
-	vaultAttr string
-	// isSubset check when checking equality of []interface{} state value
-	isSubset bool
-}
-
-func assertVaultState(tfs *terraform.State, path string, stateTests ...*vaultStateTest) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-	resp, err := client.Logical().Read(path)
-	if err != nil {
-		return fmt.Errorf("%q doesn't exist", path)
-	}
-
-	for _, st := range stateTests {
-		rs := tfs.Modules[0].Resources[st.rs]
-		if rs == nil || (rs != nil && rs.Primary == nil) {
-			return fmt.Errorf("resource not found in state")
-		}
-		attrs := rs.Primary.Attributes
-
-		s := attrs[st.stateAttr]
-		v := resp.Data[st.vaultAttr]
-		if v == nil && s == "" {
-			continue
-		}
-
-		errFmt := fmt.Sprintf("expected %s (%%s in state) of %q to be %%#v, got %%#v",
-			st.vaultAttr, path)
-
-		switch v := v.(type) {
-		case json.Number:
-			actual, err := v.Int64()
-			if err != nil {
-				return fmt.Errorf("expected API field %s to be an int, was %T", st.vaultAttr, v)
-			}
-			expected, err := strconv.ParseInt(s, 10, 64)
-			if err != nil {
-				return fmt.Errorf("expected state field %s to be a %T, was %T", st.stateAttr, v, s)
-			}
-			if actual != expected {
-				return fmt.Errorf(errFmt, st.stateAttr, expected, actual)
-			}
-		case bool:
-			actual := v
-			if s != "" {
-				expected, err := strconv.ParseBool(s)
-				if err != nil {
-					return fmt.Errorf("expected state field %s to be a %T, was %T", st.stateAttr, v, s)
-				}
-				if actual != expected {
-					return fmt.Errorf(errFmt, st.stateAttr, expected, actual)
-				}
-			}
-		case []interface{}:
-			actual := v
-			l := len(v)
-			expected := []interface{}{}
-			for i := 0; i < l; i++ {
-				if v, ok := attrs[fmt.Sprintf("%s.%d", st.stateAttr, i)]; ok {
-					expected = append(expected, v)
-				}
-			}
-
-			if st.isSubset {
-				if len(expected) > len(actual) {
-					return fmt.Errorf(errFmt, st.stateAttr, expected, actual)
-				}
-
-				var count int
-				for _, v := range expected {
-					for _, a := range actual {
-						if reflect.DeepEqual(v, a) {
-							count++
-						}
-					}
-				}
-				if len(expected) != count {
-					return fmt.Errorf(errFmt, st.stateAttr, expected, actual)
-				}
-			} else {
-				if !reflect.DeepEqual(expected, actual) {
-					return fmt.Errorf(errFmt, st.stateAttr, expected, actual)
-				}
-			}
-
-		case string:
-			if v != s {
-				return fmt.Errorf(errFmt, st.stateAttr, s, v)
-			}
-		default:
-			return fmt.Errorf("unsupported type %T", v)
-		}
-	}
-
-	return nil
-}
-
 func testAccIdentityGroupMemberEntityIdsCheckAttrs(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs := s.Modules[0].Resources[resourceName]
-		if rs == nil || (rs != nil && rs.Primary == nil) {
-			return fmt.Errorf("resource %q not found in state", resourceName)
+		rs, err := testutil.GetResourceFromRootModule(s, resourceName)
+		if err != nil {
+			return err
+		}
+
+		client, err := provider.GetClient(rs.Primary, testProvider.Meta())
+		if err != nil {
+			return err
 		}
 
 		var isSubset bool
@@ -510,20 +412,20 @@ func testAccIdentityGroupMemberEntityIdsCheckAttrs(resourceName string) resource
 
 		id := rs.Primary.ID
 		path := identityGroupIDPath(id)
-		tAttrs := []*vaultStateTest{
+		tAttrs := []*testutil.VaultStateTest{
 			{
-				rs:        resourceName,
-				stateAttr: "group_id",
-				vaultAttr: "id",
+				ResourceName: resourceName,
+				StateAttr:    "group_id",
+				VaultAttr:    "id",
 			},
 			{
-				rs:        resourceName,
-				stateAttr: "member_entity_ids",
-				vaultAttr: "member_entity_ids",
-				isSubset:  isSubset,
+				ResourceName: resourceName,
+				StateAttr:    "member_entity_ids",
+				VaultAttr:    "member_entity_ids",
+				IsSubset:     isSubset,
 			},
 		}
-		return assertVaultState(s, path, tAttrs...)
+		return testutil.AssertVaultState(client, s, path, tAttrs...)
 	}
 }
 

--- a/vault/resource_identity_group_policies_test.go
+++ b/vault/resource_identity_group_policies_test.go
@@ -1,10 +1,8 @@
 package vault
 
 import (
-	"encoding/json"
 	"fmt"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -16,6 +14,7 @@ import (
 )
 
 func TestAccIdentityGroupPoliciesExclusive(t *testing.T) {
+	resourceName := "vault_identity_group_policies.policies"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
@@ -23,15 +22,15 @@ func TestAccIdentityGroupPoliciesExclusive(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIdentityGroupPoliciesConfigExclusive(),
-				Check:  testAccIdentityGroupPoliciesCheckAttrs("vault_identity_group_policies.policies"),
+				Check:  testAccIdentityGroupPoliciesCheckAttrs(resourceName),
 			},
 			{
 				Config: testAccIdentityGroupPoliciesConfigExclusiveUpdate(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccIdentityGroupPoliciesCheckAttrs("vault_identity_group_policies.policies"),
-					resource.TestCheckResourceAttr("vault_identity_group_policies.policies", "policies.#", "2"),
-					resource.TestCheckResourceAttr("vault_identity_group_policies.policies", "policies.0", "dev"),
-					resource.TestCheckResourceAttr("vault_identity_group_policies.policies", "policies.1", "test"),
+					resource.TestCheckResourceAttr(resourceName, "policies.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "policies.0", "dev"),
+					resource.TestCheckResourceAttr(resourceName, "policies.1", "test"),
+					testAccIdentityGroupPoliciesCheckAttrs(resourceName),
 				),
 			},
 		},
@@ -39,6 +38,9 @@ func TestAccIdentityGroupPoliciesExclusive(t *testing.T) {
 }
 
 func TestAccIdentityGroupPoliciesNonExclusive(t *testing.T) {
+	resourceNameDev := "vault_identity_group_policies.dev"
+	resourceNameTest := "vault_identity_group_policies.test"
+	resourceNameGroup := "vault_identity_group.group"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
@@ -47,20 +49,25 @@ func TestAccIdentityGroupPoliciesNonExclusive(t *testing.T) {
 			{
 				Config: testAccIdentityGroupPoliciesConfigNonExclusive(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_identity_group_policies.dev", "policies.#", "1"),
-					resource.TestCheckResourceAttr("vault_identity_group_policies.dev", "policies.0", "dev"),
-					resource.TestCheckResourceAttr("vault_identity_group_policies.test", "policies.#", "1"),
-					resource.TestCheckResourceAttr("vault_identity_group_policies.test", "policies.0", "test"),
+					resource.TestCheckResourceAttr(resourceNameDev, "policies.#", "1"),
+					resource.TestCheckResourceAttr(resourceNameDev, "policies.0", "dev"),
+					resource.TestCheckResourceAttr(resourceNameTest, "policies.#", "1"),
+					resource.TestCheckResourceAttr(resourceNameTest, "policies.0", "test"),
+					testAccIdentityGroupCheckAttrs(resourceNameGroup),
+					testAccIdentityGroupPoliciesCheckAttrs(resourceNameDev),
+					testAccIdentityGroupPoliciesCheckAttrs(resourceNameTest),
 				),
 			},
 			{
 				Config: testAccIdentityGroupPoliciesConfigNonExclusiveUpdate(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccIdentityGroupPoliciesCheckLogical("vault_identity_group.group", []string{"dev", "foo"}),
-					resource.TestCheckResourceAttr("vault_identity_group_policies.dev", "policies.#", "1"),
-					resource.TestCheckResourceAttr("vault_identity_group_policies.dev", "policies.0", "dev"),
-					resource.TestCheckResourceAttr("vault_identity_group_policies.test", "policies.#", "1"),
-					resource.TestCheckResourceAttr("vault_identity_group_policies.test", "policies.0", "foo"),
+					resource.TestCheckResourceAttr(resourceNameDev, "policies.#", "1"),
+					resource.TestCheckResourceAttr(resourceNameDev, "policies.0", "dev"),
+					resource.TestCheckResourceAttr(resourceNameTest, "policies.#", "1"),
+					resource.TestCheckResourceAttr(resourceNameTest, "policies.0", "foo"),
+					testAccIdentityGroupCheckAttrs(resourceNameGroup),
+					testAccIdentityGroupPoliciesCheckAttrs(resourceNameDev),
+					testAccIdentityGroupPoliciesCheckAttrs(resourceNameTest),
 				),
 			},
 		},
@@ -105,149 +112,49 @@ func testAccCheckidentityGroupPoliciesDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccIdentityGroupPoliciesCheckAttrs(resource string) resource.TestCheckFunc {
+func testAccIdentityGroupPoliciesCheckAttrs(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		resourceState := s.Modules[0].Resources[resource]
-		if resourceState == nil {
-			return fmt.Errorf("resource not found in state")
-		}
-
-		instanceState := resourceState.Primary
-		if instanceState == nil {
-			return fmt.Errorf("resource not found in state")
-		}
-
-		id := instanceState.ID
-
-		path := identityGroupIDPath(id)
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-		resp, err := client.Logical().Read(path)
+		rs, err := testutil.GetResourceFromRootModule(s, resourceName)
 		if err != nil {
-			return fmt.Errorf("%q doesn't exist", path)
+			return err
 		}
+
+		v, err := strconv.ParseBool(rs.Primary.Attributes["exclusive"])
+		if err != nil {
+			return err
+		}
+
+		isSubset := !v
+
+		client, err := provider.GetClient(rs.Primary, testProvider.Meta())
+		if err != nil {
+			return err
+		}
+
+		path := identityGroupIDPath(rs.Primary.ID)
 
 		attrs := map[string]string{
 			"group_id":   "id",
 			"group_name": "name",
 			"policies":   "policies",
 		}
-		for stateAttr, apiAttr := range attrs {
-			if resp.Data[apiAttr] == nil && instanceState.Attributes[stateAttr] == "" {
-				continue
+
+		tAttrs := []*testutil.VaultStateTest{}
+		for k, v := range attrs {
+			ta := &testutil.VaultStateTest{
+				ResourceName: resourceName,
+				StateAttr:    k,
+				VaultAttr:    v,
 			}
-			var match bool
-			switch resp.Data[apiAttr].(type) {
-			case json.Number:
-				apiData, err := resp.Data[apiAttr].(json.Number).Int64()
-				if err != nil {
-					return fmt.Errorf("expected API field %s to be an int, was %q", apiAttr, resp.Data[apiAttr])
-				}
-				stateData, err := strconv.ParseInt(instanceState.Attributes[stateAttr], 10, 64)
-				if err != nil {
-					return fmt.Errorf("expected state field %s to be an int, was %q", stateAttr, instanceState.Attributes[stateAttr])
-				}
-				match = apiData == stateData
-			case bool:
-				if _, ok := resp.Data[apiAttr]; !ok && instanceState.Attributes[stateAttr] == "" {
-					match = true
-				} else {
-					stateData, err := strconv.ParseBool(instanceState.Attributes[stateAttr])
-					if err != nil {
-						return fmt.Errorf("expected state field %s to be a bool, was %q", stateAttr, instanceState.Attributes[stateAttr])
-					}
-					match = resp.Data[apiAttr] == stateData
-				}
-			case []interface{}:
-				apiData := resp.Data[apiAttr].([]interface{})
-				length := instanceState.Attributes[stateAttr+".#"]
-				if length == "" {
-					if len(resp.Data[apiAttr].([]interface{})) != 0 {
-						return fmt.Errorf("expected state field %s to have %d entries, had 0", stateAttr, len(apiData))
-					}
-					match = true
-				} else {
-					count, err := strconv.Atoi(length)
-					if err != nil {
-						return fmt.Errorf("expected %s.# to be a number, got %q", stateAttr, instanceState.Attributes[stateAttr+".#"])
-					}
-					if count != len(apiData) {
-						return fmt.Errorf("expected %s to have %d entries in state, has %d", stateAttr, len(apiData), count)
-					}
-
-					for i := 0; i < count; i++ {
-						found := false
-						for stateKey, stateValue := range instanceState.Attributes {
-							if strings.HasPrefix(stateKey, stateAttr) {
-								if apiData[i] == stateValue {
-									found = true
-								}
-							}
-						}
-						if !found {
-							return fmt.Errorf("Expected item %d of %s (%s in state) of %q to be in state but wasn't", i, apiAttr, stateAttr, apiData[i])
-						}
-					}
-					match = true
-				}
-			default:
-				match = resp.Data[apiAttr] == instanceState.Attributes[stateAttr]
-			}
-			if !match {
-				return fmt.Errorf("expected %s (%s in state) of %q to be %q, got %q", apiAttr, stateAttr, path, instanceState.Attributes[stateAttr], resp.Data[apiAttr])
-			}
-		}
-		return nil
-	}
-}
-
-func testAccIdentityGroupPoliciesCheckLogical(resource string, policies []string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		resourceState := s.Modules[0].Resources[resource]
-		if resourceState == nil {
-			return fmt.Errorf("resource not found in state")
-		}
-
-		instanceState := resourceState.Primary
-		if instanceState == nil {
-			return fmt.Errorf("resource not found in state")
-		}
-
-		id := instanceState.ID
-
-		path := identityGroupIDPath(id)
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-		resp, err := client.Logical().Read(path)
-		if err != nil {
-			return fmt.Errorf("%q doesn't exist", path)
-		}
-
-		if resp.Data["policies"] == nil && policies == nil {
-			return nil
-		}
-
-		apiPolicies := resp.Data["policies"].([]interface{})
-
-		if len(apiPolicies) != len(policies) {
-			return fmt.Errorf("expected group %s to have %d policies, has %d", id, len(policies), len(apiPolicies))
-		}
-
-		for _, apiPolicyI := range apiPolicies {
-			apiPolicy := apiPolicyI.(string)
-
-			found := false
-			for _, policy := range policies {
-				if apiPolicy == policy {
-					found = true
-					break
-				}
+			if k == "policies" {
+				ta.IsSubset = isSubset
+				ta.AsSet = true
 			}
 
-			if !found {
-				return fmt.Errorf("unexpected policy %s in group %s", apiPolicy, id)
-			}
+			tAttrs = append(tAttrs, ta)
 		}
 
-		return nil
+		return testutil.AssertVaultState(client, s, path, tAttrs...)
 	}
 }
 

--- a/vault/resource_identity_group_test.go
+++ b/vault/resource_identity_group_test.go
@@ -1,7 +1,6 @@
 package vault
 
 import (
-	"encoding/json"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -19,6 +18,7 @@ import (
 func TestAccIdentityGroup(t *testing.T) {
 	group := acctest.RandomWithPrefix("test-group")
 
+	resourceName := "vault_identity_group.group"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
@@ -26,7 +26,7 @@ func TestAccIdentityGroup(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIdentityGroupConfig(group),
-				Check:  testAccIdentityGroupCheckAttrs(),
+				Check:  testAccIdentityGroupCheckAttrs(resourceName),
 			},
 		},
 	})
@@ -36,6 +36,7 @@ func TestAccIdentityGroupUpdate(t *testing.T) {
 	group := acctest.RandomWithPrefix("test-group")
 	entity := acctest.RandomWithPrefix("test-entity")
 
+	resourceName := "vault_identity_group.group"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
@@ -44,55 +45,55 @@ func TestAccIdentityGroupUpdate(t *testing.T) {
 			{
 				Config: testAccIdentityGroupConfig(group),
 				Check: resource.ComposeTestCheckFunc(
-					testAccIdentityGroupCheckAttrs(),
-					resource.TestCheckResourceAttr("vault_identity_group.group", "type", "external"),
-					resource.TestCheckResourceAttr("vault_identity_group.group", "policies.#", "1"),
-					resource.TestCheckResourceAttr("vault_identity_group.group", "policies.0", "test"),
-					resource.TestCheckResourceAttr("vault_identity_group.group", "metadata.version", "1"),
+					testAccIdentityGroupCheckAttrs(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "type", "external"),
+					resource.TestCheckResourceAttr(resourceName, "policies.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "policies.0", "test"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.version", "1"),
 				),
 			},
 			{
 				Config: testAccIdentityGroupConfigUpdate(group),
 				Check: resource.ComposeTestCheckFunc(
-					testAccIdentityGroupCheckAttrs(),
-					resource.TestCheckResourceAttr("vault_identity_group.group", "name", fmt.Sprintf("%s-2", group)),
-					resource.TestCheckResourceAttr("vault_identity_group.group", "type", "internal"),
-					resource.TestCheckResourceAttr("vault_identity_group.group", "metadata.version", "2"),
-					resource.TestCheckResourceAttr("vault_identity_group.group", "policies.#", "2"),
-					resource.TestCheckResourceAttr("vault_identity_group.group", "policies.0", "dev"),
-					resource.TestCheckResourceAttr("vault_identity_group.group", "policies.1", "test"),
-					resource.TestCheckResourceAttr("vault_identity_group.group", "member_entity_ids.#", "0"),
-					resource.TestCheckResourceAttr("vault_identity_group.group", "member_group_ids.#", "0"),
+					testAccIdentityGroupCheckAttrs(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s-2", group)),
+					resource.TestCheckResourceAttr(resourceName, "type", "internal"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.version", "2"),
+					resource.TestCheckResourceAttr(resourceName, "policies.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "policies.0", "dev"),
+					resource.TestCheckResourceAttr(resourceName, "policies.1", "test"),
+					resource.TestCheckResourceAttr(resourceName, "member_entity_ids.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "member_group_ids.#", "0"),
 				),
 			},
 			{
 				Config: testAccIdentityGroupConfigUpdateRemovePolicies(group),
 				Check: resource.ComposeTestCheckFunc(
-					testAccIdentityGroupCheckAttrs(),
-					resource.TestCheckResourceAttr("vault_identity_group.group", "type", "internal"),
-					resource.TestCheckResourceAttr("vault_identity_group.group", "policies.#", "0"),
+					testAccIdentityGroupCheckAttrs(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "type", "internal"),
+					resource.TestCheckResourceAttr(resourceName, "policies.#", "0"),
 				),
 			},
 			{
 				Config: testAccIdentityGroupConfigUpdateMembers(group, entity),
 				Check: resource.ComposeTestCheckFunc(
-					testAccIdentityGroupCheckAttrs(),
-					resource.TestCheckResourceAttr("vault_identity_group.group", "type", "internal"),
-					resource.TestCheckResourceAttr("vault_identity_group.group", "policies.#", "2"),
-					resource.TestCheckResourceAttr("vault_identity_group.group", "policies.0", "dev"),
-					resource.TestCheckResourceAttr("vault_identity_group.group", "policies.1", "test"),
-					resource.TestCheckResourceAttr("vault_identity_group.group", "member_entity_ids.#", "1"),
-					resource.TestCheckResourceAttr("vault_identity_group.group", "member_group_ids.#", "1"),
+					testAccIdentityGroupCheckAttrs(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "type", "internal"),
+					resource.TestCheckResourceAttr(resourceName, "policies.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "policies.0", "dev"),
+					resource.TestCheckResourceAttr(resourceName, "policies.1", "test"),
+					resource.TestCheckResourceAttr(resourceName, "member_entity_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "member_group_ids.#", "1"),
 				),
 			},
 			{
 				Config: testAccIdentityGroupConfigExternalMembers(group),
 				Check: resource.ComposeTestCheckFunc(
-					testAccIdentityGroupCheckAttrs(),
-					resource.TestCheckResourceAttr("vault_identity_group.group", "type", "external"),
-					resource.TestCheckResourceAttr("vault_identity_group.group", "policies.#", "1"),
-					resource.TestCheckResourceAttr("vault_identity_group.group", "member_entity_ids.#", "0"),
-					resource.TestCheckResourceAttr("vault_identity_group.group", "member_group_ids.#", "0"),
+					testAccIdentityGroupCheckAttrs(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "type", "external"),
+					resource.TestCheckResourceAttr(resourceName, "policies.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "member_entity_ids.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "member_group_ids.#", "0"),
 				),
 			},
 		},
@@ -102,6 +103,7 @@ func TestAccIdentityGroupUpdate(t *testing.T) {
 func TestAccIdentityGroupExternal(t *testing.T) {
 	group := acctest.RandomWithPrefix("test-group")
 
+	resourceName := "vault_identity_group.group"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
@@ -109,7 +111,7 @@ func TestAccIdentityGroupExternal(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIdentityGroupConfig(group),
-				Check:  testAccIdentityGroupCheckAttrs(),
+				Check:  testAccIdentityGroupCheckAttrs(resourceName),
 			},
 		},
 	})
@@ -166,98 +168,54 @@ func testAccCheckIdentityGroupDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccIdentityGroupCheckAttrs() resource.TestCheckFunc {
+func testAccIdentityGroupCheckAttrs(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		resourceState := s.Modules[0].Resources["vault_identity_group.group"]
-		if resourceState == nil {
-			return fmt.Errorf("resource not found in state")
-		}
-
-		instanceState := resourceState.Primary
-		if instanceState == nil {
-			return fmt.Errorf("resource not found in state")
-		}
-
-		id := instanceState.ID
-
-		path := identityGroupIDPath(id)
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-		resp, err := client.Logical().Read(path)
+		rs, err := testutil.GetResourceFromRootModule(s, resourceName)
 		if err != nil {
-			return fmt.Errorf("%q doesn't exist", path)
+			return err
 		}
+
+		extPolicies, err := strconv.ParseBool(rs.Primary.Attributes["external_policies"])
+		if err != nil {
+			return err
+		}
+
+		client, err := provider.GetClient(rs.Primary, testProvider.Meta())
+		if err != nil {
+			return err
+		}
+
+		id := rs.Primary.ID
+		path := identityGroupIDPath(id)
 
 		attrs := map[string]string{
 			"name":     "name",
 			"policies": "policies",
 			"type":     "type",
 		}
-		for stateAttr, apiAttr := range attrs {
-			if resp.Data[apiAttr] == nil && instanceState.Attributes[stateAttr] == "" {
-				continue
-			}
-			var match bool
-			switch resp.Data[apiAttr].(type) {
-			case json.Number:
-				apiData, err := resp.Data[apiAttr].(json.Number).Int64()
-				if err != nil {
-					return fmt.Errorf("expected API field %s to be an int, was %q", apiAttr, resp.Data[apiAttr])
-				}
-				stateData, err := strconv.ParseInt(instanceState.Attributes[stateAttr], 10, 64)
-				if err != nil {
-					return fmt.Errorf("expected state field %s to be an int, was %q", stateAttr, instanceState.Attributes[stateAttr])
-				}
-				match = apiData == stateData
-			case bool:
-				if _, ok := resp.Data[apiAttr]; !ok && instanceState.Attributes[stateAttr] == "" {
-					match = true
-				} else {
-					stateData, err := strconv.ParseBool(instanceState.Attributes[stateAttr])
-					if err != nil {
-						return fmt.Errorf("expected state field %s to be a bool, was %q", stateAttr, instanceState.Attributes[stateAttr])
-					}
-					match = resp.Data[apiAttr] == stateData
-				}
-			case []interface{}:
-				apiData := resp.Data[apiAttr].([]interface{})
-				length := instanceState.Attributes[stateAttr+".#"]
-				if length == "" {
-					if len(resp.Data[apiAttr].([]interface{})) != 0 {
-						return fmt.Errorf("expected state field %s to have %d entries, had 0", stateAttr, len(apiData))
-					}
-					match = true
-				} else {
-					count, err := strconv.Atoi(length)
-					if err != nil {
-						return fmt.Errorf("expected %s.# to be a number, got %q", stateAttr, instanceState.Attributes[stateAttr+".#"])
-					}
-					if count != len(apiData) {
-						return fmt.Errorf("expected %s to have %d entries in state, has %d", stateAttr, len(apiData), count)
-					}
 
-					for i := 0; i < count; i++ {
-						found := false
-						for stateKey, stateValue := range instanceState.Attributes {
-							if strings.HasPrefix(stateKey, stateAttr) {
-								if apiData[i] == stateValue {
-									found = true
-								}
-							}
-						}
-						if !found {
-							return fmt.Errorf("expected item %d of %s (%s in state) of %q to be in state but wasn't", i, apiAttr, stateAttr, apiData[i])
-						}
-					}
-					match = true
+		tAttrs := []*testutil.VaultStateTest{}
+		for k, v := range attrs {
+			ta := &testutil.VaultStateTest{
+				ResourceName: resourceName,
+				StateAttr:    k,
+				VaultAttr:    v,
+			}
+
+			// in the case of external policies it is possible that the resource_identity_group's policies are out of
+			// sync with vault, in the case where the group is resource created/updated within the same terraform
+			// apply operation. We can skip this test for now.
+			if k == "policies" {
+				if extPolicies {
+					continue
 				}
-			default:
-				match = resp.Data[apiAttr] == instanceState.Attributes[stateAttr]
+				ta.AsSet = true
 			}
-			if !match {
-				return fmt.Errorf("expected %s (%s in state) of %q to be %q, got %q", apiAttr, stateAttr, path, instanceState.Attributes[stateAttr], resp.Data[apiAttr])
-			}
+
+			tAttrs = append(tAttrs, ta)
 		}
-		return nil
+
+		return testutil.AssertVaultState(client, s, path, tAttrs...)
 	}
 }
 

--- a/vault/resource_identity_oidc_key_test.go
+++ b/vault/resource_identity_oidc_key_test.go
@@ -1,11 +1,8 @@
 package vault
 
 import (
-	"encoding/json"
 	"fmt"
 	"regexp"
-	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -19,6 +16,7 @@ import (
 func TestAccIdentityOidcKey(t *testing.T) {
 	key := acctest.RandomWithPrefix("test-key")
 
+	resourceName := "vault_identity_oidc_key.key"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
@@ -32,16 +30,16 @@ func TestAccIdentityOidcKey(t *testing.T) {
 			{
 				Config: testAccIdentityOidcKeyConfig(key),
 				Check: resource.ComposeTestCheckFunc(
-					testAccIdentityOidcKeyCheckAttrs(),
-					resource.TestCheckResourceAttr("vault_identity_oidc_key.key", "name", key),
-					resource.TestCheckResourceAttr("vault_identity_oidc_key.key", "rotation_period", "86400"),
-					resource.TestCheckResourceAttr("vault_identity_oidc_key.key", "verification_ttl", "86400"),
-					resource.TestCheckResourceAttr("vault_identity_oidc_key.key", "algorithm", "RS256"),
-					resource.TestCheckResourceAttr("vault_identity_oidc_key.key", "allowed_client_ids.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name", key),
+					resource.TestCheckResourceAttr(resourceName, "rotation_period", "86400"),
+					resource.TestCheckResourceAttr(resourceName, "verification_ttl", "86400"),
+					resource.TestCheckResourceAttr(resourceName, "algorithm", "RS256"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_client_ids.#", "0"),
+					testAccIdentityOidcKeyCheckAttrs(resourceName),
 				),
 			},
 			{
-				ResourceName:      "vault_identity_oidc_key.key",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -52,6 +50,7 @@ func TestAccIdentityOidcKey(t *testing.T) {
 func TestAccIdentityOidcKeyUpdate(t *testing.T) {
 	key := acctest.RandomWithPrefix("test-key")
 
+	resourceName := "vault_identity_oidc_key.key"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
@@ -59,28 +58,28 @@ func TestAccIdentityOidcKeyUpdate(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIdentityOidcKeyConfig(key),
-				Check:  testAccIdentityOidcKeyCheckAttrs(),
+				Check:  testAccIdentityOidcKeyCheckAttrs(resourceName),
 			},
 			{
 				Config: testAccIdentityOidcKeyConfigUpdate(key),
 				Check: resource.ComposeTestCheckFunc(
-					testAccIdentityOidcKeyCheckAttrs(),
-					resource.TestCheckResourceAttr("vault_identity_oidc_key.key", "name", key),
-					resource.TestCheckResourceAttr("vault_identity_oidc_key.key", "rotation_period", "3600"),
-					resource.TestCheckResourceAttr("vault_identity_oidc_key.key", "verification_ttl", "3600"),
-					resource.TestCheckResourceAttr("vault_identity_oidc_key.key", "algorithm", "ES256"),
-					resource.TestCheckResourceAttr("vault_identity_oidc_key.key", "allowed_client_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "name", key),
+					resource.TestCheckResourceAttr(resourceName, "rotation_period", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "verification_ttl", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "algorithm", "ES256"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_client_ids.#", "1"),
+					testAccIdentityOidcKeyCheckAttrs(resourceName),
 				),
 			},
 			{
 				Config: testAccIdentityOidcKeyConfig(key),
 				Check: resource.ComposeTestCheckFunc(
-					testAccIdentityOidcKeyCheckAttrs(),
-					resource.TestCheckResourceAttr("vault_identity_oidc_key.key", "name", key),
-					resource.TestCheckResourceAttr("vault_identity_oidc_key.key", "rotation_period", "86400"),
-					resource.TestCheckResourceAttr("vault_identity_oidc_key.key", "verification_ttl", "86400"),
-					resource.TestCheckResourceAttr("vault_identity_oidc_key.key", "algorithm", "RS256"),
-					resource.TestCheckResourceAttr("vault_identity_oidc_key.key", "allowed_client_ids.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "name", key),
+					resource.TestCheckResourceAttr(resourceName, "rotation_period", "86400"),
+					resource.TestCheckResourceAttr(resourceName, "verification_ttl", "86400"),
+					resource.TestCheckResourceAttr(resourceName, "algorithm", "RS256"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_client_ids.#", "0"),
+					testAccIdentityOidcKeyCheckAttrs(resourceName),
 				),
 			},
 			{
@@ -110,25 +109,19 @@ func testAccCheckIdentityOidcKeyDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccIdentityOidcKeyCheckAttrs() resource.TestCheckFunc {
+func testAccIdentityOidcKeyCheckAttrs(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		resourceState := s.Modules[0].Resources["vault_identity_oidc_key.key"]
-		if resourceState == nil {
-			return fmt.Errorf("resource not found in state")
-		}
-
-		instanceState := resourceState.Primary
-		if instanceState == nil {
-			return fmt.Errorf("resource not found in state")
-		}
-
-		id := instanceState.ID
-		path := identityOidcKeyPath(id)
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-		resp, err := identityOidcKeyApiRead(id, client)
+		rs, err := testutil.GetResourceFromRootModule(s, resourceName)
 		if err != nil {
-			return fmt.Errorf("%q doesn't exist", id)
+			return err
 		}
+
+		client, err := provider.GetClient(rs.Primary, testProvider.Meta())
+		if err != nil {
+			return err
+		}
+
+		path := identityOidcKeyPath(rs.Primary.ID)
 
 		attrs := map[string]string{
 			"rotation_period":    "rotation_period",
@@ -136,73 +129,19 @@ func testAccIdentityOidcKeyCheckAttrs() resource.TestCheckFunc {
 			"algorithm":          "algorithm",
 			"allowed_client_ids": "allowed_client_ids",
 		}
-		for stateAttr, apiAttr := range attrs {
-			if resp[apiAttr] == nil && instanceState.Attributes[stateAttr] == "" {
-				continue
-			}
-			var match bool
-			switch resp[apiAttr].(type) {
-			case json.Number:
-				apiData, err := resp[apiAttr].(json.Number).Int64()
-				if err != nil {
-					return fmt.Errorf("expected API field %s to be an int, was %q", apiAttr, resp[apiAttr])
-				}
-				stateData, err := strconv.ParseInt(instanceState.Attributes[stateAttr], 10, 64)
-				if err != nil {
-					return fmt.Errorf("expected state field %s to be an int, was %q", stateAttr, instanceState.Attributes[stateAttr])
-				}
-				match = apiData == stateData
-			case bool:
-				if _, ok := resp[apiAttr]; !ok && instanceState.Attributes[stateAttr] == "" {
-					match = true
-				} else {
-					stateData, err := strconv.ParseBool(instanceState.Attributes[stateAttr])
-					if err != nil {
-						return fmt.Errorf("expected state field %s to be a bool, was %q", stateAttr, instanceState.Attributes[stateAttr])
-					}
-					match = resp[apiAttr] == stateData
-				}
-			case []interface{}:
-				apiData := resp[apiAttr].([]interface{})
-				length := instanceState.Attributes[stateAttr+".#"]
-				if length == "" {
-					if len(resp[apiAttr].([]interface{})) != 0 {
-						return fmt.Errorf("expected state field %s to have %d entries, had 0", stateAttr, len(apiData))
-					}
-					match = true
-				} else {
-					count, err := strconv.Atoi(length)
-					if err != nil {
-						return fmt.Errorf("expected %s.# to be a number, got %q", stateAttr, instanceState.Attributes[stateAttr+".#"])
-					}
-					if count != len(apiData) {
-						return fmt.Errorf("expected %s to have %d entries in state, has %d", stateAttr, len(apiData), count)
-					}
 
-					for i := 0; i < count; i++ {
-						found := false
-						for stateKey, stateValue := range instanceState.Attributes {
-							if strings.HasPrefix(stateKey, stateAttr) {
-								if apiData[i] == stateValue {
-									found = true
-									break
-								}
-							}
-						}
-						if !found {
-							return fmt.Errorf("Expected item %d of %s (%s in state) of %q to be in state but wasn't", i, apiAttr, stateAttr, apiData[i])
-						}
-					}
-					match = true
-				}
-			default:
-				match = resp[apiAttr] == instanceState.Attributes[stateAttr]
+		tAttrs := []*testutil.VaultStateTest{}
+		for k, v := range attrs {
+			ta := &testutil.VaultStateTest{
+				ResourceName: resourceName,
+				StateAttr:    k,
+				VaultAttr:    v,
 			}
-			if !match {
-				return fmt.Errorf("expected %s (%s in state) of %q to be %q, got %q", apiAttr, stateAttr, path, instanceState.Attributes[stateAttr], resp[apiAttr])
-			}
+
+			tAttrs = append(tAttrs, ta)
 		}
-		return nil
+
+		return testutil.AssertVaultState(client, s, path, tAttrs...)
 	}
 }
 

--- a/vault/resource_identity_oidc_role_test.go
+++ b/vault/resource_identity_oidc_role_test.go
@@ -1,10 +1,7 @@
 package vault
 
 import (
-	"encoding/json"
 	"fmt"
-	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -22,6 +19,7 @@ const testAccIdentityOidcRoleTemplate = `{
 func TestAccIdentityOidcRole(t *testing.T) {
 	name := acctest.RandomWithPrefix("test-role")
 
+	resourceName := "vault_identity_oidc_role.role"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
@@ -30,15 +28,15 @@ func TestAccIdentityOidcRole(t *testing.T) {
 			{
 				Config: testAccIdentityOidcRoleConfig(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccIdentityOidcRoleCheckAttrs(),
-					resource.TestCheckResourceAttr("vault_identity_oidc_role.role", "name", name),
-					resource.TestCheckResourceAttr("vault_identity_oidc_role.role", "key", name),
-					resource.TestCheckResourceAttr("vault_identity_oidc_role.role", "template", ""),
-					resource.TestCheckResourceAttr("vault_identity_oidc_role.role", "ttl", "86400"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "key", name),
+					resource.TestCheckResourceAttr(resourceName, "template", ""),
+					resource.TestCheckResourceAttr(resourceName, "ttl", "86400"),
+					testAccIdentityOidcRoleCheckAttrs(resourceName),
 				),
 			},
 			{
-				ResourceName:      "vault_identity_oidc_role.role",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -50,6 +48,7 @@ func TestAccIdentityOidcRoleWithClientId(t *testing.T) {
 	name := acctest.RandomWithPrefix("test-role")
 	clientId := acctest.RandomWithPrefix("test-client-id")
 
+	resourceName := "vault_identity_oidc_role.role"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
@@ -58,16 +57,16 @@ func TestAccIdentityOidcRoleWithClientId(t *testing.T) {
 			{
 				Config: testAccIdentityOidcRoleWithClientIdConfig(name, clientId),
 				Check: resource.ComposeTestCheckFunc(
-					testAccIdentityOidcRoleCheckAttrs(),
-					resource.TestCheckResourceAttr("vault_identity_oidc_role.role", "name", name),
-					resource.TestCheckResourceAttr("vault_identity_oidc_role.role", "key", name),
-					resource.TestCheckResourceAttr("vault_identity_oidc_role.role", "template", ""),
-					resource.TestCheckResourceAttr("vault_identity_oidc_role.role", "client_id", clientId),
-					resource.TestCheckResourceAttr("vault_identity_oidc_role.role", "ttl", "86400"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "key", name),
+					resource.TestCheckResourceAttr(resourceName, "template", ""),
+					resource.TestCheckResourceAttr(resourceName, "client_id", clientId),
+					resource.TestCheckResourceAttr(resourceName, "ttl", "86400"),
+					testAccIdentityOidcRoleCheckAttrs(resourceName),
 				),
 			},
 			{
-				ResourceName:      "vault_identity_oidc_role.role",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -80,6 +79,7 @@ func TestAccIdentityOidcRoleUpdate(t *testing.T) {
 	clientId := acctest.RandomWithPrefix("test-client-id")
 	updateClientId := acctest.RandomWithPrefix("test-update-client-id")
 
+	resourceName := "vault_identity_oidc_role.role"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
@@ -87,28 +87,28 @@ func TestAccIdentityOidcRoleUpdate(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccIdentityOidcRoleWithClientIdConfig(name, clientId),
-				Check:  testAccIdentityOidcRoleCheckAttrs(),
+				Check:  testAccIdentityOidcRoleCheckAttrs(resourceName),
 			},
 			{
 				Config: testAccIdentityOidcRoleConfigUpdate(name, updateClientId),
 				Check: resource.ComposeTestCheckFunc(
-					testAccIdentityOidcRoleCheckAttrs(),
-					resource.TestCheckResourceAttr("vault_identity_oidc_role.role", "name", name),
-					resource.TestCheckResourceAttr("vault_identity_oidc_role.role", "key", name),
-					resource.TestCheckResourceAttr("vault_identity_oidc_role.role", "template", fmt.Sprintf("%s\n", testAccIdentityOidcRoleTemplate)),
-					resource.TestCheckResourceAttr("vault_identity_oidc_role.role", "client_id", updateClientId),
-					resource.TestCheckResourceAttr("vault_identity_oidc_role.role", "ttl", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "key", name),
+					resource.TestCheckResourceAttr(resourceName, "template", fmt.Sprintf("%s\n", testAccIdentityOidcRoleTemplate)),
+					resource.TestCheckResourceAttr(resourceName, "client_id", updateClientId),
+					resource.TestCheckResourceAttr(resourceName, "ttl", "3600"),
+					testAccIdentityOidcRoleCheckAttrs(resourceName),
 				),
 			},
 			{
 				Config: testAccIdentityOidcRoleWithClientIdConfig(name, clientId),
 				Check: resource.ComposeTestCheckFunc(
-					testAccIdentityOidcRoleCheckAttrs(),
-					resource.TestCheckResourceAttr("vault_identity_oidc_role.role", "name", name),
-					resource.TestCheckResourceAttr("vault_identity_oidc_role.role", "key", name),
-					resource.TestCheckResourceAttr("vault_identity_oidc_role.role", "template", ""),
-					resource.TestCheckResourceAttr("vault_identity_oidc_role.role", "client_id", clientId),
-					resource.TestCheckResourceAttr("vault_identity_oidc_role.role", "ttl", "86400"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "key", name),
+					resource.TestCheckResourceAttr(resourceName, "template", ""),
+					resource.TestCheckResourceAttr(resourceName, "client_id", clientId),
+					resource.TestCheckResourceAttr(resourceName, "ttl", "86400"),
+					testAccIdentityOidcRoleCheckAttrs(resourceName),
 				),
 			},
 		},
@@ -133,26 +133,19 @@ func testAccCheckIdentityOidcRoleDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccIdentityOidcRoleCheckAttrs() resource.TestCheckFunc {
+func testAccIdentityOidcRoleCheckAttrs(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		resourceState := s.Modules[0].Resources["vault_identity_oidc_role.role"]
-		if resourceState == nil {
-			return fmt.Errorf("resource not found in state")
-		}
-
-		instanceState := resourceState.Primary
-		if instanceState == nil {
-			return fmt.Errorf("resource not found in state")
-		}
-
-		id := instanceState.ID
-
-		path := identityOidcRolePath(id)
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-		resp, err := client.Logical().Read(path)
+		rs, err := testutil.GetResourceFromRootModule(s, resourceName)
 		if err != nil {
-			return fmt.Errorf("%q doesn't exist", path)
+			return err
 		}
+
+		client, err := provider.GetClient(rs.Primary, testProvider.Meta())
+		if err != nil {
+			return err
+		}
+
+		path := identityOidcRolePath(rs.Primary.ID)
 
 		attrs := map[string]string{
 			"key":       "key",
@@ -160,73 +153,19 @@ func testAccIdentityOidcRoleCheckAttrs() resource.TestCheckFunc {
 			"ttl":       "ttl",
 			"client_id": "client_id",
 		}
-		for stateAttr, apiAttr := range attrs {
-			if resp.Data[apiAttr] == nil && instanceState.Attributes[stateAttr] == "" {
-				continue
-			}
-			var match bool
-			switch resp.Data[apiAttr].(type) {
-			case json.Number:
-				apiData, err := resp.Data[apiAttr].(json.Number).Int64()
-				if err != nil {
-					return fmt.Errorf("expected API field %s to be an int, was %q", apiAttr, resp.Data[apiAttr])
-				}
-				stateData, err := strconv.ParseInt(instanceState.Attributes[stateAttr], 10, 64)
-				if err != nil {
-					return fmt.Errorf("expected state field %s to be an int, was %q", stateAttr, instanceState.Attributes[stateAttr])
-				}
-				match = apiData == stateData
-			case bool:
-				if _, ok := resp.Data[apiAttr]; !ok && instanceState.Attributes[stateAttr] == "" {
-					match = true
-				} else {
-					stateData, err := strconv.ParseBool(instanceState.Attributes[stateAttr])
-					if err != nil {
-						return fmt.Errorf("expected state field %s to be a bool, was %q", stateAttr, instanceState.Attributes[stateAttr])
-					}
-					match = resp.Data[apiAttr] == stateData
-				}
-			case []interface{}:
-				apiData := resp.Data[apiAttr].([]interface{})
-				length := instanceState.Attributes[stateAttr+".#"]
-				if length == "" {
-					if len(resp.Data[apiAttr].([]interface{})) != 0 {
-						return fmt.Errorf("expected state field %s to have %d entries, had 0", stateAttr, len(apiData))
-					}
-					match = true
-				} else {
-					count, err := strconv.Atoi(length)
-					if err != nil {
-						return fmt.Errorf("expected %s.# to be a number, got %q", stateAttr, instanceState.Attributes[stateAttr+".#"])
-					}
-					if count != len(apiData) {
-						return fmt.Errorf("expected %s to have %d entries in state, has %d", stateAttr, len(apiData), count)
-					}
 
-					for i := 0; i < count; i++ {
-						found := false
-						for stateKey, stateValue := range instanceState.Attributes {
-							if strings.HasPrefix(stateKey, stateAttr) {
-								if apiData[i] == stateValue {
-									found = true
-									break
-								}
-							}
-						}
-						if !found {
-							return fmt.Errorf("Expected item %d of %s (%s in state) of %q to be in state but wasn't", i, apiAttr, stateAttr, apiData[i])
-						}
-					}
-					match = true
-				}
-			default:
-				match = resp.Data[apiAttr] == instanceState.Attributes[stateAttr]
+		tAttrs := []*testutil.VaultStateTest{}
+		for k, v := range attrs {
+			ta := &testutil.VaultStateTest{
+				ResourceName: resourceName,
+				StateAttr:    k,
+				VaultAttr:    v,
 			}
-			if !match {
-				return fmt.Errorf("expected %s (%s in state) of %q to be %q, got %q", apiAttr, stateAttr, path, instanceState.Attributes[stateAttr], resp.Data[apiAttr])
-			}
+
+			tAttrs = append(tAttrs, ta)
 		}
-		return nil
+
+		return testutil.AssertVaultState(client, s, path, tAttrs...)
 	}
 }
 

--- a/vault/resource_identity_oidc_test.go
+++ b/vault/resource_identity_oidc_test.go
@@ -1,10 +1,7 @@
 package vault
 
 import (
-	"encoding/json"
 	"fmt"
-	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -18,6 +15,7 @@ func TestAccIdentityOidc(t *testing.T) {
 	issuer := "https://www.acme.com"
 	issuerNew := "https://www.acme-two.com"
 
+	const resourceName = "vault_identity_oidc.server"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
@@ -26,15 +24,15 @@ func TestAccIdentityOidc(t *testing.T) {
 			{
 				Config: testAccIdentityOidcConfig(issuer),
 				Check: resource.ComposeTestCheckFunc(
-					testAccIdentityOidcCheckAttrs(),
-					resource.TestCheckResourceAttr("vault_identity_oidc.server", "issuer", issuer),
+					resource.TestCheckResourceAttr(resourceName, "issuer", issuer),
+					testAccIdentityOidcCheckAttrs(resourceName),
 				),
 			},
 			{
 				Config: testAccIdentityOidcConfig(issuerNew),
 				Check: resource.ComposeTestCheckFunc(
-					testAccIdentityOidcCheckAttrs(),
-					resource.TestCheckResourceAttr("vault_identity_oidc.server", "issuer", issuerNew),
+					testAccIdentityOidcCheckAttrs(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "issuer", issuerNew),
 				),
 			},
 		},
@@ -60,95 +58,36 @@ func testAccCheckIdentityOidcDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccIdentityOidcCheckAttrs() resource.TestCheckFunc {
+func testAccIdentityOidcCheckAttrs(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		resourceState := s.Modules[0].Resources["vault_identity_oidc.server"]
-		if resourceState == nil {
-			return fmt.Errorf("resource not found in state")
+		rs, err := testutil.GetResourceFromRootModule(s, resourceName)
+		if err != nil {
+			return err
 		}
 
-		instanceState := resourceState.Primary
-		if instanceState == nil {
-			return fmt.Errorf("resource not found in state")
+		client, err := provider.GetClient(rs.Primary, testProvider.Meta())
+		if err != nil {
+			return err
 		}
 
 		path := identityOidcPathTemplate
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-		resp, err := client.Logical().Read(path)
-		if err != nil {
-			return fmt.Errorf("%q doesn't exist", path)
-		}
 
 		attrs := map[string]string{
 			"issuer": "issuer",
 		}
-		for stateAttr, apiAttr := range attrs {
-			if resp.Data[apiAttr] == nil && instanceState.Attributes[stateAttr] == "" {
-				continue
-			}
-			var match bool
-			switch resp.Data[apiAttr].(type) {
-			case json.Number:
-				apiData, err := resp.Data[apiAttr].(json.Number).Int64()
-				if err != nil {
-					return fmt.Errorf("expected API field %s to be an int, was %q", apiAttr, resp.Data[apiAttr])
-				}
-				stateData, err := strconv.ParseInt(instanceState.Attributes[stateAttr], 10, 64)
-				if err != nil {
-					return fmt.Errorf("expected state field %s to be an int, was %q", stateAttr, instanceState.Attributes[stateAttr])
-				}
-				match = apiData == stateData
-			case bool:
-				if _, ok := resp.Data[apiAttr]; !ok && instanceState.Attributes[stateAttr] == "" {
-					match = true
-				} else {
-					stateData, err := strconv.ParseBool(instanceState.Attributes[stateAttr])
-					if err != nil {
-						return fmt.Errorf("expected state field %s to be a bool, was %q", stateAttr, instanceState.Attributes[stateAttr])
-					}
-					match = resp.Data[apiAttr] == stateData
-				}
-			case []interface{}:
-				apiData := resp.Data[apiAttr].([]interface{})
-				length := instanceState.Attributes[stateAttr+".#"]
-				if length == "" {
-					if len(resp.Data[apiAttr].([]interface{})) != 0 {
-						return fmt.Errorf("expected state field %s to have %d entries, had 0", stateAttr, len(apiData))
-					}
-					match = true
-				} else {
-					count, err := strconv.Atoi(length)
-					if err != nil {
-						return fmt.Errorf("expected %s.# to be a number, got %q", stateAttr, instanceState.Attributes[stateAttr+".#"])
-					}
-					if count != len(apiData) {
-						return fmt.Errorf("expected %s to have %d entries in state, has %d", stateAttr, len(apiData), count)
-					}
 
-					for i := 0; i < count; i++ {
-						found := false
-						for stateKey, stateValue := range instanceState.Attributes {
-							if strings.HasPrefix(stateKey, stateAttr) {
-								if apiData[i] == stateValue {
-									found = true
-									break
-								}
-							}
-						}
-						if !found {
-							return fmt.Errorf("Expected item %d of %s (%s in state) of %q to be in state but wasn't", i, apiAttr, stateAttr, apiData[i])
-						}
-					}
-					match = true
-				}
-			default:
-				match = resp.Data[apiAttr] == instanceState.Attributes[stateAttr]
+		tAttrs := []*testutil.VaultStateTest{}
+		for k, v := range attrs {
+			ta := &testutil.VaultStateTest{
+				ResourceName: resourceName,
+				StateAttr:    k,
+				VaultAttr:    v,
 			}
-			if !match {
-				return fmt.Errorf("expected %s (%s in state) of %q to be %q, got %q", apiAttr, stateAttr, path, instanceState.Attributes[stateAttr], resp.Data[apiAttr])
-			}
+
+			tAttrs = append(tAttrs, ta)
 		}
-		return nil
+
+		return testutil.AssertVaultState(client, s, path, tAttrs...)
 	}
 }
 

--- a/vault/resource_ldap_auth_backend_user_test.go
+++ b/vault/resource_ldap_auth_backend_user_test.go
@@ -1,9 +1,7 @@
 package vault
 
 import (
-	"encoding/json"
 	"fmt"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -15,41 +13,6 @@ import (
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 	"github.com/hashicorp/terraform-provider-vault/util"
 )
-
-func TestLDAPAuthBackendUser_import(t *testing.T) {
-	backend := acctest.RandomWithPrefix("tf-test-ldap-backend")
-	username := acctest.RandomWithPrefix("tf-test-ldap-user")
-
-	policies := []string{
-		acctest.RandomWithPrefix("policy"),
-		acctest.RandomWithPrefix("policy"),
-	}
-
-	groups := []string{
-		acctest.RandomWithPrefix("group"),
-		acctest.RandomWithPrefix("group"),
-	}
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testutil.TestAccPreCheck(t) },
-		Providers:    testProviders,
-		CheckDestroy: testLDAPAuthBackendUserDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testLDAPAuthBackendUserConfig_basic(backend, username, policies, groups),
-				Check: resource.ComposeTestCheckFunc(
-					testLDAPAuthBackendUserCheck_attrs(backend, username),
-					testLDAPAuthBackendUserCheck_groups(backend, username, groups),
-				),
-			},
-			{
-				ResourceName:      "vault_ldap_auth_backend_user.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
 
 func TestLDAPAuthBackendUser_basic(t *testing.T) {
 	backend := acctest.RandomWithPrefix("tf-test-ldap-backend")
@@ -65,6 +28,7 @@ func TestLDAPAuthBackendUser_basic(t *testing.T) {
 		acctest.RandomWithPrefix("group"),
 	}
 
+	resourceName := "vault_ldap_auth_backend_user.test"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
@@ -73,9 +37,13 @@ func TestLDAPAuthBackendUser_basic(t *testing.T) {
 			{
 				Config: testLDAPAuthBackendUserConfig_basic(backend, username, policies, groups),
 				Check: resource.ComposeTestCheckFunc(
-					testLDAPAuthBackendUserCheck_attrs(backend, username),
-					testLDAPAuthBackendUserCheck_groups(backend, username, groups),
+					testLDAPAuthBackendUserCheck_attrs(resourceName, backend, username),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -85,10 +53,10 @@ func TestLDAPAuthBackendUser_noGroups(t *testing.T) {
 	backend := acctest.RandomWithPrefix("tf-test-ldap-backend")
 	username := acctest.RandomWithPrefix("tf-test-ldap-user")
 
-	policies := []string{}
+	var policies []string
+	var groups []string
 
-	groups := []string{}
-
+	resourceName := "vault_ldap_auth_backend_user.test"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
@@ -97,9 +65,13 @@ func TestLDAPAuthBackendUser_noGroups(t *testing.T) {
 			{
 				Config: testLDAPAuthBackendUserConfig_basic(backend, username, policies, groups),
 				Check: resource.ComposeTestCheckFunc(
-					testLDAPAuthBackendUserCheck_attrs(backend, username),
-					testLDAPAuthBackendUserCheck_groups(backend, username, groups),
+					testLDAPAuthBackendUserCheck_attrs(resourceName, backend, username),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -109,12 +81,12 @@ func TestLDAPAuthBackendUser_oneGroup(t *testing.T) {
 	backend := acctest.RandomWithPrefix("tf-test-ldap-backend")
 	username := acctest.RandomWithPrefix("tf-test-ldap-user")
 
-	policies := []string{}
-
+	var policies []string
 	groups := []string{
 		acctest.RandomWithPrefix("group"),
 	}
 
+	resourceName := "vault_ldap_auth_backend_user.test"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		Providers:    testProviders,
@@ -123,9 +95,13 @@ func TestLDAPAuthBackendUser_oneGroup(t *testing.T) {
 			{
 				Config: testLDAPAuthBackendUserConfig_basic(backend, username, policies, groups),
 				Check: resource.ComposeTestCheckFunc(
-					testLDAPAuthBackendUserCheck_attrs(backend, username),
-					testLDAPAuthBackendUserCheck_groups(backend, username, groups),
+					testLDAPAuthBackendUserCheck_attrs(resourceName, backend, username),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -149,75 +125,24 @@ func testLDAPAuthBackendUserDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testLDAPAuthBackendUserCheck_groups(backend, username string, groups []string) resource.TestCheckFunc {
+func testLDAPAuthBackendUserCheck_attrs(resourceName, backend, username string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		resourceState := s.Modules[0].Resources["vault_ldap_auth_backend_user.test"]
-		if resourceState == nil {
-			return fmt.Errorf("resource not found in state")
-		}
-
-		instanceState := resourceState.Primary
-		if instanceState == nil {
-			return fmt.Errorf("resource has no primary instance")
-		}
-
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-		resp, err := client.Logical().Read(instanceState.ID)
+		rs, err := testutil.GetResourceFromRootModule(s, resourceName)
 		if err != nil {
 			return err
 		}
 
-		vaultGroups := []string{}
-		if resp.Data["groups"].(string) != "" {
-			for _, group := range strings.Split(resp.Data["groups"].(string), ",") {
-				vaultGroups = append(vaultGroups, group)
-			}
-		}
-
-		count, err := strconv.Atoi(instanceState.Attributes["groups.#"])
-		if err != nil {
-			return err
-		}
-		if len(vaultGroups) != count {
-			return fmt.Errorf("saw %d groups on server, expected %d", len(vaultGroups), count)
-		}
-
-		for _, group := range vaultGroups {
-			found := false
-			for stateKey, stateValue := range instanceState.Attributes {
-				if strings.HasPrefix(stateKey, "groups.") {
-					if stateValue == group {
-						found = true
-						break
-					}
-				}
-			}
-			if !found {
-				return fmt.Errorf("unable to find group %s in state file", group)
-			}
-		}
-		return nil
-	}
-}
-
-func testLDAPAuthBackendUserCheck_attrs(backend, username string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		resourceState := s.Modules[0].Resources["vault_ldap_auth_backend_user.test"]
-		if resourceState == nil {
-			return fmt.Errorf("resource not found in state")
-		}
-
-		instanceState := resourceState.Primary
-		if instanceState == nil {
-			return fmt.Errorf("resource has no primary instance")
-		}
-
+		path := rs.Primary.ID
 		endpoint := "auth/" + strings.Trim(backend, "/") + "/users/" + username
-		if endpoint != instanceState.ID {
-			return fmt.Errorf("expected ID to be %q, got %q instead", endpoint, instanceState.ID)
+		if endpoint != path {
+			return fmt.Errorf("expected id to be %q, got %q instead", endpoint, path)
 		}
 
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		client, err := provider.GetClient(rs.Primary, testProvider.Meta())
+		if err != nil {
+			return err
+		}
+
 		authMounts, err := client.Sys().ListAuth()
 		if err != nil {
 			return err
@@ -232,86 +157,27 @@ func testLDAPAuthBackendUserCheck_attrs(backend, username string) resource.TestC
 			return fmt.Errorf("incorrect mount type: %s", authMount.Type)
 		}
 
-		resp, err := client.Logical().Read(instanceState.ID)
-		if err != nil {
-			return err
-		}
-
 		attrs := map[string]string{
 			"policies": "policies",
+			"groups":   "groups",
 		}
 
-		for stateAttr, apiAttr := range attrs {
-			if resp.Data[apiAttr] == nil && instanceState.Attributes[stateAttr] == "" {
-				continue
-			}
-			var match bool
-			switch resp.Data[apiAttr].(type) {
-			case json.Number:
-				apiData, err := resp.Data[apiAttr].(json.Number).Int64()
-				if err != nil {
-					return fmt.Errorf("expected api field %s to be an int, was %q", apiAttr, resp.Data[apiAttr])
-				}
-				stateData, err := strconv.ParseInt(instanceState.Attributes[stateAttr], 10, 64)
-				if err != nil {
-					return fmt.Errorf("expected state field %s to be an int, was %q", stateAttr, instanceState.Attributes[stateAttr])
-				}
-				match = apiData == stateData
-			case bool:
-				if _, ok := resp.Data[apiAttr]; !ok && instanceState.Attributes[stateAttr] == "" {
-					match = true
-				} else {
-					stateData, err := strconv.ParseBool(instanceState.Attributes[stateAttr])
-					if err != nil {
-						return fmt.Errorf("expected state field %s to be a bool, was %q", stateAttr, instanceState.Attributes[stateAttr])
-					}
-					match = resp.Data[apiAttr] == stateData
-				}
-
-			case []interface{}:
-				apiData := resp.Data[apiAttr].([]interface{})
-				length := instanceState.Attributes[stateAttr+".#"]
-				if length == "" {
-					if len(resp.Data[apiAttr].([]interface{})) != 0 {
-						return fmt.Errorf("expected state field %s to have %d entries, had 0", stateAttr, len(apiData))
-					}
-					match = true
-				} else {
-					count, err := strconv.Atoi(length)
-					if err != nil {
-						return fmt.Errorf("expected %s.# to be a number, got %q", stateAttr, instanceState.Attributes[stateAttr+".#"])
-					}
-					if count != len(apiData) {
-						return fmt.Errorf("expected %s to have %d entries in state, has %d", stateAttr, len(apiData), count)
-					}
-
-					for i := 0; i < count; i++ {
-						found := false
-						for stateKey, stateValue := range instanceState.Attributes {
-							if strings.HasPrefix(stateKey, stateAttr) {
-								if apiData[i] == stateValue {
-									found = true
-									break
-								}
-							}
-						}
-						if !found {
-							return fmt.Errorf("expected item %d of %s (%s in state) of %q to be in state but wasn't", i, apiAttr, stateAttr, endpoint)
-						}
-					}
-					match = true
-				}
-			default:
-				match = resp.Data[apiAttr] == instanceState.Attributes[stateAttr]
-
-			}
-			if !match {
-				return fmt.Errorf("expected %s (%s in state) of %q to be %q, got %q", apiAttr, stateAttr, endpoint, instanceState.Attributes[stateAttr], resp.Data[apiAttr])
+		tAttrs := []*testutil.VaultStateTest{}
+		for k, v := range attrs {
+			ta := &testutil.VaultStateTest{
+				ResourceName: resourceName,
+				StateAttr:    k,
+				VaultAttr:    v,
 			}
 
+			if k == "groups" {
+				ta.TransformVaultValue = testutil.SplitVaultValueString
+			}
+
+			tAttrs = append(tAttrs, ta)
 		}
 
-		return nil
+		return testutil.AssertVaultState(client, s, path, tAttrs...)
 	}
 }
 

--- a/vault/resource_pki_secret_backend_cert_test.go
+++ b/vault/resource_pki_secret_backend_cert_test.go
@@ -307,7 +307,7 @@ resource "vault_pki_secret_backend_cert" "test" {
 
 func testCapturePKICert(resourceName string, store *testPKICertStore) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, err := testGetResourceFromRootModule(s, resourceName)
+		rs, err := testutil.GetResourceFromRootModule(s, resourceName)
 		if err != nil {
 			return err
 		}
@@ -411,7 +411,7 @@ func testPKICertRevocation(path string, store *testPKICertStore) resource.TestCh
 
 func testPKICertReIssued(resourceName string, store *testPKICertStore) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, err := testGetResourceFromRootModule(s, resourceName)
+		rs, err := testutil.GetResourceFromRootModule(s, resourceName)
 		if err != nil {
 			return err
 		}
@@ -425,12 +425,4 @@ func testPKICertReIssued(resourceName string, store *testPKICertStore) resource.
 
 		return nil
 	}
-}
-
-func testGetResourceFromRootModule(s *terraform.State, resourceName string) (*terraform.ResourceState, error) {
-	if rs, ok := s.RootModule().Resources[resourceName]; ok {
-		return rs, nil
-	}
-
-	return nil, fmt.Errorf("expected resource %q, not found in state", resourceName)
 }

--- a/vault/resource_pki_secret_backend_sign_test.go
+++ b/vault/resource_pki_secret_backend_sign_test.go
@@ -300,7 +300,7 @@ EOT
 
 func testValidateCSR(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, err := testGetResourceFromRootModule(s, resourceName)
+		rs, err := testutil.GetResourceFromRootModule(s, resourceName)
 		if err != nil {
 			return err
 		}

--- a/vault/resource_token_auth_backend_role_test.go
+++ b/vault/resource_token_auth_backend_role_test.go
@@ -1,10 +1,7 @@
 package vault
 
 import (
-	"encoding/json"
 	"fmt"
-	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -26,7 +23,7 @@ func TestAccTokenAuthBackendRole(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTokenAuthBackendRoleConfig(role),
-				Check:  testAccTokenAuthBackendRoleCheck_attrs(role),
+				Check:  testAccTokenAuthBackendRoleCheck_attrs(resourceName, role),
 			},
 			{
 				ResourceName:      resourceName,
@@ -49,12 +46,12 @@ func TestAccTokenAuthBackendRoleUpdate(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTokenAuthBackendRoleConfig(role),
-				Check:  testAccTokenAuthBackendRoleCheck_attrs(role),
+				Check:  testAccTokenAuthBackendRoleCheck_attrs(resourceName, role),
 			},
 			{
 				Config: testAccTokenAuthBackendRoleConfigUpdate(role),
 				Check: resource.ComposeTestCheckFunc(
-					testAccTokenAuthBackendRoleCheck_attrs(role),
+					testAccTokenAuthBackendRoleCheck_attrs(resourceName, role),
 					resource.TestCheckResourceAttr(resourceName, "role_name", role),
 					resource.TestCheckResourceAttr(resourceName, "allowed_policies.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "allowed_policies.0", "dev"),
@@ -81,7 +78,7 @@ func TestAccTokenAuthBackendRoleUpdate(t *testing.T) {
 			{
 				Config: testAccTokenAuthBackendRoleConfigUpdate(roleUpdated),
 				Check: resource.ComposeTestCheckFunc(
-					testAccTokenAuthBackendRoleCheck_attrs(roleUpdated),
+					testAccTokenAuthBackendRoleCheck_attrs(resourceName, roleUpdated),
 					testAccTokenAuthBackendRoleCheck_deleted(role),
 					resource.TestCheckResourceAttr(resourceName, "role_name", roleUpdated),
 					resource.TestCheckResourceAttr(resourceName, "allowed_policies.#", "2"),
@@ -109,7 +106,7 @@ func TestAccTokenAuthBackendRoleUpdate(t *testing.T) {
 			{
 				Config: testAccTokenAuthBackendRoleConfig(roleUpdated),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccTokenAuthBackendRoleCheck_attrs(roleUpdated),
+					testAccTokenAuthBackendRoleCheck_attrs(resourceName, roleUpdated),
 					resource.TestCheckResourceAttr(resourceName, "role_name", roleUpdated),
 					resource.TestCheckResourceAttr(resourceName, "allowed_policies.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "disallowed_policies.#", "0"),
@@ -170,28 +167,22 @@ func testAccTokenAuthBackendRoleCheck_deleted(role string) resource.TestCheckFun
 	}
 }
 
-func testAccTokenAuthBackendRoleCheck_attrs(role string) resource.TestCheckFunc {
+func testAccTokenAuthBackendRoleCheck_attrs(resourceName string, role string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		resourceState := s.Modules[0].Resources["vault_token_auth_backend_role.role"]
-		if resourceState == nil {
-			return fmt.Errorf("resource not found in state")
-		}
-
-		instanceState := resourceState.Primary
-		if instanceState == nil {
-			return fmt.Errorf("resource not found in state")
-		}
-
-		endpoint := instanceState.ID
-
-		if endpoint != "auth/token/roles/"+role {
-			return fmt.Errorf("expected ID to be %q, got %q instead", "auth/token/roles/"+role, endpoint)
-		}
-
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-		resp, err := client.Logical().Read(endpoint)
+		rs, err := testutil.GetResourceFromRootModule(s, resourceName)
 		if err != nil {
-			return fmt.Errorf("%q doesn't exist", endpoint)
+			return err
+		}
+
+		path := rs.Primary.ID
+
+		if path != "auth/token/roles/"+role {
+			return fmt.Errorf("expected ID to be %q, got %q instead", "auth/token/roles/"+role, path)
+		}
+
+		client, err := provider.GetClient(rs.Primary, testProvider.Meta())
+		if err != nil {
+			return err
 		}
 
 		attrs := map[string]string{
@@ -206,76 +197,23 @@ func testAccTokenAuthBackendRoleCheck_attrs(role string) resource.TestCheckFunc 
 			"token_explicit_max_ttl":   "token_explicit_max_ttl",
 			"path_suffix":              "path_suffix",
 			"renewable":                "renewable",
-			"token_bound_cidrs":        "token_bound_cidrs",
-			"token_type":               "token_type",
+			// TODO investigate why we do not get this field back from vault
+			//"token_bound_cidrs":        "token_bound_cidrs",
+			"token_type": "token_type",
 		}
 
-		for stateAttr, apiAttr := range attrs {
-			if resp.Data[apiAttr] == nil && instanceState.Attributes[stateAttr] == "" {
-				continue
+		tAttrs := []*testutil.VaultStateTest{}
+		for k, v := range attrs {
+			ta := &testutil.VaultStateTest{
+				ResourceName: resourceName,
+				StateAttr:    k,
+				VaultAttr:    v,
 			}
-			var match bool
-			switch resp.Data[apiAttr].(type) {
-			case json.Number:
-				apiData, err := resp.Data[apiAttr].(json.Number).Int64()
-				if err != nil {
-					return fmt.Errorf("expected API field %s to be an int, was %q", apiAttr, resp.Data[apiAttr])
-				}
-				stateData, err := strconv.ParseInt(instanceState.Attributes[stateAttr], 10, 64)
-				if err != nil {
-					return fmt.Errorf("expected state field %s to be an int, was %q", stateAttr, instanceState.Attributes[stateAttr])
-				}
-				match = apiData == stateData
-			case bool:
-				if _, ok := resp.Data[apiAttr]; !ok && instanceState.Attributes[stateAttr] == "" {
-					match = true
-				} else {
-					stateData, err := strconv.ParseBool(instanceState.Attributes[stateAttr])
-					if err != nil {
-						return fmt.Errorf("expected state field %s to be a bool, was %q", stateAttr, instanceState.Attributes[stateAttr])
-					}
-					match = resp.Data[apiAttr] == stateData
-				}
-			case []interface{}:
-				apiData := resp.Data[apiAttr].([]interface{})
-				length := instanceState.Attributes[stateAttr+".#"]
-				if length == "" {
-					if len(resp.Data[apiAttr].([]interface{})) != 0 {
-						return fmt.Errorf("expected state field %s to have %d entries, had 0", stateAttr, len(apiData))
-					}
-					match = true
-				} else {
-					count, err := strconv.Atoi(length)
-					if err != nil {
-						return fmt.Errorf("expected %s.# to be a number, got %q", stateAttr, instanceState.Attributes[stateAttr+".#"])
-					}
-					if count != len(apiData) {
-						return fmt.Errorf("expected %s to have %d entries in state, has %d", stateAttr, len(apiData), count)
-					}
 
-					for i := 0; i < count; i++ {
-						found := false
-						for stateKey, stateValue := range instanceState.Attributes {
-							if strings.HasPrefix(stateKey, stateAttr) {
-								if apiData[i] == stateValue {
-									found = true
-								}
-							}
-						}
-						if !found {
-							return fmt.Errorf("Expected item %d of %s (%s in state) of %q to be in state but wasn't", i, apiAttr, stateAttr, apiData[i])
-						}
-					}
-					match = true
-				}
-			default:
-				match = resp.Data[apiAttr] == instanceState.Attributes[stateAttr]
-			}
-			if !match {
-				return fmt.Errorf("expected %s (%s in state) of %q to be %q, got %q", apiAttr, stateAttr, endpoint, instanceState.Attributes[stateAttr], resp.Data[apiAttr])
-			}
+			tAttrs = append(tAttrs, ta)
 		}
-		return nil
+
+		return testutil.AssertVaultState(client, s, path, tAttrs...)
 	}
 }
 


### PR DESCRIPTION
This change does the following:

- makes vault attribute to state validation checks more reliable by
  relying on shared test helper code
- greatly reduces the amount of copy paste test code that was littered
  throughout, and in multiple derivative forms
- supports ProviderMeta namespace functionality
- fix: numerous pre-existing test issues
- fix: mismatches between some vault and provider fields
- fix: provider.GetClient()'s error handling

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
