### PR TITLE
Update namespace tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v0.3.1
 	github.com/Azure/go-autorest/autorest v0.11.24
 	github.com/aws/aws-sdk-go v1.41.8
+	github.com/cenkalti/backoff/v4 v4.1.2
 	github.com/containerd/containerd v1.6.6 // indirect
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
 	github.com/denisenkom/go-mssqldb v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -293,6 +293,7 @@ github.com/cenkalti/backoff/v3 v3.2.2 h1:cfUAAO3yvKMYKPrvhDuHSwQnhZNk/RMHKdZqKTx
 github.com/cenkalti/backoff/v3 v3.2.2/go.mod h1:cIeZDE3IrqwwJl6VUwCN6trj1oXrTS4rc0ij+ULvLYs=
 github.com/cenkalti/backoff/v4 v4.1.0/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
+github.com/cenkalti/backoff/v4 v4.1.2 h1:6Yo7N8UP2K6LWZnW94DLVSSrbobcWdVzAYOisuDPIFo=
 github.com/cenkalti/backoff/v4 v4.1.2/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/centrify/cloud-golang-sdk v0.0.0-20210923165758-a8c48d049166/go.mod h1:c/gmvyN8lq6lYtHvrqqoXrg2xyN65N0mBmbikxFWXNE=

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -1,22 +1,34 @@
 package consts
 
 const (
-	// common field names
-	FieldPath       = "path"
-	FieldParameters = "parameters"
-	FieldMethod     = "method"
-	FieldNamespace  = "namespace"
-	FieldBackend    = "backend"
+	/*
+		common field names
+	*/
+	FieldPath        = "path"
+	FieldParameters  = "parameters"
+	FieldMethod      = "method"
+	FieldNamespace   = "namespace"
+	FieldNamespaceID = "namespace_id"
+	FieldBackend     = "backend"
 
-	// env vars
+	/*
+		common environment variables
+	*/
 	EnvVarVaultNamespaceImport = "TERRAFORM_VAULT_NAMESPACE_IMPORT"
 	EnvVarSkipChildToken       = "TERRAFORM_VAULT_SKIP_CHILD_TOKEN"
 
-	// common mount types
+	/*
+		common mount types
+	*/
 	MountTypeDatabase = "database"
 	MountTypePKI      = "pki"
 	MountTypeAWS      = "aws"
 	MountTypeKMIP     = "kmip"
 	MountTypeRabbitMQ = "rabbitmq"
 	MountTypeNomad    = "nomad"
+
+	/*
+		misc. path related constants
+	*/
+	PathDelim = "/"
 )

--- a/util/util.go
+++ b/util/util.go
@@ -14,6 +14,8 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 )
 
 func JsonDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
@@ -308,7 +310,12 @@ func SetResourceData(d *schema.ResourceData, data map[string]interface{}) error 
 
 // NormalizeMountPath to be in a form valid for accessing values from api.MountOutput
 func NormalizeMountPath(path string) string {
-	return strings.Trim(path, "/") + "/"
+	return TrimSlashes(path) + consts.PathDelim
+}
+
+// TrimSlashes from path.
+func TrimSlashes(path string) string {
+	return strings.Trim(path, consts.PathDelim)
 }
 
 // CheckMountEnabled in Vault, path must contain a trailing '/',

--- a/vault/data_identity_entity.go
+++ b/vault/data_identity_entity.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/identity/entity"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
@@ -22,7 +23,7 @@ var (
 		"last_update_time",
 		"merged_entity_ids",
 		"metadata",
-		"namespace_id",
+		consts.FieldNamespaceID,
 		"policies",
 	}
 
@@ -172,7 +173,7 @@ func identityEntityDataSource() *schema.Resource {
 				Type:     schema.TypeMap,
 				Computed: true,
 			},
