### PR TITLE
Add multi-issuer and managed keys support for PKI

### DIFF
--- a/vault/resource_pki_secret_backend_intermediate_cert_request_test.go
+++ b/vault/resource_pki_secret_backend_intermediate_cert_request_test.go
@@ -53,3 +53,52 @@ resource "vault_pki_secret_backend_intermediate_cert_request" "test" {
 }
 `, path)
 }
+
+func TestPkiSecretBackendIntermediateCertRequest_existing(t *testing.T) {
+	path := "pki-" + strconv.Itoa(acctest.RandInt())
+
+	resourceName := "vault_pki_secret_backend_intermediate_cert_request.existing"
+	resource.Test(t, resource.TestCase{
+		Providers:    testProviders,
+		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		CheckDestroy: testCheckMountDestroyed("vault_mount", consts.MountTypePKI, consts.FieldPath),
+		Steps: []resource.TestStep{
+			{
+				Config: testPkiSecretBackendIntermediateCertRequestConfig_existing(path),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "backend", path),
+					resource.TestCheckResourceAttr(resourceName, "type", "existing"),
+					resource.TestCheckResourceAttr(resourceName, "common_name", "test2.my.domain"),
+				),
+			},
+		},
+	})
+}
+
+func testPkiSecretBackendIntermediateCertRequestConfig_existing(path string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "test" {
+  path                      = "%s"
+  type                      = "pki"
+  description               = "test"
+  default_lease_ttl_seconds = 86400
+  max_lease_ttl_seconds     = 86400
+}
+
+resource "vault_pki_secret_backend_intermediate_cert_request" "internal" {
+  backend     = vault_mount.test.path
+  type        = "internal"
+  key_name    = "test_key"
+  key_type    = "rsa"
+  key_bits    = "4096"
+  common_name = "test.my.domain"
+}
+
+resource "vault_pki_secret_backend_intermediate_cert_request" "existing" {
+  backend     = vault_mount.test.path
+  type        = "existing"
+  key_ref     = vault_pki_secret_backend_intermediate_cert_request.internal.key_name
+  common_name = "test2.my.domain"
+}
+`, path)
+}

--- a/vault/resource_pki_secret_backend_role.go
+++ b/vault/resource_pki_secret_backend_role.go
@@ -42,6 +42,12 @@ func pkiSecretBackendRoleResource() *schema.Resource {
 				ForceNew:    true,
 				Description: "Unique name for the role.",
 			},
