### PR TITLE
Fix documentation for KV resources

### DIFF
--- a/vault/provider.go
+++ b/vault/provider.go
@@ -305,23 +305,23 @@ var (
 			PathInventory: []string{"/identity/oidc/provider/{name}/.well-known/openid-configuration"},
 		},
 		"vault_kv_secret": {
-			Resource:      kvSecretDataSource(),
+			Resource:      updateSchemaResource(kvSecretDataSource()),
 			PathInventory: []string{"/secret/{path}"},
 		},
 		"vault_kv_secret_v2": {
-			Resource:      kvSecretV2DataSource(),
+			Resource:      updateSchemaResource(kvSecretV2DataSource()),
 			PathInventory: []string{"/secret/data/{path}/?version={version}}"},
 		},
 		"vault_kv_secrets_list": {
-			Resource:      kvSecretListDataSource(),
+			Resource:      updateSchemaResource(kvSecretListDataSource()),
 			PathInventory: []string{"/secret/{path}/?list=true"},
 		},
 		"vault_kv_secrets_list_v2": {
-			Resource:      kvSecretListDataSourceV2(),
+			Resource:      updateSchemaResource(kvSecretListDataSourceV2()),
 			PathInventory: []string{"/secret/metadata/{path}/?list=true"},
 		},
 		"vault_kv_secret_subkeys_v2": {
-			Resource:      kvSecretSubkeysV2DataSource(),
+			Resource:      updateSchemaResource(kvSecretSubkeysV2DataSource()),
 			PathInventory: []string{"/secret/subkeys/{path}"},
 		},
 	}
@@ -769,15 +769,15 @@ var (
 			PathInventory: []string{"/identity/oidc/provider/{name}"},
 		},
 		"vault_kv_secret_backend_v2": {
-			Resource:      kvSecretBackendV2Resource(),
+			Resource:      updateSchemaResource(kvSecretBackendV2Resource()),
 			PathInventory: []string{"/secret/data/{path}"},
 		},
 		"vault_kv_secret": {
-			Resource:      kvSecretResource("vault_kv_secret"),
+			Resource:      updateSchemaResource(kvSecretResource("vault_kv_secret")),
 			PathInventory: []string{"/secret/{path}"},
 		},
 		"vault_kv_secret_v2": {
-			Resource:      kvSecretV2Resource("vault_kv_secret_v2"),
+			Resource:      updateSchemaResource(kvSecretV2Resource("vault_kv_secret_v2")),
 			PathInventory: []string{"/secret/data/{path}"},
 		},
 	}

--- a/website/docs/d/kv_secret.html.md
+++ b/website/docs/d/kv_secret.html.md
@@ -65,7 +65,7 @@ Use of this resource requires the `read` capability on the given path.
 
 The following attributes are exported:
 
-* `data` - A mapping whose keys are the top-level data keys returned from
+* `data_json` - A mapping whose keys are the top-level data keys returned from
   Vault and whose values are the corresponding values. This map can only
   represent string data, so any non-string values returned from Vault are
   serialized as JSON.

--- a/website/docs/d/kv_secret_v2.html.md
+++ b/website/docs/d/kv_secret_v2.html.md
@@ -78,7 +78,7 @@ The following attributes are exported:
 
 * `path` - Full path where the KVV2 secret is written.
 
-* `data` - A mapping whose keys are the top-level data keys returned from
+* `data_json` - A mapping whose keys are the top-level data keys returned from
   Vault and whose values are the corresponding values. This map can only
   represent string data, so any non-string values returned from Vault are
   serialized as JSON.

--- a/website/docs/d/kv_subkeys_v2.html.md
+++ b/website/docs/d/kv_subkeys_v2.html.md
@@ -83,5 +83,5 @@ The following attributes are exported:
 
 * `path` - Full path where the KV-V2 secrets are listed.
 
-* `subkeys` - Subkeys for the KV-V2 secret read from Vault..
+* `data_json` - Subkeys for the KV-V2 secret read from Vault..
 

--- a/website/docs/r/kv_secret_backend_v2.html.md
+++ b/website/docs/r/kv_secret_backend_v2.html.md
@@ -49,8 +49,8 @@ The following arguments are supported:
 * `cas_required` - (Optional) If true, all keys will require the cas
   parameter to be set on all write requests.
 
-* `delete_version_after_input` - (Optional) If set, specifies the length of time before
-  a version is deleted. Accepts Go duration format string.
+* `delete_version_after` - (Optional) If set, specifies the length of time before
+  a version is deleted. Accepts duration in integer seconds.
 
 ## Required Vault Capabilities
 
@@ -61,11 +61,7 @@ and the `read` capability for drift detection (by default).
 
 ## Attributes Reference
 
-The following attributes are exported in addition to the above:
-
-* `delete_version_after` - The full duration string for
-  `delete_version_after_input` formatted by Vault in
-  `00h00m00s` format.
+No additional attributes are exported by this resource.
 
 ## Import
 


### PR DESCRIPTION
This PR fixes docs for a few fields in the KVSecret Engine resources and data sources.

Fixes #1513 

Additionally, it adds the `namespace` schema field to KV resources that was previously missing.
