### PR TITLE
Add JWT auth namespace tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
           MSSQL_URL: "sqlserver://sa:${{ secrets.MSSQL_SA_PASSWORD }}@mssql:1433"
           POSTGRES_URL: "postgres://postgres:secret@postgres:5432/database?sslmode=disable"
         run: |
-          make testacc-ent TESTARGS='-v' SKIP_MSSQL_MULTI_CI=true SKIP_RAFT_TESTS=true
+          make testacc-ent TESTARGS='-test.v -test.parallel=10' SKIP_MSSQL_MULTI_CI=true SKIP_RAFT_TESTS=true
       - name: "Generate Vault API Path Coverage Report"
         run: |
           go run cmd/coverage/main.go -openapi-doc=./testdata/openapi.json

--- a/vault/resource_jwt_auth_backend_test.go
+++ b/vault/resource_jwt_auth_backend_test.go
@@ -16,100 +16,198 @@ import (
 
 func TestAccJWTAuthBackend(t *testing.T) {
 	path := acctest.RandomWithPrefix("jwt")
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testutil.TestAccPreCheck(t) },
-		Providers:    testProviders,
-		CheckDestroy: testJWTAuthBackend_Destroyed(path),
-		Steps: []resource.TestStep{
+	resourceName := "vault_jwt_auth_backend.jwt"
+
+	getSteps := func(path, ns string) []resource.TestStep {
+		var commonChecks []resource.TestCheckFunc
+		if ns != "" {
+			commonChecks = append(commonChecks,
+				resource.TestCheckResourceAttr(resourceName, consts.FieldNamespace, ns),
+			)
+		}
+
+		steps := []resource.TestStep{
 			{
-				Config: testAccJWTAuthBackendConfig(path),
+				Config: testAccJWTAuthBackendConfig(path, ns, false),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend.jwt", "description", "JWT backend"),
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend.jwt", "oidc_discovery_url", "https://myco.auth0.com/"),
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend.jwt", "path", path),
-					resource.TestCheckResourceAttrSet("vault_jwt_auth_backend.jwt", "accessor"),
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend.jwt", "bound_issuer", ""),
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend.jwt", "type", "jwt"),
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend.jwt", "local", "false"),
+					append(commonChecks,
+						resource.TestCheckResourceAttr(resourceName, "description", "JWT backend"),
+						resource.TestCheckResourceAttr(resourceName, "oidc_discovery_url", "https://myco.auth0.com/"),
+						resource.TestCheckResourceAttr(resourceName, "path", path),
+						resource.TestCheckResourceAttrSet(resourceName, "accessor"),
+						resource.TestCheckResourceAttr(resourceName, "bound_issuer", ""),
+						resource.TestCheckResourceAttr(resourceName, "type", "jwt"),
+						resource.TestCheckResourceAttr(resourceName, "local", "false"),
+					)...,
 				),
 			},
 			{
-				Config: testAccJWTAuthLocalBackendConfig(path),
+				Config: testAccJWTAuthBackendConfig(path, ns, true),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend.jwt", "description", "JWT backend"),
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend.jwt", "oidc_discovery_url", "https://myco.auth0.com/"),
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend.jwt", "path", path),
-					resource.TestCheckResourceAttrSet("vault_jwt_auth_backend.jwt", "accessor"),
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend.jwt", "bound_issuer", ""),
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend.jwt", "type", "jwt"),
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend.jwt", "local", "true"),
+					append(commonChecks,
+						resource.TestCheckResourceAttr(resourceName, "description", "JWT backend"),
+						resource.TestCheckResourceAttr(resourceName, "oidc_discovery_url", "https://myco.auth0.com/"),
+						resource.TestCheckResourceAttr(resourceName, "path", path),
+						resource.TestCheckResourceAttrSet(resourceName, "accessor"),
+						resource.TestCheckResourceAttr(resourceName, "bound_issuer", ""),
+						resource.TestCheckResourceAttr(resourceName, "type", "jwt"),
+						resource.TestCheckResourceAttr(resourceName, "local", "true"),
+					)...,
 				),
 			},
 			{
-				Config: testAccJWTAuthBackendConfigFullOIDC(path, "https://myco.auth0.com/", "api://default", "\"RS512\""),
+				Config: testAccJWTAuthBackendConfigFullOIDC(path, "https://myco.auth0.com/", "api://default", "\"RS512\"", ns),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend.jwt", "oidc_discovery_url", "https://myco.auth0.com/"),
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend.jwt", "bound_issuer", "api://default"),
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend.jwt", "jwt_supported_algs.#", "1"),
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend.jwt", "type", "jwt"),
+					append(commonChecks,
+						resource.TestCheckResourceAttr(resourceName, "oidc_discovery_url", "https://myco.auth0.com/"),
+						resource.TestCheckResourceAttr(resourceName, "bound_issuer", "api://default"),
+						resource.TestCheckResourceAttr(resourceName, "jwt_supported_algs.#", "1"),
+						resource.TestCheckResourceAttr(resourceName, "type", "jwt"),
+					)...,
 				),
 			},
 			{
-				Config: testAccJWTAuthBackendConfigFullOIDC(path, "https://myco.auth0.com/", "api://default", "\"RS256\",\"RS512\""),
+				Config: testAccJWTAuthBackendConfigFullOIDC(path, "https://myco.auth0.com/", "api://default", "\"RS256\",\"RS512\"", ns),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend.jwt", "oidc_discovery_url", "https://myco.auth0.com/"),
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend.jwt", "bound_issuer", "api://default"),
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend.jwt", "jwt_supported_algs.#", "2"),
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend.jwt", "type", "jwt"),
+					append(commonChecks,
+						resource.TestCheckResourceAttr(resourceName, "oidc_discovery_url", "https://myco.auth0.com/"),
+						resource.TestCheckResourceAttr(resourceName, "bound_issuer", "api://default"),
+						resource.TestCheckResourceAttr(resourceName, "jwt_supported_algs.#", "2"),
+						resource.TestCheckResourceAttr(resourceName, "type", "jwt"),
+					)...,
 				),
 			},
