### PR TITLE
feat: lazy Client init

### DIFF
--- a/generated/resources/transform/alphabet/name_test.go
+++ b/generated/resources/transform/alphabet/name_test.go
@@ -58,7 +58,10 @@ func TestAlphabetName(t *testing.T) {
 }
 
 func destroy(s *terraform.State) error {
-	client := nameTestProvider.SchemaProvider().Meta().(*provider.ProviderMeta).GetClient()
+	client, err := nameTestProvider.SchemaProvider().Meta().(*provider.ProviderMeta).GetClient()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_transform_alphabet_name" {

--- a/generated/resources/transform/role/name_test.go
+++ b/generated/resources/transform/role/name_test.go
@@ -61,7 +61,10 @@ func TestRoleName(t *testing.T) {
 }
 
 func destroy(s *terraform.State) error {
-	client := nameTestProvider.SchemaProvider().Meta().(*provider.ProviderMeta).GetClient()
+	client, err := nameTestProvider.SchemaProvider().Meta().(*provider.ProviderMeta).GetClient()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_transform_role_name" {

--- a/generated/resources/transform/template/name_test.go
+++ b/generated/resources/transform/template/name_test.go
@@ -78,7 +78,10 @@ func TestTemplateName(t *testing.T) {
 }
 
 func destroy(s *terraform.State) error {
-	client := nameTestProvider.SchemaProvider().Meta().(*provider.ProviderMeta).GetClient()
+	client, err := nameTestProvider.SchemaProvider().Meta().(*provider.ProviderMeta).GetClient()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_transform_template_name" {

--- a/generated/resources/transform/transformation/name_test.go
+++ b/generated/resources/transform/transformation/name_test.go
@@ -104,7 +104,10 @@ func TestTransformationName(t *testing.T) {
 }
 
 func destroy(s *terraform.State) error {
-	client := nameTestProvider.SchemaProvider().Meta().(*provider.ProviderMeta).GetClient()
+	client, err := nameTestProvider.SchemaProvider().Meta().(*provider.ProviderMeta).GetClient()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_transform_transformation_name" {

--- a/internal/provider/meta_test.go
+++ b/internal/provider/meta_test.go
@@ -37,7 +37,7 @@ func TestProviderMeta_GetNSClient(t *testing.T) {
 			client:       nil,
 			resourceData: &schema.ResourceData{},
 			wantErr:      true,
-			expectErr:    errors.New("root api.Client not set, init with NewProviderMeta()"),
+			expectErr:    errors.New("empty namespace not allowed"),
 		},
 		{
 			name:         "no-resource-data",
@@ -115,6 +115,7 @@ func TestProviderMeta_GetNSClient(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			p := &ProviderMeta{
 				client:       tt.client,

--- a/vault/resource_approle_auth_backend_role_secret_id_test.go
+++ b/vault/resource_approle_auth_backend_role_secret_id_test.go
@@ -287,7 +287,11 @@ provider "vault" {
 
 func testAssertClientNamespace(expectedNS string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		client, err := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		if err != nil {
+			return err
+		}
+
 		actualNS := client.Headers().Get(helper.NamespaceHeaderName)
 		if actualNS != expectedNS {
 			return fmt.Errorf("expected namespace %v, actual %v", expectedNS, actualNS)

--- a/vault/resource_auth_backend_test.go
+++ b/vault/resource_auth_backend_test.go
@@ -239,7 +239,11 @@ resource "vault_auth_backend" "test" {
 
 func checkAuthMount(backend string, checker func(*api.AuthMount) error) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		client, err := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		if err != nil {
+			return err
+		}
+
 		auths, err := client.Sys().ListAuth()
 		if err != nil {
 			return fmt.Errorf("error reading back auth: %s", err)

--- a/vault/resource_azure_auth_backend_config.go
+++ b/vault/resource_azure_auth_backend_config.go
@@ -66,7 +66,10 @@ func azureAuthBackendConfigResource() *schema.Resource {
 }
 
 func azureAuthBackendWrite(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*provider.ProviderMeta).GetClient()
+	config, err := meta.(*provider.ProviderMeta).GetClient()
+	if err != nil {
+		return fmt.Errorf("error obtaining Vault client: %w", err)
+	}
 
 	// if backend comes from the config, it won't have the StateFunc
 	// applied yet, so we need to apply it again.
@@ -88,8 +91,7 @@ func azureAuthBackendWrite(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Writing Azure auth backend config to %q", path)
-	_, err := config.Logical().Write(path, data)
-	if err != nil {
+	if _, err := config.Logical().Write(path, data); err != nil {
 		return fmt.Errorf("error writing to %q: %s", path, err)
 	}
 	log.Printf("[DEBUG] Wrote Azure auth backend config to %q", path)
@@ -100,7 +102,10 @@ func azureAuthBackendWrite(d *schema.ResourceData, meta interface{}) error {
 }
 
 func azureAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*provider.ProviderMeta).GetClient()
+	config, err := meta.(*provider.ProviderMeta).GetClient()
+	if err != nil {
+		return fmt.Errorf("error obtaining Vault client: %w", err)
+	}
 
 	log.Printf("[DEBUG] Reading Azure auth backend config")
 	secret, err := config.Logical().Read(d.Id())
@@ -130,11 +135,13 @@ func azureAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func azureAuthBackendDelete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*provider.ProviderMeta).GetClient()
+	config, err := meta.(*provider.ProviderMeta).GetClient()
+	if err != nil {
+		return fmt.Errorf("error obtaining Vault client: %w", err)
+	}
 
 	log.Printf("[DEBUG] Deleting Azure auth backend config from %q", d.Id())
-	_, err := config.Logical().Delete(d.Id())
-	if err != nil {
+	if _, err = config.Logical().Delete(d.Id()); err != nil {
 		return fmt.Errorf("error deleting Azure auth backend config from %q: %s", d.Id(), err)
 	}
 	log.Printf("[DEBUG] Deleted Azure auth backend config from %q", d.Id())
@@ -143,7 +150,10 @@ func azureAuthBackendDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func azureAuthBackendExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	config := meta.(*provider.ProviderMeta).GetClient()
+	config, err := meta.(*provider.ProviderMeta).GetClient()
+	if err != nil {
+		return true, fmt.Errorf("error obtaining Vault client: %w", err)
+	}
 
 	log.Printf("[DEBUG] Checking if Azure auth backend is configured at %q", d.Id())
 	secret, err := config.Logical().Read(d.Id())

--- a/vault/resource_azure_auth_backend_config_test.go
+++ b/vault/resource_azure_auth_backend_config_test.go
@@ -53,7 +53,10 @@ func TestAccAzureAuthBackendConfig_basic(t *testing.T) {
 }
 
 func testAccCheckAzureAuthBackendConfigDestroy(s *terraform.State) error {
-	config := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+	config, err := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+	if err != nil {
+		return err
+	}
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_azure_auth_backend_config" {
@@ -106,7 +109,11 @@ func testAccAzureAuthBackendConfigCheck_attrs(backend string) resource.TestCheck
 			return fmt.Errorf("expected ID to be %q, got %q", "auth/"+backend+"/config", endpoint)
 		}
 
-		config := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		config, err := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		if err != nil {
+			return err
+		}
+
 		resp, err := config.Logical().Read(endpoint)
 		if err != nil {
 			return fmt.Errorf("error reading back Azure auth config from %q: %s", endpoint, err)

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -595,7 +595,10 @@ func TestAccDatabaseSecretBackendConnectionTemplatedUpdateExcludePassword_mysql(
 				Config: testAccDatabaseSecretBackendConnectionConfigTemplated_mysql(name, backend, testConnURL, secondaryRootUsername, secondaryRootPassword, 10),
 				PreConfig: func() {
 					path := fmt.Sprintf("%s/rotate-root/%s", backend, name)
-					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+					client, err := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+					if err != nil {
+						t.Fatal(err)
+					}
 
 					resp, err := client.Logical().Write(path, map[string]interface{}{})
 					if err != nil {

--- a/vault/resource_database_secrets_mount_test.go
+++ b/vault/resource_database_secrets_mount_test.go
@@ -70,7 +70,10 @@ func TestAccDatabaseSecretsMount_mssql(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+					client, err := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+					if err != nil {
+						t.Fatal(err)
+					}
 
 					resp, err := client.Logical().Read(fmt.Sprintf("%s/creds/%s", backend, "dev"))
 					if err != nil {
@@ -172,7 +175,10 @@ func TestAccDatabaseSecretsMount_mssql_multi(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+					client, err := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+					if err != nil {
+						t.Fatal(err)
+					}
 
 					for _, role := range []string{"dev1", "dev2"} {
 						resp, err := client.Logical().Read(fmt.Sprintf("%s/creds/%s", backend, role))

--- a/vault/resource_generic_secret_test.go
+++ b/vault/resource_generic_secret_test.go
@@ -109,10 +109,12 @@ func TestResourceGenericSecret_deleted(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
-					_, err := client.Logical().Delete(path)
+					client, err := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 					if err != nil {
+						t.Fatal(err)
+					}
+
+					if _, err := client.Logical().Delete(path); err != nil {
 						t.Fatalf("unable to manually delete the secret via the SDK: %s", err)
 					}
 				},

--- a/vault/resource_github_auth_backend.go
+++ b/vault/resource_github_auth_backend.go
@@ -212,5 +212,10 @@ func githubAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func githubAuthBackendDelete(d *schema.ResourceData, meta interface{}) error {
-	return authMountDisable(meta.(*provider.ProviderMeta).GetClient(), d.Id())
+	client, err := meta.(*provider.ProviderMeta).GetClient()
+	if err != nil {
+		return fmt.Errorf("error obtaining Vault client: %w", err)
+	}
+
+	return authMountDisable(client, d.Id())
 }

--- a/vault/resource_identity_entity_alias_test.go
+++ b/vault/resource_identity_entity_alias_test.go
@@ -186,7 +186,10 @@ resource "vault_identity_entity_alias" "test2" {
 			{
 				// delete one of the alias's to ensure an update operation re-creates it.
 				PreConfig: func() {
-					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+					client, err := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+					if err != nil {
+						t.Fatal(err)
+					}
 
 					aliases, err := entity.FindAliases(client, &entity.FindAliasParams{
 						Name: alias,

--- a/vault/resource_identity_oidc_test.go
+++ b/vault/resource_identity_oidc_test.go
@@ -40,7 +40,11 @@ func TestAccIdentityOidc(t *testing.T) {
 }
 
 func testAccCheckIdentityOidcDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+	client, err := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+	if err != nil {
+		return err
+	}
+
 	path := identityOidcPathTemplate
 
 	resp, err := client.Logical().Read(path)

--- a/vault/resource_jwt_auth_backend_test.go
+++ b/vault/resource_jwt_auth_backend_test.go
@@ -364,7 +364,10 @@ resource "vault_namespace" "test" {
 
 func testJWTAuthBackend_Destroyed(path string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		client, err := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		if err != nil {
+			return err
+		}
 
 		authMounts, err := client.Sys().ListAuth()
 		if err != nil {

--- a/vault/resource_kubernetes_auth_backend_config_test.go
+++ b/vault/resource_kubernetes_auth_backend_config_test.go
@@ -370,7 +370,10 @@ func TestAccKubernetesAuthBackendConfig_localCA(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+					client, err := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+					if err != nil {
+						t.Fatal(err)
+					}
 
 					path := kubernetesAuthBackendConfigPath(backend)
 					if _, err := client.Logical().Write(path, map[string]interface{}{

--- a/vault/resource_mfa_totp_test.go
+++ b/vault/resource_mfa_totp_test.go
@@ -35,7 +35,10 @@ func TestMFATOTPBasic(t *testing.T) {
 			},
 			{
 				PreConfig: func() {
-					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+					client, err := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+					if err != nil {
+						t.Fatal(err)
+					}
 
 					resp, err := client.Logical().Read(mfaTOTPPath(path))
 					if err != nil {

--- a/vault/resource_mount_test.go
+++ b/vault/resource_mount_test.go
@@ -664,7 +664,10 @@ resource "vault_mount" "test" {
 }
 
 func findMount(path string) (*api.MountOutput, error) {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+	client, err := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+	if err != nil {
+		return nil, err
+	}
 
 	path = path + "/"
 

--- a/vault/resource_namespace_test.go
+++ b/vault/resource_namespace_test.go
@@ -106,7 +106,10 @@ func testNamespaceCheckAttrs() resource.TestCheckFunc {
 
 func testNamespaceDestroy(path string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		client, err := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		if err != nil {
+			return err
+		}
 
 		namespaceRef, err := client.Logical().Read(fmt.Sprintf("%s/%s", SysNamespaceRoot, path))
 		if err != nil {

--- a/vault/resource_nomad_secret_backend_test.go
+++ b/vault/resource_nomad_secret_backend_test.go
@@ -68,7 +68,10 @@ func TestAccNomadSecretBackend(t *testing.T) {
 }
 
 func testAccNomadSecretBackendCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+	client, err := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+	if err != nil {
+		return err
+	}
 
 	mounts, err := client.Sys().ListMounts()
 	if err != nil {

--- a/vault/resource_okta_auth_backend.go
+++ b/vault/resource_okta_auth_backend.go
@@ -289,7 +289,12 @@ func oktaAuthBackendDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func oktaAuthBackendExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	return isOktaAuthBackendPresent(meta.(*provider.ProviderMeta).GetClient(), d.Id())
+	client, err := meta.(*provider.ProviderMeta).GetClient()
+	if err != nil {
+		return true, fmt.Errorf("error obtaining Vault client: %w", err)
+	}
+
+	return isOktaAuthBackendPresent(client, d.Id())
 }
 
 func oktaAuthBackendRead(d *schema.ResourceData, meta interface{}) error {

--- a/vault/resource_okta_auth_backend_group_test.go
+++ b/vault/resource_okta_auth_backend_group_test.go
@@ -111,7 +111,10 @@ func testAccOktaAuthBackendGroup_InitialCheck(s *terraform.State) error {
 
 func testAccOktaAuthBackendGroup_Destroyed(path, groupName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		client, err := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		if err != nil {
+			return err
+		}
 
 		group, err := client.Logical().Read(fmt.Sprintf("/auth/%s/groups/%s", path, groupName))
 		if err != nil {

--- a/vault/resource_okta_auth_backend_test.go
+++ b/vault/resource_okta_auth_backend_test.go
@@ -254,7 +254,10 @@ func testAccOktaAuthBackend_InitialCheck(s *terraform.State) error {
 
 func testAccOktaAuthBackend_GroupsCheck(path, groupName string, expectedPolicies []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		client, err := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		if err != nil {
+			return err
+		}
 
 		groupList, err := client.Logical().List(fmt.Sprintf("/auth/%s/groups", path))
 		if err != nil {
@@ -294,7 +297,10 @@ func testAccOktaAuthBackend_GroupsCheck(path, groupName string, expectedPolicies
 
 func testAccOktaAuthBackend_UsersCheck(path, userName string, expectedGroups, expectedPolicies []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		client, err := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		if err != nil {
+			return err
+		}
 
 		userList, err := client.Logical().List(fmt.Sprintf("/auth/%s/users", path))
 		if err != nil {
@@ -357,7 +363,10 @@ func testAccOktaAuthBackend_UsersCheck(path, userName string, expectedGroups, ex
 
 func testAccOktaAuthBackend_Destroyed(path string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		client, err := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		if err != nil {
+			return err
+		}
 
 		authMounts, err := client.Sys().ListAuth()
 		if err != nil {

--- a/vault/resource_okta_auth_backend_user_test.go
+++ b/vault/resource_okta_auth_backend_user_test.go
@@ -66,7 +66,10 @@ func testAccOktaAuthBackendUser_InitialCheck(s *terraform.State) error {
 
 func testAccOktaAuthBackendUser_Destroyed(path, userName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		client, err := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		if err != nil {
+			return err
+		}
 
 		group, err := client.Logical().Read(fmt.Sprintf("/auth/%s/users/%s", path, userName))
 		if err != nil {

--- a/vault/resource_pki_secret_backend_cert_test.go
+++ b/vault/resource_pki_secret_backend_cert_test.go
@@ -212,7 +212,10 @@ func TestPkiSecretBackendCert_renew(t *testing.T) {
 			{
 				// test unmounted backend
 				PreConfig: func() {
-					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+					client, err := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+					if err != nil {
+						t.Fatal(err)
+					}
 
 					if err := client.Sys().Unmount(path); err != nil {
 						t.Fatal(err)
@@ -338,8 +341,12 @@ func testPKICertRevocation(path string, store *testPKICertStore) resource.TestCh
 		if store.cert == "" {
 			return fmt.Errorf("certificate in %#v is empty", store)
 		}
+		client, err := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		if err != nil {
+			return err
+		}
 
-		addr := testProvider.Meta().(*provider.ProviderMeta).GetClient().Address()
+		addr := client.Address()
 		url := fmt.Sprintf("%s/v1/%s/crl", addr, path)
 		c := cleanhttp.DefaultClient()
 		resp, err := c.Get(url)

--- a/vault/resource_pki_secret_backend_config_urls_test.go
+++ b/vault/resource_pki_secret_backend_config_urls_test.go
@@ -96,7 +96,10 @@ func testPkiSecretBackendConfigUrlsEmptyRead(s *terraform.State) error {
 func listPkiPaths(s *terraform.State) ([]string, error) {
 	var paths []string
 
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+	client, err := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+	if err != nil {
+		return nil, err
+	}
 
 	mounts, err := client.Sys().ListMounts()
 	if err != nil {

--- a/vault/resource_pki_secret_backend_root_cert_test.go
+++ b/vault/resource_pki_secret_backend_root_cert_test.go
@@ -55,7 +55,10 @@ func TestPkiSecretBackendRootCertificate_basic(t *testing.T) {
 			{
 				// test unmounted backend
 				PreConfig: func() {
-					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+					client, err := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+					if err != nil {
+						t.Fatal(err)
+					}
 
 					if err := client.Sys().Unmount(path); err != nil {
 						t.Fatal(err)
@@ -72,10 +75,12 @@ func TestPkiSecretBackendRootCertificate_basic(t *testing.T) {
 			{
 				// test out of band update to the root CA
 				PreConfig: func() {
-					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-
-					_, err := client.Logical().Delete(fmt.Sprintf("%s/root", path))
+					client, err := testProvider.Meta().(*provider.ProviderMeta).GetClient()
 					if err != nil {
+						t.Fatal(err)
+					}
+
+					if _, err := client.Logical().Delete(fmt.Sprintf("%s/root", path)); err != nil {
 						t.Fatal(err)
 					}
 					genPath := pkiSecretBackendIntermediateSetSignedReadPath(path, "internal")

--- a/vault/resource_pki_secret_backend_sign_test.go
+++ b/vault/resource_pki_secret_backend_sign_test.go
@@ -184,7 +184,10 @@ func TestPkiSecretBackendSign_renew(t *testing.T) {
 			{
 				// test unmounted backend
 				PreConfig: func() {
-					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+					client, err := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+					if err != nil {
+						t.Fatal(err)
+					}
 
 					if err := client.Sys().Unmount(path); err != nil {
 						t.Fatal(err)

--- a/vault/resource_quota_lease_count_test.go
+++ b/vault/resource_quota_lease_count_test.go
@@ -55,7 +55,10 @@ func TestQuotaLeaseCount(t *testing.T) {
 
 func testQuotaLeaseCountCheckDestroy(leaseCounts []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		client, err := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		if err != nil {
+			return err
+		}
 
 		for _, name := range leaseCounts {
 			resp, err := client.Logical().Read(quotaLeaseCountPath(name))

--- a/vault/resource_quota_rate_limit_test.go
+++ b/vault/resource_quota_rate_limit_test.go
@@ -67,7 +67,10 @@ func TestQuotaRateLimit(t *testing.T) {
 
 func testQuotaRateLimitCheckDestroy(rateLimits []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		client, err := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		if err != nil {
+			return err
+		}
 
 		for _, name := range rateLimits {
 			resp, err := client.Logical().Read(quotaRateLimitPath(name))

--- a/vault/resource_terraform_cloud_secret_backend_test.go
+++ b/vault/resource_terraform_cloud_secret_backend_test.go
@@ -51,7 +51,10 @@ func TestTerraformCloudSecretBackend(t *testing.T) {
 }
 
 func testAccTerraformCloudSecretBackendCheckDestroy(s *terraform.State) error {
-	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+	client, err := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+	if err != nil {
+		return err
+	}
 
 	mounts, err := client.Sys().ListMounts()
 	if err != nil {

--- a/vault/resource_token_auth_backend_role_test.go
+++ b/vault/resource_token_auth_backend_role_test.go
@@ -154,7 +154,10 @@ func testAccCheckTokenAuthBackendRoleDestroy(s *terraform.State) error {
 func testAccTokenAuthBackendRoleCheck_deleted(role string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		endpoint := "auth/token/roles"
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		client, err := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		if err != nil {
+			return err
+		}
 
 		resp, err := client.Logical().List(endpoint)
 		if err != nil {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
A previous attempt was #1128 but it changed way too much bits and used `panic`.

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
feat: lazy initialization of the Vault client such that attributes like `address` might be provided by other resources.
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v  -timeout 30m ./...
?   	github.com/hashicorp/terraform-provider-vault	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/generate	[no test files]
=== RUN   TestCodeFilePath
--- PASS: TestCodeFilePath (0.05s)
=== RUN   TestDocFilePath
--- PASS: TestDocFilePath (0.08s)
=== RUN   TestStripCurlyBraces
=== RUN   TestStripCurlyBraces/{test}
=== RUN   TestStripCurlyBraces/{{name}}
=== RUN   TestStripCurlyBraces/name
=== RUN   TestStripCurlyBraces/{name
--- PASS: TestStripCurlyBraces (0.00s)
    --- PASS: TestStripCurlyBraces/{test} (0.00s)
    --- PASS: TestStripCurlyBraces/{{name}} (0.00s)
    --- PASS: TestStripCurlyBraces/name (0.00s)
    --- PASS: TestStripCurlyBraces/{name (0.00s)
=== RUN   TestFormat
=== RUN   TestFormat/alphabet
=== RUN   TestFormat/{name}
=== RUN   TestFormat/{role_name}
=== RUN   TestFormat/{name}#01
=== RUN   TestFormat/{version}
=== RUN   TestFormat/unlikely
=== RUN   TestFormat/{role_name_}
=== RUN   TestFormat/{role__name}
=== RUN   TestFormat/{role_name_here}
=== RUN   TestFormat/{rOlE_nAmE}
=== RUN   TestFormat/{ROLE_NAME}
--- PASS: TestFormat (0.00s)
    --- PASS: TestFormat/alphabet (0.00s)
    --- PASS: TestFormat/{name} (0.00s)
    --- PASS: TestFormat/{role_name} (0.00s)
    --- PASS: TestFormat/{name}#01 (0.00s)
    --- PASS: TestFormat/{version} (0.00s)
    --- PASS: TestFormat/unlikely (0.00s)
    --- PASS: TestFormat/{role_name_} (0.00s)
    --- PASS: TestFormat/{role__name} (0.00s)
    --- PASS: TestFormat/{role_name_here} (0.00s)
    --- PASS: TestFormat/{rOlE_nAmE} (0.00s)
    --- PASS: TestFormat/{ROLE_NAME} (0.00s)
=== RUN   TestValidate
=== RUN   TestValidate/nil_inputs_error
=== RUN   TestValidate/blank_endpoints_error
=== RUN   TestValidate/blank_dirnames_error
=== RUN   TestValidate/blank_upper_case_differentiators_error
=== RUN   TestValidate/blank_lower_case_differentiators_error
=== RUN   TestValidate/valid_endpoint
=== RUN   TestValidate/bad_parameter_type
=== RUN   TestValidate/good_parameter_type
=== RUN   TestValidate/array_of_strings_param
=== RUN   TestValidate/array_of_objects_param
--- PASS: TestValidate (0.00s)
    --- PASS: TestValidate/nil_inputs_error (0.00s)
    --- PASS: TestValidate/blank_endpoints_error (0.00s)
    --- PASS: TestValidate/blank_dirnames_error (0.00s)
    --- PASS: TestValidate/blank_upper_case_differentiators_error (0.00s)
    --- PASS: TestValidate/blank_lower_case_differentiators_error (0.00s)
    --- PASS: TestValidate/valid_endpoint (0.00s)
    --- PASS: TestValidate/bad_parameter_type (0.00s)
    --- PASS: TestValidate/good_parameter_type (0.00s)
    --- PASS: TestValidate/array_of_strings_param (0.00s)
    --- PASS: TestValidate/array_of_objects_param (0.00s)
=== RUN   TestToTemplatableParam
--- PASS: TestToTemplatableParam (0.00s)
=== RUN   TestParseParameters
=== RUN   TestParseParameters//transform/role/{name}
=== RUN   TestParseParameters//transform/alphabet/{name}
--- PASS: TestParseParameters (0.00s)
    --- PASS: TestParseParameters//transform/role/{name} (0.00s)
    --- PASS: TestParseParameters//transform/alphabet/{name} (0.00s)
=== RUN   TestTemplateHandler
--- PASS: TestTemplateHandler (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/codegen	(cached)
?   	github.com/hashicorp/terraform-provider-vault/generated	[no test files]
=== RUN   TestDecodeBasic
    testutil.go:69: "TF_ACC_ENTERPRISE" must be set
--- SKIP: TestDecodeBasic (0.00s)
=== RUN   TestDecodeBatch
    testutil.go:69: "TF_ACC_ENTERPRISE" must be set
--- SKIP: TestDecodeBatch (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode	(cached)
=== RUN   TestEncodeBasic
    testutil.go:69: "TF_ACC_ENTERPRISE" must be set
--- SKIP: TestEncodeBasic (0.00s)
=== RUN   TestEncodeBatch
    testutil.go:69: "TF_ACC_ENTERPRISE" must be set
--- SKIP: TestEncodeBatch (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode	(cached)
=== RUN   TestAlphabetName
    testutil.go:69: "TF_ACC_ENTERPRISE" must be set
--- SKIP: TestAlphabetName (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet	(cached)
=== RUN   TestRoleName
    testutil.go:69: "TF_ACC_ENTERPRISE" must be set
--- SKIP: TestRoleName (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role	(cached)
=== RUN   TestTemplateName
    testutil.go:69: "TF_ACC_ENTERPRISE" must be set
--- SKIP: TestTemplateName (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template	(cached)
=== RUN   TestTransformationName
    testutil.go:69: "TF_ACC_ENTERPRISE" must be set
--- SKIP: TestTransformationName (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation	(cached)
?   	github.com/hashicorp/terraform-provider-vault/helper	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/consts	[no test files]
=== RUN   TestFindAliases
=== PAUSE TestFindAliases
=== CONT  TestFindAliases
=== RUN   TestFindAliases/empty
=== RUN   TestFindAliases/all
=== RUN   TestFindAliases/name-only
=== RUN   TestFindAliases/name-and-mount-accessor
=== RUN   TestFindAliases/mount-accessor-mismatch
=== RUN   TestFindAliases/error-on-list
=== RUN   TestFindAliases/error-on-read
--- PASS: TestFindAliases (8.07s)
    --- PASS: TestFindAliases/empty (0.00s)
    --- PASS: TestFindAliases/all (0.00s)
    --- PASS: TestFindAliases/name-only (0.00s)
    --- PASS: TestFindAliases/name-and-mount-accessor (0.00s)
    --- PASS: TestFindAliases/mount-accessor-mismatch (0.00s)
    --- PASS: TestFindAliases/error-on-list (4.02s)
    --- PASS: TestFindAliases/error-on-read (4.04s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/internal/identity/entity	8.072s
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/group	[no test files]
=== RUN   TestProviderMeta_GetNSClient
=== RUN   TestProviderMeta_GetNSClient/no-client
=== RUN   TestProviderMeta_GetNSClient/no-resource-data
=== RUN   TestProviderMeta_GetNSClient/basic-no-root-ns
=== RUN   TestProviderMeta_GetNSClient/basic-root-ns
=== RUN   TestProviderMeta_GetNSClient/basic-root-ns-trimmed
--- PASS: TestProviderMeta_GetNSClient (0.00s)
    --- PASS: TestProviderMeta_GetNSClient/no-client (0.00s)
    --- PASS: TestProviderMeta_GetNSClient/no-resource-data (0.00s)
    --- PASS: TestProviderMeta_GetNSClient/basic-no-root-ns (0.00s)
    --- PASS: TestProviderMeta_GetNSClient/basic-root-ns (0.00s)
    --- PASS: TestProviderMeta_GetNSClient/basic-root-ns-trimmed (0.00s)
=== RUN   TestGetClient
=== RUN   TestGetClient/rsc-data
=== RUN   TestGetClient/inst-state
=== RUN   TestGetClient/import-env
2022/07/20 06:57:55 [DEBUG] Value for "namespace" set from environment
=== RUN   TestGetClient/ignore-env-rsc-data
=== RUN   TestGetClient/ignore-env-inst-state
=== RUN   TestGetClient/error-unsupported-type
=== RUN   TestGetClient/error-not-provider-meta
--- PASS: TestGetClient (0.00s)
    --- PASS: TestGetClient/rsc-data (0.00s)
    --- PASS: TestGetClient/inst-state (0.00s)
    --- PASS: TestGetClient/import-env (0.00s)
    --- PASS: TestGetClient/ignore-env-rsc-data (0.00s)
    --- PASS: TestGetClient/ignore-env-inst-state (0.00s)
    --- PASS: TestGetClient/error-unsupported-type (0.00s)
    --- PASS: TestGetClient/error-not-provider-meta (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/internal/provider	0.015s
?   	github.com/hashicorp/terraform-provider-vault/schema	[no test files]
=== RUN   Test_assertVaultState
=== RUN   Test_assertVaultState/string
=== RUN   Test_assertVaultState/bool
=== RUN   Test_assertVaultState/slice-ordered
=== RUN   Test_assertVaultState/slice-set-cmp
=== RUN   Test_assertVaultState/slice-subset-cmp
=== RUN   Test_assertVaultState/slice-superset-error
--- PASS: Test_assertVaultState (0.00s)
    --- PASS: Test_assertVaultState/string (0.00s)
    --- PASS: Test_assertVaultState/bool (0.00s)
    --- PASS: Test_assertVaultState/slice-ordered (0.00s)
    --- PASS: Test_assertVaultState/slice-set-cmp (0.00s)
    --- PASS: Test_assertVaultState/slice-subset-cmp (0.00s)
    --- PASS: Test_assertVaultState/slice-superset-error (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/testutil	(cached)
=== RUN   TestExpiredTokenError
--- PASS: TestExpiredTokenError (0.00s)
=== RUN   TestSliceHasElement_scalar
--- PASS: TestSliceHasElement_scalar (0.00s)
=== RUN   TestSliceHasElement_struct
--- PASS: TestSliceHasElement_struct (0.00s)
=== RUN   TestSliceAppendIfMissing_scalar
--- PASS: TestSliceAppendIfMissing_scalar (0.00s)
=== RUN   TestSliceAppendIfMissing_struct
--- PASS: TestSliceAppendIfMissing_struct (0.00s)
=== RUN   TestSliceRemoveIfPresent_scalar
--- PASS: TestSliceRemoveIfPresent_scalar (0.00s)
=== RUN   TestSliceRemoveIfPresent_struct
--- PASS: TestSliceRemoveIfPresent_struct (0.00s)
=== RUN   TestParsePath
=== RUN   TestParsePath/my/transform/hello
=== RUN   TestParsePath/jwt-1914071788362821795
=== RUN   TestParsePath/accounting-transit
--- PASS: TestParsePath (0.00s)
    --- PASS: TestParsePath/my/transform/hello (0.00s)
    --- PASS: TestParsePath/jwt-1914071788362821795 (0.00s)
    --- PASS: TestParsePath/accounting-transit (0.00s)
=== RUN   TestPathParameters
=== RUN   TestPathParameters//transform/role/{name}
=== RUN   TestPathParameters//transit/sign/{name}/{urlalgorithm}
=== RUN   TestPathParameters//transit/sign/{name}/{urlalgorithm}#01
=== RUN   TestPathParameters//auth/approle/tidy/secret-id
=== RUN   TestPathParameters//sys/mfa/method/totp/{name}/admin-generate
--- PASS: TestPathParameters (0.00s)
    --- PASS: TestPathParameters//transform/role/{name} (0.00s)
    --- PASS: TestPathParameters//transit/sign/{name}/{urlalgorithm} (0.00s)
    --- PASS: TestPathParameters//transit/sign/{name}/{urlalgorithm}#01 (0.00s)
    --- PASS: TestPathParameters//auth/approle/tidy/secret-id (0.00s)
    --- PASS: TestPathParameters//sys/mfa/method/totp/{name}/admin-generate (0.00s)
=== RUN   TestGetAPIRequestData
=== RUN   TestGetAPIRequestData/basic-default
=== RUN   TestGetAPIRequestData/basic-remap
=== RUN   TestGetAPIRequestData/map
=== RUN   TestGetAPIRequestData/set
--- PASS: TestGetAPIRequestData (0.00s)
    --- PASS: TestGetAPIRequestData/basic-default (0.00s)
    --- PASS: TestGetAPIRequestData/basic-remap (0.00s)
    --- PASS: TestGetAPIRequestData/map (0.00s)
    --- PASS: TestGetAPIRequestData/set (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/util	(cached)
=== RUN   Test_handleCIDRField
=== RUN   Test_handleCIDRField/basic
=== RUN   Test_handleCIDRField/unsupported-schema-type
--- PASS: Test_handleCIDRField (0.00s)
    --- PASS: Test_handleCIDRField/basic (0.00s)
    --- PASS: Test_handleCIDRField/unsupported-schema-type (0.00s)
=== RUN   TestDataSourceIdentityEntityName
--- PASS: TestDataSourceIdentityEntityName (0.89s)
=== RUN   TestDataSourceIdentityEntityAlias
--- PASS: TestDataSourceIdentityEntityAlias (0.86s)
=== RUN   TestDataSourceIdentityGroupName
--- PASS: TestDataSourceIdentityGroupName (1.00s)
=== RUN   TestDataSourceIdentityGroupAlias
--- PASS: TestDataSourceIdentityGroupAlias (0.85s)
=== RUN   TestDataSourceIdentityOIDCClientCreds
--- PASS: TestDataSourceIdentityOIDCClientCreds (1.20s)
=== RUN   TestDataSourceIdentityOIDCOpenIDConfig
--- PASS: TestDataSourceIdentityOIDCOpenIDConfig (1.04s)
=== RUN   TestDataSourceIdentityOIDCPublicKeys
--- PASS: TestDataSourceIdentityOIDCPublicKeys (1.17s)
=== RUN   TestAccDataSourceADAccessCredentials_basic
    testutil.go:69: "AD_BINDDN" must be set
--- SKIP: TestAccDataSourceADAccessCredentials_basic (0.00s)
=== RUN   TestAccAppRoleAuthBackendRoleID_basic
--- PASS: TestAccAppRoleAuthBackendRoleID_basic (1.52s)
=== RUN   TestAccAppRoleAuthBackendRoleID_customID
--- PASS: TestAccAppRoleAuthBackendRoleID_customID (1.53s)
=== RUN   TestDataSourceAuthBackend
--- PASS: TestDataSourceAuthBackend (1.47s)
=== RUN   TestAccDataSourceAWSAccessCredentials_basic
    testutil.go:69: "AWS_ACCESS_KEY_ID" must be set
--- SKIP: TestAccDataSourceAWSAccessCredentials_basic (0.00s)
=== RUN   TestAccDataSourceAWSAccessCredentials_sts
    testutil.go:69: "AWS_ACCESS_KEY_ID" must be set
--- SKIP: TestAccDataSourceAWSAccessCredentials_sts (0.00s)
=== RUN   TestAccDataSourceAWSAccessCredentials_sts_ttl
    testutil.go:69: "AWS_ACCESS_KEY_ID" must be set
--- SKIP: TestAccDataSourceAWSAccessCredentials_sts_ttl (0.00s)
=== RUN   TestAccDataSourceAzureAccessCredentials_basic
    testutil.go:69: "AZURE_SUBSCRIPTION_ID" must be set
--- SKIP: TestAccDataSourceAzureAccessCredentials_basic (0.00s)
=== RUN   TestAccGCPAuthBackendRoleDataSource_basic
--- PASS: TestAccGCPAuthBackendRoleDataSource_basic (1.63s)
=== RUN   TestAccGCPAuthBackendRoleDataSource_gce
--- PASS: TestAccGCPAuthBackendRoleDataSource_gce (1.52s)
=== RUN   TestAccGCPAuthBackendRoleDataSource_none
--- PASS: TestAccGCPAuthBackendRoleDataSource_none (0.19s)
=== RUN   TestDataSourceGenericSecret
--- PASS: TestDataSourceGenericSecret (0.95s)
=== RUN   TestDataSourceGenericSecret_v2
--- PASS: TestDataSourceGenericSecret_v2 (2.21s)
=== RUN   TestAccKubernetesAuthBackendConfigDataSource_basic
--- PASS: TestAccKubernetesAuthBackendConfigDataSource_basic (1.55s)
=== RUN   TestAccKubernetesAuthBackendConfigDataSource_full
--- PASS: TestAccKubernetesAuthBackendConfigDataSource_full (1.50s)
=== RUN   TestAccKubernetesAuthBackendRoleDataSource_basic
--- PASS: TestAccKubernetesAuthBackendRoleDataSource_basic (0.90s)
=== RUN   TestAccKubernetesAuthBackendRoleDataSource_full
--- PASS: TestAccKubernetesAuthBackendRoleDataSource_full (0.85s)
=== RUN   TestDataSourceKVSecret
--- PASS: TestDataSourceKVSecret (1.65s)
=== RUN   TestDataSourceKVV2Secret
--- PASS: TestDataSourceKVV2Secret (0.87s)
=== RUN   TestDataSourceKVSecretList
--- PASS: TestDataSourceKVSecretList (1.57s)
=== RUN   TestDataSourceKVSecretListV2
--- PASS: TestDataSourceKVSecretListV2 (1.60s)
=== RUN   TestDataSourceKVSubkeys
--- PASS: TestDataSourceKVSubkeys (0.99s)
=== RUN   TestAccDataSourceNomadAccessCredentialsClientBasic
    testutil.go:69: "NOMAD_TOKEN" must be set
--- SKIP: TestAccDataSourceNomadAccessCredentialsClientBasic (0.00s)
=== RUN   TestAccDataSourceNomadAccessCredentialsManagementBasic
    testutil.go:69: "NOMAD_TOKEN" must be set
--- SKIP: TestAccDataSourceNomadAccessCredentialsManagementBasic (0.00s)
=== RUN   TestDataSourcePolicyDocument
--- PASS: TestDataSourcePolicyDocument (0.78s)
=== RUN   TestDataSourceTransitDecrypt
--- PASS: TestDataSourceTransitDecrypt (0.88s)
=== RUN   TestDataSourceTransitEncrypt
--- PASS: TestDataSourceTransitEncrypt (0.87s)
=== RUN   TestAccAuthBackend_importBasic
--- PASS: TestAccAuthBackend_importBasic (1.01s)
=== RUN   TestAccConsulSecretBackend_import
--- PASS: TestAccConsulSecretBackend_import (1.14s)
=== RUN   TestAccGenericSecret_importBasic
--- PASS: TestAccGenericSecret_importBasic (1.04s)
=== RUN   TestAccGenericSecret_importBasicNS
    import_generic_secret_test.go:38: VAULT-4254: namespaced resource imports require provider config
--- SKIP: TestAccGenericSecret_importBasicNS (0.00s)
=== RUN   TestAccMount_importBasic
--- PASS: TestAccMount_importBasic (1.02s)
=== RUN   TestAccPolicy_importBasic
--- PASS: TestAccPolicy_importBasic (1.09s)
=== RUN   TestProvider
--- PASS: TestProvider (0.01s)
=== RUN   TestAccAuthLoginProviderConfigure
--- PASS: TestAccAuthLoginProviderConfigure (0.85s)
=== RUN   TestTokenReadProviderConfigureWithHeaders
--- PASS: TestTokenReadProviderConfigureWithHeaders (0.86s)
=== RUN   TestAccNamespaceProviderConfigure
    testutil.go:69: "TF_ACC_ENTERPRISE" must be set
--- SKIP: TestAccNamespaceProviderConfigure (0.00s)
=== RUN   TestAccProviderToken
=== RUN   TestAccProviderToken/None
=== RUN   TestAccProviderToken/File
=== RUN   TestAccProviderToken/CustomHelper
=== RUN   TestAccProviderToken/Schema
--- PASS: TestAccProviderToken (0.01s)
    --- PASS: TestAccProviderToken/None (0.00s)
    --- PASS: TestAccProviderToken/File (0.00s)
    --- PASS: TestAccProviderToken/CustomHelper (0.01s)
    --- PASS: TestAccProviderToken/Schema (0.00s)
=== RUN   TestAccTokenName
--- PASS: TestAccTokenName (6.35s)
=== RUN   TestAccChildToken
--- PASS: TestAccChildToken (6.44s)
=== RUN   TestAccProviderVaultAddrEnv
=== RUN   TestAccProviderVaultAddrEnv/AddAddressToEnvNotConfigured
=== RUN   TestAccProviderVaultAddrEnv/AddAddressToEnvIsFalse
=== RUN   TestAccProviderVaultAddrEnv/AddAddressToEnvIsTrue
--- PASS: TestAccProviderVaultAddrEnv (0.02s)
    --- PASS: TestAccProviderVaultAddrEnv/AddAddressToEnvNotConfigured (0.01s)
    --- PASS: TestAccProviderVaultAddrEnv/AddAddressToEnvIsFalse (0.01s)
    --- PASS: TestAccProviderVaultAddrEnv/AddAddressToEnvIsTrue (0.01s)
=== RUN   TestADSecretBackend
    testutil.go:69: "AD_BINDDN" must be set
--- SKIP: TestADSecretBackend (0.00s)
=== RUN   TestAccADSecretBackendLibrary_basic
    testutil.go:69: "AD_BINDDN" must be set
--- SKIP: TestAccADSecretBackendLibrary_basic (0.00s)
=== RUN   TestAccADSecretBackendLibrary_import
    testutil.go:69: "AD_BINDDN" must be set
--- SKIP: TestAccADSecretBackendLibrary_import (0.00s)
=== RUN   TestAccADSecretBackendRole_basic
    testutil.go:69: "AD_BINDDN" must be set
--- SKIP: TestAccADSecretBackendRole_basic (0.00s)
=== RUN   TestAccADSecretBackendRole_import
    testutil.go:69: "AD_BINDDN" must be set
--- SKIP: TestAccADSecretBackendRole_import (0.00s)
=== RUN   TestAlicloudAuthBackendRole_basic
--- PASS: TestAlicloudAuthBackendRole_basic (1.77s)
=== RUN   TestAccAppRoleAuthBackendLogin_basic
--- PASS: TestAccAppRoleAuthBackendLogin_basic (0.92s)
=== RUN   TestAccAppRoleAuthBackendRoleSecretID_basic
--- PASS: TestAccAppRoleAuthBackendRoleSecretID_basic (0.93s)
=== RUN   TestAccAppRoleAuthBackendRoleSecretID_wrapped
--- PASS: TestAccAppRoleAuthBackendRoleSecretID_wrapped (0.87s)
=== RUN   TestAccAppRoleAuthBackendRoleSecretID_wrapped_withWrappedAccessor
--- PASS: TestAccAppRoleAuthBackendRoleSecretID_wrapped_withWrappedAccessor (0.86s)
=== RUN   TestAccAppRoleAuthBackendRoleSecretID_wrapped_namespace
    testutil.go:69: "TF_ACC_ENTERPRISE" must be set
--- SKIP: TestAccAppRoleAuthBackendRoleSecretID_wrapped_namespace (0.00s)
=== RUN   TestAccAppRoleAuthBackendRoleSecretID_wrapped_namespace_withWrappedAccessor
    testutil.go:69: "TF_ACC_ENTERPRISE" must be set
--- SKIP: TestAccAppRoleAuthBackendRoleSecretID_wrapped_namespace_withWrappedAccessor (0.00s)
=== RUN   TestAccAppRoleAuthBackendRoleSecretID_full
--- PASS: TestAccAppRoleAuthBackendRoleSecretID_full (0.85s)
=== RUN   TestAccAppRoleAuthBackendRole_import
--- PASS: TestAccAppRoleAuthBackendRole_import (1.09s)
=== RUN   TestAccAppRoleAuthBackendRole_basic
--- PASS: TestAccAppRoleAuthBackendRole_basic (0.94s)
=== RUN   TestAccAppRoleAuthBackendRole_update
--- PASS: TestAccAppRoleAuthBackendRole_update (1.50s)
=== RUN   TestAccAppRoleAuthBackendRole_full
--- PASS: TestAccAppRoleAuthBackendRole_full (0.92s)
=== RUN   TestAccAppRoleAuthBackendRole_fullUpdate
--- PASS: TestAccAppRoleAuthBackendRole_fullUpdate (2.24s)
=== RUN   TestResourceAudit
--- PASS: TestResourceAudit (0.88s)
=== RUN   TestAuthBackendMigrateState
--- PASS: TestAuthBackendMigrateState (0.00s)
=== RUN   TestResourceAuth
--- PASS: TestResourceAuth (1.61s)
=== RUN   TestResourceAuthTune
--- PASS: TestResourceAuthTune (1.48s)
=== RUN   TestAccAWSAuthBackendCert_import
--- PASS: TestAccAWSAuthBackendCert_import (1.04s)
=== RUN   TestAccAWSAuthBackendCert_basic
--- PASS: TestAccAWSAuthBackendCert_basic (0.91s)
=== RUN   TestAccAWSAuthBackendClient_import
--- PASS: TestAccAWSAuthBackendClient_import (1.04s)
=== RUN   TestAccAWSAuthBackendClient_basic
--- PASS: TestAccAWSAuthBackendClient_basic (1.49s)
=== RUN   TestAccAWSAuthBackendClient_nested
--- PASS: TestAccAWSAuthBackendClient_nested (1.51s)
=== RUN   TestAccAWSAuthBackendClient_withoutSecretKey
--- PASS: TestAccAWSAuthBackendClient_withoutSecretKey (1.60s)
=== RUN   TestAccAWSAuthBackendClientStsRegionNoEndpoint
--- PASS: TestAccAWSAuthBackendClientStsRegionNoEndpoint (0.47s)
=== RUN   TestAccAWSAuthBackendIdentityWhitelist_import
--- PASS: TestAccAWSAuthBackendIdentityWhitelist_import (1.05s)
=== RUN   TestAccAWSAuthBackendIdentityWhitelist_basic
--- PASS: TestAccAWSAuthBackendIdentityWhitelist_basic (0.84s)
=== RUN   TestAccAWSAuthBackendLogin_iamIdentity
    testutil.go:69: "AWS_ACCESS_KEY_ID" must be set
--- SKIP: TestAccAWSAuthBackendLogin_iamIdentity (0.00s)
=== RUN   TestAccAWSAuthBackendLogin_pkcs7
    testutil.go:69: "TF_AWS_META" must be set
--- SKIP: TestAccAWSAuthBackendLogin_pkcs7 (0.00s)
=== RUN   TestAccAWSAuthBackendLogin_ec2Identity
    testutil.go:69: "TF_AWS_META" must be set
--- SKIP: TestAccAWSAuthBackendLogin_ec2Identity (0.00s)
=== RUN   TestAccAWSAuthBackendRoleTag_basic
--- PASS: TestAccAWSAuthBackendRoleTag_basic (0.89s)
=== RUN   TestAccAWSAuthBackendRole_importInferred
--- PASS: TestAccAWSAuthBackendRole_importInferred (1.14s)
=== RUN   TestAccAWSAuthBackendRole_importEC2
--- PASS: TestAccAWSAuthBackendRole_importEC2 (1.15s)
=== RUN   TestAccAWSAuthBackendRole_importIAM
--- PASS: TestAccAWSAuthBackendRole_importIAM (1.25s)
=== RUN   TestAccAWSAuthBackendRole_inferred
--- PASS: TestAccAWSAuthBackendRole_inferred (1.03s)
=== RUN   TestAccAWSAuthBackendRole_ec2
--- PASS: TestAccAWSAuthBackendRole_ec2 (1.01s)
=== RUN   TestAccAWSAuthBackendRole_iam
--- PASS: TestAccAWSAuthBackendRole_iam (1.22s)
=== RUN   TestAccAWSAuthBackendRole_iam_resolve_aws_unique_ids
--- PASS: TestAccAWSAuthBackendRole_iam_resolve_aws_unique_ids (1.02s)
=== RUN   TestAccAWSAuthBackendRole_iamUpdate
--- PASS: TestAccAWSAuthBackendRole_iamUpdate (3.19s)
=== RUN   TestAccAWSAuthBackendRoleTagBlacklist_import
--- PASS: TestAccAWSAuthBackendRoleTagBlacklist_import (1.15s)
=== RUN   TestAccAWSAuthBackendRoleTagBlacklist_basic
--- PASS: TestAccAWSAuthBackendRoleTagBlacklist_basic (0.89s)
=== RUN   TestAccAWSAuthBackendRoleTagBlacklist_updated
--- PASS: TestAccAWSAuthBackendRoleTagBlacklist_updated (2.38s)
=== RUN   TestAccAWSAuthBackendSTSRole_import
--- PASS: TestAccAWSAuthBackendSTSRole_import (1.50s)
=== RUN   TestAccAWSAuthBackendSTSRole_basic
--- PASS: TestAccAWSAuthBackendSTSRole_basic (1.62s)
=== RUN   TestAccAWSSecretBackendRole_basic
    testutil.go:69: "AWS_ACCESS_KEY_ID" must be set
--- SKIP: TestAccAWSSecretBackendRole_basic (0.00s)
=== RUN   TestAccAWSSecretBackendRole_import
    testutil.go:69: "AWS_ACCESS_KEY_ID" must be set
--- SKIP: TestAccAWSSecretBackendRole_import (0.00s)
=== RUN   TestAccAWSSecretBackendRole_nested
    testutil.go:69: "AWS_ACCESS_KEY_ID" must be set
--- SKIP: TestAccAWSSecretBackendRole_nested (0.00s)
=== RUN   TestAccAWSSecretBackend_basic
    testutil.go:69: "AWS_ACCESS_KEY_ID" must be set
--- SKIP: TestAccAWSSecretBackend_basic (0.00s)
=== RUN   TestAccAWSSecretBackend_usernameTempl
    testutil.go:69: "AWS_ACCESS_KEY_ID" must be set
--- SKIP: TestAccAWSSecretBackend_usernameTempl (0.00s)
=== RUN   TestAccAzureAuthBackendConfig_import
--- PASS: TestAccAzureAuthBackendConfig_import (1.11s)
=== RUN   TestAccAzureAuthBackendConfig_basic
--- PASS: TestAccAzureAuthBackendConfig_basic (1.57s)
=== RUN   TestAzureAuthBackendRole_basic
--- PASS: TestAzureAuthBackendRole_basic (1.01s)
=== RUN   TestAzureAuthBackendRole
--- PASS: TestAzureAuthBackendRole (1.61s)
=== RUN   TestAzureSecretBackendRole
    resource_azure_secret_backend_role_test.go:20: ARM_SUBSCRIPTION_ID not set
--- SKIP: TestAzureSecretBackendRole (0.00s)
=== RUN   TestAzureSecretBackend
--- PASS: TestAzureSecretBackend (2.33s)
=== RUN   TestCertAuthBackend
--- PASS: TestCertAuthBackend (1.72s)
=== RUN   TestConsulSecretBackendRole
    resource_consul_secret_backend_role_test.go:52: Step 2/4 error: Check failed: Check 4/9 error: vault_consul_secret_backend_role.test: Attribute 'policies.#' expected "1", got "0"
--- FAIL: TestConsulSecretBackendRole (0.90s)
=== RUN   TestConsulSecretBackendRoleNameFromPath
--- PASS: TestConsulSecretBackendRoleNameFromPath (0.00s)
=== RUN   TestConsulSecretBackendRoleBackendFromPath
--- PASS: TestConsulSecretBackendRoleBackendFromPath (0.00s)
=== RUN   TestConsulSecretBackend
--- PASS: TestConsulSecretBackend (3.65s)
=== RUN   TestAccDatabaseSecretBackendConnection_postgresql_import
    testutil.go:69: "POSTGRES_URL" must be set
--- SKIP: TestAccDatabaseSecretBackendConnection_postgresql_import (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_cassandra
    testutil.go:69: "CASSANDRA_HOST" must be set
--- SKIP: TestAccDatabaseSecretBackendConnection_cassandra (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_cassandraProtocol
    testutil.go:69: "CASSANDRA_HOST" must be set
--- SKIP: TestAccDatabaseSecretBackendConnection_cassandraProtocol (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_couchbase
    testutil.go:69: "COUCHBASE_HOST_1" must be set
--- SKIP: TestAccDatabaseSecretBackendConnection_couchbase (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_influxdb
    testutil.go:69: "INFLUXDB_HOST" must be set
--- SKIP: TestAccDatabaseSecretBackendConnection_influxdb (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_mongodbatlas
    testutil.go:69: "MONGODB_ATLAS_PUBLIC_KEY" must be set
--- SKIP: TestAccDatabaseSecretBackendConnection_mongodbatlas (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_mongodb
    testutil.go:69: "MONGODB_URL" must be set
--- SKIP: TestAccDatabaseSecretBackendConnection_mongodb (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_mssql
--- PASS: TestAccDatabaseSecretBackendConnection_mssql (97.53s)
=== RUN   TestAccDatabaseSecretBackendConnection_mysql
    testutil.go:69: "MYSQL_CONNECTION_URL" must be set
--- SKIP: TestAccDatabaseSecretBackendConnection_mysql (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnectionUpdate_mysql
    testutil.go:69: "MYSQL_CONNECTION_URL" must be set
--- SKIP: TestAccDatabaseSecretBackendConnectionUpdate_mysql (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnectionTemplatedUpdateExcludePassword_mysql
    testutil.go:69: "MYSQL_CONNECTION_URL" must be set
--- SKIP: TestAccDatabaseSecretBackendConnectionTemplatedUpdateExcludePassword_mysql (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_mysql_tls
    testutil.go:69: "MYSQL_CA" must be set
--- SKIP: TestAccDatabaseSecretBackendConnection_mysql_tls (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_postgresql
    testutil.go:69: "POSTGRES_URL" must be set
--- SKIP: TestAccDatabaseSecretBackendConnection_postgresql (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_elasticsearch
    testutil.go:69: "ELASTIC_URL" must be set
--- SKIP: TestAccDatabaseSecretBackendConnection_elasticsearch (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_snowflake
    testutil.go:69: "SNOWFLAKE_URL" must be set
--- SKIP: TestAccDatabaseSecretBackendConnection_snowflake (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_redshift
    resource_database_secret_backend_connection_test.go:805: REDSHIFT_URL not set
--- SKIP: TestAccDatabaseSecretBackendConnection_redshift (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_invalid_plugin
--- PASS: TestAccDatabaseSecretBackendConnection_invalid_plugin (0.18s)
=== RUN   Test_dbEngine_GetPluginName
=== RUN   Test_dbEngine_GetPluginName/default
=== RUN   Test_dbEngine_GetPluginName/set
=== RUN   Test_dbEngine_GetPluginName/default-prefixed
=== RUN   Test_dbEngine_GetPluginName/set-prefixed
=== RUN   Test_dbEngine_GetPluginName/fail
--- PASS: Test_dbEngine_GetPluginName (0.00s)
    --- PASS: Test_dbEngine_GetPluginName/default (0.00s)
    --- PASS: Test_dbEngine_GetPluginName/set (0.00s)
    --- PASS: Test_dbEngine_GetPluginName/default-prefixed (0.00s)
    --- PASS: Test_dbEngine_GetPluginName/set-prefixed (0.00s)
    --- PASS: Test_dbEngine_GetPluginName/fail (0.00s)
=== RUN   Test_getDBEngine
=== RUN   Test_getDBEngine/basic
=== RUN   Test_getDBEngine/not-found
--- PASS: Test_getDBEngine (0.00s)
    --- PASS: Test_getDBEngine/basic (0.00s)
    --- PASS: Test_getDBEngine/not-found (0.00s)
=== RUN   Test_getDBEngineFromResp
=== RUN   Test_getDBEngineFromResp/basic
=== RUN   Test_getDBEngineFromResp/variant
=== RUN   Test_getDBEngineFromResp/unsupported
=== RUN   Test_getDBEngineFromResp/invalid-empty-prefix
=== RUN   Test_getDBEngineFromResp/invalid-empty-plugin-name
=== RUN   Test_getDBEngineFromResp/invalid-data
--- PASS: Test_getDBEngineFromResp (0.00s)
    --- PASS: Test_getDBEngineFromResp/basic (0.00s)
    --- PASS: Test_getDBEngineFromResp/variant (0.00s)
    --- PASS: Test_getDBEngineFromResp/unsupported (0.00s)
    --- PASS: Test_getDBEngineFromResp/invalid-empty-prefix (0.00s)
    --- PASS: Test_getDBEngineFromResp/invalid-empty-plugin-name (0.00s)
    --- PASS: Test_getDBEngineFromResp/invalid-data (0.00s)
=== RUN   TestAccDatabaseSecretBackendRole_import
    resource_database_secret_backend_role_test.go:19: MYSQL_URL not set
--- SKIP: TestAccDatabaseSecretBackendRole_import (0.00s)
=== RUN   TestAccDatabaseSecretBackendRole_basic
    resource_database_secret_backend_role_test.go:52: MYSQL_URL not set
--- SKIP: TestAccDatabaseSecretBackendRole_basic (0.00s)
=== RUN   TestAccDatabaseSecretBackendStaticRole_import
    resource_database_secret_backend_static_role_test.go:22: MYSQL_URL not set
--- SKIP: TestAccDatabaseSecretBackendStaticRole_import (0.00s)
=== RUN   TestAccDatabaseSecretBackendStaticRole_basic
    resource_database_secret_backend_static_role_test.go:60: MYSQL_URL not set
--- SKIP: TestAccDatabaseSecretBackendStaticRole_basic (0.00s)
=== RUN   TestAccDatabaseSecretsMount_mssql
--- PASS: TestAccDatabaseSecretsMount_mssql (15.08s)
=== RUN   TestAccDatabaseSecretsMount_mssql_multi
--- PASS: TestAccDatabaseSecretsMount_mssql_multi (24.52s)
=== RUN   TestAccEndpointGoverningPolicy
    testutil.go:69: "TF_ACC_ENTERPRISE" must be set
--- SKIP: TestAccEndpointGoverningPolicy (0.00s)
=== RUN   TestGCPAuthBackend_pathRegex
=== RUN   TestGCPAuthBackend_pathRegex/no_nesting
=== RUN   TestGCPAuthBackend_pathRegex/nested
=== RUN   TestGCPAuthBackend_pathRegex/nested_with_double_'role'
--- PASS: TestGCPAuthBackend_pathRegex (0.00s)
    --- PASS: TestGCPAuthBackend_pathRegex/no_nesting (0.00s)
    --- PASS: TestGCPAuthBackend_pathRegex/nested (0.00s)
    --- PASS: TestGCPAuthBackend_pathRegex/nested_with_double_'role' (0.00s)
=== RUN   TestGCPAuthBackendRole_basic
=== RUN   TestGCPAuthBackendRole_basic/simple_backend_path
=== RUN   TestGCPAuthBackendRole_basic/nested_backend_path
--- PASS: TestGCPAuthBackendRole_basic (4.33s)
    --- PASS: TestGCPAuthBackendRole_basic/simple_backend_path (1.94s)
    --- PASS: TestGCPAuthBackendRole_basic/nested_backend_path (2.39s)
=== RUN   TestGCPAuthBackendRole_gce
--- PASS: TestGCPAuthBackendRole_gce (1.51s)
=== RUN   TestGCPAuthBackend_basic
--- PASS: TestGCPAuthBackend_basic (1.41s)
=== RUN   TestGCPAuthBackend_import
--- PASS: TestGCPAuthBackend_import (1.81s)
=== RUN   TestGCPSecretBackend
--- PASS: TestGCPSecretBackend (2.86s)
=== RUN   TestGCPSecretRoleset
    testutil.go:69: "GOOGLE_CREDENTIALS" must be set
--- SKIP: TestGCPSecretRoleset (0.00s)
=== RUN   TestGCPSecretStaticAccount
    testutil.go:69: "GOOGLE_CREDENTIALS" must be set
--- SKIP: TestGCPSecretStaticAccount (0.00s)
=== RUN   TestResourceGenericEndpoint
--- PASS: TestResourceGenericEndpoint (2.18s)
=== RUN   TestGenericSecretMigrateState
--- PASS: TestGenericSecretMigrateState (0.00s)
=== RUN   TestResourceGenericSecret
--- PASS: TestResourceGenericSecret (2.90s)
=== RUN   TestResourceGenericSecretNS
    testutil.go:69: "TF_ACC_ENTERPRISE" must be set
--- SKIP: TestResourceGenericSecretNS (0.00s)
=== RUN   TestResourceGenericSecret_deleted
--- PASS: TestResourceGenericSecret_deleted (3.15s)
=== RUN   TestResourceGenericSecret_deleteAllVersions
--- PASS: TestResourceGenericSecret_deleteAllVersions (3.07s)
=== RUN   TestAccGithubAuthBackend_basic
--- PASS: TestAccGithubAuthBackend_basic (2.78s)
=== RUN   TestAccGithubAuthBackend_tuning
--- PASS: TestAccGithubAuthBackend_tuning (2.64s)
=== RUN   TestAccGithubAuthBackend_description
--- PASS: TestAccGithubAuthBackend_description (3.03s)
=== RUN   TestAccGithubAuthBackend_importTuning
--- PASS: TestAccGithubAuthBackend_importTuning (2.20s)
=== RUN   TestAccGithubTeam_basic
--- PASS: TestAccGithubTeam_basic (2.99s)
=== RUN   TestAccGithubTeam_teamConfigError
--- PASS: TestAccGithubTeam_teamConfigError (0.31s)
=== RUN   TestAccGithubTeam_importBasic
--- PASS: TestAccGithubTeam_importBasic (2.02s)
=== RUN   TestGithubTeamBackEndPath
=== RUN   TestGithubTeamBackEndPath/With_default_mount
=== RUN   TestGithubTeamBackEndPath/With_custom_mount
--- PASS: TestGithubTeamBackEndPath (0.00s)
    --- PASS: TestGithubTeamBackEndPath/With_default_mount (0.00s)
    --- PASS: TestGithubTeamBackEndPath/With_custom_mount (0.00s)
=== RUN   TestAccGithubUser_basic
--- PASS: TestAccGithubUser_basic (2.60s)
=== RUN   TestAccGithubUser_importBasic
--- PASS: TestAccGithubUser_importBasic (1.78s)
=== RUN   TestGithubUserBackEndPath
=== RUN   TestGithubUserBackEndPath/With_default_mount
=== RUN   TestGithubUserBackEndPath/With_custom_mount
--- PASS: TestGithubUserBackEndPath (0.00s)
    --- PASS: TestGithubUserBackEndPath/With_default_mount (0.00s)
    --- PASS: TestGithubUserBackEndPath/With_custom_mount (0.00s)
=== RUN   TestAccIdentityEntityAlias
--- PASS: TestAccIdentityEntityAlias (2.21s)
=== RUN   TestAccIdentityEntityAliasDuplicateFlow
--- PASS: TestAccIdentityEntityAliasDuplicateFlow (6.24s)
=== RUN   TestAccIdentityEntityAlias_Update
--- PASS: TestAccIdentityEntityAlias_Update (3.17s)
=== RUN   TestAccIdentityEntityAlias_Metadata
--- PASS: TestAccIdentityEntityAlias_Metadata (2.73s)
=== RUN   TestAccIdentityEntityPoliciesExclusive
--- PASS: TestAccIdentityEntityPoliciesExclusive (2.62s)
=== RUN   TestAccIdentityEntityPoliciesNonExclusive
--- PASS: TestAccIdentityEntityPoliciesNonExclusive (2.56s)
=== RUN   TestAccIdentityEntity
--- PASS: TestAccIdentityEntity (1.41s)
=== RUN   TestAccIdentityEntityUpdate
--- PASS: TestAccIdentityEntityUpdate (2.73s)
=== RUN   TestAccIdentityEntityUpdateRemoveValues
--- PASS: TestAccIdentityEntityUpdateRemoveValues (2.74s)
=== RUN   TestAccIdentityEntityUpdateRemovePolicies
--- PASS: TestAccIdentityEntityUpdateRemovePolicies (2.62s)
=== RUN   TestReadEntity
=== PAUSE TestReadEntity
=== RUN   TestIsEntityNotFoundError
=== RUN   TestIsEntityNotFoundError/default
=== RUN   TestIsEntityNotFoundError/wrapped
=== RUN   TestIsEntityNotFoundError/not
--- PASS: TestIsEntityNotFoundError (0.00s)
    --- PASS: TestIsEntityNotFoundError/default (0.00s)
    --- PASS: TestIsEntityNotFoundError/wrapped (0.00s)
    --- PASS: TestIsEntityNotFoundError/not (0.00s)
=== RUN   TestAccIdentityGroupAlias
--- PASS: TestAccIdentityGroupAlias (1.43s)
=== RUN   TestAccIdentityGroupAliasUpdate
--- PASS: TestAccIdentityGroupAliasUpdate (2.68s)
=== RUN   TestAccIdentityGroupMemberEntityIdsExclusiveEmpty
--- PASS: TestAccIdentityGroupMemberEntityIdsExclusiveEmpty (3.63s)
=== RUN   TestAccIdentityGroupMemberEntityIdsExclusive
--- PASS: TestAccIdentityGroupMemberEntityIdsExclusive (2.63s)
=== RUN   TestAccIdentityGroupMemberEntityIdsNonExclusiveEmpty
--- PASS: TestAccIdentityGroupMemberEntityIdsNonExclusiveEmpty (3.84s)
=== RUN   TestAccIdentityGroupMemberEntityIdsNonExclusive
--- PASS: TestAccIdentityGroupMemberEntityIdsNonExclusive (4.09s)
=== RUN   TestAccIdentityGroupMemberEntityIdsDynamic
--- PASS: TestAccIdentityGroupMemberEntityIdsDynamic (7.16s)
=== RUN   TestAccIdentityGroupPoliciesExclusive
--- PASS: TestAccIdentityGroupPoliciesExclusive (2.97s)
=== RUN   TestAccIdentityGroupPoliciesNonExclusive
--- PASS: TestAccIdentityGroupPoliciesNonExclusive (3.04s)
=== RUN   TestAccIdentityGroup
--- PASS: TestAccIdentityGroup (1.51s)
=== RUN   TestAccIdentityGroupUpdate
--- PASS: TestAccIdentityGroupUpdate (5.80s)
=== RUN   TestAccIdentityGroupExternal
--- PASS: TestAccIdentityGroupExternal (1.38s)
=== RUN   TestAccIdentityGroup_DuplicateCreate
--- PASS: TestAccIdentityGroup_DuplicateCreate (0.97s)
=== RUN   TestAccIdentityOIDCAssignment
--- PASS: TestAccIdentityOIDCAssignment (3.40s)
=== RUN   TestAccIdentityOIDCClient
--- PASS: TestAccIdentityOIDCClient (2.90s)
=== RUN   TestAccIdentityOidcKeyAllowedClientId
--- PASS: TestAccIdentityOidcKeyAllowedClientId (5.06s)
=== RUN   TestAccIdentityOidcKey
--- PASS: TestAccIdentityOidcKey (3.75s)
=== RUN   TestAccIdentityOidcKeyUpdate
--- PASS: TestAccIdentityOidcKeyUpdate (4.89s)
=== RUN   TestAccIdentityOIDCProvider
--- PASS: TestAccIdentityOIDCProvider (1.75s)
=== RUN   TestAccIdentityOidcRole
--- PASS: TestAccIdentityOidcRole (1.80s)
=== RUN   TestAccIdentityOidcRoleWithClientId
--- PASS: TestAccIdentityOidcRoleWithClientId (2.50s)
=== RUN   TestAccIdentityOidcRoleUpdate
--- PASS: TestAccIdentityOidcRoleUpdate (3.80s)
=== RUN   TestAccIdentityOIDCScope
--- PASS: TestAccIdentityOIDCScope (2.31s)
=== RUN   TestAccIdentityOidc
--- PASS: TestAccIdentityOidc (2.36s)
=== RUN   TestAccJWTAuthBackendRole_import
--- PASS: TestAccJWTAuthBackendRole_import (1.82s)
=== RUN   TestAccJWTAuthBackendRole_basic
--- PASS: TestAccJWTAuthBackendRole_basic (1.35s)
=== RUN   TestAccJWTAuthBackendRole_update
--- PASS: TestAccJWTAuthBackendRole_update (2.48s)
=== RUN   TestAccJWTAuthBackendRole_full
--- PASS: TestAccJWTAuthBackendRole_full (1.43s)
=== RUN   TestAccJWTAuthBackendRoleOIDC_full
--- PASS: TestAccJWTAuthBackendRoleOIDC_full (2.04s)
=== RUN   TestAccJWTAuthBackendRoleOIDC_disableParsing
--- PASS: TestAccJWTAuthBackendRoleOIDC_disableParsing (1.44s)
=== RUN   TestAccJWTAuthBackendRole_fullUpdate
--- PASS: TestAccJWTAuthBackendRole_fullUpdate (3.53s)
=== RUN   TestAccJWTAuthBackend
=== RUN   TestAccJWTAuthBackend/basic
=== PAUSE TestAccJWTAuthBackend/basic
=== RUN   TestAccJWTAuthBackend/ns
=== PAUSE TestAccJWTAuthBackend/ns
=== CONT  TestAccJWTAuthBackend/basic
=== CONT  TestAccJWTAuthBackend/ns
    testutil.go:69: "TF_ACC_ENTERPRISE" must be set
--- PASS: TestAccJWTAuthBackend (0.00s)
    --- SKIP: TestAccJWTAuthBackend/ns (0.00s)
    --- PASS: TestAccJWTAuthBackend/basic (4.71s)
=== RUN   TestAccJWTAuthBackendProviderConfig
=== RUN   TestAccJWTAuthBackendProviderConfig/basic
=== PAUSE TestAccJWTAuthBackendProviderConfig/basic
=== RUN   TestAccJWTAuthBackendProviderConfig/ns
=== PAUSE TestAccJWTAuthBackendProviderConfig/ns
=== CONT  TestAccJWTAuthBackendProviderConfig/basic
=== CONT  TestAccJWTAuthBackendProviderConfig/ns
    testutil.go:69: "TF_ACC_ENTERPRISE" must be set
--- PASS: TestAccJWTAuthBackendProviderConfig (0.00s)
    --- SKIP: TestAccJWTAuthBackendProviderConfig/ns (0.00s)
    --- PASS: TestAccJWTAuthBackendProviderConfig/basic (1.42s)
=== RUN   TestAccJWTAuthBackend_OIDC
=== RUN   TestAccJWTAuthBackend_OIDC/basic
=== PAUSE TestAccJWTAuthBackend_OIDC/basic
=== RUN   TestAccJWTAuthBackend_OIDC/ns
=== PAUSE TestAccJWTAuthBackend_OIDC/ns
=== CONT  TestAccJWTAuthBackend_OIDC/basic
=== CONT  TestAccJWTAuthBackend_OIDC/ns
    resource_jwt_auth_backend_test.go:210: Step 1/1 error: Error running apply: exit status 1
        
        Error: error writing to Vault: Error making API request.
        
        URL: PUT http://localhost:8200/v1/sys/namespaces/ns-7793054712754462669
        Code: 404. Errors:
        
        * 1 error occurred:
        	* unsupported path
        
        
        
          with vault_namespace.test,
          on terraform_plugin_test.tf line 2, in resource "vault_namespace" "test":
           2: resource "vault_namespace" "test" {
        
--- FAIL: TestAccJWTAuthBackend_OIDC (0.00s)
    --- FAIL: TestAccJWTAuthBackend_OIDC/ns (0.74s)
    --- PASS: TestAccJWTAuthBackend_OIDC/basic (1.79s)
=== RUN   TestAccJWTAuthBackend_invalid
--- PASS: TestAccJWTAuthBackend_invalid (0.43s)
=== RUN   TestAccJWTAuthBackend_missingMandatory
--- PASS: TestAccJWTAuthBackend_missingMandatory (3.16s)
=== RUN   TestAccJWTAuthBackendProviderConfigConversionBool
--- PASS: TestAccJWTAuthBackendProviderConfigConversionBool (0.00s)
=== RUN   TestAccJWTAuthBackendProviderConfigConversionInt
--- PASS: TestAccJWTAuthBackendProviderConfigConversionInt (0.00s)
=== RUN   TestAccJWTAuthBackendProviderConfig_negative
    resource_jwt_auth_backend_test.go:518: true
--- SKIP: TestAccJWTAuthBackendProviderConfig_negative (0.00s)
=== RUN   TestAccKMIPSecretBackend_basic
    testutil.go:69: "TF_ACC_ENTERPRISE" must be set
--- SKIP: TestAccKMIPSecretBackend_basic (0.00s)
=== RUN   TestAccKMIPSecretBackend_remount
    testutil.go:69: "TF_ACC_ENTERPRISE" must be set
--- SKIP: TestAccKMIPSecretBackend_remount (0.00s)
=== RUN   TestAccKMIPSecretRole_basic
    testutil.go:69: "TF_ACC_ENTERPRISE" must be set
--- SKIP: TestAccKMIPSecretRole_basic (0.00s)
=== RUN   TestAccKMIPSecretRole_remount
    testutil.go:69: "TF_ACC_ENTERPRISE" must be set
--- SKIP: TestAccKMIPSecretRole_remount (0.00s)
=== RUN   TestAccKMIPSecretScope_remount
    testutil.go:69: "TF_ACC_ENTERPRISE" must be set
--- SKIP: TestAccKMIPSecretScope_remount (0.00s)
=== RUN   TestAccKubernetesAuthBackendConfig_import
--- PASS: TestAccKubernetesAuthBackendConfig_import (3.45s)
=== RUN   TestAccKubernetesAuthBackendConfig_basic
--- PASS: TestAccKubernetesAuthBackendConfig_basic (1.80s)
=== RUN   TestAccKubernetesAuthBackendConfig_update
--- PASS: TestAccKubernetesAuthBackendConfig_update (3.62s)
=== RUN   TestAccKubernetesAuthBackendConfig_full
--- PASS: TestAccKubernetesAuthBackendConfig_full (1.90s)
=== RUN   TestAccKubernetesAuthBackendConfig_fullUpdate
--- PASS: TestAccKubernetesAuthBackendConfig_fullUpdate (4.13s)
=== RUN   TestAccKubernetesAuthBackendConfig_localCA
    resource_kubernetes_auth_backend_config_test.go:353: Step 1/2 error: Error running apply: exit status 1
        
        Error: error writing Kubernetes auth backend config "auth/kubernetes-7539726916010768616/config": Error making API request.
        
        URL: PUT http://localhost:8200/v1/auth/kubernetes-7539726916010768616/config
        Code: 500. Errors:
        
        * 1 error occurred:
        	* open /var/run/secrets/kubernetes.io/serviceaccount/ca.crt: no such file or directory
        
        
        
          with vault_kubernetes_auth_backend_config.config,
          on terraform_plugin_test.tf line 7, in resource "vault_kubernetes_auth_backend_config" "config":
           7: resource "vault_kubernetes_auth_backend_config" "config" {
        
--- FAIL: TestAccKubernetesAuthBackendConfig_localCA (4.89s)
=== RUN   TestAccKubernetesAuthBackendRole_import
--- PASS: TestAccKubernetesAuthBackendRole_import (1.10s)
=== RUN   TestAccKubernetesAuthBackendRole_basic
--- PASS: TestAccKubernetesAuthBackendRole_basic (0.87s)
=== RUN   TestAccKubernetesAuthBackendRole_update
--- PASS: TestAccKubernetesAuthBackendRole_update (2.40s)
=== RUN   TestAccKubernetesAuthBackendRole_full
--- PASS: TestAccKubernetesAuthBackendRole_full (2.08s)
=== RUN   TestAccKubernetesAuthBackendRole_fullUpdate
--- PASS: TestAccKubernetesAuthBackendRole_fullUpdate (7.87s)
=== RUN   TestAccKVSecretBackendV2
--- PASS: TestAccKVSecretBackendV2 (2.79s)
=== RUN   TestAccKVSecret
--- PASS: TestAccKVSecret (2.00s)
=== RUN   TestAccKVSecretV2
--- PASS: TestAccKVSecretV2 (1.68s)
=== RUN   TestLDAPAuthBackendGroup_import
--- PASS: TestLDAPAuthBackendGroup_import (1.59s)
=== RUN   TestLDAPAuthBackendGroup_basic
--- PASS: TestLDAPAuthBackendGroup_basic (1.34s)
=== RUN   TestLDAPAuthBackend_basic
--- PASS: TestLDAPAuthBackend_basic (6.40s)
=== RUN   TestLDAPAuthBackend_tls
--- PASS: TestLDAPAuthBackend_tls (6.38s)
=== RUN   TestLDAPAuthBackendUser_basic
--- PASS: TestLDAPAuthBackendUser_basic (1.70s)
=== RUN   TestLDAPAuthBackendUser_noGroups
--- PASS: TestLDAPAuthBackendUser_noGroups (2.05s)
=== RUN   TestLDAPAuthBackendUser_oneGroup
--- PASS: TestLDAPAuthBackendUser_oneGroup (2.09s)
=== RUN   TestMFADuoBasic
    testutil.go:69: "TF_ACC_ENTERPRISE" must be set
--- SKIP: TestMFADuoBasic (0.00s)
=== RUN   TestMFAOktaBasic
    testutil.go:69: "TF_ACC_ENTERPRISE" must be set
--- SKIP: TestMFAOktaBasic (0.00s)
=== RUN   TestMFAPingIDBasic
    testutil.go:69: "TF_ACC_ENTERPRISE" must be set
--- SKIP: TestMFAPingIDBasic (0.00s)
=== RUN   TestMFATOTPBasic
    testutil.go:69: "TF_ACC_ENTERPRISE" must be set
--- SKIP: TestMFATOTPBasic (0.00s)
=== RUN   TestZeroTTLDoesNotCauseUpdate
--- PASS: TestZeroTTLDoesNotCauseUpdate (2.29s)
=== RUN   TestResourceMount
--- PASS: TestResourceMount (3.69s)
=== RUN   TestResourceMount_Local
--- PASS: TestResourceMount_Local (2.56s)
=== RUN   TestResourceMount_SealWrap
--- PASS: TestResourceMount_SealWrap (2.94s)
=== RUN   TestResourceMount_AuditNonHMACRequestKeys
--- PASS: TestResourceMount_AuditNonHMACRequestKeys (2.85s)
=== RUN   TestResourceMount_KVV2
--- PASS: TestResourceMount_KVV2 (2.11s)
=== RUN   TestResourceMount_ExternalEntropyAccess
--- PASS: TestResourceMount_ExternalEntropyAccess (7.25s)
=== RUN   TestAccNamespace
    testutil.go:69: "TF_ACC_ENTERPRISE" must be set
--- SKIP: TestAccNamespace (0.00s)
=== RUN   TestAccNomadSecretBackend
    testutil.go:69: "NOMAD_TOKEN" must be set
--- SKIP: TestAccNomadSecretBackend (0.00s)
=== RUN   TestAccNomadSecretBackendRoleClientBasic
    testutil.go:69: "NOMAD_TOKEN" must be set
--- SKIP: TestAccNomadSecretBackendRoleClientBasic (0.00s)
=== RUN   TestAccNomadSecretBackendRoleManagementBasic
    testutil.go:69: "NOMAD_TOKEN" must be set
--- SKIP: TestAccNomadSecretBackendRoleManagementBasic (0.00s)
=== RUN   TestAccNomadSecretBackendRoleImport
    testutil.go:69: "NOMAD_TOKEN" must be set
--- SKIP: TestAccNomadSecretBackendRoleImport (0.00s)
=== RUN   TestAccOktaAuthBackendGroup_basic
--- PASS: TestAccOktaAuthBackendGroup_basic (1.64s)
=== RUN   TestAccOktaAuthBackendGroup_specialChar
--- PASS: TestAccOktaAuthBackendGroup_specialChar (1.61s)
=== RUN   TestAccOktaAuthBackend_basic
--- PASS: TestAccOktaAuthBackend_basic (2.41s)
=== RUN   TestAccOktaAuthBackend_import
--- PASS: TestAccOktaAuthBackend_import (3.01s)
=== RUN   TestAccOktaAuthBackend_invalid_ttl
--- PASS: TestAccOktaAuthBackend_invalid_ttl (0.27s)
=== RUN   TestAccOktaAuthBackend_invalid_max_ttl
--- PASS: TestAccOktaAuthBackend_invalid_max_ttl (0.26s)
=== RUN   TestAccOktaAuthBackendUser
--- PASS: TestAccOktaAuthBackendUser (1.47s)
=== RUN   TestAccPasswordPolicy
--- PASS: TestAccPasswordPolicy (2.25s)
=== RUN   TestAccPasswordPolicy_import
--- PASS: TestAccPasswordPolicy_import (1.63s)
=== RUN   TestPkiSecretBackendCert_basic
--- PASS: TestPkiSecretBackendCert_basic (8.06s)
=== RUN   TestPkiSecretBackendCert_renew
--- PASS: TestPkiSecretBackendCert_renew (23.64s)
=== RUN   TestPkiSecretBackendConfigCA_basic
--- PASS: TestPkiSecretBackendConfigCA_basic (3.08s)
=== RUN   TestPkiSecretBackendConfigUrls_basic
--- PASS: TestPkiSecretBackendConfigUrls_basic (5.47s)
=== RUN   TestPkiSecretBackendCrlConfig_basic
--- PASS: TestPkiSecretBackendCrlConfig_basic (9.31s)
=== RUN   TestPkiSecretBackendIntermediateCertRequest_basic
--- PASS: TestPkiSecretBackendIntermediateCertRequest_basic (2.70s)
=== RUN   TestPkiSecretBackendIntermediateSetSigned_basic
--- PASS: TestPkiSecretBackendIntermediateSetSigned_basic (3.27s)
=== RUN   TestPkiSecretBackendRole_basic
--- PASS: TestPkiSecretBackendRole_basic (5.05s)
=== RUN   TestPkiSecretBackendRootCertificate_basic
--- PASS: TestPkiSecretBackendRootCertificate_basic (16.61s)
=== RUN   Test_pkiSecretSerialNumberUpgradeV0
=== RUN   Test_pkiSecretSerialNumberUpgradeV0/basic
--- PASS: Test_pkiSecretSerialNumberUpgradeV0 (0.00s)
    --- PASS: Test_pkiSecretSerialNumberUpgradeV0/basic (0.00s)
=== RUN   TestPkiSecretBackendRootSignIntermediate_basic_default
--- PASS: TestPkiSecretBackendRootSignIntermediate_basic_default (7.67s)
=== RUN   TestPkiSecretBackendRootSignIntermediate_basic_pem
--- PASS: TestPkiSecretBackendRootSignIntermediate_basic_pem (5.86s)
=== RUN   TestPkiSecretBackendRootSignIntermediate_basic_der
--- PASS: TestPkiSecretBackendRootSignIntermediate_basic_der (4.13s)
=== RUN   TestPkiSecretBackendRootSignIntermediate_basic_pem_bundle
--- PASS: TestPkiSecretBackendRootSignIntermediate_basic_pem_bundle (4.38s)
=== RUN   TestPkiSecretBackendRootSignIntermediate_basic_pem_bundle_multiple_intermediates
    resource_pki_secret_backend_root_sign_intermediate_test.go:210: Step 1/1 error: Check failed: Check 11/11 error: vault_pki_secret_backend_root_sign_intermediate.two: Attribute 'ca_chain.#' expected "2", got "3"
--- FAIL: TestPkiSecretBackendRootSignIntermediate_basic_pem_bundle_multiple_intermediates (8.66s)
=== RUN   Test_pkiSecretRootSignIntermediateRUpgradeV0
=== RUN   Test_pkiSecretRootSignIntermediateRUpgradeV0/basic
=== RUN   Test_pkiSecretRootSignIntermediateRUpgradeV0/invalid-no-issuing-ca
=== RUN   Test_pkiSecretRootSignIntermediateRUpgradeV0/invalid-no-certificate
--- PASS: Test_pkiSecretRootSignIntermediateRUpgradeV0 (0.00s)
    --- PASS: Test_pkiSecretRootSignIntermediateRUpgradeV0/basic (0.00s)
    --- PASS: Test_pkiSecretRootSignIntermediateRUpgradeV0/invalid-no-issuing-ca (0.00s)
    --- PASS: Test_pkiSecretRootSignIntermediateRUpgradeV0/invalid-no-certificate (0.00s)
=== RUN   Test_setCAChain
=== RUN   Test_setCAChain/empty-ca-chain-pem
=== RUN   Test_setCAChain/empty-ca-chain-pem-bundle
=== RUN   Test_setCAChain/empty-ca-chain-2-pem
=== RUN   Test_setCAChain/empty-ca-chain-2-duplicate-pem
=== RUN   Test_setCAChain/empty-ca-chain-2-pem-bundle
=== RUN   Test_setCAChain/empty-ca-chain-2-duplicate-pem-bundle
=== RUN   Test_setCAChain/empty-ca-chain-der
=== RUN   Test_setCAChain/absent-ca-chain-der
=== RUN   Test_setCAChain/populated-ca-chain
=== RUN   Test_setCAChain/invalid-ca-chain-type
=== RUN   Test_setCAChain/missing-intermediate-cert
=== RUN   Test_setCAChain/missing-issuing-ca
--- PASS: Test_setCAChain (0.00s)
    --- PASS: Test_setCAChain/empty-ca-chain-pem (0.00s)
    --- PASS: Test_setCAChain/empty-ca-chain-pem-bundle (0.00s)
    --- PASS: Test_setCAChain/empty-ca-chain-2-pem (0.00s)
    --- PASS: Test_setCAChain/empty-ca-chain-2-duplicate-pem (0.00s)
    --- PASS: Test_setCAChain/empty-ca-chain-2-pem-bundle (0.00s)
    --- PASS: Test_setCAChain/empty-ca-chain-2-duplicate-pem-bundle (0.00s)
    --- PASS: Test_setCAChain/empty-ca-chain-der (0.00s)
    --- PASS: Test_setCAChain/absent-ca-chain-der (0.00s)
    --- PASS: Test_setCAChain/populated-ca-chain (0.00s)
    --- PASS: Test_setCAChain/invalid-ca-chain-type (0.00s)
    --- PASS: Test_setCAChain/missing-intermediate-cert (0.00s)
    --- PASS: Test_setCAChain/missing-issuing-ca (0.00s)
=== RUN   TestPkiSecretBackendSign_basic
--- PASS: TestPkiSecretBackendSign_basic (5.00s)
=== RUN   TestPkiSecretBackendSign_renew
--- PASS: TestPkiSecretBackendSign_renew (19.10s)
=== RUN   TestResourcePolicy
--- PASS: TestResourcePolicy (2.84s)
=== RUN   TestQuotaLeaseCount
    testutil.go:69: "TF_ACC_ENTERPRISE" must be set
--- SKIP: TestQuotaLeaseCount (0.00s)
=== RUN   TestQuotaRateLimit
--- PASS: TestQuotaRateLimit (4.62s)
=== RUN   TestAccRabbitMQSecretBackendRole_basic
    testutil.go:69: "RMQ_CONNECTION_URI" must be set
--- SKIP: TestAccRabbitMQSecretBackendRole_basic (0.00s)
=== RUN   TestAccRabbitMQSecretBackendRole_nested
    testutil.go:69: "RMQ_CONNECTION_URI" must be set
--- SKIP: TestAccRabbitMQSecretBackendRole_nested (0.00s)
=== RUN   TestAccRabbitMQSecretBackendRole_topic
    testutil.go:69: "RMQ_CONNECTION_URI" must be set
--- SKIP: TestAccRabbitMQSecretBackendRole_topic (0.00s)
=== RUN   TestAccRabbitMQSecretBackend_basic
    testutil.go:69: "RMQ_CONNECTION_URI" must be set
--- SKIP: TestAccRabbitMQSecretBackend_basic (0.00s)
=== RUN   TestAccRabbitMQSecretBackend_template
    testutil.go:69: "RMQ_CONNECTION_URI" must be set
--- SKIP: TestAccRabbitMQSecretBackend_template (0.00s)
=== RUN   TestAccRaftAutopilotConfig_basic
    resource_raft_autopilot_test.go:16: Step 1/2 error: Error running apply: exit status 1
        
        Error: error writing "sys/storage/raft/autopilot/configuration": Error making API request.
        
        URL: PUT http://localhost:8200/v1/sys/storage/raft/autopilot/configuration
        Code: 404. Errors:
        
        * 1 error occurred:
        	* unsupported path
        
        
        
          with vault_raft_autopilot.test,
          on terraform_plugin_test.tf line 2, in resource "vault_raft_autopilot" "test":
           2: resource "vault_raft_autopilot" "test" {
        
--- FAIL: TestAccRaftAutopilotConfig_basic (0.83s)
=== RUN   TestAccRaftSnapshotAgentConfig_basic
    testutil.go:69: "TF_ACC_ENTERPRISE" must be set
--- SKIP: TestAccRaftSnapshotAgentConfig_basic (0.00s)
=== RUN   TestAccRaftSnapshotAgentConfig_import
    testutil.go:69: "TF_ACC_ENTERPRISE" must be set
--- SKIP: TestAccRaftSnapshotAgentConfig_import (0.00s)
=== RUN   TestAccRoleGoverningPolicy
    testutil.go:69: "TF_ACC_ENTERPRISE" must be set
--- SKIP: TestAccRoleGoverningPolicy (0.00s)
=== RUN   TestAccSSHSecretBackendCA_basic
--- PASS: TestAccSSHSecretBackendCA_basic (4.17s)
=== RUN   TestAccSSHSecretBackendCA_provided
--- PASS: TestAccSSHSecretBackendCA_provided (1.56s)
=== RUN   TestAccSSHSecretBackend_import
--- PASS: TestAccSSHSecretBackend_import (8.22s)
=== RUN   TestAccSSHSecretBackendRole
--- PASS: TestAccSSHSecretBackendRole (5.14s)
=== RUN   TestAccSSHSecretBackendRoleOTP_basic
--- PASS: TestAccSSHSecretBackendRoleOTP_basic (1.67s)
=== RUN   TestTerraformCloudSecretBackend
--- PASS: TestTerraformCloudSecretBackend (3.05s)
=== RUN   TestAccResourceTerraformCloudSecretCredsOrganizationBasic
    resource_terraform_cloud_secret_creds_test.go:28: TEST_TF_TOKEN and TEST_TF_ORGANIZATION must be set. Are currently  and  respectively
--- SKIP: TestAccResourceTerraformCloudSecretCredsOrganizationBasic (0.00s)
=== RUN   TestAccResourceTerraformCloudSecretCredsTeamBasic
    resource_terraform_cloud_secret_creds_test.go:57: TEST_TF_TOKEN, TEST_TF_ORGANIZATION, and TEST_TF_TEAM_ID must be set. Are currently ,  and  respectively
--- SKIP: TestAccResourceTerraformCloudSecretCredsTeamBasic (0.00s)
=== RUN   TestAccResourceTerraformCloudSecretCredsUserBasic
    resource_terraform_cloud_secret_creds_test.go:86: TEST_TF_TOKEN and TEST_TF_USER_ID must be set. Are currently  and  respectively
--- SKIP: TestAccResourceTerraformCloudSecretCredsUserBasic (0.00s)
=== RUN   TestTerraformCloudSecretRole
    resource_terraform_cloud_secret_role_test.go:28: TEST_TF_TOKEN, TEST_TF_TEAM_ID and TEST_TF_USER_ID must be set.
--- SKIP: TestTerraformCloudSecretRole (0.00s)
=== RUN   TestTerraformCloudSecretBackendRoleNameFromPath
--- PASS: TestTerraformCloudSecretBackendRoleNameFromPath (0.00s)
=== RUN   TestTerraformCloudSecretBackendRoleBackendFromPath
--- PASS: TestTerraformCloudSecretBackendRoleBackendFromPath (0.00s)
=== RUN   TestAccTokenAuthBackendRole
--- PASS: TestAccTokenAuthBackendRole (2.05s)
=== RUN   TestAccTokenAuthBackendRoleUpdate
--- PASS: TestAccTokenAuthBackendRoleUpdate (6.07s)
=== RUN   TestResourceToken_basic
--- PASS: TestResourceToken_basic (1.67s)
=== RUN   TestResourceToken_import
--- PASS: TestResourceToken_import (2.08s)
=== RUN   TestResourceToken_full
--- PASS: TestResourceToken_full (1.60s)
=== RUN   TestResourceToken_lookup
--- PASS: TestResourceToken_lookup (1.69s)
=== RUN   TestResourceToken_expire
--- PASS: TestResourceToken_expire (14.74s)
=== RUN   TestResourceToken_renew
--- PASS: TestResourceToken_renew (23.37s)
=== RUN   TestAccTransitCacheConfig
--- PASS: TestAccTransitCacheConfig (3.30s)
=== RUN   TestTransitSecretBackendKey_basic
--- PASS: TestTransitSecretBackendKey_basic (5.33s)
=== RUN   TestTransitSecretBackendKey_rsa4096
--- PASS: TestTransitSecretBackendKey_rsa4096 (4.89s)
=== RUN   TestExpandAuthMethodTune
--- PASS: TestExpandAuthMethodTune (0.00s)
=== RUN   TestFlattenAuthMethodTune
--- PASS: TestFlattenAuthMethodTune (0.00s)
=== RUN   Test_validateNoTrailingSlash
--- PASS: Test_validateNoTrailingSlash (0.00s)
=== RUN   Test_validateNoLeadingTrailingSlashes
=== RUN   Test_validateNoLeadingTrailingSlashes/valid
=== RUN   Test_validateNoLeadingTrailingSlashes/invalid-leading
=== RUN   Test_validateNoLeadingTrailingSlashes/invalid-trailing
=== RUN   Test_validateNoLeadingTrailingSlashes/invalid-both
--- PASS: Test_validateNoLeadingTrailingSlashes (0.00s)
    --- PASS: Test_validateNoLeadingTrailingSlashes/valid (0.00s)
    --- PASS: Test_validateNoLeadingTrailingSlashes/invalid-leading (0.00s)
    --- PASS: Test_validateNoLeadingTrailingSlashes/invalid-trailing (0.00s)
    --- PASS: Test_validateNoLeadingTrailingSlashes/invalid-both (0.00s)
=== CONT  TestReadEntity
=== RUN   TestReadEntity/retry-none
=== RUN   TestReadEntity/retry-ok-404
=== RUN   TestReadEntity/retry-ok-412
=== RUN   TestReadEntity/retry-exhausted-default-max-404
=== RUN   TestReadEntity/retry-exhausted-default-max-412
=== RUN   TestReadEntity/retry-exhausted-custom-max-404
=== RUN   TestReadEntity/retry-exhausted-custom-max-412
--- PASS: TestReadEntity (180.49s)
    --- PASS: TestReadEntity/retry-none (0.00s)
    --- PASS: TestReadEntity/retry-ok-404 (3.46s)
    --- PASS: TestReadEntity/retry-ok-412 (3.32s)
    --- PASS: TestReadEntity/retry-exhausted-default-max-404 (65.04s)
    --- PASS: TestReadEntity/retry-exhausted-default-max-412 (72.26s)
    --- PASS: TestReadEntity/retry-exhausted-custom-max-404 (19.03s)
    --- PASS: TestReadEntity/retry-exhausted-custom-max-412 (17.39s)
FAIL
FAIL	github.com/hashicorp/terraform-provider-vault/vault	935.007s
FAIL
```