+			"issuer_ref": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the default issuer. May be the value \"default\", a name, or an issuer ID.",
+				Default:     "default",
+			},
 			"ttl": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -367,6 +373,7 @@ func pkiSecretBackendRoleCreate(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	data := map[string]interface{}{
+		"issuer_ref":                         d.Get("issuer_ref"),
 		"ttl":                                d.Get("ttl"),
 		"max_ttl":                            d.Get("max_ttl"),
 		"allow_localhost":                    d.Get("allow_localhost"),
@@ -504,6 +511,7 @@ func pkiSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("backend", backend)
 	d.Set("name", name)
+	d.Set("issuer_ref", secret.Data["issuer_ref"])
 	d.Set("ttl", secret.Data["ttl"])
 	d.Set("max_ttl", secret.Data["max_ttl"])
 	d.Set("allow_localhost", secret.Data["allow_localhost"])
@@ -585,6 +593,7 @@ func pkiSecretBackendRoleUpdate(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	data := map[string]interface{}{
+		"issuer_ref":                         d.Get("issuer_ref"),
 		"ttl":                                d.Get("ttl"),
 		"max_ttl":                            d.Get("max_ttl"),
 		"allow_localhost":                    d.Get("allow_localhost"),

--- a/vault/resource_pki_secret_backend_role_test.go
+++ b/vault/resource_pki_secret_backend_role_test.go
@@ -20,6 +20,7 @@ func TestPkiSecretBackendRole_basic(t *testing.T) {
 	checks := []resource.TestCheckFunc{
 		resource.TestCheckResourceAttr(resourceName, "name", name),
 		resource.TestCheckResourceAttr(resourceName, "backend", backend),
+		resource.TestCheckResourceAttr(resourceName, "issuer_ref", "default"),
 		resource.TestCheckResourceAttr(resourceName, "allow_localhost", "true"),
 		resource.TestCheckResourceAttr(resourceName, "allowed_domains.#", "1"),
 		resource.TestCheckResourceAttr(resourceName, "allowed_domains.0", "test.domain"),
@@ -98,6 +99,7 @@ func TestPkiSecretBackendRole_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "issuer_ref", "default"),
 					resource.TestCheckResourceAttr(resourceName, "ttl", "1800"),
 					resource.TestCheckResourceAttr(resourceName, "max_ttl", "3600"),
 					resource.TestCheckResourceAttr(resourceName, "allow_localhost", "true"),
@@ -207,6 +209,7 @@ resource "vault_pki_secret_backend_role" "test" {
   depends_on = [ "vault_mount.pki" ]
   backend = vault_mount.pki.path
   name = "%s"
+  issuer_ref = "default"
   ttl = 1800
   max_ttl = 3600
   allow_localhost = true

--- a/vault/resource_pki_secret_backend_root_cert.go
+++ b/vault/resource_pki_secret_backend_root_cert.go
@@ -79,9 +79,36 @@ func pkiSecretBackendRootCertResource() *schema.Resource {
 			"type": {
 				Type:         schema.TypeString,
 				Required:     true,
-				Description:  "Type of intermediate to create. Must be either \"exported\" or \"internal\".",
+				Description:  "Type of root to create. Must be either \"exported\", \"internal\", \"existing\" or \"kms\".",
 				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{"exported", "internal"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"exported", "internal", "existing", "kms"}, false),
+			},
+			"issuer_name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "Provides a name to the specified issuer.",
+				ValidateFunc: validation.StringNotInSlice([]string{"default"}, false),
+			},
+			"key_name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "Specifies the name of the key when it is created with this resource.",
+				ForceNew:     true,
+				ValidateFunc: validation.StringNotInSlice([]string{"default"}, false),
+			},
+			"key_ref": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the key (either default, by name, or by identifier) to use.",
+				ForceNew:    true,
+				Default:     "default",
+				// Suppress the diff if group type is not "existing" as it is only suitable for type "existing".
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if d.Get("type").(string) != "existing" {
+						return true
+					}
+					return false
+				},
 			},
 			"common_name": {
 				Type:        schema.TypeString,
@@ -154,6 +181,13 @@ func pkiSecretBackendRootCertResource() *schema.Resource {
 				ForceNew:     true,
 				Default:      "rsa",
 				ValidateFunc: validation.StringInSlice([]string{"rsa", "ec", "ed25519"}, false),
+				// Suppress the diff if group type is "existing" or "kms" because we cannot manage the key type.
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if d.Get("type").(string) == "existing" || d.Get("type").(string) == "kms" {
+						return true
+					}
+					return false
+				},
 			},
 			"key_bits": {
 				Type:        schema.TypeInt,
@@ -161,6 +195,13 @@ func pkiSecretBackendRootCertResource() *schema.Resource {
 				Description: "The number of bits to use.",
 				ForceNew:    true,
 				Default:     2048,
+				// Suppress the diff if group type is "existing" or "kms" because we cannot manage the key bits.
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if d.Get("type").(string) == "existing" || d.Get("type").(string) == "kms" {
+						return true
+					}
+					return false
+				},
 			},
 			"max_path_length": {
 				Type:        schema.TypeInt,
@@ -247,6 +288,31 @@ func pkiSecretBackendRootCertResource() *schema.Resource {
 				Computed:    true,
 				Description: "The certificate's serial number, hex formatted.",
 			},
+			"not_before_duration": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the duration by which to backdate the NotBefore property.",
+				ForceNew:    true,
+				Default:     "30s",
+			},
+			"not_after": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Set the Not After field of the certificate with specified date value.",
+				ForceNew:    true,
+			},
+			"managed_key_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The managed key's configured name.",
+				ForceNew:    true,
+			},
+			"managed_key_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The managed key's UUID.",
+				ForceNew:    true,
+			},
 		},
 	}
 }