-		},
-	})
+		}
+
+		return steps
+	}
+
+	t.Run("basic", func(t *testing.T) {
+		resource.Test(t, resource.TestCase{
+			PreCheck:     func() { testutil.TestAccPreCheck(t) },
+			Providers:    testProviders,
+			CheckDestroy: testJWTAuthBackend_Destroyed(path),
+			Steps:        getSteps(path, ""),
+		})
+	},
+	)
+
+	t.Run("ns", func(t *testing.T) {
+		ns := acctest.RandomWithPrefix("ns")
+		path := acctest.RandomWithPrefix("jwt")
+		resource.Test(t, resource.TestCase{
+			PreCheck:     func() { testutil.TestEntPreCheck(t) },
+			Providers:    testProviders,
+			CheckDestroy: testJWTAuthBackend_Destroyed(path),
+			Steps:        getSteps(path, ns),
+		})
+	},
+	)
 }
 
 func TestAccJWTAuthBackendProviderConfig(t *testing.T) {
 	path := acctest.RandomWithPrefix("oidc")
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testutil.TestAccPreCheck(t) },
-		Providers:    testProviders,
-		CheckDestroy: testJWTAuthBackend_Destroyed(path),
-		Steps: []resource.TestStep{
+	resourceName := "vault_jwt_auth_backend.oidc"
+	getSteps := func(path, ns string) []resource.TestStep {
+		var commonChecks []resource.TestCheckFunc
+		if ns != "" {
+			commonChecks = append(commonChecks,
+				resource.TestCheckResourceAttr(resourceName, consts.FieldNamespace, ns),
+			)
+		}
+		steps := []resource.TestStep{
 			{
-				Config: testAccJWTAuthBackendProviderConfig(path),
+				Config: testAccJWTAuthBackendProviderConfig(path, ns),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend.oidc", "oidc_discovery_url", "https://myco.auth0.com/"),
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend.oidc", "type", "oidc"),
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend.oidc", "provider_config.provider", "azure"),
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend.oidc", "provider_config.groups_recurse_max_depth", "1"),
+					append(commonChecks,
+						resource.TestCheckResourceAttr(resourceName, "oidc_discovery_url", "https://myco.auth0.com/"),
+						resource.TestCheckResourceAttr(resourceName, "type", "oidc"),
+						resource.TestCheckResourceAttr(resourceName, "provider_config.provider", "azure"),
+						resource.TestCheckResourceAttr(resourceName, "provider_config.groups_recurse_max_depth", "1"),
+					)...,
 				),
 			},
-		},
-	})
+		}
+
+		return steps
+	}
+
+	t.Run("basic", func(t *testing.T) {
+		resource.Test(t, resource.TestCase{
+			PreCheck:     func() { testutil.TestAccPreCheck(t) },
+			Providers:    testProviders,
+			CheckDestroy: testJWTAuthBackend_Destroyed(path),
+			Steps:        getSteps(path, ""),
+		})
+	},
+	)
+
+	t.Run("ns", func(t *testing.T) {
+		ns := acctest.RandomWithPrefix("ns")
+		path := acctest.RandomWithPrefix("jwt")
+		resource.Test(t, resource.TestCase{
+			PreCheck:     func() { testutil.TestEntPreCheck(t) },
+			Providers:    testProviders,
+			CheckDestroy: testJWTAuthBackend_Destroyed(path),
+			Steps:        getSteps(path, ns),
+		})
+	},
+	)
 }
 
 func TestAccJWTAuthBackend_OIDC(t *testing.T) {
-	path := acctest.RandomWithPrefix("oidc")
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testutil.TestAccPreCheck(t) },
-		Providers:    testProviders,
-		CheckDestroy: testJWTAuthBackend_Destroyed(path),
-		Steps: []resource.TestStep{
+	resourceName := "vault_jwt_auth_backend.oidc"
+	getSteps := func(path, ns string) []resource.TestStep {
+		var commonChecks []resource.TestCheckFunc
+		if ns != "" {
+			commonChecks = append(commonChecks,
+				resource.TestCheckResourceAttr(resourceName, consts.FieldNamespace, ns),
+			)
+		}
+		steps := []resource.TestStep{
 			{
-				Config: testAccJWTAuthBackendConfigOIDC(path),
+				Config: testAccJWTAuthBackendConfigOIDC(path, ns),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend.oidc", "oidc_discovery_url", "https://myco.auth0.com/"),
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend.oidc", "bound_issuer", "api://default"),
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend.oidc", "oidc_client_id", "client"),
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend.oidc", "oidc_client_secret", "secret"),
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend.oidc", "oidc_response_mode", "query"),
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend.oidc", "oidc_response_types.#", "1"),
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend.oidc", "oidc_response_types.0", "code"),
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend.oidc", "type", "oidc"),
-					resource.TestCheckResourceAttr("vault_jwt_auth_backend.oidc", "default_role", "api"),
+					append(commonChecks,
+						resource.TestCheckResourceAttr(resourceName, "oidc_discovery_url", "https://myco.auth0.com/"),
+						resource.TestCheckResourceAttr(resourceName, "bound_issuer", "api://default"),
+						resource.TestCheckResourceAttr(resourceName, "oidc_client_id", "client"),
+						resource.TestCheckResourceAttr(resourceName, "oidc_client_secret", "secret"),
+						resource.TestCheckResourceAttr(resourceName, "oidc_response_mode", "query"),
+						resource.TestCheckResourceAttr(resourceName, "oidc_response_types.#", "1"),
+						resource.TestCheckResourceAttr(resourceName, "oidc_response_types.0", "code"),
+						resource.TestCheckResourceAttr(resourceName, "type", "oidc"),
+						resource.TestCheckResourceAttr(resourceName, "default_role", "api"),
+					)...,
 				),
 			},
-		},
-	})
+		}
+
+		return steps
+	}
+
+	t.Run("basic", func(t *testing.T) {
+		path := acctest.RandomWithPrefix("oidc")
+		resource.Test(t, resource.TestCase{
+			PreCheck:     func() { testutil.TestAccPreCheck(t) },
+			Providers:    testProviders,
+			CheckDestroy: testJWTAuthBackend_Destroyed(path),
+			Steps:        getSteps(path, ""),
+		})
+	},
+	)
+
+	t.Run("ns", func(t *testing.T) {
+		ns := acctest.RandomWithPrefix("ns")
+		path := acctest.RandomWithPrefix("oidc")
+		resource.Test(t, resource.TestCase{
+			PreCheck:     func() { testutil.TestAccPreCheck(t) },
+			Providers:    testProviders,
+			CheckDestroy: testJWTAuthBackend_Destroyed(path),
+			Steps:        getSteps(path, ns),
+		})
+	},
+	)
 }
 
 func TestAccJWTAuthBackend_invalid(t *testing.T) {
@@ -120,7 +218,7 @@ func TestAccJWTAuthBackend_invalid(t *testing.T) {
 		Providers: testProviders,
 		Steps: []resource.TestStep{
 			{
-				Config:  testAccJWTAuthBackendConfig(invalidPath),
+				Config:  testAccJWTAuthBackendConfig(invalidPath, "", false),
 				Destroy: false,
 				ExpectError: regexp.MustCompile(
 					fmt.Sprintf(`invalid value "%s" for "path", contains leading/trailing "%s"`,
@@ -142,93 +240,148 @@ func TestAccJWTAuthBackend_invalid(t *testing.T) {
 	})
 }
 
-func testAccJWTAuthBackendConfig(path string) string {
-	return fmt.Sprintf(`
-resource "vault_jwt_auth_backend" "jwt" {
-  description = "JWT backend"
-  oidc_discovery_url = "https://myco.auth0.com/"
-  path = "%s"
-}
-`, path)
+func testAccJWTAuthBackendConfig(path, ns string, local bool) string {
+	var config string
+	if ns != "" {
+		config = fmt.Sprintf(`
+resource "vault_namespace" "test" {
+	path = "%s"
 }
 
-func testAccJWTAuthLocalBackendConfig(path string) string {
-	return fmt.Sprintf(`
 resource "vault_jwt_auth_backend" "jwt" {
-  description = "JWT backend"
+  namespace          = vault_namespace.test.path
+  description        = "JWT backend"
   oidc_discovery_url = "https://myco.auth0.com/"
-  path = "%s"
-  local = true
+  path               = "%s"
+  local              = %t
 }
-`, path)
+`, ns, path, local)
+	} else {
+		config = fmt.Sprintf(`
+resource "vault_jwt_auth_backend" "jwt" {
+  description        = "JWT backend"
+  oidc_discovery_url = "https://myco.auth0.com/"
+  path               = "%s"
+  local              = %t
+}
+`, path, local)
+	}
+
+	return config
 }
 
-func testAccJWTAuthBackendConfigFullOIDC(path string, oidcDiscoveryUrl string, boundIssuer string, supportedAlgs string) string {
-	return fmt.Sprintf(`
+func testAccJWTAuthBackendConfigFullOIDC(path string, oidcDiscoveryUrl string, boundIssuer string, supportedAlgs string, ns string) string {
+	var config string
+
+	if ns != "" {
+		config = fmt.Sprintf(`
+resource "vault_namespace" "test" {
+	path = "%s"
+}
+
 resource "vault_jwt_auth_backend" "jwt" {
-  description = "JWT backend"
+  namespace          = vault_namespace.test.path
+  description        = "JWT backend"
   oidc_discovery_url = "%s"
-  bound_issuer = "%s"
+  bound_issuer       = "%s"
   jwt_supported_algs = [%s]
-  path = "%s"
+  path               = "%s"
+}
+`, ns, oidcDiscoveryUrl, boundIssuer, supportedAlgs, path)
+	} else {
+		config = fmt.Sprintf(`
+resource "vault_jwt_auth_backend" "jwt" {
+  description        = "JWT backend"
+  oidc_discovery_url = "%s"
+  bound_issuer       = "%s"
+  jwt_supported_algs = [%s]
+  path               = "%s"
 }
 `, oidcDiscoveryUrl, boundIssuer, supportedAlgs, path)
+	}
+
+	return config
 }
 
-func testAccJWTAuthBackendConfigPubKeys(path string, validationPublicKeys string, boundIssuer string, supportedAlgs string) string {
-	return fmt.Sprintf(`
-resource "vault_jwt_auth_backend" "jwt" {
-  description = "JWT backend"
-  jwt_validation_pubkeys = [%s]
-  bound_issuer = "%s"
-  jwt_supported_algs = [%s]
-  path = "%s"
-}
-`, validationPublicKeys, boundIssuer, supportedAlgs, path)
+func testAccJWTAuthBackendConfigOIDC(path string, ns string) string {
+	var config string
+	if ns != "" {
+		config = fmt.Sprintf(`
+resource "vault_namespace" "test" {
+	path = "%s"
 }
 
-func testAccJWTAuthBackendConfigJWKS(path string, jwks string, boundIssuer string, supportedAlgs string) string {
-	return fmt.Sprintf(`
-resource "vault_jwt_auth_backend" "jwt" {
-  description = "JWT backend"
-  jwks_url = "%s"
-  bound_issuer = "%s"
-  jwt_supported_algs = [%s]
-  path = "%s"
-}
-`, jwks, boundIssuer, supportedAlgs, path)
-}
-
-func testAccJWTAuthBackendConfigOIDC(path string) string {
-	return fmt.Sprintf(`
 resource "vault_jwt_auth_backend" "oidc" {
-  description = "OIDC backend"
-  oidc_discovery_url = "https://myco.auth0.com/"
-  oidc_client_id = "client"
-  oidc_client_secret = "secret"
-  bound_issuer = "api://default"
-  path = "%s"
-  type = "oidc"
-  default_role = "api"
+  namespace           = vault_namespace.test.path
+  description         = "OIDC backend"
+  oidc_discovery_url  = "https://myco.auth0.com/"
+  oidc_client_id      = "client"
+  oidc_client_secret  = "secret"
+  bound_issuer        = "api://default"
+  path                = "%s"
+  type                = "oidc"
+  default_role        = "api"
+  oidc_response_mode  = "query"
+  oidc_response_types = ["code"]
+}
+`, ns, path)
+	} else {
+		config = fmt.Sprintf(`
+resource "vault_jwt_auth_backend" "oidc" {
+  description         = "OIDC backend"
+  oidc_discovery_url  = "https://myco.auth0.com/"
+  oidc_client_id      = "client"
+  oidc_client_secret  = "secret"
+  bound_issuer        = "api://default"
+  path                = "%s"
+  type                = "oidc"
+  default_role        = "api"
   oidc_response_mode  = "query"
   oidc_response_types = ["code"]
 }
 `, path)
+	}
+
+	return config
 }
 
-func testAccJWTAuthBackendProviderConfig(path string) string {
-	return fmt.Sprintf(`
+func testAccJWTAuthBackendProviderConfig(path string, ns string) string {
+	var config string
+
+	if ns != "" {
+		config = fmt.Sprintf(`
+resource "vault_namespace" "test" {
+	path = "%s"
+}
+
 resource "vault_jwt_auth_backend" "oidc" {
-  description = "OIDC backend"
+  namespace          = vault_namespace.test.path
+  description        = "OIDC backend"
   oidc_discovery_url = "https://myco.auth0.com/"
-  path = "%s"
-  type = "oidc"
+  path               = "%s"
+  type               = "oidc"
   provider_config = {
-	provider = "azure"
-	groups_recurse_max_depth = "1"
+    provider                 = "azure"
+    groups_recurse_max_depth = "1"
+  }
+}
+`, ns, path)
+	} else {
+		config = fmt.Sprintf(`
+resource "vault_jwt_auth_backend" "oidc" {
+  description        = "OIDC backend"
+  oidc_discovery_url = "https://myco.auth0.com/"
+  path               = "%s"
+  type               = "oidc"
+  provider_config = {
+    provider                 = "azure"
+    groups_recurse_max_depth = "1"
   }
 }
 `, path)
+	}
+
+	return config
 }
 
 func testJWTAuthBackend_Destroyed(path string) resource.TestCheckFunc {

--- a/vault/resource_jwt_auth_backend_test.go
+++ b/vault/resource_jwt_auth_backend_test.go
@@ -83,6 +83,7 @@ func TestAccJWTAuthBackend(t *testing.T) {
 	}
 
 	t.Run("basic", func(t *testing.T) {
+		t.Parallel()
 		resource.Test(t, resource.TestCase{
 			PreCheck:     func() { testutil.TestAccPreCheck(t) },
 			Providers:    testProviders,
@@ -93,6 +94,7 @@ func TestAccJWTAuthBackend(t *testing.T) {
 	)
 
 	t.Run("ns", func(t *testing.T) {
+		t.Parallel()
 		ns := acctest.RandomWithPrefix("ns")
 		path := acctest.RandomWithPrefix("jwt")
 		resource.Test(t, resource.TestCase{
@@ -133,6 +135,7 @@ func TestAccJWTAuthBackendProviderConfig(t *testing.T) {
 	}
 
 	t.Run("basic", func(t *testing.T) {
+		t.Parallel()
 		resource.Test(t, resource.TestCase{
 			PreCheck:     func() { testutil.TestAccPreCheck(t) },
 			Providers:    testProviders,
@@ -143,6 +146,7 @@ func TestAccJWTAuthBackendProviderConfig(t *testing.T) {
 	)
 
 	t.Run("ns", func(t *testing.T) {
+		t.Parallel()
 		ns := acctest.RandomWithPrefix("ns")
 		path := acctest.RandomWithPrefix("jwt")
 		resource.Test(t, resource.TestCase{
@@ -187,6 +191,7 @@ func TestAccJWTAuthBackend_OIDC(t *testing.T) {
 	}
 
 	t.Run("basic", func(t *testing.T) {
+		t.Parallel()
 		path := acctest.RandomWithPrefix("oidc")
 		resource.Test(t, resource.TestCase{
 			PreCheck:     func() { testutil.TestAccPreCheck(t) },
@@ -198,6 +203,7 @@ func TestAccJWTAuthBackend_OIDC(t *testing.T) {
 	)
 
 	t.Run("ns", func(t *testing.T) {
+		t.Parallel()
 		ns := acctest.RandomWithPrefix("ns")
 		path := acctest.RandomWithPrefix("oidc")
 		resource.Test(t, resource.TestCase{


### PR DESCRIPTION
This PR extends the current JWT auth backend tests to cover provisioning in Vault namespaces. It also includes our first foray into parallel acceptance tests.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
 $ time make testacc-ent TESTARGS='-v -test.count 1 -test.run TestAccJWTAuthBackend -parallel=5'
make testacc TF_ACC_ENTERPRISE=1
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -v -test.count 1 -test.run TestAccJWTAuthBackend -parallel=5 -timeout 30m ./...


=== RUN   TestAccJWTAuthBackendRole_import
--- PASS: TestAccJWTAuthBackendRole_import (1.88s)
=== RUN   TestAccJWTAuthBackendRole_basic
--- PASS: TestAccJWTAuthBackendRole_basic (1.12s)
=== RUN   TestAccJWTAuthBackendRole_update
--- PASS: TestAccJWTAuthBackendRole_update (1.99s)
=== RUN   TestAccJWTAuthBackendRole_full
--- PASS: TestAccJWTAuthBackendRole_full (1.14s)
=== RUN   TestAccJWTAuthBackendRoleOIDC_full
--- PASS: TestAccJWTAuthBackendRoleOIDC_full (1.51s)
=== RUN   TestAccJWTAuthBackendRoleOIDC_disableParsing
--- PASS: TestAccJWTAuthBackendRoleOIDC_disableParsing (1.43s)
=== RUN   TestAccJWTAuthBackendRole_fullUpdate
--- PASS: TestAccJWTAuthBackendRole_fullUpdate (3.00s)
=== RUN   TestAccJWTAuthBackend
=== RUN   TestAccJWTAuthBackend/basic
=== PAUSE TestAccJWTAuthBackend/basic
=== RUN   TestAccJWTAuthBackend/ns
=== PAUSE TestAccJWTAuthBackend/ns
=== CONT  TestAccJWTAuthBackend/basic
=== CONT  TestAccJWTAuthBackend/ns
--- PASS: TestAccJWTAuthBackend (0.00s)
    --- PASS: TestAccJWTAuthBackend/basic (4.35s)
    --- PASS: TestAccJWTAuthBackend/ns (4.67s)
=== RUN   TestAccJWTAuthBackendProviderConfig
=== RUN   TestAccJWTAuthBackendProviderConfig/basic
=== PAUSE TestAccJWTAuthBackendProviderConfig/basic
=== RUN   TestAccJWTAuthBackendProviderConfig/ns
=== PAUSE TestAccJWTAuthBackendProviderConfig/ns
=== CONT  TestAccJWTAuthBackendProviderConfig/basic
=== CONT  TestAccJWTAuthBackendProviderConfig/ns
--- PASS: TestAccJWTAuthBackendProviderConfig (0.00s)
    --- PASS: TestAccJWTAuthBackendProviderConfig/basic (1.27s)
    --- PASS: TestAccJWTAuthBackendProviderConfig/ns (1.44s)
=== RUN   TestAccJWTAuthBackend_OIDC
=== RUN   TestAccJWTAuthBackend_OIDC/basic
=== PAUSE TestAccJWTAuthBackend_OIDC/basic
=== RUN   TestAccJWTAuthBackend_OIDC/ns
=== PAUSE TestAccJWTAuthBackend_OIDC/ns
=== CONT  TestAccJWTAuthBackend_OIDC/basic
=== CONT  TestAccJWTAuthBackend_OIDC/ns
--- PASS: TestAccJWTAuthBackend_OIDC (0.00s)
    --- PASS: TestAccJWTAuthBackend_OIDC/basic (1.49s)
    --- PASS: TestAccJWTAuthBackend_OIDC/ns (1.65s)
=== RUN   TestAccJWTAuthBackend_invalid
--- PASS: TestAccJWTAuthBackend_invalid (0.30s)
=== RUN   TestAccJWTAuthBackend_missingMandatory
--- PASS: TestAccJWTAuthBackend_missingMandatory (1.80s)
=== RUN   TestAccJWTAuthBackendProviderConfigConversionBool
--- PASS: TestAccJWTAuthBackendProviderConfigConversionBool (0.00s)
=== RUN   TestAccJWTAuthBackendProviderConfigConversionInt
--- PASS: TestAccJWTAuthBackendProviderConfigConversionInt (0.00s)
=== RUN   TestAccJWTAuthBackendProviderConfig_negative
    resource_jwt_auth_backend_test.go:543: true
--- SKIP: TestAccJWTAuthBackendProviderConfig_negative (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     23.974s
make testacc-ent   46.33s user 22.88s system 235% cpu 29.376 total

```
