### PR TITLE
Support getting a namespaced api.Client within various test contexts.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v0.3.1
 	github.com/Azure/go-autorest/autorest v0.11.24
 	github.com/aws/aws-sdk-go v1.41.8
+	github.com/cenkalti/backoff/v4 v4.1.2
 	github.com/containerd/containerd v1.6.6 // indirect
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
 	github.com/denisenkom/go-mssqldb v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -293,6 +293,7 @@ github.com/cenkalti/backoff/v3 v3.2.2 h1:cfUAAO3yvKMYKPrvhDuHSwQnhZNk/RMHKdZqKTx
 github.com/cenkalti/backoff/v3 v3.2.2/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/cenkalti/backoff/v4 v4.1.0/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
+github.com/cenkalti/backoff/v4 v4.1.2 h1:6Yo7N8UP2K6LWZnW94DLVSSrbobcWdVzAYOisuDPIFo=
 github.com/cenkalti/backoff/v4 v4.1.2/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/centrify/cloud-golang-sdk v0.0.0-20210923165758-a8c48d049166/go.mod h1:c/gmvyN8lq6lYtHvrqqoXrg2xyN65N0mBmbikxFWXNE=

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -6,8 +6,17 @@ const (
 	FieldParameters = "parameters"
 	FieldMethod     = "method"
 	FieldNamespace  = "namespace"
+	FieldBackend    = "backend"
 
 	// env vars
 	EnvVarVaultNamespaceImport = "TERRAFORM_VAULT_NAMESPACE_IMPORT"
 	EnvVarSkipChildToken       = "TERRAFORM_VAULT_SKIP_CHILD_TOKEN"
+
+	// common mount types
+	MountTypeDatabase = "database"
+	MountTypePKI      = "pki"
+	MountTypeAWS      = "aws"
+	MountTypeKMIP     = "kmip"
+	MountTypeRabbitMQ = "rabbitmq"
+	MountTypeNomad    = "nomad"
 )

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -1,22 +1,34 @@
 package consts
 
 const (
-	// common field names
-	FieldPath       = "path"
-	FieldParameters = "parameters"
-	FieldMethod     = "method"
-	FieldNamespace  = "namespace"
-	FieldBackend    = "backend"
+	/*
+		common field names
+	*/
+	FieldPath        = "path"
+	FieldParameters  = "parameters"
+	FieldMethod      = "method"
+	FieldNamespace   = "namespace"
+	FieldNamespaceID = "namespace_id"
+	FieldBackend     = "backend"
 
-	// env vars
+	/*
+		common environment variables
+	*/
 	EnvVarVaultNamespaceImport = "TERRAFORM_VAULT_NAMESPACE_IMPORT"
 	EnvVarSkipChildToken       = "TERRAFORM_VAULT_SKIP_CHILD_TOKEN"
 
-	// common mount types
+	/*
+		common mount types
+	*/
 	MountTypeDatabase = "database"
 	MountTypePKI      = "pki"
 	MountTypeAWS      = "aws"
 	MountTypeKMIP     = "kmip"
 	MountTypeRabbitMQ = "rabbitmq"
 	MountTypeNomad    = "nomad"
+
+	/*
+		misc. path related constants
+	*/
+	PathDelim = "/"
 )

--- a/util/util.go
+++ b/util/util.go
@@ -14,6 +14,8 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 )
 
 func JsonDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
@@ -308,7 +310,12 @@ func SetResourceData(d *schema.ResourceData, data map[string]interface{}) error 
 
 // NormalizeMountPath to be in a form valid for accessing values from api.MountOutput
 func NormalizeMountPath(path string) string {
-	return strings.Trim(path, "/") + "/"
+	return TrimSlashes(path) + consts.PathDelim
+}
+
+// TrimSlashes from path.
+func TrimSlashes(path string) string {
+	return strings.Trim(path, consts.PathDelim)
 }
 
 // CheckMountEnabled in Vault, path must contain a trailing '/',

--- a/vault/data_identity_entity.go
+++ b/vault/data_identity_entity.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/identity/entity"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
@@ -22,7 +23,7 @@ var (
 		"last_update_time",
 		"merged_entity_ids",
 		"metadata",
-		"namespace_id",
+		consts.FieldNamespaceID,
 		"policies",
 	}
 
@@ -172,7 +173,7 @@ func identityEntityDataSource() *schema.Resource {
 				Type:     schema.TypeMap,
 				Computed: true,
 			},