-			"namespace_id": {
+			consts.FieldNamespaceID: {
 				Type:     schema.TypeString,
 				Computed: true,
 			},

--- a/vault/data_identity_group.go
+++ b/vault/data_identity_group.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/identity/group"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
@@ -20,7 +21,7 @@ var (
 		"member_group_ids",
 		"metadata",
 		"modify_index",
-		"namespace_id",
+		consts.FieldNamespaceID,
 		"parent_group_ids",
 		"policies",
 		"type",
@@ -112,7 +113,7 @@ func identityGroupDataSource() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
-			"namespace_id": {
+			consts.FieldNamespaceID: {
 				Type:     schema.TypeString,
 				Computed: true,
 			},

--- a/vault/resource_auth_backend_test.go
+++ b/vault/resource_auth_backend_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/vault/api"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
@@ -23,17 +24,17 @@ func TestResourceAuth(t *testing.T) {
 		PreCheck:  func() { testutil.TestAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: testResourceAuth_initialConfig(path + pathDelim),
+				Config: testResourceAuth_initialConfig(path + consts.PathDelim),
 				ExpectError: regexp.MustCompile(
 					fmt.Sprintf(`invalid value "%s" for %q, contains leading/trailing %q`,
-						path+pathDelim, "path", pathDelim),
+						path+consts.PathDelim, "path", consts.PathDelim),
 				),
 			},
 			{
-				Config: testResourceAuth_initialConfig(pathDelim + path),
+				Config: testResourceAuth_initialConfig(consts.PathDelim + path),
 				ExpectError: regexp.MustCompile(
 					fmt.Sprintf(`invalid value "%s" for %q, contains leading/trailing %q`,
-						pathDelim+path, "path", pathDelim),
+						consts.PathDelim+path, "path", consts.PathDelim),
 				),
 			},
 			{

--- a/vault/resource_jwt_auth_backend_test.go
+++ b/vault/resource_jwt_auth_backend_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
@@ -113,7 +114,7 @@ func TestAccJWTAuthBackend_OIDC(t *testing.T) {
 
 func TestAccJWTAuthBackend_invalid(t *testing.T) {
 	path := acctest.RandomWithPrefix("jwt")
-	invalidPath := path + pathDelim
+	invalidPath := path + consts.PathDelim
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testutil.TestAccPreCheck(t) },
 		Providers: testProviders,
@@ -123,7 +124,7 @@ func TestAccJWTAuthBackend_invalid(t *testing.T) {
 				Destroy: false,
 				ExpectError: regexp.MustCompile(
 					fmt.Sprintf(`invalid value "%s" for "path", contains leading/trailing "%s"`,
-						invalidPath, pathDelim)),
+						invalidPath, consts.PathDelim)),
 			},
 			{
 				Config: fmt.Sprintf(`resource "vault_jwt_auth_backend" "jwt" {

--- a/vault/resource_mfa_pingid.go
+++ b/vault/resource_mfa_pingid.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
@@ -73,7 +74,7 @@ func mfaPingIDResource() *schema.Resource {
 				Optional:    true,
 				Description: "ID computed by Vault.",
 			},
-			"namespace_id": {
+			consts.FieldNamespaceID: {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Namespace ID computed by Vault.",
@@ -160,7 +161,7 @@ func mfaPingIDRead(d *schema.ResourceData, meta interface{}) error {
 	fields := []string{
 		"name", "idp_url", "admin_url",
 		"authenticator_url", "org_alias", "type",
-		"use_signature", "id", "namespace_id",
+		"use_signature", "id", consts.FieldNamespaceID,
 	}
 
 	for _, k := range fields {

--- a/vault/resource_mfa_pingid_test.go
+++ b/vault/resource_mfa_pingid_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -27,7 +28,7 @@ func TestMFAPingIDBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "username_format", "user@example.com"),
 					resource.TestCheckResourceAttr(resourceName, "type", "pingid"),
 					resource.TestCheckResourceAttr(resourceName, "use_signature", "true"),
-					resource.TestCheckResourceAttr(resourceName, "namespace_id", ""),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldNamespaceID, ""),
 					resource.TestCheckResourceAttr(resourceName, "settings_file_base64", settingsFile),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 				),

--- a/vault/validators.go
+++ b/vault/validators.go
@@ -6,13 +6,15 @@ import (
 	"time"
 
 	"github.com/gosimple/slug"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 )
 
 const pathDelim = "/"
 
 var (
-	regexpPathLeading  = regexp.MustCompile(fmt.Sprintf(`^%s`, pathDelim))
-	regexpPathTrailing = regexp.MustCompile(fmt.Sprintf(`%s$`, pathDelim))
+	regexpPathLeading  = regexp.MustCompile(fmt.Sprintf(`^%s`, consts.PathDelim))
+	regexpPathTrailing = regexp.MustCompile(fmt.Sprintf(`%s$`, consts.PathDelim))
 	regexpPath         = regexp.MustCompile(fmt.Sprintf(`%s|%s`, regexpPathLeading, regexpPathTrailing))
 )
 
@@ -71,7 +73,7 @@ func validatePath(r *regexp.Regexp, i interface{}, k string) error {
 	}
 
 	if r.MatchString(v) {
-		return fmt.Errorf("invalid value %q for %q, contains leading/trailing %q", v, k, pathDelim)
+		return fmt.Errorf("invalid value %q for %q, contains leading/trailing %q", v, k, consts.PathDelim)
 	}
 
 	return nil

--- a/vault/validators_test.go
+++ b/vault/validators_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 )
 
 func Test_validateNoTrailingSlash(t *testing.T) {
@@ -103,7 +105,7 @@ func Test_validateNoLeadingTrailingSlashes(t *testing.T) {
 			if tt.wantErr {
 				expectedErrs = []error{
 					fmt.Errorf(`invalid value %q for %q, contains leading/trailing %q`,
-						tt.args.i, tt.args.k, pathDelim),
+						tt.args.i, tt.args.k, consts.PathDelim),
 				}
 			}
 


### PR DESCRIPTION
- add workaround to handle child namespace deletion failures on
  vault-1.10+

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ time make testacc-ent TESTARGS='-v -test.count 1 -test.run TestAccNamespace$$'
make testacc TF_ACC_ENTERPRISE=1
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -v -test.count 1 -test.run TestAccNamespace$ -timeout 30m ./...

=== RUN   TestAccNamespace
--- PASS: TestAccNamespace (4.71s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     7.043s
make testacc-ent TESTARGS='-v -test.count 1 -test.run TestAccNamespace$$'  26.49s user 10.76s system 332% cpu 11.196 total

```
