### PR TITLE
Fix: cert-auth allowed_organizational_units handling

### DIFF
--- a/website/docs/r/cert_auth_backend_role.html.md
+++ b/website/docs/r/cert_auth_backend_role.html.md
@@ -52,7 +52,8 @@ The following arguments are supported:
 
 * `allowed_uri_sans` - (Optional) Allowed URIs for authenticated client certificates
 
-* `allowed_organization_units` - (Optional) Allowed organization units for authenticated client certificates
+* `allowed_organizational_units` - (Optional) Allowed organization units for authenticated client certificates.
+ *In previous provider releases this field was incorrectly named `allowed_organization_units`, please update accordingly*
 
 * `required_extensions` - (Optional) TLS extensions required on client certificates
 


### PR DESCRIPTION
This PR fixes the following issues with the `cert_auth_backend_role` resource:

- `allowed_organizational_units` is not a `Computed` value
- add tests to ensure that `allowed_organizational_units` field is properly
handled for all lifecycle changes.  
- update docs

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