@@ -297,8 +363,6 @@ func pkiSecretBackendRootCertCreate(d *schema.ResourceData, meta interface{}) er
 		"ttl":                  d.Get("ttl").(string),
 		"format":               d.Get("format").(string),
 		"private_key_format":   d.Get("private_key_format").(string),
-		"key_type":             d.Get("key_type").(string),
-		"key_bits":             d.Get("key_bits").(int),
 		"max_path_length":      d.Get("max_path_length").(int),
 		"exclude_cn_from_sans": d.Get("exclude_cn_from_sans").(bool),
 		"ou":                   d.Get("ou").(string),
@@ -308,6 +372,7 @@ func pkiSecretBackendRootCertCreate(d *schema.ResourceData, meta interface{}) er
 		"province":             d.Get("province").(string),
 		"street_address":       d.Get("street_address").(string),
 		"postal_code":          d.Get("postal_code").(string),
+		"not_before_duration":  d.Get("not_before_duration").(string),
 	}
 
 	if len(altNames) > 0 {
@@ -328,6 +393,38 @@ func pkiSecretBackendRootCertCreate(d *schema.ResourceData, meta interface{}) er
 
 	if len(permittedDNSDomains) > 0 {
 		data["permitted_dns_domains"] = strings.Join(permittedDNSDomains, ",")
+	}
+
+	if v, ok := d.GetOk("issuer_name"); ok {
+		data["issuer_name"] = v.(string)
+	}
+
+	if v, ok := d.GetOk("key_ref"); ok {
+		data["key_ref"] = v.(string)
+	}
+
+	if v, ok := d.GetOk("key_type"); ok {
+		data["key_type"] = v.(string)
+	}
+
+	if v, ok := d.GetOk("key_bits"); ok {
+		data["key_bits"] = v.(int)
+	}
+
+	if v, ok := d.GetOk("key_name"); ok {
+		data["key_name"] = v.(string)
+	}
+
+	if v, ok := d.GetOk("not_after"); ok {
+		data["not_after"] = v.(string)
+	}
+
+	if v, ok := d.GetOk("managed_key_name"); ok {
+		data["managed_key_name"] = v.(string)
+	}
+
+	if v, ok := d.GetOk("managed_key_id"); ok {
+		data["managed_key_id"] = v.(string)
 	}
 
 	log.Printf("[DEBUG] Creating root cert on PKI secret backend %q", backend)

--- a/vault/resource_pki_secret_backend_sign.go
+++ b/vault/resource_pki_secret_backend_sign.go
@@ -42,6 +42,13 @@ func pkiSecretBackendSignResource() *schema.Resource {
 				Description: "Name of the role to create the certificate against.",
 				ForceNew:    true,
 			},
+			"issuer_ref": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Reference to an existing issuer, either Vault-generated identifier or name assigned to an issuer.",
+				ForceNew:    true,
+				Default:     "default",
+			},
 			"csr": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -166,8 +173,9 @@ func pkiSecretBackendSignCreate(d *schema.ResourceData, meta interface{}) error 
 
 	backend := d.Get("backend").(string)
 	name := d.Get("name").(string)
+	issuerRef := d.Get("issuer_ref").(string)
 
-	path := pkiSecretBackendIssuePath(backend, name)
+	path := pkiSecretBackendIssuePath(backend, name, issuerRef)
 
 	commonName := d.Get("common_name").(string)
 
@@ -245,6 +253,9 @@ func pkiSecretBackendSignDelete(d *schema.ResourceData, meta interface{}) error 
 	return nil
 }
 
