### PR TITLE
Fix typo in pkiSecretBackendRootCertResource

### DIFF
--- a/vault/resource_pki_secret_backend_root_cert.go
+++ b/vault/resource_pki_secret_backend_root_cert.go
@@ -79,14 +79,14 @@ func pkiSecretBackendRootCertResource() *schema.Resource {
 			"type": {
 				Type:         schema.TypeString,
 				Required:     true,
-				Description:  "Type of intermediate to create. Must be either \"exported\" or \"internal\".",
+				Description:  "Type of root to create. Must be either \"exported\" or \"internal\".",
 				ForceNew:     true,
 				ValidateFunc: validation.StringInSlice([]string{"exported", "internal"}, false),
 			},
 			"common_name": {
 				Type:        schema.TypeString,
 				Required:    true,
-				Description: "CN of intermediate to create.",
+				Description: "CN of root to create.",
 				ForceNew:    true,
 			},
 			"alt_names": {


### PR DESCRIPTION
Replace `intermediate` by `root` in `pkiSecretBackendRootCertResource` function that is related to generate root certificate and key.