### PR TITLE
Add support for Consul secrets engine enhancements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,7 @@ jobs:
         env:
           VAULT_DEV_ROOT_TOKEN_ID: root
           VAULT_LICENSE: ${{ secrets.VAULT_LICENSE }}
+          TF_VAULT_VERSION: 1.10
         options: >-
           --health-cmd "VAULT_ADDR=http://127.0.0.1:8200 vault status"
           --health-interval 1s

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,6 @@ jobs:
         env:
           VAULT_DEV_ROOT_TOKEN_ID: root
           VAULT_LICENSE: ${{ secrets.VAULT_LICENSE }}
-          TF_VAULT_VERSION: 1.10
         options: >-
           --health-cmd "VAULT_ADDR=http://127.0.0.1:8200 vault status"
           --health-interval 1s
@@ -77,6 +76,7 @@ jobs:
           MONGODB_URL: "mongodb://root:mongodb@mongo:27017/admin?ssl=false"
           MSSQL_URL: "sqlserver://sa:${{ secrets.MSSQL_SA_PASSWORD }}@mssql:1433"
           POSTGRES_URL: "postgres://postgres:secret@postgres:5432/database?sslmode=disable"
+          TF_VAULT_VERSION: "1.10"
         run: |
           make testacc-ent TESTARGS='-test.v -test.parallel=10' SKIP_MSSQL_MULTI_CI=true SKIP_RAFT_TESTS=true SKIP_VAULT_NEXT_TESTS=true
       - name: "Generate Vault API Path Coverage Report"

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ There may be additional variables for specific tests. Consult the specific test(
     - `ARM_CLIENT_ID`
     - `ARM_CLIENT_SECRET`
     - `ARM_RESOURCE_GROUP`
+    - `TF_VAULT_VERSION`
 4. Run `make testacc`
 
 If you wish to run specific tests, use the `TESTARGS` environment variable:

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.0
 	github.com/hashicorp/go-secure-stdlib/awsutil v0.1.6
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.6
+	github.com/hashicorp/go-version v1.4.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.16.0
 	github.com/hashicorp/vault v1.10.3
 	github.com/hashicorp/vault/api v1.6.0

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -183,10 +183,11 @@ func GetTestNomadCreds(t *testing.T) (string, string) {
 	return v[0], v[1]
 }
 
-func CheckTestVaultVersion(t *testing.T) bool {
+// Returns true if TF_VAULT_VERSION is greater than or equal to the given Vault version
+func CheckTestVaultVersion(t *testing.T, cutoff string) bool {
 	v := SkipTestEnvUnset(t, "TF_VAULT_VERSION")
 
-	cutoffVersion, _ := goversion.NewVersion("1.11")
+	cutoffVersion, _ := goversion.NewVersion(cutoff)
 	envVersion, err := goversion.NewVersion(v[0])
 	if err != nil {
 		t.Fatalf("error parsing vault version from TF_VAULT_VERSION environment variable: %v", err)

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -181,6 +181,11 @@ func GetTestNomadCreds(t *testing.T) (string, string) {
 	return v[0], v[1]
 }
 
+func GetTestVaultVersion(t *testing.T) string {
+	v := SkipTestEnvUnset(t, "TF_VAULT_VERSION")
+	return v[0]
+}
+
 func TestCheckResourceAttrJSON(name, key, expectedValue string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		resourceState, ok := s.RootModule().Resources[name]

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -19,6 +19,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/vault/api"
 	"github.com/mitchellh/go-homedir"
+
+	goversion "github.com/hashicorp/go-version"
 )
 
 const (
@@ -181,9 +183,18 @@ func GetTestNomadCreds(t *testing.T) (string, string) {
 	return v[0], v[1]
 }
 
-func GetTestVaultVersion(t *testing.T) string {
+func CheckTestVaultVersion(t *testing.T) bool {
 	v := SkipTestEnvUnset(t, "TF_VAULT_VERSION")
-	return v[0]
+
+	cutoffVersion, _ := goversion.NewVersion("1.11")
+	envVersion, err := goversion.NewVersion(v[0])
+	if err != nil {
+		t.Fatalf("error parsing vault version from TF_VAULT_VERSION environment variable: %v", err)
+	} else {
+		return envVersion.GreaterThanOrEqual(cutoffVersion)
+	}
+
+	return false
 }
 
 func TestCheckResourceAttrJSON(name, key, expectedValue string) resource.TestCheckFunc {

--- a/vault/resource_consul_secret_backend.go
+++ b/vault/resource_consul_secret_backend.go
@@ -67,7 +67,7 @@ func consulSecretBackendResource() *schema.Resource {
 			},
 			"token": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				Description: "Specifies the Consul ACL token to use. This must be a management type token.",
 				Sensitive:   true,
 			},
@@ -143,12 +143,15 @@ func consulSecretBackendCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Writing Consul configuration to %q", configPath)
 	data := map[string]interface{}{
 		"address":     address,
-		"token":       token,
 		"scheme":      scheme,
 		"ca_cert":     ca_cert,
 		"client_cert": client_cert,
 		"client_key":  client_key,
 	}
+	if token != "" {
+		data["token"] = token
+	}
+
 	if _, err := client.Logical().Write(configPath, data); err != nil {
 		return fmt.Errorf("Error writing Consul configuration for %q: %s", path, err)
 	}

--- a/vault/resource_consul_secret_backend_role.go
+++ b/vault/resource_consul_secret_backend_role.go
@@ -117,7 +117,6 @@ func consulSecretBackendRoleResource() *schema.Resource {
 				Optional:    true,
 				Description: "Specifies the type of token to create when using this role. Valid values are \"client\" or \"management\".",
 				Default:     "client",
-				Deprecated:  "Deprecated in Vault as of 1.11",
 			},
 			"local": {
 				Type:        schema.TypeBool,
@@ -255,7 +254,7 @@ func consulSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error
 
 	if _, exists := secret.Data["consul_policies"]; exists {
 		if _, ok := d.GetOk("policies"); ok {
-			params["policies"] = "consul_policies"
+			params["consul_policies"] = "policies"
 		} else {
 			params["consul_policies"] = "consul_policies"
 		}
@@ -271,7 +270,7 @@ func consulSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error
 			case "consul_roles", "consul_namespace", "partition":
 				continue
 			// TODO case this by Vault version (vault-1.11+ request params)
-			case "service_identities", "node_identities":
+			case "consul_policies", "service_identities", "node_identities":
 				continue
 			}
 		}

--- a/vault/resource_consul_secret_backend_role.go
+++ b/vault/resource_consul_secret_backend_role.go
@@ -52,7 +52,7 @@ func consulSecretBackendRoleResource() *schema.Resource {
 				ConflictsWith: []string{"consul_policies"},
 			},
 			"consul_policies": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "List of Consul policies to associate with this role",
 				Elem: &schema.Schema{
@@ -154,7 +154,7 @@ func consulSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) erro
 	path := consulSecretBackendRolePath(backend, name)
 
 	policies := d.Get("policies").([]interface{})
-	consulPolicies := d.Get("consul_policies").([]interface{})
+	consulPolicies := d.Get("consul_policies").(*schema.Set).List()
 	roles := d.Get("consul_roles").(*schema.Set).List()
 	serviceIdentities := d.Get("service_identities").(*schema.Set).List()
 	nodeIdentities := d.Get("node_identities").(*schema.Set).List()
@@ -252,12 +252,8 @@ func consulSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error
 		"node_identities":    "node_identities",
 	}
 
-	if _, exists := secret.Data["consul_policies"]; exists {
-		if _, ok := d.GetOk("policies"); ok {
-			params["consul_policies"] = "policies"
-		} else {
-			params["consul_policies"] = "consul_policies"
-		}
+	if _, exists := data["consul_policies"]; exists {
+		params["consul_policies"] = "consul_policies"
 	} else {
 		params["policies"] = "policies"
 	}

--- a/vault/resource_consul_secret_backend_role.go
+++ b/vault/resource_consul_secret_backend_role.go
@@ -256,13 +256,8 @@ func consulSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error
 		"partition":          "partition",
 		"service_identities": "service_identities",
 		"node_identities":    "node_identities",
-	}
-
-	if _, ok := d.GetOk("policies"); ok {
-		params["policies"] = "policies"
-	}
-	if _, ok := d.GetOk("consul_policies"); ok {
-		params["consul_policies"] = "consul_policies"
+		"policies":           "policies",
+		"consul_policies":    "consul_policies",
 	}
 
 	for k, v := range params {

--- a/vault/resource_consul_secret_backend_role.go
+++ b/vault/resource_consul_secret_backend_role.go
@@ -160,11 +160,6 @@ func consulSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) erro
 	serviceIdentities := d.Get("service_identities").(*schema.Set).List()
 	nodeIdentities := d.Get("node_identities").(*schema.Set).List()
 
-	if len(consulPolicies) == 0 && len(roles) == 0 &&
-		len(serviceIdentities) == 0 && len(nodeIdentities) == 0 {
-		return fmt.Errorf("consul_policies, consul_roles, service_identities, or node_identities must be set")
-	}
-
 	data := map[string]interface{}{
 		"policies":           policies,
 		"consul_policies":    consulPolicies,
@@ -256,8 +251,16 @@ func consulSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error
 		"partition":          "partition",
 		"service_identities": "service_identities",
 		"node_identities":    "node_identities",
-		"policies":           "policies",
-		"consul_policies":    "consul_policies",
+	}
+
+	if _, exists := secret.Data["consul_policies"]; exists {
+		if _, ok := d.GetOk("policies"); ok {
+			params["policies"] = "consul_policies"
+		} else {
+			params["consul_policies"] = "consul_policies"
+		}
+	} else {
+		params["policies"] = "policies"
 	}
 
 	for k, v := range params {

--- a/vault/resource_consul_secret_backend_role_test.go
+++ b/vault/resource_consul_secret_backend_role_test.go
@@ -38,7 +38,7 @@ func TestConsulSecretBackendRole(t *testing.T) {
 		resource.TestCheckResourceAttr(resourcePath, "partition", "partition-1"),
 	}
 
-	testNewParameters := testutil.CheckTestVaultVersion(t)
+	testNewParameters := testutil.CheckTestVaultVersion(t, "1.11")
 	if testNewParameters {
 		missingParametersError = "Use either a policy document, a list of policies or roles, or a set of service or node identities, depending on your Consul version"
 

--- a/vault/resource_consul_secret_backend_role_test.go
+++ b/vault/resource_consul_secret_backend_role_test.go
@@ -46,13 +46,14 @@ func TestConsulSecretBackendRole(t *testing.T) {
 	envVersion, err := goversion.NewVersion(version)
 
 	if err != nil {
-		t.Fatalf("error parsing vault version from VAULT_VERSION environment variable: %v", err)
+		t.Fatalf("error parsing vault version from TF_VAULT_VERSION environment variable: %v", err)
 	} else {
 		if envVersion.GreaterThanOrEqual(cutoffVersion) {
 			isVersion111orNewer = true
 			missingParametersError = "Use either a policy document, a list of policies or roles, or a set of service or node identities, depending on your Consul version"
 
 			createTestCheckFuncs = append(createTestCheckFuncs,
+				resource.TestCheckResourceAttr(resourcePath, "policies.#", "0"),
 				resource.TestCheckResourceAttr(resourcePath, "consul_policies.#", "1"),
 				resource.TestCheckTypeSetElemAttr(resourcePath, "consul_policies.*", "foo"),
 				resource.TestCheckResourceAttr(resourcePath, "consul_roles.#", "1"),
@@ -63,6 +64,7 @@ func TestConsulSecretBackendRole(t *testing.T) {
 				resource.TestCheckTypeSetElemAttr(resourcePath, "node_identities.*", "server-0:dc1"))
 
 			updateTestCheckFuncs = append(updateTestCheckFuncs,
+				resource.TestCheckResourceAttr(resourcePath, "policies.#", "0"),
 				resource.TestCheckResourceAttr(resourcePath, "consul_policies.#", "2"),
 				resource.TestCheckTypeSetElemAttr(resourcePath, "consul_policies.*", "foo"),
 				resource.TestCheckTypeSetElemAttr(resourcePath, "consul_policies.*", "bar"),
@@ -78,10 +80,12 @@ func TestConsulSecretBackendRole(t *testing.T) {
 				resource.TestCheckTypeSetElemAttr(resourcePath, "node_identities.*", "client-0:dc1"))
 		} else {
 			createTestCheckFuncs = append(createTestCheckFuncs,
+				resource.TestCheckResourceAttr(resourcePath, "consul_policies.#", "0"),
 				resource.TestCheckResourceAttr(resourcePath, "policies.#", "1"),
 				resource.TestCheckResourceAttr(resourcePath, "policies.0", "boo"))
 
 			updateTestCheckFuncs = append(updateTestCheckFuncs,
+				resource.TestCheckResourceAttr(resourcePath, "consul_policies.#", "0"),
 				resource.TestCheckResourceAttr(resourcePath, "policies.#", "2"),
 				resource.TestCheckResourceAttr(resourcePath, "policies.0", "boo"),
 				resource.TestCheckResourceAttr(resourcePath, "policies.1", "far"))

--- a/vault/resource_consul_secret_backend_role_test.go
+++ b/vault/resource_consul_secret_backend_role_test.go
@@ -141,7 +141,7 @@ func testAccConsulSecretBackendRoleCheckDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testConsulSecretBackendRole_initialConfig(backend, name, token string, withPolicies, isVersion111OrNewer bool) string {
+func testConsulSecretBackendRole_initialConfig(backend, name, token string, withPolicies, isAboveVersionThreshold bool) string {
 	config := fmt.Sprintf(`
 resource "vault_consul_secret_backend" "test" {
   path = "%s"
@@ -167,7 +167,7 @@ resource "vault_consul_secret_backend_role" "test" {
 `
 	}
 
-	if isVersion111OrNewer {
+	if isAboveVersionThreshold {
 		config += `
 consul_policies = [
 	"foo",
@@ -196,7 +196,7 @@ node_identities = [
 	return config + "}"
 }
 
-func testConsulSecretBackendRole_updateConfig(backend, name, token string, withPolicies, isVersion111OrNewer bool) string {
+func testConsulSecretBackendRole_updateConfig(backend, name, token string, withPolicies, isAboveVersionThreshold bool) string {
 	config := fmt.Sprintf(`
 resource "vault_consul_secret_backend" "test" {
   path = "%s"
@@ -227,7 +227,7 @@ resource "vault_consul_secret_backend_role" "test" {
 `
 	}
 
-	if isVersion111OrNewer {
+	if isAboveVersionThreshold {
 		config += `
 consul_policies = [
 	"foo",

--- a/website/docs/r/consul_secret_backend_role.html.md
+++ b/website/docs/r/consul_secret_backend_role.html.md
@@ -44,15 +44,19 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the Consul secrets engine role to create.
 
-* `consul_policies` - (Required)<sup><a href="#note-about-required-arguments">SEE NOTE</a></sup> The list of Consul ACL policies to associate with these roles.
+* `policies` - (Optional) The list of Consul ACL policies to associate with these roles.
+  **NOTE:** The new parameter `consul_policies` should be used in favor of this. This parameter,
+  `policies`, remains supported for legacy users, but Vault has deprecated this field.
 
-* `consul_roles` - (Required)<sup><a href="#note-about-required-arguments">SEE NOTE</a></sup> Set of Consul roles to attach to the token.
+* `consul_policies` - (Optional)<sup><a href="#note-about-required-arguments">SEE NOTE</a></sup> The list of Consul ACL policies to associate with these roles.
+
+* `consul_roles` - (Optional)<sup><a href="#note-about-required-arguments">SEE NOTE</a></sup> Set of Consul roles to attach to the token.
    Applicable for Vault 1.10+ with Consul 1.5+.
 
-* `service_identities` - (Required)<sup><a href="#note-about-required-arguments">SEE NOTE</a></sup> Set of Consul
+* `service_identities` - (Optional)<sup><a href="#note-about-required-arguments">SEE NOTE</a></sup> Set of Consul
 service identities to attach to the token. Applicable for Vault 1.11+ with Consul 1.5+.
 
-* `node_identities` - (Required)<sup><a href="#note-about-required-arguments">SEE NOTE</a></sup> Set of Consul node
+* `node_identities` - (Optional)<sup><a href="#note-about-required-arguments">SEE NOTE</a></sup> Set of Consul node
 identities to attach to the token. Applicable for Vault 1.11+ with Consul 1.8+.
 
 * `consul_namespace` - (Optional) The Consul namespace that the token will be created in.

--- a/website/docs/r/consul_secret_backend_role.html.md
+++ b/website/docs/r/consul_secret_backend_role.html.md
@@ -25,7 +25,7 @@ resource "vault_consul_secret_backend_role" "example" {
   name    = "test-role"
   backend = vault_consul_secret_backend.test.path
 
-  policies = [
+  consul_policies = [
     "example-policy",
   ]
 }
@@ -43,23 +43,30 @@ The following arguments are supported:
 * `backend` - (Optional) The unique name of an existing Consul secrets backend mount. Must not begin or end with a `/`. One of `path` or `backend` is required.
 
 * `name` - (Required) The name of the Consul secrets engine role to create.
- 
+
+* `consul_policies` - (Required)<sup><a href="#note-about-required-arguments">SEE NOTE</a></sup> The list of Consul ACL policies to associate with these roles.
+
+* `consul_roles` - (Required)<sup><a href="#note-about-required-arguments">SEE NOTE</a></sup> Set of Consul roles to attach to the token.
+   Applicable for Vault 1.10+ with Consul 1.5+.
+
+* `service_identities` - (Required)<sup><a href="#note-about-required-arguments">SEE NOTE</a></sup> Set of Consul
+service identities to attach to the token. Applicable for Vault 1.11+ with Consul 1.5+.
+
+* `node_identities` - (Required)<sup><a href="#note-about-required-arguments">SEE NOTE</a></sup> Set of Consul node
+identities to attach to the token. Applicable for Vault 1.11+ with Consul 1.8+.
+
 * `consul_namespace` - (Optional) The Consul namespace that the token will be created in.
-   Applicable for Vault 1.10+ and Consul 1.7+",
+   Applicable for Vault 1.10+ and Consul 1.7+".
 
 * `partition` - (Optional) The admin partition that the token will be created in.
-   Applicable for Vault 1.10+ and Consul 1.11+",
-
-* `policies` - (Required when `consul_roles` is unset) The list of Consul ACL policies to associate with these roles.
-
-* `consul_roles` - (Required when `policies` is unset) Set of Consul roles to attach to the token.
-   Applicable for Vault 1.10+ with Consul 1.5+.
+   Applicable for Vault 1.10+ and Consul 1.11+".
 
 * `max_ttl` - (Optional) Maximum TTL for leases associated with this role, in seconds.
 
 * `ttl` - (Optional) Specifies the TTL for this role.
 
 * `token_type` - (Optional) Specifies the type of token to create when using this role. Valid values are "client" or "management".
+  *Deprecated: Consul 1.11 and later removed the legacy ACL system which supported this field.*
 
 * `local` - (Optional) Indicates that the token should not be replicated globally and instead be local to the current datacenter.
 
@@ -74,3 +81,8 @@ Consul secret backend roles can be imported using the `backend`, `/roles/`, and 
 ```
 $ terraform import vault_consul_secret_backend_role.example consul/roles/my-role
 ```
+
+## Note About Required Arguments
+*At least one* of the four arguments `consul_policies`, `consul_roles`, `service_identities`, or
+`node_identities` is required for a token. If desired, any combination of the four arguments up-to and
+including all four, is valid.


### PR DESCRIPTION
This adds supports for service identities and node identities in Consul and for the ability to bootstrap the Consul ACL system by writing the secrets engine config without a token.

Bootstrapping example:
```
resource "vault_consul_secret_backend" "config" {
  path    = "consul"
  address = "http://127.0.0.1:8500"
}
```

Identities example:
```
resource "vault_consul_secret_backend_role" "role" {
  name               = "management"
  backend            = vault_consul_secret_backend.config.path
  node_identities    = ["server-1:dc1"]
  service_identities = ["db-service:dc1"]
}
```

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
IMPROVEMENTS
* resource/vault_consul_secret_backend: Try automatically bootstrapping the Consul ACL system when a token is not provided
* resource/vault_consul_secret_backend_role: Add support for service identities and node identities
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestConsulSecretBackendRole'
=== RUN   TestConsulSecretBackendRole
--- PASS: TestConsulSecretBackendRole (2.17s)
=== RUN   TestConsulSecretBackendRoleNameFromPath
--- PASS: TestConsulSecretBackendRoleNameFromPath (0.00s)
=== RUN   TestConsulSecretBackendRoleBackendFromPath
--- PASS: TestConsulSecretBackendRoleBackendFromPath (0.00s)
PASS
```
