### PR TITLE
Fix bug where some rabbitmq config changes trigger erroneous mount recreation.

### DIFF
--- a/vault/resource_rabbitmq_secret_backend.go
+++ b/vault/resource_rabbitmq_secret_backend.go
@@ -62,7 +62,6 @@ func rabbitMQSecretBackendResource() *schema.Resource {
 			"username": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    false,
 				Sensitive:   true,
 				Description: "Specifies the RabbitMQ management administrator username",
 			},

--- a/vault/resource_rabbitmq_secret_backend.go
+++ b/vault/resource_rabbitmq_secret_backend.go
@@ -68,7 +68,6 @@ func rabbitMQSecretBackendResource() *schema.Resource {
 			"password": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    false,
 				Sensitive:   true,
 				Description: "Specifies the RabbitMQ management administrator password",
 			},

--- a/vault/resource_rabbitmq_secret_backend.go
+++ b/vault/resource_rabbitmq_secret_backend.go
@@ -57,7 +57,6 @@ func rabbitMQSecretBackendResource() *schema.Resource {
 			"connection_uri": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    false,
 				Description: "Specifies the RabbitMQ connection URI.",
 			},
 			"username": {

--- a/vault/resource_rabbitmq_secret_backend.go
+++ b/vault/resource_rabbitmq_secret_backend.go
@@ -57,20 +57,20 @@ func rabbitMQSecretBackendResource() *schema.Resource {
 			"connection_uri": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
+				ForceNew:    false,
 				Description: "Specifies the RabbitMQ connection URI.",
 			},
 			"username": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
+				ForceNew:    false,
 				Sensitive:   true,
 				Description: "Specifies the RabbitMQ management administrator username",
 			},
 			"password": {
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
+				ForceNew:    false,
 				Sensitive:   true,
 				Description: "Specifies the RabbitMQ management administrator password",
 			},
@@ -78,7 +78,7 @@ func rabbitMQSecretBackendResource() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     true,
-				ForceNew:    true,
+				ForceNew:    false,
 				Description: "Specifies whether to verify connection URI, username, and password.",
 			},
 			"password_policy": {
@@ -197,7 +197,7 @@ func rabbitMQSecretBackendUpdate(d *schema.ResourceData, meta interface{}) error
 		log.Printf("[DEBUG] Updated lease TTLs for %q", path)
 	}
 	if d.HasChanges("connection_uri", "username", "password", "verify_connection", "username_template", "password_policy") {
-		log.Printf("[DEBUG] Updating connecion credentials at %q", path+"/config/connection")
+		log.Printf("[DEBUG] Updating connection credentials at %q", path+"/config/connection")
 		data := map[string]interface{}{
 			"connection_uri":    d.Get("connection_uri").(string),
 			"username":          d.Get("username").(string),

--- a/vault/resource_rabbitmq_secret_backend.go
+++ b/vault/resource_rabbitmq_secret_backend.go
@@ -75,7 +75,6 @@ func rabbitMQSecretBackendResource() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     true,
-				ForceNew:    false,
 				Description: "Specifies whether to verify connection URI, username, and password.",
 			},
 			"password_policy": {


### PR DESCRIPTION
RabbitMQ backend resource is forcing the mount to be recreated when most config parameters have changed. It already supports in-place upgrades (tune and update), so just needed to flip the schema.

```release-note
resource/rabbitmq_secret_backend: Fixed bug where changing config parameters would recreate the mount.
```


Acceptance tests:
```
[~/Git/terraform-provider-vault] VAULT_TOKEN=root RMQ_CONNECTION_URI="http://localhost:15672" RMQ_USERNAME="user" RMQ_PASSWORD="password" make testacc TESTARGS='-run TestAccRabbit'
=== RUN   TestAccRabbitMQSecretBackendRole_basic
--- PASS: TestAccRabbitMQSecretBackendRole_basic (6.82s)
=== RUN   TestAccRabbitMQSecretBackendRole_nested
--- PASS: TestAccRabbitMQSecretBackendRole_nested (6.85s)
=== RUN   TestAccRabbitMQSecretBackendRole_topic
--- PASS: TestAccRabbitMQSecretBackendRole_topic (6.85s)
=== RUN   TestAccRabbitMQSecretBackend_basic
--- PASS: TestAccRabbitMQSecretBackend_basic (6.77s)
=== RUN   TestAccRabbitMQSecretBackend_template
--- PASS: TestAccRabbitMQSecretBackend_template (5.60s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/vault	34.264s
```