### PR TITLE
PKI: Add support for CPS URL in custom policy identifiers

### DIFF
--- a/vault/pki.go
+++ b/vault/pki.go
@@ -1,0 +1,79 @@
+package vault
+
+import (
+	"encoding/json"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-provider-vault/helper"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// readPolicyIdentifiers converts the `policy_identifiers` list and `policy_identifier` blocks
+// into a list of strings (the OIDs) or the JSON serialization of the `policy_identifier` blocks,
+// respectively.
+func readPolicyIdentifiers(d *schema.ResourceData) interface{} {
+	policyIdentifiersList := d.Get("policy_identifiers").([]interface{})
+	policyIdentifierBlocks := d.Get("policy_identifier").(*schema.Set)
+	policyIdentifiers := make([]string, 0, len(policyIdentifiersList))
+	var newPolicyIdentifiers []map[string]interface{}
+
+	// If the `policy_identifier` blocks are present, send them as JSON, which is only supported by Vault 1.11+.
+	if policyIdentifierBlocks != nil && policyIdentifierBlocks.Len() > 0 {
+		newPolicyIdentifiers = make([]map[string]interface{}, 0, policyIdentifierBlocks.Len()+len(policyIdentifiers))
+		for _, iPolicyIdentifier := range policyIdentifierBlocks.List() {
+			policyIdentifier := iPolicyIdentifier.(map[string]interface{})
+			newPolicyIdentifiers = append(newPolicyIdentifiers, policyIdentifier)
+		}
+
+		if policyIdentifiersList != nil && len(policyIdentifiersList) > 0 {
+			log.Printf("[WARN] vault_pki_secret_backend_role policy_identifier and policy_identifiers should not both be used; ignoring legacy policy_identifiers")
+		}
+
+		// we know these maps are safe to marshal
+		policyIdentifiersJson, _ := json.Marshal(newPolicyIdentifiers)
+		return string(policyIdentifiersJson)
+	} else if policyIdentifiersList != nil && len(policyIdentifiersList) > 0 {
+		for _, iIdentifier := range policyIdentifiersList {
+			policyIdentifiers = append(policyIdentifiers, iIdentifier.(string))
+		}
+		return policyIdentifiers
+	} else {
+		return nil
+	}
+}
+
+// makePkiPolicyIdentifiersListOrSet converts the Vault "policy_identifiers" response
+// into either a list of OIDs, i.e., ["1.2.3","4.5.6"], or a set to represent
+// `policy_identifier` blocks. We return either of these so that round-tripping is stable,
+// and to preserve backwards compatibility with previous versions of Vault.
+func makePkiPolicyIdentifiersListOrSet(rawPolicyIdentifiers []interface{}) ([]string, *schema.Set, error) {
+	policyIdentifiers := make([]string, 0, len(rawPolicyIdentifiers))
+	newPolicyIdentifiers := schema.NewSet(pkiPolicyIdentifierHash, []interface{}{})
+	for _, iIdentifier := range rawPolicyIdentifiers {
+		policyString := iIdentifier.(string)
+		if strings.HasPrefix(policyString, "{") && strings.HasSuffix(policyString, "}") {
+			var policyMap = map[string]string{}
+			err := json.Unmarshal([]byte(policyString), &policyMap)
+			if err != nil {
+				return nil, nil, err
+			}
+			newPolicyIdentifiers.Add(policyMap)
+		} else {
+			// older Vault version with oid-only response
+			policyIdentifiers = append(policyIdentifiers, policyString)
+		}
+	}
+
+	if newPolicyIdentifiers.Len() == 0 {
+		return policyIdentifiers, nil, nil
+	}
+	return nil, newPolicyIdentifiers, nil
+}
+
+func pkiPolicyIdentifierHash(v interface{}) int {
+	m := v.(map[string]string)
+	s, _ := json.Marshal(m) // won't fail since we know the argument is a map[string]string
+	return helper.HashCodeString(string(s))
+}

--- a/vault/resource_quota_rate_limit.go
+++ b/vault/resource_quota_rate_limit.go
@@ -49,7 +49,7 @@ func quotaRateLimitResource() *schema.Resource {
 				Optional:     true,
 				Description:  "The duration in seconds to enforce rate limiting for.",
 				ValidateFunc: validation.IntAtLeast(1),
-				Computed:      true,
+				Computed:     true,
 			},
 			"block_interval": {
 				Type:         schema.TypeInt,

--- a/website/docs/r/pki_secret_backend_role.html.md
+++ b/website/docs/r/pki_secret_backend_role.html.md
@@ -51,7 +51,7 @@ The following arguments are supported:
 
 * `allow_localhost` - (Optional) Flag to allow certificates for localhost
 
-* `allowed_domains` - (Optional) List of allowed domains for certificates 
+* `allowed_domains` - (Optional) List of allowed domains for certificates
 
 * `allowed_domains_template` - (Optional) Flag, if set, `allowed_domains` can be specified using identity template expressions such as `{{identity.entity.aliases.<mount accessor>.name}}`.
 
@@ -79,7 +79,7 @@ The following arguments are supported:
 
 * `email_protection_flag` - (Optional) Flag to specify certificates for email protection use
 
-* `key_type` - (Optional) The generated key type, choices: `rsa`, `ec`, `ed25519`, `any`  
+* `key_type` - (Optional) The generated key type, choices: `rsa`, `ec`, `ed25519`, `any`
   Defaults to `rsa`
 
 * `key_bits` - (Optional) The number of bits of generated keys
@@ -112,7 +112,14 @@ The following arguments are supported:
 
 * `require_cn` - (Optional) Flag to force CN usage
 
-* `policy_identifiers` - (Optional) Specify the list of allowed policies IODs
+* `policy_identifiers` - (Optional) Specify the list of allowed policies OIDs; Deprecated: use `policy_identifier` blocks instead
+* `policy_identifier` - (Optional) (Vault 1.11+ only) A block for specifying policy identifers. The `policy_identifier` block can be repeated, and supports the following arguments:
+
+   - `oid` - (Required) The OID for the policy identifier
+
+   - `notice` - (Optional) A notice for the policy identifier
+
+   - `cps` - (Optional) The URL of the CPS for the policy identifier
 
 * `basic_constraints_valid_for_non_ca` - (Optional) Flag to mark basic constraints valid when issuing non-CA certificates
 


### PR DESCRIPTION
Update the `vault_resource_pki_secret_backend_role` to support
specifying the CPS URL when specifying policy identifiers in line with
the recent changes to the PKI Secrets Engine in Vault 1.11:
https://github.com/hashicorp/vault/pull/15751

We do this by deprecating the existing `policy_identifiers` argument and
creating a new block, `policy_identifier`, which can be specified
multiple times.

If both `policy_identifiers` and `policy_identifier` blocks are present,
then `policy_identifier` is ignored. (Otherwise, refreshing would delete
one or the other, and the state wouldn't have round trip stability.)

This was also tested locally with, for example, a terraform file like:

```hcl
provider "vault" {
}

resource "vault_mount" "pki" {
  path                      = "pki"
  type                      = "pki"
  default_lease_ttl_seconds = 3600
  max_lease_ttl_seconds     = 86400
}

resource "vault_pki_secret_backend_role" "role" {
  name = "example-dot-com"
  backend = vault_mount.pki.path
  allowed_domains = ["example.com"]
  allow_subdomains = true
  allow_bare_domains = true
  allow_glob_domains = true
  allow_ip_sans = true
  allow_localhost = "true"
  generate_lease = true
  organization = ["Hashi test"]
  country = ["USA"]
  locality = ["Area 51"]
  province = ["NV"]
  max_ttl = "720h"
  policy_identifiers = ["2.5.29.32","1.2.3"]
  // or
  policy_identifier {
    oid = "2.5.29.32"
    cps = "https://example.com/cps"
    notice = "Some notice"
  }
  policy_identifier {
    oid = "1.2.3"
  }
}
```

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
resource/pki_secret_backend_role: Add policy_identifier block, deprecate policy_identifiers
```

Output from acceptance testing:

```
$ make testacc TESTARGS="-v ./vault -run .*TestPkiSecretBackendRole.*"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -v ./vault -run .*TestPkiSecretBackendRole.* -timeout 30m ./...
=== RUN   TestPkiSecretBackendRole_basic
--- PASS: TestPkiSecretBackendRole_basic (5.07s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/vault	5.562s
...
```