### PR TITLE
Update *kv_secrets* resources to support namespaces

### DIFF
--- a/vault/data_source_kv_secret.go
+++ b/vault/data_source_kv_secret.go
@@ -49,7 +49,10 @@ func kvSecretDataSource() *schema.Resource {
 }
 
 func kvSecretDataSourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*provider.ProviderMeta).GetClient()
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 
 	path := d.Get(consts.FieldPath).(string)
 

--- a/vault/data_source_kv_secret_v2.go
+++ b/vault/data_source_kv_secret_v2.go
@@ -80,7 +80,10 @@ func kvSecretV2DataSource() *schema.Resource {
 }
 
 func kvSecretV2DataSourceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*provider.ProviderMeta).GetClient()
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 
 	mount := d.Get(consts.FieldMount).(string)
 	name := d.Get(consts.FieldName).(string)

--- a/vault/data_source_kv_secrets_list.go
+++ b/vault/data_source_kv_secrets_list.go
@@ -34,7 +34,10 @@ func kvSecretListDataSource() *schema.Resource {
 }
 
 func kvSecretListDataSourceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*provider.ProviderMeta).GetClient()
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 
 	path := d.Get(consts.FieldPath).(string)
 

--- a/vault/data_source_kv_secrets_list_v2.go
+++ b/vault/data_source_kv_secrets_list_v2.go
@@ -48,7 +48,10 @@ func kvSecretListDataSourceV2() *schema.Resource {
 }
 
 func kvSecretV2ListDataSourceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*provider.ProviderMeta).GetClient()
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 
 	mount := d.Get(consts.FieldMount).(string)
 	name := d.Get(consts.FieldName).(string)

--- a/vault/data_source_kv_subkeys_v2.go
+++ b/vault/data_source_kv_subkeys_v2.go
@@ -64,7 +64,10 @@ func kvSecretSubkeysV2DataSource() *schema.Resource {
 }
 
 func kvSecretSubkeysDataSourceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*provider.ProviderMeta).GetClient()
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 
 	mount := d.Get(consts.FieldMount).(string)
 	name := d.Get(consts.FieldName).(string)

--- a/vault/resource_kv_secret.go
+++ b/vault/resource_kv_secret.go
@@ -52,7 +52,11 @@ func kvSecretResource(name string) *schema.Resource {
 }
 
 func kvSecretWrite(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*provider.ProviderMeta).GetClient()
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
+
 	path := d.Get(consts.FieldPath).(string)
 
 	var secretData map[string]interface{}
@@ -81,7 +85,10 @@ func kvSecretRead(_ context.Context, d *schema.ResourceData, meta interface{}) d
 		return diag.FromErr(err)
 	}
 
-	client := meta.(*provider.ProviderMeta).GetClient()
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 
 	log.Printf("[DEBUG] Reading %s from Vault", path)
 	secret, err := client.Logical().Read(path)
@@ -108,7 +115,11 @@ func kvSecretRead(_ context.Context, d *schema.ResourceData, meta interface{}) d
 }
 
 func kvSecretDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*provider.ProviderMeta).GetClient()
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
+
 	path := d.Id()
 
 	log.Printf("[DEBUG] Deleting vault_kv_secret from %q", path)

--- a/vault/resource_kv_secret_backend_v2.go
+++ b/vault/resource_kv_secret_backend_v2.go
@@ -53,7 +53,11 @@ func kvSecretBackendV2Resource() *schema.Resource {
 }
 
 func kvSecretBackendV2CreateUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*provider.ProviderMeta).GetClient()
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
+
 	mount := d.Get(consts.FieldMount).(string)
 
 	data := map[string]interface{}{}
@@ -74,7 +78,11 @@ func kvSecretBackendV2CreateUpdate(ctx context.Context, d *schema.ResourceData, 
 }
 
 func kvSecretBackendV2Read(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*provider.ProviderMeta).GetClient()
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
+
 	diags := diag.Diagnostics{}
 
 	path := d.Id()

--- a/vault/resource_kv_secret_v2.go
+++ b/vault/resource_kv_secret_v2.go
@@ -109,7 +109,11 @@ func getKVV2Path(mount, name, prefix string) string {
 }
 
 func kvSecretV2Write(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*provider.ProviderMeta).GetClient()
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
+
 	mount := d.Get(consts.FieldMount).(string)
 	name := d.Get(consts.FieldName).(string)
 
@@ -149,7 +153,10 @@ func kvSecretV2Read(_ context.Context, d *schema.ResourceData, meta interface{})
 	}
 
 	if shouldRead {
-		client := meta.(*provider.ProviderMeta).GetClient()
+		client, e := provider.GetClient(d, meta)
+		if e != nil {
+			return diag.FromErr(e)
+		}
 
 		log.Printf("[DEBUG] Reading %s from Vault", path)
 		secret, err := client.Logical().Read(path)
@@ -185,7 +192,10 @@ func kvSecretV2Read(_ context.Context, d *schema.ResourceData, meta interface{})
 }
 
 func kvSecretV2Delete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*provider.ProviderMeta).GetClient()
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
 
 	mount := d.Get(consts.FieldMount).(string)
 	name := d.Get(consts.FieldName).(string)


### PR DESCRIPTION
All `*kv_secrets*` resources were not being created in the specified namespace. This PR should address that.