-func pkiSecretBackendIssuePath(backend string, name string) string {
-	return strings.Trim(backend, "/") + "/sign/" + strings.Trim(name, "/")
+func pkiSecretBackendIssuePath(backend string, name string, issuerRef string) string {
+	if issuerRef == "default" {
+		return strings.Trim(backend, "/") + "/sign/" + strings.Trim(name, "/")
+	}
+	return strings.Trim(backend, "/") + "/issuer/" + strings.Trim(issuerRef, "/") + "/sign/" + strings.Trim(name, "/")
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-vault/issues/1510

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
- add support for multi-issuer functionality and `kms` and `existing` type
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestPkiSecretBackendSign*'                                                       
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -run=TestPkiSecretBackendSign* -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/codegen   (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/internal/provider (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/testutil  (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
=== RUN   TestPkiSecretBackendSign_basic
--- PASS: TestPkiSecretBackendSign_basic (3.76s)
=== RUN   TestPkiSecretBackendSign_renew
--- PASS: TestPkiSecretBackendSign_renew (9.25s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     13.457s
...


```
```
$ make testacc TESTARGS='-run=TestPkiSecretBackendIntermediateCertRequest*'                                    
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -run=TestPkiSecretBackendIntermediateCertRequest* -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/codegen   (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/internal/provider (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/testutil  (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
=== RUN   TestPkiSecretBackendIntermediateCertRequest_basic
--- PASS: TestPkiSecretBackendIntermediateCertRequest_basic (1.14s)
=== RUN   TestPkiSecretBackendIntermediateCertRequest_existing
--- PASS: TestPkiSecretBackendIntermediateCertRequest_existing (2.06s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     3.630s

```

```
$ make testacc TESTARGS='-run=TestPkiSecretBackendRole*'                                                       
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -run=TestPkiSecretBackendRole* -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/codegen   (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/internal/provider (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/testutil  (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
=== RUN   TestPkiSecretBackendRole_basic
--- PASS: TestPkiSecretBackendRole_basic (3.18s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     3.582s

```


```
$ make testacc TESTARGS='-run=TestPkiSecretBackendRootCertificate*'                                            
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -run=TestPkiSecretBackendRootCertificate* -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/codegen   (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/internal/provider (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/testutil  (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
=== RUN   TestPkiSecretBackendRootCertificate_basic
--- PASS: TestPkiSecretBackendRootCertificate_basic (10.47s)
=== RUN   TestPkiSecretBackendRootCertificate_existing
    resource_pki_secret_backend_root_cert_test.go:177: Step 1/1 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
        -/+ destroy and then create replacement
        
        Terraform will perform the following actions:
        
          # vault_pki_secret_backend_root_cert.existing must be replaced
        -/+ resource "vault_pki_secret_backend_root_cert" "existing" {
              ~ certificate         = <<-EOT
                    -----BEGIN CERTIFICATE-----
                    MIIFQzCCAyugAwIBAgIUKugi8PyYXdjO0Gd76gx/3JFUGC0wDQYJKoZIhvcNAQEL
                    BQAwGjEYMBYGA1UEAxMPdGVzdDIubXkuZG9tYWluMCAXDTIyMDcxOTEyMjU1NVoY
                    Dzk5OTkxMjMxMjM1OTU5WjAaMRgwFgYDVQQDEw90ZXN0Mi5teS5kb21haW4wggIi
                    MA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQC1LookKI2PGRzTfbsJyTcR8a6O
                    jThCNj56jCGD/39Ii5x71jbEoSZ3NRwPI4tgmxVUTHZ7+sDzQ5h7Nh1fq8+3cXhM
                    3IfvKsoxgATfUTHwNK8tmQ4EMuuSYNCkhYd9knjPXDga2sEqCzUVRWMHi3HDj4at
                    Snn5Y7bltuZlr9ho1S+ALof70eijw/DMnIECriC6RknHjBJxQvgvCRcRV0wkyopJ
                    UYLOsX5Us5wTNBOvDe4A4Fxl7rv6dTXb01jgjzYCULWuzED76xE8arXX+CyDBvjT
                    R8Ax/Fznfc4OMDDnX8YqVHu4Oj3dWcoOt2AuRhP/JAHnMY8+Qj+AKE34xJI3lhth
                    LwBkO54R4HHiYR5efbvIhCyBu6qaGZBqrysonsfPjZlgu4nbdslH3Y7zrwgNKCXB
                    rXlH1C84DcaQcUfpC4bm4Sp68vjwbG7y9excFFtXMfeWzEVou9XJGqEon2nxW1B6
                    IHsg/rFmpt6h1sc7k0qNdrPZPtMcYO0zdLuLnV9YNymmg+A9F4pgD84LVpBkILmt
                    ugYXFBF2zs239LU6B6obTQ6HQ0UbcFIaFfBaoIUJYmWm4sXg5csOuRZ1Rpk7dmSB
                    ZAK+PK01kwqjhSpSB9TfcpAAI3PScMtnAGUK1wjdj5iOoaGe6Kwfe4Mod8kAV8G4
                    BW2g+pNR4WrjkPYh7wIDAQABo38wfTAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/
                    BAUwAwEB/zAdBgNVHQ4EFgQUn3G4eM132gDl7q+nmMSpdb+Ey7QwHwYDVR0jBBgw
                    FoAUn3G4eM132gDl7q+nmMSpdb+Ey7QwGgYDVR0RBBMwEYIPdGVzdDIubXkuZG9t
                    YWluMA0GCSqGSIb3DQEBCwUAA4ICAQBh/2AvASqMhuBGL697IEtBjlOB8AJ+ziA4
                    ob1+WksWhILRci/f/1NEBD42qITJG6izP0LDvYJJjEklgm5sQGtQhwEfvIHyxjVf
                    bxA9zHukIfYGufz9ZRtl3X7RnQFAajinGipqvtdGNDcWi1mjzoe5i/yUszsw9IGv
                    FN71IgktHV5FdkgcOpBXlFulSnwajFWtZBULEonlI1OANC1osP3Am7YRig8Ylv2L
                    fgdp7lmT2RpYEHVIcXf3/GfgfkF7k1WnxwmsVwL0dodHAshFNmNomNmnDI8O8JA6
                    Ix/5+Uu1kUWGhVRbtSVZREfse0FNYtu3aHjZV42BPOzN+LmjKlNryaRT/Sn7T4X9
                    vJdLnNls6rlHXNZ2o3wMkqqM+ozyjhoVoT7+DSYWhansdllsBA+hUzH27DjyleB1
                    r5mVdJmt4OdQ4/h1jKMMb/o3axOQlAOZSQp3bwPLv7SX2yJ2kF830DEOtjMf9BSg
                    /VK71uESs+yhjGgwpPn035YsQ0F5EGb5akfhDlvK962WBDyvO2JsmlO//JEFW35L
                    xn5LhB7bxlaTplSqyFSmjKetJQMZl77vovYpSYdUe2mzPOtQSbgTnfgX+i0KWF+c
                    ibYpssaawnJ1EyM0StO5YrrU2isb2iC7hU0PXKjBmur2vFOTO5SMluVnioEWh+Dn
                    zoJYPLk6wg==
                    -----END CERTIFICATE-----
                EOT -> (known after apply)
              ~ id                  = "pki-2658118447868244333/root/generate/existing" -> (known after apply)
              ~ issuing_ca          = <<-EOT
                    -----BEGIN CERTIFICATE-----
                    MIIFQzCCAyugAwIBAgIUKugi8PyYXdjO0Gd76gx/3JFUGC0wDQYJKoZIhvcNAQEL
                    BQAwGjEYMBYGA1UEAxMPdGVzdDIubXkuZG9tYWluMCAXDTIyMDcxOTEyMjU1NVoY
                    Dzk5OTkxMjMxMjM1OTU5WjAaMRgwFgYDVQQDEw90ZXN0Mi5teS5kb21haW4wggIi
                    MA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQC1LookKI2PGRzTfbsJyTcR8a6O
                    jThCNj56jCGD/39Ii5x71jbEoSZ3NRwPI4tgmxVUTHZ7+sDzQ5h7Nh1fq8+3cXhM
                    3IfvKsoxgATfUTHwNK8tmQ4EMuuSYNCkhYd9knjPXDga2sEqCzUVRWMHi3HDj4at
                    Snn5Y7bltuZlr9ho1S+ALof70eijw/DMnIECriC6RknHjBJxQvgvCRcRV0wkyopJ
                    UYLOsX5Us5wTNBOvDe4A4Fxl7rv6dTXb01jgjzYCULWuzED76xE8arXX+CyDBvjT
                    R8Ax/Fznfc4OMDDnX8YqVHu4Oj3dWcoOt2AuRhP/JAHnMY8+Qj+AKE34xJI3lhth
                    LwBkO54R4HHiYR5efbvIhCyBu6qaGZBqrysonsfPjZlgu4nbdslH3Y7zrwgNKCXB
                    rXlH1C84DcaQcUfpC4bm4Sp68vjwbG7y9excFFtXMfeWzEVou9XJGqEon2nxW1B6
                    IHsg/rFmpt6h1sc7k0qNdrPZPtMcYO0zdLuLnV9YNymmg+A9F4pgD84LVpBkILmt
                    ugYXFBF2zs239LU6B6obTQ6HQ0UbcFIaFfBaoIUJYmWm4sXg5csOuRZ1Rpk7dmSB
                    ZAK+PK01kwqjhSpSB9TfcpAAI3PScMtnAGUK1wjdj5iOoaGe6Kwfe4Mod8kAV8G4
                    BW2g+pNR4WrjkPYh7wIDAQABo38wfTAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/
                    BAUwAwEB/zAdBgNVHQ4EFgQUn3G4eM132gDl7q+nmMSpdb+Ey7QwHwYDVR0jBBgw
                    FoAUn3G4eM132gDl7q+nmMSpdb+Ey7QwGgYDVR0RBBMwEYIPdGVzdDIubXkuZG9t
                    YWluMA0GCSqGSIb3DQEBCwUAA4ICAQBh/2AvASqMhuBGL697IEtBjlOB8AJ+ziA4
                    ob1+WksWhILRci/f/1NEBD42qITJG6izP0LDvYJJjEklgm5sQGtQhwEfvIHyxjVf
                    bxA9zHukIfYGufz9ZRtl3X7RnQFAajinGipqvtdGNDcWi1mjzoe5i/yUszsw9IGv
                    FN71IgktHV5FdkgcOpBXlFulSnwajFWtZBULEonlI1OANC1osP3Am7YRig8Ylv2L
                    fgdp7lmT2RpYEHVIcXf3/GfgfkF7k1WnxwmsVwL0dodHAshFNmNomNmnDI8O8JA6
                    Ix/5+Uu1kUWGhVRbtSVZREfse0FNYtu3aHjZV42BPOzN+LmjKlNryaRT/Sn7T4X9
                    vJdLnNls6rlHXNZ2o3wMkqqM+ozyjhoVoT7+DSYWhansdllsBA+hUzH27DjyleB1
                    r5mVdJmt4OdQ4/h1jKMMb/o3axOQlAOZSQp3bwPLv7SX2yJ2kF830DEOtjMf9BSg
                    /VK71uESs+yhjGgwpPn035YsQ0F5EGb5akfhDlvK962WBDyvO2JsmlO//JEFW35L
                    xn5LhB7bxlaTplSqyFSmjKetJQMZl77vovYpSYdUe2mzPOtQSbgTnfgX+i0KWF+c
                    ibYpssaawnJ1EyM0StO5YrrU2isb2iC7hU0PXKjBmur2vFOTO5SMluVnioEWh+Dn
                    zoJYPLk6wg==
                    -----END CERTIFICATE-----
                EOT -> (known after apply)
              ~ serial              = "2a:e8:22:f0:fc:98:5d:d8:ce:d0:67:7b:ea:0c:7f:dc:91:54:18:2d" -> (known after apply) # forces replacement
              ~ serial_number       = "2a:e8:22:f0:fc:98:5d:d8:ce:d0:67:7b:ea:0c:7f:dc:91:54:18:2d" -> (known after apply)
                # (10 unchanged attributes hidden)
            }
        
        Plan: 1 to add, 0 to change, 1 to destroy.
--- FAIL: TestPkiSecretBackendRootCertificate_existing (1.64s)
FAIL
FAIL    github.com/hashicorp/terraform-provider-vault/vault     12.525s
FAIL
make: *** [testacc] Error 1
```
`TestPkiSecretBackendRootCertificate_existing` is failing after detected drift of the deprecated `serial` field and I have not been able to work out why.