-			"namespace_id": {
+			consts.FieldNamespaceID: {
 				Type:     schema.TypeString,
 				Computed: true,
 			},

--- a/vault/data_identity_group.go
+++ b/vault/data_identity_group.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/identity/group"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
@@ -20,7 +21,7 @@ var (
 		"member_group_ids",
 		"metadata",
 		"modify_index",
-		"namespace_id",
+		consts.FieldNamespaceID,
 		"parent_group_ids",
 		"policies",
 		"type",
@@ -112,7 +113,7 @@ func identityGroupDataSource() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
-			"namespace_id": {
+			consts.FieldNamespaceID: {
 				Type:     schema.TypeString,
 				Computed: true,
 			},

--- a/vault/resource_ad_secret_backend_test.go
+++ b/vault/resource_ad_secret_backend_test.go
@@ -56,17 +56,21 @@ func TestADSecretBackend(t *testing.T) {
 }
 
 func testAccADSecretBackendCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
-	mounts, err := client.Sys().ListMounts()
-	if err != nil {
-		return err
-	}
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_ad_secret_backend" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
+		mounts, err := client.Sys().ListMounts()
+		if err != nil {
+			return err
+		}
+
 		for backend, mount := range mounts {
 			backend = strings.Trim(backend, "/")
 			rsBackend := strings.Trim(rs.Primary.Attributes["backend"], "/")

--- a/vault/resource_ad_secret_library_test.go
+++ b/vault/resource_ad_secret_library_test.go
@@ -76,12 +76,16 @@ func TestAccADSecretBackendLibrary_import(t *testing.T) {
 }
 
 func testAccADSecretBackendLibraryCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_ad_secret_library" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return err

--- a/vault/resource_ad_secret_roles_test.go
+++ b/vault/resource_ad_secret_roles_test.go
@@ -73,12 +73,16 @@ func TestAccADSecretBackendRole_import(t *testing.T) {
 }
 
 func testAccADSecretBackendRoleCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_ad_secret_role" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return err

--- a/vault/resource_alicloud_auth_backend_role_test.go
+++ b/vault/resource_alicloud_auth_backend_role_test.go
@@ -50,12 +50,16 @@ func TestAlicloudAuthBackendRole_basic(t *testing.T) {
 }
 
 func testAlicloudAuthBackedRoleDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_alicloud_auth_backend_role" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("Error checking for AliCloud Auth Backend role %q: %s", rs.Primary.ID, err)

--- a/vault/resource_approle_auth_backend_role_secret_id_test.go
+++ b/vault/resource_approle_auth_backend_role_secret_id_test.go
@@ -181,12 +181,16 @@ func TestAccAppRoleAuthBackendRoleSecretID_full(t *testing.T) {
 }
 
 func testAccCheckAppRoleAuthBackendRoleSecretIDDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_approle_auth_backend_role_secret_id" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error checking for AppRole auth backend role SecretID %q: %s", rs.Primary.ID, err)

--- a/vault/resource_approle_auth_backend_role_test.go
+++ b/vault/resource_approle_auth_backend_role_test.go
@@ -310,12 +310,16 @@ func TestAccAppRoleAuthBackendRole_fullUpdate(t *testing.T) {
 }
 
 func testAccCheckAppRoleAuthBackendRoleDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_approle_auth_backend_role" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error checking for AppRole auth backend role %q: %s", rs.Primary.ID, err)

--- a/vault/resource_audit_test.go
+++ b/vault/resource_audit_test.go
@@ -43,12 +43,11 @@ resource "vault_audit" "test" {
 
 func testResourceAudit_initialCheck(expectedPath string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		resourceState := s.Modules[0].Resources["vault_audit.test"]
-		if resourceState == nil {
-			return fmt.Errorf("resource not found in state")
+		rs, err := testutil.GetResourceFromRootModule(s, "vault_audit.test")
+		if err != nil {
+			return err
 		}
-
-		instanceState := resourceState.Primary
+		instanceState := rs.Primary
 		if instanceState == nil {
 			return fmt.Errorf("resource has no primary instance")
 		}
@@ -63,7 +62,12 @@ func testResourceAudit_initialCheck(expectedPath string) resource.TestCheckFunc 
 			return fmt.Errorf("unexpected path %q, expected %q", path, expectedPath)
 		}
 
-		audit, err := findAudit(path)
+		client, e := provider.GetClient(instanceState, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
+		audit, err := findAudit(client, path)
 		if err != nil {
 			return fmt.Errorf("error reading back mount %q: %s", path, err)
 		}
@@ -88,9 +92,7 @@ func testResourceAudit_initialCheck(expectedPath string) resource.TestCheckFunc 
 	}
 }
 
-func findAudit(path string) (*api.Audit, error) {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
+func findAudit(client *api.Client, path string) (*api.Audit, error) {
 	path = path + "/"
 
 	audits, err := client.Sys().ListAudit()

--- a/vault/resource_auth_backend_test.go
+++ b/vault/resource_auth_backend_test.go
@@ -53,12 +53,6 @@ func TestResourceAuth(t *testing.T) {
 }
 
 func testAccCheckAuthBackendDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
-	auths, err := client.Sys().ListAuth()
-	if err != nil {
-		return err
-	}
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_auth_backend" {
 			continue
@@ -66,6 +60,16 @@ func testAccCheckAuthBackendDestroy(s *terraform.State) error {
 		instanceState := rs.Primary
 		if instanceState == nil {
 			return fmt.Errorf("resource not found in state")
+		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
+		auths, err := client.Sys().ListAuth()
+		if err != nil {
+			return err
 		}
 
 		if _, ok := auths[instanceState.ID]; ok {
@@ -129,7 +133,11 @@ func testResourceAuth_initialCheck(expectedPath string) resource.TestCheckFunc {
 			return fmt.Errorf("unexpected auth local")
 		}
 
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		client, e := provider.GetClient(instanceState, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		auths, err := client.Sys().ListAuth()
 		if err != nil {
 			return fmt.Errorf("error reading back auth: %s", err)

--- a/vault/resource_auth_backend_test.go
+++ b/vault/resource_auth_backend_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
@@ -23,17 +24,17 @@ func TestResourceAuth(t *testing.T) {
 		PreCheck:  func() { testutil.TestAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: testResourceAuth_initialConfig(path + pathDelim),
+				Config: testResourceAuth_initialConfig(path + consts.PathDelim),
 				ExpectError: regexp.MustCompile(
 					fmt.Sprintf(`invalid value "%s" for %q, contains leading/trailing %q`,
-						path+pathDelim, "path", pathDelim),
+						path+consts.PathDelim, "path", consts.PathDelim),
 				),
 			},
 			{
-				Config: testResourceAuth_initialConfig(pathDelim + path),
+				Config: testResourceAuth_initialConfig(consts.PathDelim + path),
 				ExpectError: regexp.MustCompile(
 					fmt.Sprintf(`invalid value "%s" for %q, contains leading/trailing %q`,
-						pathDelim+path, "path", pathDelim),
+						consts.PathDelim+path, "path", consts.PathDelim),
 				),
 			},
 			{

--- a/vault/resource_aws_auth_backend_cert_test.go
+++ b/vault/resource_aws_auth_backend_cert_test.go
@@ -55,11 +55,16 @@ func TestAccAWSAuthBackendCert_basic(t *testing.T) {
 }
 
 func testAccCheckAWSAuthBackendCertDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_aws_auth_backend_cert" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error checking for AWS Auth Backend certificate %q: %s", rs.Primary.ID, err)
@@ -105,7 +110,11 @@ func testAccAWSAuthBackendCertCheck_attrs(backend, name string) resource.TestChe
 			return fmt.Errorf("expected ID to be %q, got %q", "auth/"+backend+"/config/certificate/"+name, endpoint)
 		}
 
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		client, e := provider.GetClient(instanceState, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		resp, err := client.Logical().Read(endpoint)
 		if err != nil {
 			return fmt.Errorf("error reading back AWS auth certificate from %q: %s", endpoint, err)

--- a/vault/resource_aws_auth_backend_client_test.go
+++ b/vault/resource_aws_auth_backend_client_test.go
@@ -115,12 +115,16 @@ func TestAccAWSAuthBackendClientStsRegionNoEndpoint(t *testing.T) {
 }
 
 func testAccCheckAWSAuthBackendClientDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_aws_auth_backend_client" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error checking for AWS auth backend %q client config: %s", rs.Primary.ID, err)
@@ -150,7 +154,11 @@ func testAccAWSAuthBackendClientCheck_attrs(backend string) resource.TestCheckFu
 			return fmt.Errorf("expected ID to be %q, got %q", "auth/"+backend+"/config/client", endpoint)
 		}
 
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		client, e := provider.GetClient(instanceState, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		resp, err := client.Logical().Read(endpoint)
 		if err != nil {
 			return fmt.Errorf("error reading back AWS auth client config from %q: %s", endpoint, err)

--- a/vault/resource_aws_auth_backend_identity_whitelist_test.go
+++ b/vault/resource_aws_auth_backend_identity_whitelist_test.go
@@ -50,11 +50,16 @@ func TestAccAWSAuthBackendIdentityWhitelist_basic(t *testing.T) {
 }
 
 func testAccCheckAWSAuthBackendIdentityWhitelistDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_aws_auth_backend_identity_whitelist" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error checking for AWS Auth Backend identity whitelist %q: %s", rs.Primary.ID, err)
@@ -98,7 +103,11 @@ func testAccAWSAuthBackendIdentityWhitelistCheck_attrs(backend string) resource.
 			return fmt.Errorf("expected ID to be %q, got %q", "auth/"+backend+"/config/tidy/identity-whitelist", endpoint)
 		}
 
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		client, e := provider.GetClient(instanceState, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		resp, err := client.Logical().Read(endpoint)
 		if err != nil {
 			return fmt.Errorf("error reading back AWS auth bavkend identity whitelist config from %q: %s", endpoint, err)

--- a/vault/resource_aws_auth_backend_role_test.go
+++ b/vault/resource_aws_auth_backend_role_test.go
@@ -207,12 +207,16 @@ func TestAccAWSAuthBackendRole_iamUpdate(t *testing.T) {
 }
 
 func testAccCheckAWSAuthBackendRoleDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_aws_auth_backend_role" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error checking for AWS auth backend role %q: %s", rs.Primary.ID, err)

--- a/vault/resource_aws_auth_backend_roletag_blacklist_test.go
+++ b/vault/resource_aws_auth_backend_roletag_blacklist_test.go
@@ -87,11 +87,16 @@ func TestAccAWSAuthBackendRoleTagBlacklist_updated(t *testing.T) {
 }
 
 func testAccCheckAWSAuthBackendRoleTagBlacklistDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_aws_auth_backend_roletag_blacklist" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("Error checking for AWS Auth Backend roletag blacklist %q: %s", rs.Primary.ID, err)
@@ -163,7 +168,11 @@ func testAccAWSAuthBackendRoleTagBlacklistCheck_attrs(backend string) resource.T
 			return fmt.Errorf("expected ID to be %q, got %q", "auth/"+backend+"/config/tidy/roletag-blacklist", endpoint)
 		}
 
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		client, e := provider.GetClient(instanceState, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		resp, err := client.Logical().Read(endpoint)
 		if err != nil {
 			return fmt.Errorf("error reading back AWS auth bavkend roletag blacklist config from %q: %s", endpoint, err)

--- a/vault/resource_aws_auth_backend_sts_role_test.go
+++ b/vault/resource_aws_auth_backend_sts_role_test.go
@@ -58,12 +58,16 @@ func TestAccAWSAuthBackendSTSRole_basic(t *testing.T) {
 }
 
 func testAccCheckAWSAuthBackendSTSRoleDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_aws_auth_backend_sts_role" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("Error checking for AWS auth backend STS role %q: %s", rs.Primary.ID, err)
@@ -93,7 +97,11 @@ func testAccAWSAuthBackendSTSRoleCheck_attrs(backend, accountID, stsRole string)
 			return fmt.Errorf("expected ID to be %q, got %q instead", "auth/"+backend+"/config/sts/"+accountID, endpoint)
 		}
 
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		client, e := provider.GetClient(instanceState, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		resp, err := client.Logical().Read(endpoint)
 		if err != nil {
 			return fmt.Errorf("error reading back sts role from %q: %s", endpoint, err)

--- a/vault/resource_aws_secret_backend.go
+++ b/vault/resource_aws_secret_backend.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
@@ -117,7 +118,7 @@ func awsSecretBackendCreate(d *schema.ResourceData, meta interface{}) error {
 	d.Partial(true)
 	log.Printf("[DEBUG] Mounting AWS backend at %q", path)
 	err := client.Sys().Mount(path, &api.MountInput{
-		Type:        "aws",
+		Type:        consts.MountTypeAWS,
 		Description: description,
 		Config: api.MountConfigInput{
 			DefaultLeaseTTL: fmt.Sprintf("%ds", defaultTTL),

--- a/vault/resource_aws_secret_backend_role_test.go
+++ b/vault/resource_aws_secret_backend_role_test.go
@@ -115,12 +115,16 @@ func TestAccAWSSecretBackendRole_nested(t *testing.T) {
 }
 
 func testAccAWSSecretBackendRoleCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_aws_secret_backend_role" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return err

--- a/vault/resource_aws_secret_backend_test.go
+++ b/vault/resource_aws_secret_backend_test.go
@@ -2,25 +2,24 @@ package vault
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
 func TestAccAWSSecretBackend_basic(t *testing.T) {
 	path := acctest.RandomWithPrefix("tf-test-aws")
-	resourceName := "vault_aws_secret_backend.test"
+	resourceType := "vault_aws_secret_backend"
+	resourceName := resourceType + ".test"
 	accessKey, secretKey := testutil.GetTestAWSCreds(t)
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
-		CheckDestroy: testAccAWSSecretBackendCheckDestroy,
+		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeAWS, consts.FieldPath),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSecretBackendConfig_basic(path, accessKey, secretKey),
@@ -78,13 +77,14 @@ func TestAccAWSSecretBackend_basic(t *testing.T) {
 
 func TestAccAWSSecretBackend_usernameTempl(t *testing.T) {
 	path := acctest.RandomWithPrefix("tf-test-aws")
-	resourceName := "vault_aws_secret_backend.test"
+	resourceType := "vault_aws_secret_backend"
+	resourceName := resourceType + ".test"
 	accessKey, secretKey := testutil.GetTestAWSCreds(t)
 	templ := fmt.Sprintf(`{{ printf "vault-%%s-%%s-%%s" (printf "%%s-%%s" (.DisplayName) (.PolicyName) | truncate 42) (unix_time) (random 20) | truncate 64 }}`)
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
-		CheckDestroy: testAccAWSSecretBackendCheckDestroy,
+		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeAWS, consts.FieldPath),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSSecretBackendConfig_userTemplate(path, accessKey, secretKey, templ),
@@ -101,29 +101,6 @@ func TestAccAWSSecretBackend_usernameTempl(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccAWSSecretBackendCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
-	mounts, err := client.Sys().ListMounts()
-	if err != nil {
-		return err
-	}
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "vault_aws_secret_backend" {
-			continue
-		}
-		for path, mount := range mounts {
-			path = strings.Trim(path, "/")
-			rsPath := strings.Trim(rs.Primary.Attributes["path"], "/")
-			if mount.Type == "aws" && path == rsPath {
-				return fmt.Errorf("mount %q still exists", path)
-			}
-		}
-	}
-	return nil
 }
 
 func testAccAWSSecretBackendConfig_basic(path, accessKey, secretKey string) string {

--- a/vault/resource_azure_auth_backend_role_test.go
+++ b/vault/resource_azure_auth_backend_role_test.go
@@ -64,12 +64,16 @@ func TestAzureAuthBackendRole(t *testing.T) {
 }
 
 func testAzureAuthBackendRoleDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_azure_auth_backend_role" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("Error checking for Azure auth backend role %q: %s", rs.Primary.ID, err)

--- a/vault/resource_azure_secret_backend_role_test.go
+++ b/vault/resource_azure_secret_backend_role_test.go
@@ -52,17 +52,21 @@ func TestAzureSecretBackendRole(t *testing.T) {
 }
 
 func testAccAzureSecretBackendRoleCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
-	mounts, err := client.Sys().ListMounts()
-	if err != nil {
-		return err
-	}
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_azure_secret_backend" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
+		mounts, err := client.Sys().ListMounts()
+		if err != nil {
+			return err
+		}
+
 		for path, mount := range mounts {
 			path = strings.Trim(path, "/")
 			rsPath := strings.Trim(rs.Primary.Attributes["path"], "/")

--- a/vault/resource_azure_secret_backend_test.go
+++ b/vault/resource_azure_secret_backend_test.go
@@ -61,17 +61,21 @@ func TestAzureSecretBackend(t *testing.T) {
 }
 
 func testAccAzureSecretBackendCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
-	mounts, err := client.Sys().ListMounts()
-	if err != nil {
-		return err
-	}
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_azure_secret_backend" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
+		mounts, err := client.Sys().ListMounts()
+		if err != nil {
+			return err
+		}
+
 		for path, mount := range mounts {
 			path = strings.Trim(path, "/")
 			rsPath := strings.Trim(rs.Primary.Attributes["path"], "/")

--- a/vault/resource_cert_auth_backend_role_test.go
+++ b/vault/resource_cert_auth_backend_role_test.go
@@ -116,12 +116,16 @@ func TestCertAuthBackend(t *testing.T) {
 }
 
 func testCertAuthBackendDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_cert_auth_backend_role" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("Error checking for Cert auth backend role %q: %s", rs.Primary.ID, err)

--- a/vault/resource_consul_secret_backend_role_test.go
+++ b/vault/resource_consul_secret_backend_role_test.go
@@ -75,12 +75,16 @@ func TestConsulSecretBackendRole(t *testing.T) {
 }
 
 func testAccConsulSecretBackendRoleCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_consul_secret_backend_role" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return err

--- a/vault/resource_consul_secret_backend_test.go
+++ b/vault/resource_consul_secret_backend_test.go
@@ -106,17 +106,21 @@ func TestConsulSecretBackend(t *testing.T) {
 }
 
 func testAccConsulSecretBackendCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
-	mounts, err := client.Sys().ListMounts()
-	if err != nil {
-		return err
-	}
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_consul_secret_backend" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
+		mounts, err := client.Sys().ListMounts()
+		if err != nil {
+			return err
+		}
+
 		for path, mount := range mounts {
 			path = strings.Trim(path, "/")
 			rsPath := strings.Trim(rs.Primary.Attributes["path"], "/")

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -595,10 +595,7 @@ func TestAccDatabaseSecretBackendConnectionTemplatedUpdateExcludePassword_mysql(
 				Config: testAccDatabaseSecretBackendConnectionConfigTemplated_mysql(name, backend, testConnURL, secondaryRootUsername, secondaryRootPassword, 10),
 				PreConfig: func() {
 					path := fmt.Sprintf("%s/rotate-root/%s", backend, name)
-					client, e := testProvider.Meta().(*provider.ProviderMeta).GetNSClient("")
-					if e != nil {
-						t.Fatal(e)
-					}
+					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 					resp, err := client.Logical().Write(path, map[string]interface{}{})
 					if err != nil {

--- a/vault/resource_database_secret_backend_role_test.go
+++ b/vault/resource_database_secret_backend_role_test.go
@@ -87,12 +87,16 @@ func TestAccDatabaseSecretBackendRole_basic(t *testing.T) {
 }
 
 func testAccDatabaseSecretBackendRoleCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_database_secret_backend_role" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return err

--- a/vault/resource_database_secret_backend_static_role_test.go
+++ b/vault/resource_database_secret_backend_static_role_test.go
@@ -99,12 +99,16 @@ func TestAccDatabaseSecretBackendStaticRole_basic(t *testing.T) {
 }
 
 func testAccDatabaseSecretBackendStaticRoleCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_database_secret_backend_static_role" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return err

--- a/vault/resource_database_secrets_mount.go
+++ b/vault/resource_database_secrets_mount.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
@@ -219,7 +220,7 @@ func databaseSecretsMountCreateOrUpdate(d *schema.ResourceData, meta interface{}
 	var root string
 	if d.IsNewResource() {
 		root = d.Get("path").(string)
-		if err := createMount(d, client, root, "database"); err != nil {
+		if err := createMount(d, client, root, consts.MountTypeDatabase); err != nil {
 			return err
 		}
 	} else {

--- a/vault/resource_database_secrets_mount_test.go
+++ b/vault/resource_database_secrets_mount_test.go
@@ -70,10 +70,7 @@ func TestAccDatabaseSecretsMount_mssql(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					client, e := testProvider.Meta().(*provider.ProviderMeta).GetNSClient("")
-					if e != nil {
-						t.Fatal(e)
-					}
+					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 					resp, err := client.Logical().Read(fmt.Sprintf("%s/creds/%s", backend, "dev"))
 					if err != nil {
@@ -175,10 +172,7 @@ func TestAccDatabaseSecretsMount_mssql_multi(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					client, e := testProvider.Meta().(*provider.ProviderMeta).GetNSClient("")
-					if e != nil {
-						t.Fatal(e)
-					}
+					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 					for _, role := range []string{"dev1", "dev2"} {
 						resp, err := client.Logical().Read(fmt.Sprintf("%s/creds/%s", backend, role))

--- a/vault/resource_database_secrets_mount_test.go
+++ b/vault/resource_database_secrets_mount_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	mssqlhelper "github.com/hashicorp/vault/helper/testhelpers/mssql"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
@@ -37,39 +37,44 @@ func TestAccDatabaseSecretsMount_mssql(t *testing.T) {
 		"mssql.0.password",
 		"mssql.0.connection_url",
 	}
-	resourcePath := "vault_database_secrets_mount.db"
+	resourceType := "vault_database_secrets_mount"
+	resourceName := resourceType + ".db"
 
 	username := parsedURL.User.Username()
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
-		CheckDestroy: testAccDatabaseSecretsMountCheckDestroy,
+		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeDatabase, consts.FieldPath),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDatabaseSecretsMount_mssql(name, backend, pluginName, parsedURL),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourcePath, "mssql.#", "1"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.connection_url", connURL),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.max_open_connections", "2"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.max_idle_connections", "0"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.max_connection_lifetime", "0"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.username", username),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.name", name),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.contained_db", "false"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.connection_url", connURL),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.max_open_connections", "2"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.max_idle_connections", "0"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.max_connection_lifetime", "0"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.username", username),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.name", name),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.contained_db", "false"),
 				),
 			},
 			{
-				ResourceName:            resourcePath,
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: importIgnoreKeys,
 			},
 			{
 				PreConfig: func() {
-					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+					client, e := testProvider.Meta().(*provider.ProviderMeta).GetNSClient("")
+					if e != nil {
+						t.Fatal(e)
+					}
+
 					resp, err := client.Logical().Read(fmt.Sprintf("%s/creds/%s", backend, "dev"))
 					if err != nil {
 						t.Fatal(err)
@@ -80,21 +85,21 @@ func TestAccDatabaseSecretsMount_mssql(t *testing.T) {
 				},
 				Config: testAccDatabaseSecretsMount_mssql(name2, backend, pluginName, parsedURL),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourcePath, "mssql.#", "1"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.connection_url", connURL),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.max_open_connections", "2"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.max_idle_connections", "0"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.max_connection_lifetime", "0"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.username", username),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.name", name2),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.contained_db", "false"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.connection_url", connURL),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.max_open_connections", "2"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.max_idle_connections", "0"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.max_connection_lifetime", "0"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.username", username),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.name", name2),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.contained_db", "false"),
 				),
 			},
 			{
-				ResourceName:            resourcePath,
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: importIgnoreKeys,
@@ -138,38 +143,42 @@ func TestAccDatabaseSecretsMount_mssql_multi(t *testing.T) {
 		"mssql.1.connection_url",
 	}
 
-	resourcePath := "vault_database_secrets_mount.db"
+	resourceType := "vault_database_secrets_mount"
+	resourceName := resourceType + ".db"
 	username := parsedURL.User.Username()
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
-		CheckDestroy: testAccDatabaseSecretsMountCheckDestroy,
+		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeDatabase, consts.FieldPath),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDatabaseSecretsMount_mssql_dual(name, name2, backend, pluginName, parsedURL, parsedURL2),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourcePath, "mssql.#", "2"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.allowed_roles.#", "1"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.allowed_roles.0", "dev1"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.connection_url", connURL),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.max_open_connections", "2"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.max_idle_connections", "0"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.max_connection_lifetime", "0"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.username", username),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.contained_db", "false"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.1.allowed_roles.#", "1"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.1.allowed_roles.0", "dev2"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.1.connection_url", connURL2),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.1.max_open_connections", "2"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.1.max_idle_connections", "0"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.1.max_connection_lifetime", "0"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.1.username", username),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.1.contained_db", "false"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.allowed_roles.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.allowed_roles.0", "dev1"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.connection_url", connURL),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.max_open_connections", "2"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.max_idle_connections", "0"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.max_connection_lifetime", "0"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.username", username),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.contained_db", "false"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.1.allowed_roles.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.1.allowed_roles.0", "dev2"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.1.connection_url", connURL2),
+					resource.TestCheckResourceAttr(resourceName, "mssql.1.max_open_connections", "2"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.1.max_idle_connections", "0"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.1.max_connection_lifetime", "0"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.1.username", username),
+					resource.TestCheckResourceAttr(resourceName, "mssql.1.contained_db", "false"),
 				),
 			},
 			{
 				PreConfig: func() {
-					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+					client, e := testProvider.Meta().(*provider.ProviderMeta).GetNSClient("")
+					if e != nil {
+						t.Fatal(e)
+					}
 
 					for _, role := range []string{"dev1", "dev2"} {
 						resp, err := client.Logical().Read(fmt.Sprintf("%s/creds/%s", backend, role))
@@ -183,27 +192,27 @@ func TestAccDatabaseSecretsMount_mssql_multi(t *testing.T) {
 				},
 				Config: testAccDatabaseSecretsMount_mssql_dual(name, name2, backend, pluginName, parsedURL, parsedURL2),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourcePath, "mssql.#", "2"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.allowed_roles.#", "1"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.allowed_roles.0", "dev1"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.connection_url", connURL),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.max_open_connections", "2"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.max_idle_connections", "0"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.max_connection_lifetime", "0"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.username", username),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.contained_db", "false"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.1.allowed_roles.#", "1"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.1.allowed_roles.0", "dev2"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.1.connection_url", connURL2),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.1.max_open_connections", "2"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.1.max_idle_connections", "0"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.1.max_connection_lifetime", "0"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.1.username", username),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.1.contained_db", "false"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.allowed_roles.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.allowed_roles.0", "dev1"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.connection_url", connURL),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.max_open_connections", "2"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.max_idle_connections", "0"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.max_connection_lifetime", "0"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.username", username),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.contained_db", "false"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.1.allowed_roles.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.1.allowed_roles.0", "dev2"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.1.connection_url", connURL2),
+					resource.TestCheckResourceAttr(resourceName, "mssql.1.max_open_connections", "2"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.1.max_idle_connections", "0"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.1.max_connection_lifetime", "0"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.1.username", username),
+					resource.TestCheckResourceAttr(resourceName, "mssql.1.contained_db", "false"),
 				),
 			},
 			{
-				ResourceName:            resourcePath,
+				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: importIgnoreKeys,
@@ -211,16 +220,16 @@ func TestAccDatabaseSecretsMount_mssql_multi(t *testing.T) {
 			{
 				Config: testAccDatabaseSecretsMount_mssql(name, backend, pluginName, parsedURL),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourcePath, "mssql.#", "1"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.allowed_roles.#", "2"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.allowed_roles.0", "dev"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.allowed_roles.1", "prod"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.connection_url", connURL),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.max_open_connections", "2"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.max_idle_connections", "0"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.max_connection_lifetime", "0"),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.username", username),
-					resource.TestCheckResourceAttr(resourcePath, "mssql.0.contained_db", "false"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.connection_url", connURL),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.max_open_connections", "2"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.max_idle_connections", "0"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.max_connection_lifetime", "0"),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.username", username),
+					resource.TestCheckResourceAttr(resourceName, "mssql.0.contained_db", "false"),
 				),
 			},
 		},
@@ -318,22 +327,4 @@ resource "vault_database_secret_backend_role" "test2" {
 		name2, parsedURL2.String(), parsedURL2.User.Username(), password2))
 
 	return result
-}
-
-func testAccDatabaseSecretsMountCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "vault_database_secrets_mount" {
-			continue
-		}
-		secret, err := client.Logical().Read(rs.Primary.ID)
-		if err != nil {
-			return err
-		}
-		if secret != nil {
-			return fmt.Errorf("mount %q still exists", rs.Primary.ID)
-		}
-	}
-	return nil
 }

--- a/vault/resource_egp_policy_test.go
+++ b/vault/resource_egp_policy_test.go
@@ -42,11 +42,16 @@ func TestAccEndpointGoverningPolicy(t *testing.T) {
 }
 
 func testAccEndpointGoverningPolicyCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_egp_policy" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		name := rs.Primary.Attributes["name"]
 		data, err := client.Logical().Read(fmt.Sprintf("sys/policies/egp/%s", name))
 		if err != nil {

--- a/vault/resource_gcp_auth_backend_role_test.go
+++ b/vault/resource_gcp_auth_backend_role_test.go
@@ -129,12 +129,16 @@ func TestGCPAuthBackendRole_gce(t *testing.T) {
 }
 
 func testGCPAuthBackendRoleDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_gcp_auth_backend_role" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("Error checking for GCP auth backend role %q: %s", rs.Primary.ID, err)

--- a/vault/resource_gcp_auth_backend_test.go
+++ b/vault/resource_gcp_auth_backend_test.go
@@ -67,12 +67,16 @@ func TestGCPAuthBackend_import(t *testing.T) {
 }
 
 func testGCPAuthBackendDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_gcp_auth_backend" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error checking for gcp auth backend %q: %s", rs.Primary.ID, err)

--- a/vault/resource_gcp_secret_backend_test.go
+++ b/vault/resource_gcp_secret_backend_test.go
@@ -47,17 +47,21 @@ func TestGCPSecretBackend(t *testing.T) {
 }
 
 func testAccGCPSecretBackendCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
-	mounts, err := client.Sys().ListMounts()
-	if err != nil {
-		return err
-	}
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_gcp_secret_backend" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
+		mounts, err := client.Sys().ListMounts()
+		if err != nil {
+			return err
+		}
+
 		for path, mount := range mounts {
 			path = strings.Trim(path, "/")
 			rsPath := strings.Trim(rs.Primary.Attributes["path"], "/")

--- a/vault/resource_gcp_secret_roleset_test.go
+++ b/vault/resource_gcp_secret_roleset_test.go
@@ -169,12 +169,16 @@ func testGCPSecretRolesetAttrs(resourceName, backend, roleset string, ignoreFiel
 }
 
 func testGCPSecretRolesetDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_gcp_secret_roleset" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error checking for GCP Secrets Roleset %q: %s", rs.Primary.ID, err)

--- a/vault/resource_gcp_secret_static_account_test.go
+++ b/vault/resource_gcp_secret_static_account_test.go
@@ -175,12 +175,16 @@ func testGCPSecretStaticAccountAttrs(resourceName, backend, staticAccount string
 }
 
 func testGCPSecretStaticAccountDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_gcp_secret_static_account" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error checking for GCP Secrets StaticAccount %q: %s", rs.Primary.ID, err)

--- a/vault/resource_generic_endpoint_test.go
+++ b/vault/resource_generic_endpoint_test.go
@@ -7,17 +7,26 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
 func TestResourceGenericEndpoint(t *testing.T) {
 	path := acctest.RandomWithPrefix("userpass")
+	resourceNames := []string{
+		"vault_generic_endpoint.up1",
+		"vault_generic_endpoint.up2",
+		"vault_generic_endpoint.u1",
+		"vault_generic_endpoint.u1_token",
+		"vault_generic_endpoint.u1_entity",
+	}
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
-		CheckDestroy: testResourceGenericEndpoint_destroyCheck(path),
+		CheckDestroy: testResourceGenericEndpoint_destroyCheck(resourceNames, path),
 		Steps: []resource.TestStep{
 			{
 				Config: testResourceGenericEndpoint_initialConfig(path),
@@ -171,15 +180,35 @@ func testResourceGenericEndpoint_initialCheck(s *terraform.State) error {
 	return nil
 }
 
-func testResourceGenericEndpoint_destroyCheck(path string) resource.TestCheckFunc {
+func testResourceGenericEndpoint_destroyCheck(resourceNames []string, path string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
-		for _, rs := range s.RootModule().Resources {
-			if rs.Type != "vault_generic_endpoint" {
-				continue
+		var ns string
+		var client *api.Client
+		for _, name := range resourceNames {
+			rs, err := testutil.GetResourceFromRootModule(s, name)
+			if err != nil {
+				return err
 			}
+
 			instanceState := rs.Primary
+
+			if client == nil {
+				c, err := provider.GetClient(instanceState, testProvider.Meta())
+				if err != nil {
+					return err
+				}
+
+				client = c
+			}
+
+			if n, ok := instanceState.Attributes[consts.FieldNamespace]; ok {
+				if ns != n {
+					return fmt.Errorf("all test resources must be in the same namepace")
+				}
+
+				ns = n
+			}
+
 			// Check to make sure resources that we can read are no longer
 			// there.
 			if instanceState.Attributes["disable_read"] != "true" {

--- a/vault/resource_generic_secret_test.go
+++ b/vault/resource_generic_secret_test.go
@@ -109,7 +109,11 @@ func TestResourceGenericSecret_deleted(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+					client, e := testProvider.Meta().(*provider.ProviderMeta).GetNSClient("")
+					if e != nil {
+						t.Fatal(e)
+					}
+
 					_, err := client.Logical().Delete(path)
 					if err != nil {
 						t.Fatalf("unable to manually delete the secret via the SDK: %s", err)
@@ -331,7 +335,10 @@ func testResourceGenericSecret_initialCheck_v2(expectedPath string, wantValue st
 			return fmt.Errorf("unexpected secret path")
 		}
 
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		client, e := provider.GetClient(instanceState, testProvider.Meta())
+		if e != nil {
+			return e
+		}
 
 		// Checking KV-V2 Secrets
 		resp, err := client.Logical().List("secretsv2/metadata")
@@ -385,12 +392,16 @@ func testResourceGenericSecret_checkVersions(client *api.Client, keyName string,
 }
 
 func testAllVersionDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_generic_secret" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error checking for generic secret %q: %s", rs.Primary.ID, err)

--- a/vault/resource_generic_secret_test.go
+++ b/vault/resource_generic_secret_test.go
@@ -109,10 +109,7 @@ func TestResourceGenericSecret_deleted(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					client, e := testProvider.Meta().(*provider.ProviderMeta).GetNSClient("")
-					if e != nil {
-						t.Fatal(e)
-					}
+					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 					_, err := client.Logical().Delete(path)
 					if err != nil {

--- a/vault/resource_github_team_test.go
+++ b/vault/resource_github_team_test.go
@@ -100,14 +100,18 @@ func TestGithubTeamBackEndPath(t *testing.T) {
 }
 
 func testAccGithubTeamCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-	for _, r := range s.RootModule().Resources {
-		if r.Type != "vault_github_team" {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "vault_github_team" {
 			continue
 		}
 
-		resp, err := client.RawRequest(client.NewRequest("GET", "/v1/"+r.Primary.ID))
-		log.Printf("[DEBUG] Checking if resource '%s' is destroyed, statusCode: %d, error: %s", r.Primary.ID, resp.StatusCode, err)
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
+		resp, err := client.RawRequest(client.NewRequest("GET", "/v1/"+rs.Primary.ID))
+		log.Printf("[DEBUG] Checking if resource '%s' is destroyed, statusCode: %d, error: %s", rs.Primary.ID, resp.StatusCode, err)
 		if resp.StatusCode == 404 {
 			return nil
 		}

--- a/vault/resource_github_user_test.go
+++ b/vault/resource_github_user_test.go
@@ -83,14 +83,18 @@ func TestGithubUserBackEndPath(t *testing.T) {
 }
 
 func testAccGithubUserCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-	for _, r := range s.RootModule().Resources {
-		if r.Type != "vault_github_user" {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "vault_github_user" {
 			continue
 		}
 
-		resp, err := client.RawRequest(client.NewRequest("GET", "/v1/"+r.Primary.ID))
-		log.Printf("[DEBUG] Checking if resource '%s' is destroyed, statusCode: %d, error: %s", r.Primary.ID, resp.StatusCode, err)
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
+		resp, err := client.RawRequest(client.NewRequest("GET", "/v1/"+rs.Primary.ID))
+		log.Printf("[DEBUG] Checking if resource '%s' is destroyed, statusCode: %d, error: %s", rs.Primary.ID, resp.StatusCode, err)
 		if resp.StatusCode == 404 {
 			return nil
 		}

--- a/vault/resource_identity_entity_alias_test.go
+++ b/vault/resource_identity_entity_alias_test.go
@@ -186,10 +186,7 @@ resource "vault_identity_entity_alias" "test2" {
 			{
 				// delete one of the alias's to ensure an update operation re-creates it.
 				PreConfig: func() {
-					client, e := testProvider.Meta().(*provider.ProviderMeta).GetNSClient("")
-					if e != nil {
-						t.Fatal(e)
-					}
+					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 					aliases, err := entity.FindAliases(client, &entity.FindAliasParams{
 						Name: alias,

--- a/vault/resource_identity_entity_alias_test.go
+++ b/vault/resource_identity_entity_alias_test.go
@@ -186,7 +186,11 @@ resource "vault_identity_entity_alias" "test2" {
 			{
 				// delete one of the alias's to ensure an update operation re-creates it.
 				PreConfig: func() {
-					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+					client, e := testProvider.Meta().(*provider.ProviderMeta).GetNSClient("")
+					if e != nil {
+						t.Fatal(e)
+					}
+
 					aliases, err := entity.FindAliases(client, &entity.FindAliasParams{
 						Name: alias,
 					})
@@ -259,12 +263,16 @@ func TestAccIdentityEntityAlias_Update(t *testing.T) {
 }
 
 func testAccCheckIdentityEntityAliasDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_identity_entity_alias" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(entity.JoinAliasID(rs.Primary.ID))
 		if err != nil {
 			return fmt.Errorf("error checking for identity entity %q: %s", rs.Primary.ID, err)

--- a/vault/resource_identity_entity_policies_test.go
+++ b/vault/resource_identity_entity_policies_test.go
@@ -70,11 +70,14 @@ func TestAccIdentityEntityPoliciesNonExclusive(t *testing.T) {
 }
 
 func testAccCheckidentityEntityPoliciesDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_identity_entity_policies" {
 			continue
+		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
 		}
 
 		if _, err := readIdentityEntity(client, rs.Primary.ID, false); err != nil {
@@ -157,7 +160,11 @@ func testAccIdentityEntityPoliciesCheckLogical(resource string, policies []strin
 		id := instanceState.ID
 
 		path := entity.JoinEntityID(id)
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		client, e := provider.GetClient(instanceState, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		resp, err := client.Logical().Read(path)
 		if err != nil {
 			return fmt.Errorf("%q doesn't exist", path)

--- a/vault/resource_identity_entity_test.go
+++ b/vault/resource_identity_entity_test.go
@@ -119,12 +119,16 @@ func TestAccIdentityEntityUpdateRemovePolicies(t *testing.T) {
 }
 
 func testAccCheckIdentityEntityDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_identity_entity" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(entity.JoinEntityID(rs.Primary.ID))
 		if err != nil {
 			return fmt.Errorf("error checking for identity entity %q: %s", rs.Primary.ID, err)

--- a/vault/resource_identity_group_alias_test.go
+++ b/vault/resource_identity_group_alias_test.go
@@ -73,12 +73,16 @@ func TestAccIdentityGroupAliasUpdate(t *testing.T) {
 }
 
 func testAccCheckIdentityGroupAliasDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_identity_group_alias" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(identityGroupAliasIDPath(rs.Primary.ID))
 		if err != nil {
 			return fmt.Errorf("error checking for identity group %q: %s", rs.Primary.ID, err)

--- a/vault/resource_identity_group_member_entity_ids_test.go
+++ b/vault/resource_identity_group_member_entity_ids_test.go
@@ -351,11 +351,14 @@ func (r *memberEntityTester) CheckMemberEntities(resourceName string) resource.T
 }
 
 func testAccCheckidentityGroupMemberEntityIdsDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_identity_group_member_entity_ids" {
 			continue
+		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
 		}
 
 		if _, err := readIdentityGroup(client, rs.Primary.ID, false); err != nil {

--- a/vault/resource_identity_group_policies_test.go
+++ b/vault/resource_identity_group_policies_test.go
@@ -75,11 +75,14 @@ func TestAccIdentityGroupPoliciesNonExclusive(t *testing.T) {
 }
 
 func testAccCheckidentityGroupPoliciesDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_identity_group_policies" {
 			continue
+		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
 		}
 
 		if _, err := readIdentityGroup(client, rs.Primary.ID, false); err != nil {

--- a/vault/resource_identity_group_test.go
+++ b/vault/resource_identity_group_test.go
@@ -151,12 +151,16 @@ resource "vault_identity_group" "test_upper" {
 }
 
 func testAccCheckIdentityGroupDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_identity_group" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(identityGroupIDPath(rs.Primary.ID))
 		if err != nil {
 			return fmt.Errorf("error checking for identity group %q: %s", rs.Primary.ID, err)

--- a/vault/resource_identity_oidc_assignment_test.go
+++ b/vault/resource_identity_oidc_assignment_test.go
@@ -88,12 +88,16 @@ resource "vault_identity_oidc_assignment" "test" {
 }
 
 func testAccCheckOIDCAssignmentDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_identity_oidc_assignment" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		resp, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error checking for OIDC assignment at %s, err=%w", rs.Primary.ID, err)

--- a/vault/resource_identity_oidc_client_test.go
+++ b/vault/resource_identity_oidc_client_test.go
@@ -126,12 +126,16 @@ resource "vault_identity_oidc_client" "client" {
 }
 
 func testAccCheckOIDCClientDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_identity_oidc_client" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		resp, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error checking for OIDC client at %s, err=%w", rs.Primary.ID, err)

--- a/vault/resource_identity_oidc_key_allowed_client_id_test.go
+++ b/vault/resource_identity_oidc_key_allowed_client_id_test.go
@@ -55,12 +55,16 @@ func TestAccIdentityOidcKeyAllowedClientId(t *testing.T) {
 }
 
 func testAccCheckIdentityOidcKeyAllowedClientIdDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_identity_oidc_key_allowed_client_id" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		resp, err := identityOidcKeyApiRead(rs.Primary.ID, client)
 		if err != nil {
 			return err
@@ -90,7 +94,11 @@ func testAccIdentityOidcKeyAllowedClientIdCheckAttrs(clientIDResource string, cl
 		}
 
 		id := instanceState.ID
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		client, e := provider.GetClient(instanceState, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		resp, err := identityOidcKeyApiRead(id, client)
 		if err != nil {
 			return err

--- a/vault/resource_identity_oidc_key_test.go
+++ b/vault/resource_identity_oidc_key_test.go
@@ -92,12 +92,16 @@ func TestAccIdentityOidcKeyUpdate(t *testing.T) {
 }
 
 func testAccCheckIdentityOidcKeyDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_identity_oidc_key" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		resp, err := identityOidcKeyApiRead(rs.Primary.Attributes["name"], client)
 		if err != nil {
 			return fmt.Errorf("error checking for identity oidc key %q: %s", rs.Primary.ID, err)

--- a/vault/resource_identity_oidc_provider_test.go
+++ b/vault/resource_identity_oidc_provider_test.go
@@ -93,12 +93,16 @@ resource "vault_identity_oidc_provider" "test" {
 }
 
 func testAccCheckOIDCProviderDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_identity_oidc_provider" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		resp, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error checking for OIDC provider at %s, err=%w", rs.Primary.ID, err)

--- a/vault/resource_identity_oidc_role_test.go
+++ b/vault/resource_identity_oidc_role_test.go
@@ -116,12 +116,16 @@ func TestAccIdentityOidcRoleUpdate(t *testing.T) {
 }
 
 func testAccCheckIdentityOidcRoleDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_identity_oidc_role" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(identityOidcRolePath(rs.Primary.ID))
 		if err != nil {
 			return fmt.Errorf("error checking for identity oidc role %q: %s", rs.Primary.ID, err)

--- a/vault/resource_identity_oidc_scope_test.go
+++ b/vault/resource_identity_oidc_scope_test.go
@@ -74,12 +74,16 @@ resource "vault_identity_oidc_scope" "test" {
 }
 
 func testAccCheckOIDCScopeDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_identity_oidc_scope" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		resp, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error checking for OIDC scope at %s, err=%w", rs.Primary.ID, err)

--- a/vault/resource_jwt_auth_backend_role_test.go
+++ b/vault/resource_jwt_auth_backend_role_test.go
@@ -491,12 +491,16 @@ func TestAccJWTAuthBackendRole_fullUpdate(t *testing.T) {
 }
 
 func testAccCheckJWTAuthBackendRoleDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_jwt_auth_backend_role" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error checking for JWT auth backend role %q: %s", rs.Primary.ID, err)

--- a/vault/resource_jwt_auth_backend_test.go
+++ b/vault/resource_jwt_auth_backend_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
@@ -113,7 +114,7 @@ func TestAccJWTAuthBackend_OIDC(t *testing.T) {
 
 func TestAccJWTAuthBackend_invalid(t *testing.T) {
 	path := acctest.RandomWithPrefix("jwt")
-	invalidPath := path + pathDelim
+	invalidPath := path + consts.PathDelim
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testutil.TestAccPreCheck(t) },
 		Providers: testProviders,
@@ -123,7 +124,7 @@ func TestAccJWTAuthBackend_invalid(t *testing.T) {
 				Destroy: false,
 				ExpectError: regexp.MustCompile(
 					fmt.Sprintf(`invalid value "%s" for "path", contains leading/trailing "%s"`,
-						invalidPath, pathDelim)),
+						invalidPath, consts.PathDelim)),
 			},
 			{
 				Config: fmt.Sprintf(`resource "vault_jwt_auth_backend" "jwt" {

--- a/vault/resource_kmip_secret_backend.go
+++ b/vault/resource_kmip_secret_backend.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
 
@@ -118,7 +119,7 @@ func kmipSecretBackendCreate(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Mounting KMIP backend at %q", path)
 	if err := client.Sys().Mount(path, &api.MountInput{
-		Type:        "kmip",
+		Type:        consts.MountTypeKMIP,
 		Description: d.Get("description").(string),
 		Config: api.MountConfigInput{
 			DefaultLeaseTTL: defaultTLSClientTTL,

--- a/vault/resource_kmip_secret_backend_test.go
+++ b/vault/resource_kmip_secret_backend_test.go
@@ -2,14 +2,12 @@ package vault
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -17,7 +15,8 @@ func TestAccKMIPSecretBackend_basic(t *testing.T) {
 	testutil.SkipTestAccEnt(t)
 
 	path := acctest.RandomWithPrefix("tf-test-kmip")
-	resourceName := "vault_kmip_secret_backend.test"
+	resourceType := "vault_kmip_secret_backend"
+	resourceName := resourceType + ".test"
 
 	lns, closer, err := testutil.GetDynamicTCPListeners("127.0.0.1", 2)
 	if err != nil {
@@ -33,7 +32,7 @@ func TestAccKMIPSecretBackend_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestEntPreCheck(t) },
-		CheckDestroy: testAccKMIPSecretBackendCheckDestroy,
+		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeKMIP, consts.FieldPath),
 		Steps: []resource.TestStep{
 			{
 				Config: testKMIPSecretBackend_initialConfig(path, addr1),
@@ -80,7 +79,8 @@ func TestAccKMIPSecretBackend_remount(t *testing.T) {
 
 	path := acctest.RandomWithPrefix("tf-test-kmip")
 	remountPath := acctest.RandomWithPrefix("tf-test-kmip-updated")
-	resourceName := "vault_kmip_secret_backend.test"
+	resourceType := "vault_kmip_secret_backend"
+	resourceName := resourceType + ".test"
 
 	lns, closer, err := testutil.GetDynamicTCPListeners("127.0.0.1", 1)
 	if err != nil {
@@ -96,7 +96,7 @@ func TestAccKMIPSecretBackend_remount(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestEntPreCheck(t) },
-		CheckDestroy: testAccKMIPSecretBackendCheckDestroy,
+		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeKMIP, consts.FieldPath),
 		Steps: []resource.TestStep{
 			{
 				Config: testKMIPSecretBackend_initialConfig(path, addr1),
@@ -134,30 +134,6 @@ func TestAccKMIPSecretBackend_remount(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccKMIPSecretBackendCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
-	mounts, err := client.Sys().ListMounts()
-	if err != nil {
-		return err
-	}
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "vault_kmip_secret_backend" {
-			continue
-		}
-		for path, mount := range mounts {
-			path = strings.Trim(path, "/")
-			rsPath := strings.Trim(rs.Primary.Attributes["path"], "/")
-			if mount.Type == "kmip" && path == rsPath {
-				return fmt.Errorf("mount %q still exists", path)
-			}
-		}
-	}
-
-	return nil
 }
 
 func testKMIPSecretBackend_initialConfig(path, addr string) string {

--- a/vault/resource_kubernetes_auth_backend_config_test.go
+++ b/vault/resource_kubernetes_auth_backend_config_test.go
@@ -370,10 +370,7 @@ func TestAccKubernetesAuthBackendConfig_localCA(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					client, e := testProvider.Meta().(*provider.ProviderMeta).GetNSClient("")
-					if e != nil {
-						t.Fatal(e)
-					}
+					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 					path := kubernetesAuthBackendConfigPath(backend)
 					if _, err := client.Logical().Write(path, map[string]interface{}{

--- a/vault/resource_kubernetes_auth_backend_config_test.go
+++ b/vault/resource_kubernetes_auth_backend_config_test.go
@@ -158,12 +158,16 @@ func TestAccKubernetesAuthBackendConfig_basic(t *testing.T) {
 }
 
 func testAccCheckKubernetesAuthBackendConfigDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_kubernetes_auth_backend_config" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error checking for Kubernetes auth backend config %q: %s", rs.Primary.ID, err)
@@ -366,7 +370,11 @@ func TestAccKubernetesAuthBackendConfig_localCA(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+					client, e := testProvider.Meta().(*provider.ProviderMeta).GetNSClient("")
+					if e != nil {
+						t.Fatal(e)
+					}
+
 					path := kubernetesAuthBackendConfigPath(backend)
 					if _, err := client.Logical().Write(path, map[string]interface{}{
 						"kubernetes_ca_cert": kubernetesCAcert,

--- a/vault/resource_kubernetes_auth_backend_role_test.go
+++ b/vault/resource_kubernetes_auth_backend_role_test.go
@@ -433,12 +433,16 @@ func TestAccKubernetesAuthBackendRole_fullUpdate(t *testing.T) {
 }
 
 func testAccCheckKubernetesAuthBackendRoleDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_kubernetes_auth_backend_role" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error checking for Kubernetes auth backend role %q: %s", rs.Primary.ID, err)

--- a/vault/resource_ldap_auth_backend_group_test.go
+++ b/vault/resource_ldap_auth_backend_group_test.go
@@ -66,12 +66,16 @@ func TestLDAPAuthBackendGroup_basic(t *testing.T) {
 }
 
 func testLDAPAuthBackendGroupDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_ldap_auth_backend_group" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error checking for ldap auth backend group %q: %s", rs.Primary.ID, err)

--- a/vault/resource_ldap_auth_backend_test.go
+++ b/vault/resource_ldap_auth_backend_test.go
@@ -92,12 +92,16 @@ func TestLDAPAuthBackend_tls(t *testing.T) {
 }
 
 func testLDAPAuthBackendDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_ldap_auth_backend" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error checking for ldap auth backend %q: %s", rs.Primary.ID, err)

--- a/vault/resource_ldap_auth_backend_user_test.go
+++ b/vault/resource_ldap_auth_backend_user_test.go
@@ -108,12 +108,16 @@ func TestLDAPAuthBackendUser_oneGroup(t *testing.T) {
 }
 
 func testLDAPAuthBackendUserDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_ldap_auth_backend_user" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error checking for ldap auth backend user %q: %s", rs.Primary.ID, err)

--- a/vault/resource_mfa_pingid.go
+++ b/vault/resource_mfa_pingid.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
@@ -73,7 +74,7 @@ func mfaPingIDResource() *schema.Resource {
 				Optional:    true,
 				Description: "ID computed by Vault.",
 			},
-			"namespace_id": {
+			consts.FieldNamespaceID: {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Namespace ID computed by Vault.",
@@ -160,7 +161,7 @@ func mfaPingIDRead(d *schema.ResourceData, meta interface{}) error {
 	fields := []string{
 		"name", "idp_url", "admin_url",
 		"authenticator_url", "org_alias", "type",
-		"use_signature", "id", "namespace_id",
+		"use_signature", "id", consts.FieldNamespaceID,
 	}
 
 	for _, k := range fields {

--- a/vault/resource_mfa_pingid_test.go
+++ b/vault/resource_mfa_pingid_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -27,7 +28,7 @@ func TestMFAPingIDBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "username_format", "user@example.com"),
 					resource.TestCheckResourceAttr(resourceName, "type", "pingid"),
 					resource.TestCheckResourceAttr(resourceName, "use_signature", "true"),
-					resource.TestCheckResourceAttr(resourceName, "namespace_id", ""),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldNamespaceID, ""),
 					resource.TestCheckResourceAttr(resourceName, "settings_file_base64", settingsFile),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 				),

--- a/vault/resource_mfa_totp_test.go
+++ b/vault/resource_mfa_totp_test.go
@@ -35,7 +35,11 @@ func TestMFATOTPBasic(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+					client, e := testProvider.Meta().(*provider.ProviderMeta).GetNSClient("")
+					if e != nil {
+						t.Fatal(e)
+					}
+
 					resp, err := client.Logical().Read(mfaTOTPPath(path))
 					if err != nil {
 						t.Fatal(err)

--- a/vault/resource_mfa_totp_test.go
+++ b/vault/resource_mfa_totp_test.go
@@ -35,10 +35,7 @@ func TestMFATOTPBasic(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					client, e := testProvider.Meta().(*provider.ProviderMeta).GetNSClient("")
-					if e != nil {
-						t.Fatal(e)
-					}
+					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 					resp, err := client.Logical().Read(mfaTOTPPath(path))
 					if err != nil {

--- a/vault/resource_nomad_secret_backend.go
+++ b/vault/resource_nomad_secret_backend.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
 
@@ -120,7 +121,7 @@ func createNomadAccessConfigResource(d *schema.ResourceData, meta interface{}) e
 
 	log.Printf("[DEBUG] Mounting Nomad backend at %q", backend)
 	err := client.Sys().Mount(backend, &api.MountInput{
-		Type:        "nomad",
+		Type:        consts.MountTypeNomad,
 		Description: description,
 		Local:       local,
 		Config: api.MountConfigInput{

--- a/vault/resource_nomad_secret_role_test.go
+++ b/vault/resource_nomad_secret_role_test.go
@@ -86,12 +86,16 @@ func TestAccNomadSecretBackendRoleImport(t *testing.T) {
 }
 
 func testAccNomadSecretBackendRoleCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_nomad_secret_role" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return err

--- a/vault/resource_okta_auth_backend_test.go
+++ b/vault/resource_okta_auth_backend_test.go
@@ -203,7 +203,10 @@ func testAccOktaAuthBackend_InitialCheck(s *terraform.State) error {
 		return fmt.Errorf("id doesn't match path")
 	}
 
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+	client, e := provider.GetClient(instanceState, testProvider.Meta())
+	if e != nil {
+		return e
+	}
 
 	authMounts, err := client.Sys().ListAuth()
 	if err != nil {

--- a/vault/resource_password_policy_test.go
+++ b/vault/resource_password_policy_test.go
@@ -62,11 +62,16 @@ func TestAccPasswordPolicy_import(t *testing.T) {
 }
 
 func testAccPasswordPolicyCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_password_policy" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		name := rs.Primary.Attributes["name"]
 		data, err := client.Logical().Read(fmt.Sprintf("sys/policies/password/%s", name))
 		if err != nil {

--- a/vault/resource_pki_secret_backend_cert_test.go
+++ b/vault/resource_pki_secret_backend_cert_test.go
@@ -212,10 +212,7 @@ func TestPkiSecretBackendCert_renew(t *testing.T) {
 			{
 				// test unmounted backend
 				PreConfig: func() {
-					client, e := testProvider.Meta().(*provider.ProviderMeta).GetNSClient("")
-					if e != nil {
-						t.Fatal(e)
-					}
+					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 					if err := client.Sys().Unmount(path); err != nil {
 						t.Fatal(err)

--- a/vault/resource_pki_secret_backend_cert_test.go
+++ b/vault/resource_pki_secret_backend_cert_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
@@ -47,7 +48,7 @@ func TestPkiSecretBackendCert_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
-		CheckDestroy: testPkiSecretBackendCertDestroy,
+		CheckDestroy: testCheckMountDestroyed("vault_mount", consts.MountTypePKI, consts.FieldPath),
 		Steps: []resource.TestStep{
 			{
 				Config: testPkiSecretBackendCertConfig_basic(rootPath, intermediatePath, true, false),
@@ -79,29 +80,6 @@ func TestPkiSecretBackendCert_basic(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testPkiSecretBackendCertDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
-	mounts, err := client.Sys().ListMounts()
-	if err != nil {
-		return err
-	}
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "vault_mount" {
-			continue
-		}
-		for path, mount := range mounts {
-			path = strings.Trim(path, "/")
-			rsPath := strings.Trim(rs.Primary.Attributes["path"], "/")
-			if mount.Type == "pki" && path == rsPath {
-				return fmt.Errorf("Mount %q still exists", path)
-			}
-		}
-	}
-	return nil
 }
 
 func testPkiSecretBackendCertConfig_basic(rootPath, intermediatePath string, withCert, revoke bool) string {
@@ -210,7 +188,7 @@ func TestPkiSecretBackendCert_renew(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
-		CheckDestroy: testPkiSecretBackendCertDestroy,
+		CheckDestroy: testCheckMountDestroyed("vault_mount", consts.MountTypePKI, consts.FieldPath),
 		Steps: []resource.TestStep{
 			{
 				Config: testPkiSecretBackendCertConfig_renew(path),
@@ -234,7 +212,11 @@ func TestPkiSecretBackendCert_renew(t *testing.T) {
 			{
 				// test unmounted backend
 				PreConfig: func() {
-					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+					client, e := testProvider.Meta().(*provider.ProviderMeta).GetNSClient("")
+					if e != nil {
+						t.Fatal(e)
+					}
+
 					if err := client.Sys().Unmount(path); err != nil {
 						t.Fatal(err)
 					}

--- a/vault/resource_pki_secret_backend_config_urls_test.go
+++ b/vault/resource_pki_secret_backend_config_urls_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
@@ -22,7 +23,8 @@ func TestPkiSecretBackendConfigUrls_basic(t *testing.T) {
 	crlDistributionPoints := "http://127.0.0.1:8200/v1/pki/crl"
 	ocspServers := "http://127.0.0.1:8200/v1/pki/oscp"
 
-	resourceName := "vault_pki_secret_backend_config_urls.test"
+	resourceType := "vault_pki_secret_backend_config_urls"
+	resourceName := resourceType + ".test"
 	getChecks := func(i, c, o string) []resource.TestCheckFunc {
 		checks := []resource.TestCheckFunc{
 			resource.TestCheckResourceAttr(
@@ -44,7 +46,7 @@ func TestPkiSecretBackendConfigUrls_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
-		CheckDestroy: testPkiSecretBackendConfigUrlsDestroy,
+		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypePKI, consts.FieldPath),
 		Steps: []resource.TestStep{
 			{
 				// Test that reading from an unconfigured mount succeeds
@@ -88,18 +90,6 @@ func testPkiSecretBackendConfigUrlsEmptyRead(s *terraform.State) error {
 			return err
 		}
 	}
-	return nil
-}
-
-func testPkiSecretBackendConfigUrlsDestroy(s *terraform.State) error {
-	paths, err := listPkiPaths(s)
-	if err != nil {
-		return err
-	}
-	for _, path := range paths {
-		return fmt.Errorf("mount %q still exists", path)
-	}
-
 	return nil
 }
 

--- a/vault/resource_pki_secret_backend_config_urls_test.go
+++ b/vault/resource_pki_secret_backend_config_urls_test.go
@@ -46,7 +46,7 @@ func TestPkiSecretBackendConfigUrls_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
-		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypePKI, consts.FieldPath),
+		CheckDestroy: testCheckMountDestroyed("vault_mount", consts.MountTypePKI, consts.FieldPath),
 		Steps: []resource.TestStep{
 			{
 				// Test that reading from an unconfigured mount succeeds

--- a/vault/resource_pki_secret_backend_crl_config_test.go
+++ b/vault/resource_pki_secret_backend_crl_config_test.go
@@ -3,14 +3,12 @@ package vault
 import (
 	"fmt"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -20,7 +18,7 @@ func TestPkiSecretBackendCrlConfig_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
-		CheckDestroy: testPkiSecretBackendCrlConfigDestroy,
+		CheckDestroy: testCheckMountDestroyed("vault_mount", consts.MountTypePKI, consts.FieldPath),
 		Steps: []resource.TestStep{
 			{
 				Config: testPkiSecretBackendCrlConfigConfig_basic(rootPath),
@@ -31,29 +29,6 @@ func TestPkiSecretBackendCrlConfig_basic(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testPkiSecretBackendCrlConfigDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
-	mounts, err := client.Sys().ListMounts()
-	if err != nil {
-		return err
-	}
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "vault_mount" {
-			continue
-		}
-		for path, mount := range mounts {
-			path = strings.Trim(path, "/")
-			rsPath := strings.Trim(rs.Primary.Attributes["path"], "/")
-			if mount.Type == "pki" && path == rsPath {
-				return fmt.Errorf("mount %q still exists", path)
-			}
-		}
-	}
-	return nil
 }
 
 func testPkiSecretBackendCrlConfigConfig_basic(rootPath string) string {

--- a/vault/resource_pki_secret_backend_intermediate_cert_request_test.go
+++ b/vault/resource_pki_secret_backend_intermediate_cert_request_test.go
@@ -3,14 +3,12 @@ package vault
 import (
 	"fmt"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -21,7 +19,7 @@ func TestPkiSecretBackendIntermediateCertRequest_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
-		CheckDestroy: testPkiSecretBackendIntermediateCertRequestDestroy,
+		CheckDestroy: testCheckMountDestroyed("vault_mount", consts.MountTypePKI, consts.FieldPath),
 		Steps: []resource.TestStep{
 			{
 				Config: testPkiSecretBackendIntermediateCertRequestConfig_basic(path),
@@ -35,29 +33,6 @@ func TestPkiSecretBackendIntermediateCertRequest_basic(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testPkiSecretBackendIntermediateCertRequestDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
-	mounts, err := client.Sys().ListMounts()
-	if err != nil {
-		return err
-	}
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "vault_mount" {
-			continue
-		}
-		for path, mount := range mounts {
-			path = strings.Trim(path, "/")
-			rsPath := strings.Trim(rs.Primary.Attributes["path"], "/")
-			if mount.Type == "pki" && path == rsPath {
-				return fmt.Errorf("Mount %q still exists", path)
-			}
-		}
-	}
-	return nil
 }
 
 func testPkiSecretBackendIntermediateCertRequestConfig_basic(path string) string {

--- a/vault/resource_pki_secret_backend_intermediate_set_signed_test.go
+++ b/vault/resource_pki_secret_backend_intermediate_set_signed_test.go
@@ -3,14 +3,12 @@ package vault
 import (
 	"fmt"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -22,7 +20,7 @@ func TestPkiSecretBackendIntermediateSetSigned_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
-		CheckDestroy: testPkiSecretBackendIntermediateSetSignedDestroy,
+		CheckDestroy: testCheckMountDestroyed("vault_mount", consts.MountTypePKI, consts.FieldPath),
 		Steps: []resource.TestStep{
 			{
 				Config: testPkiSecretBackendIntermediateSetSignedConfig_basic(rootPath, intermediatePath),
@@ -32,29 +30,6 @@ func TestPkiSecretBackendIntermediateSetSigned_basic(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testPkiSecretBackendIntermediateSetSignedDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
-	mounts, err := client.Sys().ListMounts()
-	if err != nil {
-		return err
-	}
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "vault_mount" {
-			continue
-		}
-		for path, mount := range mounts {
-			path = strings.Trim(path, "/")
-			rsPath := strings.Trim(rs.Primary.Attributes["path"], "/")
-			if mount.Type == "pki" && path == rsPath {
-				return fmt.Errorf("Mount %q still exists", path)
-			}
-		}
-	}
-	return nil
 }
 
 func testPkiSecretBackendIntermediateSetSignedConfig_basic(rootPath string, intermediatePath string) string {

--- a/vault/resource_pki_secret_backend_role_test.go
+++ b/vault/resource_pki_secret_backend_role_test.go
@@ -248,12 +248,16 @@ resource "vault_pki_secret_backend_role" "test" {
 }
 
 func testPkiSecretBackendRoleCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_pki_secret_backend_role" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return err

--- a/vault/resource_pki_secret_backend_root_cert_test.go
+++ b/vault/resource_pki_secret_backend_root_cert_test.go
@@ -55,10 +55,7 @@ func TestPkiSecretBackendRootCertificate_basic(t *testing.T) {
 			{
 				// test unmounted backend
 				PreConfig: func() {
-					client, e := testProvider.Meta().(*provider.ProviderMeta).GetNSClient("")
-					if e != nil {
-						t.Fatal(e)
-					}
+					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 					if err := client.Sys().Unmount(path); err != nil {
 						t.Fatal(err)
@@ -75,10 +72,7 @@ func TestPkiSecretBackendRootCertificate_basic(t *testing.T) {
 			{
 				// test out of band update to the root CA
 				PreConfig: func() {
-					client, e := testProvider.Meta().(*provider.ProviderMeta).GetNSClient("")
-					if e != nil {
-						t.Fatal(e)
-					}
+					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 					_, err := client.Logical().Delete(fmt.Sprintf("%s/root", path))
 					if err != nil {

--- a/vault/resource_pki_secret_backend_sign_test.go
+++ b/vault/resource_pki_secret_backend_sign_test.go
@@ -184,10 +184,7 @@ func TestPkiSecretBackendSign_renew(t *testing.T) {
 			{
 				// test unmounted backend
 				PreConfig: func() {
-					client, e := testProvider.Meta().(*provider.ProviderMeta).GetNSClient("")
-					if e != nil {
-						t.Fatal(e)
-					}
+					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 
 					if err := client.Sys().Unmount(path); err != nil {
 						t.Fatal(err)

--- a/vault/resource_policy_test.go
+++ b/vault/resource_policy_test.go
@@ -65,7 +65,11 @@ func testResourcePolicy_initialCheck(expectedName string) resource.TestCheckFunc
 			return fmt.Errorf("unexpected policy name %q, expected %q", name, expectedName)
 		}
 
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		client, e := provider.GetClient(instanceState, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		policy, err := client.Sys().GetPolicy(name)
 		if err != nil {
 			return fmt.Errorf("error reading back policy: %s", err)
@@ -98,7 +102,10 @@ func testResourcePolicy_updateCheck(s *terraform.State) error {
 
 	name := instanceState.ID
 
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+	client, e := provider.GetClient(instanceState, testProvider.Meta())
+	if e != nil {
+		return e
+	}
 
 	if name != instanceState.Attributes["name"] {
 		return fmt.Errorf("id doesn't match name")

--- a/vault/resource_rabbitmq_secret_backend.go
+++ b/vault/resource_rabbitmq_secret_backend.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
@@ -112,7 +113,7 @@ func rabbitMQSecretBackendCreate(d *schema.ResourceData, meta interface{}) error
 	d.Partial(true)
 	log.Printf("[DEBUG] Mounting Rabbitmq backend at %q", path)
 	err := client.Sys().Mount(path, &api.MountInput{
-		Type:        "rabbitmq",
+		Type:        consts.MountTypeRabbitMQ,
 		Description: description,
 		Config: api.MountConfigInput{
 			DefaultLeaseTTL: fmt.Sprintf("%ds", defaultTTL),

--- a/vault/resource_rabbitmq_secret_backend_role_test.go
+++ b/vault/resource_rabbitmq_secret_backend_role_test.go
@@ -152,12 +152,16 @@ func TestAccRabbitMQSecretBackendRole_topic(t *testing.T) {
 }
 
 func testAccRabbitMQSecretBackendRoleCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_rabbitmq_secret_backend_role" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return err

--- a/vault/resource_rabbitmq_secret_backend_test.go
+++ b/vault/resource_rabbitmq_secret_backend_test.go
@@ -2,25 +2,24 @@ package vault
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
 func TestAccRabbitMQSecretBackend_basic(t *testing.T) {
 	path := acctest.RandomWithPrefix("tf-test-rabbitmq")
 	connectionUri, username, password := testutil.GetTestRMQCreds(t)
-	resourceName := "vault_rabbitmq_secret_backend.test"
+	resourceType := "vault_rabbitmq_secret_backend"
+	resourceName := resourceType + ".test"
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
-		CheckDestroy: testAccRabbitMQSecretBackendCheckDestroy,
+		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeRabbitMQ, consts.FieldPath),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRabbitMQSecretBackendConfig_basic(path, connectionUri, username, password),
@@ -60,11 +59,12 @@ func TestAccRabbitMQSecretBackend_basic(t *testing.T) {
 func TestAccRabbitMQSecretBackend_template(t *testing.T) {
 	path := acctest.RandomWithPrefix("tf-test-rabbitmq")
 	connectionUri, username, password := testutil.GetTestRMQCreds(t)
-	resourceName := "vault_rabbitmq_secret_backend.test"
+	resourceType := "vault_rabbitmq_secret_backend"
+	resourceName := resourceType + ".test"
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
-		CheckDestroy: testAccRabbitMQSecretBackendCheckDestroy,
+		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeRabbitMQ, consts.FieldPath),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRabbitMQSecretBackendTemplateConfig(path, connectionUri, username, password, path, path),
@@ -86,29 +86,6 @@ func TestAccRabbitMQSecretBackend_template(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccRabbitMQSecretBackendCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
-	mounts, err := client.Sys().ListMounts()
-	if err != nil {
-		return err
-	}
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "vault_rabbitmq_secret_backend" {
-			continue
-		}
-		for path, mount := range mounts {
-			path = strings.Trim(path, "/")
-			rsPath := strings.Trim(rs.Primary.Attributes["path"], "/")
-			if mount.Type == "rabbitmq" && path == rsPath {
-				return fmt.Errorf("mount %q still exists", path)
-			}
-		}
-	}
-	return nil
 }
 
 func testAccRabbitMQSecretBackendConfig_basic(path, connectionUri, username, password string) string {

--- a/vault/resource_raft_autopilot_test.go
+++ b/vault/resource_raft_autopilot_test.go
@@ -48,12 +48,16 @@ func TestAccRaftAutopilotConfig_basic(t *testing.T) {
 }
 
 func testAccRaftAutopilotConfigCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_raft_autopilot_config" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		autopilot, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return err

--- a/vault/resource_raft_snapshot_agent_config_test.go
+++ b/vault/resource_raft_snapshot_agent_config_test.go
@@ -127,12 +127,16 @@ func TestAccRaftSnapshotAgentConfig_import(t *testing.T) {
 }
 
 func testAccRaftSnapshotAgentConfigCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_raft_snapshot_agent_config" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		snapshot, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return err

--- a/vault/resource_rgp_policy_test.go
+++ b/vault/resource_rgp_policy_test.go
@@ -40,11 +40,16 @@ func TestAccRoleGoverningPolicy(t *testing.T) {
 }
 
 func testAccRoleGoverningPolicyCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_rgp_policy" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		name := rs.Primary.Attributes["name"]
 		data, err := client.Logical().Read(fmt.Sprintf("sys/policies/rgp/%s", name))
 		if err != nil {

--- a/vault/resource_ssh_secret_backend_ca_test.go
+++ b/vault/resource_ssh_secret_backend_ca_test.go
@@ -65,12 +65,16 @@ func TestAccSSHSecretBackend_import(t *testing.T) {
 }
 
 func testAccCheckSSHSecretBackendCADestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_ssh_secret_backend_ca" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		backend := rs.Primary.ID
 		secret, err := client.Logical().Read(backend + "/config/ca")
 		if err != nil {

--- a/vault/resource_ssh_secret_backend_role_test.go
+++ b/vault/resource_ssh_secret_backend_role_test.go
@@ -138,12 +138,16 @@ func TestAccSSHSecretBackendRoleOTP_basic(t *testing.T) {
 }
 
 func testAccSSHSecretBackendRoleCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_ssh_secret_backend_role" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		role, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return err

--- a/vault/resource_terraform_cloud_secret_creds_test.go
+++ b/vault/resource_terraform_cloud_secret_creds_test.go
@@ -164,12 +164,16 @@ resource "vault_terraform_cloud_secret_creds" "token" {
 }
 
 func testAccResourceTerraformCloudSecretCredsCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_terraform_cloud_secret_creds" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return err

--- a/vault/resource_terraform_cloud_secret_role_test.go
+++ b/vault/resource_terraform_cloud_secret_role_test.go
@@ -75,12 +75,16 @@ func TestTerraformCloudSecretRole(t *testing.T) {
 }
 
 func testAccTerraformCloudSecretRoleCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_terraform_cloud_secret_role" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return err

--- a/vault/resource_token_auth_backend_role_test.go
+++ b/vault/resource_token_auth_backend_role_test.go
@@ -130,12 +130,16 @@ func TestAccTokenAuthBackendRoleUpdate(t *testing.T) {
 }
 
 func testAccCheckTokenAuthBackendRoleDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_token_auth_backend_role" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("error checking for Token auth backend role %q: %s", rs.Primary.ID, err)

--- a/vault/resource_token_test.go
+++ b/vault/resource_token_test.go
@@ -14,12 +14,16 @@ import (
 )
 
 func testResourceTokenCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_token" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		_, err := client.Auth().Token().LookupAccessor(rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("token with accessor %q still exists", rs.Primary.ID)
@@ -322,7 +326,10 @@ func testResourceTokenLookup(n string) resource.TestCheckFunc {
 			return fmt.Errorf("No ID is set")
 		}
 
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
 
 		_, err := client.Auth().Token().LookupAccessor(rs.Primary.ID)
 		if err != nil {
@@ -344,7 +351,10 @@ func testResourceTokenCheckExpireTime(n string) resource.TestCheckFunc {
 			return fmt.Errorf("No ID is set")
 		}
 
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
 
 		token, err := client.Auth().Token().LookupAccessor(rs.Primary.ID)
 		if err != nil {
@@ -413,7 +423,10 @@ func testResourceTokenWaitRenewMinLeaseTime(n string) resource.TestCheckFunc {
 			return fmt.Errorf("No ID is set")
 		}
 
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
 
 		token, err := client.Auth().Token().LookupAccessor(rs.Primary.ID)
 		if err != nil {

--- a/vault/resource_transit_cache_config_test.go
+++ b/vault/resource_transit_cache_config_test.go
@@ -47,12 +47,16 @@ func TestAccTransitCacheConfig(t *testing.T) {
 }
 
 func testAccTransitCacheConfigCheckDestroyed(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_transit_secret_cache_config" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("Error checking for transit cache config %q: %s", rs.Primary.ID, err)
@@ -78,7 +82,11 @@ func testAccTransitCacheConfigCheckApi(size int) resource.TestCheckFunc {
 
 		id := instanceState.ID
 
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		client, e := provider.GetClient(instanceState, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		resp, err := client.Logical().Read(id)
 		if err != nil {
 			return err

--- a/vault/resource_transit_secret_backend_key_test.go
+++ b/vault/resource_transit_secret_backend_key_test.go
@@ -263,12 +263,16 @@ resource "vault_transit_secret_backend_key" "test" {
 }
 
 func testTransitSecretBackendKeyCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_transit_secret_backend_key" {
 			continue
 		}
+
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
 			return err

--- a/vault/testhelpers_test.go
+++ b/vault/testhelpers_test.go
@@ -16,10 +16,14 @@ func testCheckMountDestroyed(resourceType, mountType, pathField string) resource
 		if pathField == "" {
 			pathField = consts.FieldPath
 		}
+
+		var resourceCount int
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != resourceType {
 				continue
 			}
+
+			resourceCount++
 
 			client, e := provider.GetClient(rs.Primary, testProvider.Meta())
 			if e != nil {
@@ -43,6 +47,10 @@ func testCheckMountDestroyed(resourceType, mountType, pathField string) resource
 					return fmt.Errorf("mount %q still exists", path)
 				}
 			}
+		}
+
+		if resourceCount == 0 {
+			return fmt.Errorf("expected at least 1 resources of type %q in State", resourceType)
 		}
 
 		return nil

--- a/vault/testhelpers_test.go
+++ b/vault/testhelpers_test.go
@@ -1,0 +1,50 @@
+package vault
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+	"github.com/hashicorp/terraform-provider-vault/util"
+)
+
+func testCheckMountDestroyed(resourceType, mountType, pathField string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if pathField == "" {
+			pathField = consts.FieldPath
+		}
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != resourceType {
+				continue
+			}
+
+			client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+			if e != nil {
+				return e
+			}
+
+			mounts, err := client.Sys().ListMounts()
+			if err != nil {
+				return err
+			}
+
+			rsPath, ok := rs.Primary.Attributes[pathField]
+			if !ok {
+				return fmt.Errorf("resource's InstanceState missing required field %q", pathField)
+			}
+
+			rsPath = util.NormalizeMountPath(rsPath)
+			for path, mount := range mounts {
+				path = util.NormalizeMountPath(path)
+				if mount.Type == mountType && path == rsPath {
+					return fmt.Errorf("mount %q still exists", path)
+				}
+			}
+		}
+
+		return nil
+	}
+}

--- a/vault/validators.go
+++ b/vault/validators.go
@@ -6,13 +6,15 @@ import (
 	"time"
 
 	"github.com/gosimple/slug"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 )
 
 const pathDelim = "/"
 
 var (
-	regexpPathLeading  = regexp.MustCompile(fmt.Sprintf(`^%s`, pathDelim))
-	regexpPathTrailing = regexp.MustCompile(fmt.Sprintf(`%s$`, pathDelim))
+	regexpPathLeading  = regexp.MustCompile(fmt.Sprintf(`^%s`, consts.PathDelim))
+	regexpPathTrailing = regexp.MustCompile(fmt.Sprintf(`%s$`, consts.PathDelim))
 	regexpPath         = regexp.MustCompile(fmt.Sprintf(`%s|%s`, regexpPathLeading, regexpPathTrailing))
 )
 
@@ -71,7 +73,7 @@ func validatePath(r *regexp.Regexp, i interface{}, k string) error {
 	}
 
 	if r.MatchString(v) {
-		return fmt.Errorf("invalid value %q for %q, contains leading/trailing %q", v, k, pathDelim)
+		return fmt.Errorf("invalid value %q for %q, contains leading/trailing %q", v, k, consts.PathDelim)
 	}
 
 	return nil

--- a/vault/validators_test.go
+++ b/vault/validators_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 )
 
 func Test_validateNoTrailingSlash(t *testing.T) {
@@ -103,7 +105,7 @@ func Test_validateNoLeadingTrailingSlashes(t *testing.T) {
 			if tt.wantErr {
 				expectedErrs = []error{
 					fmt.Errorf(`invalid value %q for %q, contains leading/trailing %q`,
-						tt.args.i, tt.args.k, pathDelim),
+						tt.args.i, tt.args.k, consts.PathDelim),
 				}
 			}
 


### PR DESCRIPTION
This PR is meant to get the acceptance tests in a better position for supporting namespaced resources/data sources.

Numerous fixes:
- factor out a common check mount destroy test function
- add new constants for mount types

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
