### PR TITLE
Properly set the base64_pem in Vault for Couchbase

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,7 @@ jobs:
       #    - 18091:18091
       #    - 18092:18092
       #    - 18093:18093
+      #    - 18094:18094
       #  options: >-
       #    --health-cmd "curl -f http://Administrator:password@127.0.0.1:8091/sampleBuckets"
       #    --health-interval 1s

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,13 +98,11 @@ jobs:
           COUCHBASE_HOST: couchbase
           COUCHBASE_USERNAME: Administrator
           COUCHBASE_PASSWORD: password
-          #COUCHBASE_HOST_2: couchbase-2
         run: |
           export TF_VAULT_VERSION=$(echo ${{ matrix.image }} | \
-           awk -F: '{match($NF, /^([0-9]+\.[0-9]+\.[0-9]+)/); printf("%s", substr($NF, RSTART, RLENGTH))}')
+            awk -F: '{match($NF, /^([0-9]+\.[0-9]+\.[0-9]+)/); printf("%s", substr($NF, RSTART, RLENGTH))}')
           [ -n "${TF_VAULT_VERSION}" ] || (echo "could not get vault version from matrix.image: ${{ matrix.image }}" >&2 ; exit 1)
-          #make testacc-ent TESTARGS='-test.v -test.parallel=10' SKIP_MSSQL_MULTI_CI=true SKIP_RAFT_TESTS=true SKIP_VAULT_NEXT_TESTS=true
-          make testacc-ent TESTARGS='-test.v -test.parallel=10 -test.run=TestAccDatabaseSecretBackendConnection_couchbase' SKIP_MSSQL_MULTI_CI=true SKIP_RAFT_TESTS=true SKIP_VAULT_NEXT_TESTS=true
+          make testacc-ent TESTARGS='-test.v -test.parallel=10' SKIP_MSSQL_MULTI_CI=true SKIP_RAFT_TESTS=true SKIP_VAULT_NEXT_TESTS=true
       - name: "Generate Vault API Path Coverage Report"
         run: |
           go run cmd/coverage/main.go -openapi-doc=./testdata/openapi.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,14 +67,14 @@ jobs:
       couchbase-1:
         image: docker.io/couchbase/server-sandbox:7.1.1
         options: >-
-          --health-cmd "curl -f 'http://Administrator:password@127.0.0.1:8091/sampleBuckets"
+          --health-cmd "curl -f http://Administrator:password@127.0.0.1:8091/sampleBuckets"
           --health-interval 1s
           --health-timeout 5s
           --health-retries 60
       couchbase-2:
         image: docker.io/couchbase/server-sandbox:7.1.1
         options: >-
-          --health-cmd "curl -f 'http://Administrator:password@127.0.0.1:8091/sampleBuckets"
+          --health-cmd "curl -f http://Administrator:password@127.0.0.1:8091/sampleBuckets"
           --health-interval 1s
           --health-timeout 5s
           --health-retries 60

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
            awk -F: '{match($NF, /^([0-9]+\.[0-9]+\.[0-9]+)/); printf("%s", substr($NF, RSTART, RLENGTH))}')
           [ -n "${TF_VAULT_VERSION}" ] || (echo "could not get vault version from matrix.image: ${{ matrix.image }}" >&2 ; exit 1)
           #make testacc-ent TESTARGS='-test.v -test.parallel=10' SKIP_MSSQL_MULTI_CI=true SKIP_RAFT_TESTS=true SKIP_VAULT_NEXT_TESTS=true
-          make testacc-ent TESTARGS='-test.v -test.parallel=10 -test.run=TestAccDatabaseSecretBackendConnection_couchbase' SKIP_MSSQL_MULTI_CI=true SKIP_RAFT_TESTS=true SKIP_VAULT_NEXT_TESTS=true
+          make testacc-ent TESTARGS='-test.v -test.parallel=10 -test.run=TestAccDatabaseSecretBackendConnection_couchbaseTLS' SKIP_MSSQL_MULTI_CI=true SKIP_RAFT_TESTS=true SKIP_VAULT_NEXT_TESTS=true
       - name: "Generate Vault API Path Coverage Report"
         run: |
           go run cmd/coverage/main.go -openapi-doc=./testdata/openapi.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,16 +67,16 @@ jobs:
       couchbase-1:
         image: docker.io/couchbase/server-sandbox:7.1.1
         ports:
-          - 8091
-          - 8092
-          - 8093
-          - 8094
-          - 11207
-          - 11210
-          - 18091
-          - 18092
-          - 18093
-          - 18094
+          - 8091:8091
+          - 8092:8092
+          - 8093:8093
+          - 8094:8094
+          - 11207:11207
+          - 11210:11210
+          - 18091:18091
+          - 18092:18092
+          - 18093:18093
+          - 18094:18094
         options: >-
           --health-cmd "curl -f http://Administrator:password@127.0.0.1:8091/sampleBuckets"
           --health-interval 1s
@@ -85,16 +85,16 @@ jobs:
       couchbase-2:
         image: docker.io/couchbase/server-sandbox:7.1.1
         ports:
-          - 8091
-          - 8092
-          - 8093
-          - 8094
-          - 11207
-          - 11210
-          - 18091
-          - 18092
-          - 18093
-          - 18094
+          - 8091:8091
+          - 8092:8092
+          - 8093:8093
+          - 8094:8094
+          - 11207:11207
+          - 11210:11210
+          - 18091:18091
+          - 18092:18092
+          - 18093:18093
+          - 18094:18094
         options: >-
           --health-cmd "curl -f http://Administrator:password@127.0.0.1:8091/sampleBuckets"
           --health-interval 1s

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,8 +66,18 @@ jobs:
           POSTGRES_DB: database
       couchbase-1:
         image: docker.io/couchbase/server-sandbox:7.1.1
+        options: >-
+          --health-cmd "curl -f 'http://Administrator:password@127.0.0.1:8091/sampleBuckets"
+          --health-interval 1s
+          --health-timeout 5s
+          --health-retries 60
       couchbase-2:
         image: docker.io/couchbase/server-sandbox:7.1.1
+        options: >-
+          --health-cmd "curl -f 'http://Administrator:password@127.0.0.1:8091/sampleBuckets"
+          --health-interval 1s
+          --health-timeout 5s
+          --health-retries 60
     steps:
       - uses: actions/checkout@v3
       - name: Acceptance Tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         # TODO: enable 1.9 job once the provider is Vault version aware
         image:
-        #- "vault-enterprise:1.10.4-ent"
+        - "vault-enterprise:1.10.4-ent"
         - "vault-enterprise:1.11.0-ent"
     container:
       image: "docker.mirror.hashicorp.services/golang:${{ needs.go-version.outputs.version }}"
@@ -64,7 +64,7 @@ jobs:
         env:
           POSTGRES_PASSWORD: secret
           POSTGRES_DB: database
-      couchbase-1:
+      couchbase:
         image: docker.io/couchbase/server-sandbox:7.1.1
         ports:
           - 8091:8091
@@ -82,24 +82,6 @@ jobs:
           --health-interval 1s
           --health-timeout 5s
           --health-retries 60
-      #couchbase-2:
-      #  image: docker.io/couchbase/server-sandbox:7.1.1
-      #  ports:
-      #    - 8091:8091
-      #    - 8092:8092
-      #    - 8093:8093
-      #    - 8094:8094
-      #    - 11207:11207
-      #    - 11210:11210
-      #    - 18091:18091
-      #    - 18092:18092
-      #    - 18093:18093
-      #    - 18094:18094
-      #  options: >-
-      #    --health-cmd "curl -f http://Administrator:password@127.0.0.1:8091/sampleBuckets"
-      #    --health-interval 1s
-      #    --health-timeout 5s
-      #    --health-retries 60
     steps:
       - uses: actions/checkout@v3
       - name: Acceptance Tests
@@ -113,16 +95,16 @@ jobs:
           MONGODB_URL: "mongodb://root:mongodb@mongo:27017/admin?ssl=false"
           MSSQL_URL: "sqlserver://sa:${{ secrets.MSSQL_SA_PASSWORD }}@mssql:1433"
           POSTGRES_URL: "postgres://postgres:secret@postgres:5432/database?sslmode=disable"
+          COUCHBASE_HOST: couchbase
           COUCHBASE_USERNAME: Administrator
           COUCHBASE_PASSWORD: password
-          COUCHBASE_HOST_1: couchbase-1
           #COUCHBASE_HOST_2: couchbase-2
         run: |
           export TF_VAULT_VERSION=$(echo ${{ matrix.image }} | \
            awk -F: '{match($NF, /^([0-9]+\.[0-9]+\.[0-9]+)/); printf("%s", substr($NF, RSTART, RLENGTH))}')
           [ -n "${TF_VAULT_VERSION}" ] || (echo "could not get vault version from matrix.image: ${{ matrix.image }}" >&2 ; exit 1)
           #make testacc-ent TESTARGS='-test.v -test.parallel=10' SKIP_MSSQL_MULTI_CI=true SKIP_RAFT_TESTS=true SKIP_VAULT_NEXT_TESTS=true
-          make testacc-ent TESTARGS='-test.v -test.parallel=10 -test.run=TestAccDatabaseSecretBackendConnection_couchbaseTLS' SKIP_MSSQL_MULTI_CI=true SKIP_RAFT_TESTS=true SKIP_VAULT_NEXT_TESTS=true
+          make testacc-ent TESTARGS='-test.v -test.parallel=10 -test.run=TestAccDatabaseSecretBackendConnection_couchbase' SKIP_MSSQL_MULTI_CI=true SKIP_RAFT_TESTS=true SKIP_VAULT_NEXT_TESTS=true
       - name: "Generate Vault API Path Coverage Report"
         run: |
           go run cmd/coverage/main.go -openapi-doc=./testdata/openapi.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,10 @@ jobs:
         env:
           POSTGRES_PASSWORD: secret
           POSTGRES_DB: database
+      couchbase-1:
+        image: docker.io/couchbase/server-sandbox:7.1.1
+      couchbase-2:
+        image: docker.io/couchbase/server-sandbox:7.1.1
     steps:
       - uses: actions/checkout@v3
       - name: Acceptance Tests
@@ -77,11 +81,16 @@ jobs:
           MONGODB_URL: "mongodb://root:mongodb@mongo:27017/admin?ssl=false"
           MSSQL_URL: "sqlserver://sa:${{ secrets.MSSQL_SA_PASSWORD }}@mssql:1433"
           POSTGRES_URL: "postgres://postgres:secret@postgres:5432/database?sslmode=disable"
+          COUCHBASE_USERNAME: Administrator
+          COUCHBASE_PASSWORD: password
+          COUCHBASE_HOST_1: couchbase-1
+          COUCHBASE_HOST_2: couchbase-2
         run: |
           export TF_VAULT_VERSION=$(echo ${{ matrix.image }} | \
            awk -F: '{match($NF, /^([0-9]+\.[0-9]+\.[0-9]+)/); printf("%s", substr($NF, RSTART, RLENGTH))}')
           [ -n "${TF_VAULT_VERSION}" ] || (echo "could not get vault version from matrix.image: ${{ matrix.image }}" >&2 ; exit 1)
-          make testacc-ent TESTARGS='-test.v -test.parallel=10' SKIP_MSSQL_MULTI_CI=true SKIP_RAFT_TESTS=true SKIP_VAULT_NEXT_TESTS=true
+          #make testacc-ent TESTARGS='-test.v -test.parallel=10' SKIP_MSSQL_MULTI_CI=true SKIP_RAFT_TESTS=true SKIP_VAULT_NEXT_TESTS=true
+          make testacc-ent TESTARGS='-test.v -test.parallel=10 -test.run=TestAccDatabaseSecretBackendConnection_couchbase' SKIP_MSSQL_MULTI_CI=true SKIP_RAFT_TESTS=true SKIP_VAULT_NEXT_TESTS=true
       - name: "Generate Vault API Path Coverage Report"
         run: |
           go run cmd/coverage/main.go -openapi-doc=./testdata/openapi.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,17 @@ jobs:
           POSTGRES_DB: database
       couchbase-1:
         image: docker.io/couchbase/server-sandbox:7.1.1
+        ports:
+          - 8091
+          - 8092
+          - 8093
+          - 8094
+          - 11207
+          - 11210
+          - 18091
+          - 18092
+          - 18093
+          - 18094
         options: >-
           --health-cmd "curl -f http://Administrator:password@127.0.0.1:8091/sampleBuckets"
           --health-interval 1s
@@ -73,6 +84,17 @@ jobs:
           --health-retries 60
       couchbase-2:
         image: docker.io/couchbase/server-sandbox:7.1.1
+        ports:
+          - 8091
+          - 8092
+          - 8093
+          - 8094
+          - 11207
+          - 11210
+          - 18091
+          - 18092
+          - 18093
+          - 18094
         options: >-
           --health-cmd "curl -f http://Administrator:password@127.0.0.1:8091/sampleBuckets"
           --health-interval 1s

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         # TODO: enable 1.9 job once the provider is Vault version aware
         image:
-        - "vault-enterprise:1.10.4-ent"
+        #- "vault-enterprise:1.10.4-ent"
         - "vault-enterprise:1.11.0-ent"
     container:
       image: "docker.mirror.hashicorp.services/golang:${{ needs.go-version.outputs.version }}"
@@ -82,24 +82,23 @@ jobs:
           --health-interval 1s
           --health-timeout 5s
           --health-retries 60
-      couchbase-2:
-        image: docker.io/couchbase/server-sandbox:7.1.1
-        ports:
-          - 8091:8091
-          - 8092:8092
-          - 8093:8093
-          - 8094:8094
-          - 11207:11207
-          - 11210:11210
-          - 18091:18091
-          - 18092:18092
-          - 18093:18093
-          - 18094:18094
-        options: >-
-          --health-cmd "curl -f http://Administrator:password@127.0.0.1:8091/sampleBuckets"
-          --health-interval 1s
-          --health-timeout 5s
-          --health-retries 60
+      #couchbase-2:
+      #  image: docker.io/couchbase/server-sandbox:7.1.1
+      #  ports:
+      #    - 8091:8091
+      #    - 8092:8092
+      #    - 8093:8093
+      #    - 8094:8094
+      #    - 11207:11207
+      #    - 11210:11210
+      #    - 18091:18091
+      #    - 18092:18092
+      #    - 18093:18093
+      #  options: >-
+      #    --health-cmd "curl -f http://Administrator:password@127.0.0.1:8091/sampleBuckets"
+      #    --health-interval 1s
+      #    --health-timeout 5s
+      #    --health-retries 60
     steps:
       - uses: actions/checkout@v3
       - name: Acceptance Tests
@@ -116,7 +115,7 @@ jobs:
           COUCHBASE_USERNAME: Administrator
           COUCHBASE_PASSWORD: password
           COUCHBASE_HOST_1: couchbase-1
-          COUCHBASE_HOST_2: couchbase-2
+          #COUCHBASE_HOST_2: couchbase-2
         run: |
           export TF_VAULT_VERSION=$(echo ${{ matrix.image }} | \
            awk -F: '{match($NF, /^([0-9]+\.[0-9]+\.[0-9]+)/); printf("%s", substr($NF, RSTART, RLENGTH))}')

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -1021,11 +1021,10 @@ func getCouchbaseConnectionDetailsFromResponse(d *schema.ResourceData, prefix st
 	if v, ok := data["insecure_tls"]; ok {
 		result["insecure_tls"] = v.(bool)
 	}
-	if v, ok := data["base64_pem"]; ok {
-		result["base64_pem"] = v.(string)
-	} else if v, ok := d.GetOk(prefix + "base64_pem"); ok {
-		result["base64_pem"] = v.(string)
-	}
+
+	// base64_pem maps to base64pem in Vault
+	result["base64_pem"] = data["base64pem"]
+
 	if v, ok := data["bucket_name"]; ok {
 		result["bucket_name"] = v.(string)
 	}
@@ -1241,7 +1240,8 @@ func setCouchbaseDatabaseConnectionData(d *schema.ResourceData, prefix string, d
 		data["insecure_tls"] = v.(bool)
 	}
 	if v, ok := d.GetOkExists(prefix + "base64_pem"); ok {
-		data["base64_pem"] = v.(string)
+		// base64_pem maps to base64pem in Vault
+		data["base64pem"] = v.(string)
 	}
 	if v, ok := d.GetOkExists(prefix + "bucket_name"); ok {
 		data["bucket_name"] = v.(string)

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -1228,10 +1228,10 @@ func setCouchbaseDatabaseConnectionData(d *schema.ResourceData, prefix string, d
 		data["hosts"] = strings.Join(hosts, ",")
 	}
 	if v, ok := d.GetOk(prefix + "username"); ok {
-		data["username"] = v.(string)
+		data["username"] = v
 	}
 	if v, ok := d.GetOk(prefix + "password"); ok {
-		data["password"] = v.(string)
+		data["password"] = v
 	}
 	if v, ok := d.GetOkExists(prefix + "tls"); ok {
 		data["tls"] = v.(bool)
@@ -1239,15 +1239,15 @@ func setCouchbaseDatabaseConnectionData(d *schema.ResourceData, prefix string, d
 	if v, ok := d.GetOkExists(prefix + "insecure_tls"); ok {
 		data["insecure_tls"] = v.(bool)
 	}
-	if v, ok := d.GetOkExists(prefix + "base64_pem"); ok {
+	if v, ok := d.GetOk(prefix + "base64_pem"); ok {
 		// base64_pem maps to base64pem in Vault
-		data["base64pem"] = v.(string)
+		data["base64pem"] = v
 	}
-	if v, ok := d.GetOkExists(prefix + "bucket_name"); ok {
-		data["bucket_name"] = v.(string)
+	if v, ok := d.GetOk(prefix + "bucket_name"); ok {
+		data["bucket_name"] = v
 	}
-	if v, ok := d.GetOkExists(prefix + "username_template"); ok {
-		data["username_template"] = v.(int)
+	if v, ok := d.GetOk(prefix + "username_template"); ok {
+		data["username_template"] = v
 	}
 }
 

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -221,7 +221,7 @@ func TestAccDatabaseSecretBackendConnection_couchbaseTLS(t *testing.T) {
 	host1TLS := fmt.Sprintf("couchbases://%s", host1)
 
 	getBase64PEM := func(host string) string {
-		resp, err := http.Get(fmt.Sprintf("http://%s:8091", host))
+		resp, err := http.Get(fmt.Sprintf("http://%s:8091/pools/default/certificate", host))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1097,6 +1097,7 @@ resource "vault_database_secret_backend_connection" "test" {
     hosts       = ["%s"]
     username    = "%s"
     password    = "%s"
+    tls         = true
     base64_pem  = "%s"
   }
 }

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -2,9 +2,12 @@ package vault
 
 import (
 	"database/sql"
+	"encoding/base64"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"log"
+	"net/http"
 	"net/url"
 	"os"
 	"reflect"
@@ -168,6 +171,25 @@ func TestAccDatabaseSecretBackendConnection_couchbase(t *testing.T) {
 	host2 := values[1]
 	username := values[2]
 	password := values[3]
+	host1TLS := fmt.Sprintf("couchbases://%s", host1)
+
+	getBase64PEM := func(host string) string {
+		resp, err := http.Get(fmt.Sprintf("http://%s:8091"))
+		defer resp.Body.Close()
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return base64.StdEncoding.EncodeToString(b)
+	}
+
+	host1Base64PEM := getBase64PEM(host1)
+
 	backend := acctest.RandomWithPrefix("tf-test-db")
 	pluginName := dbEngineCouchbase.DefaultPluginName()
 	name := acctest.RandomWithPrefix("db")
@@ -194,6 +216,32 @@ func TestAccDatabaseSecretBackendConnection_couchbase(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "couchbase.0.tls", "false"),
 					resource.TestCheckResourceAttr(resourceName, "couchbase.0.insecure_tls", "false"),
 					resource.TestCheckResourceAttr(resourceName, "couchbase.0.base64_pem", ""),
+					resource.TestCheckResourceAttr(resourceName, "couchbase.0.bucket_name", "travel-sample"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"verify_connection", "couchbase.0.password"},
+			},
+			{
+				Config: testAccDatabaseSecretBackendConnectionConfig_couchbaseTLS(
+					name, backend, host1TLS, username, password, host1Base64PEM),
+				Check: testComposeCheckFuncCommonDatabaseSecretBackend(name, backend, pluginName,
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr(resourceName, "verify_connection", "true"),
+					resource.TestCheckResourceAttr(resourceName, "couchbase.0.hosts.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "couchbase.0.hosts.*", host1TLS),
+					resource.TestCheckResourceAttr(resourceName, "couchbase.0.username", username),
+					resource.TestCheckResourceAttr(resourceName, "couchbase.0.password", password),
+					resource.TestCheckResourceAttr(resourceName, "couchbase.0.tls", "true"),
+					resource.TestCheckResourceAttr(resourceName, "couchbase.0.insecure_tls", "false"),
+					resource.TestCheckResourceAttr(resourceName, "couchbase.0.base64_pem", host1Base64PEM),
 					resource.TestCheckResourceAttr(resourceName, "couchbase.0.bucket_name", "travel-sample"),
 				),
 			},
@@ -1011,6 +1059,29 @@ resource "vault_database_secret_backend_connection" "test" {
   }
 }
 `, path, name, host1, host2, username, password)
+}
+
+func testAccDatabaseSecretBackendConnectionConfig_couchbaseTLS(name, path, host1, username, password, base64PEM string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "db" {
+  path = "%s"
+  type = "database"
+}
+
+resource "vault_database_secret_backend_connection" "test" {
+  backend                  = vault_mount.db.path
+  name                     = "%s"
+  allowed_roles            = ["dev", "prod"]
+  root_rotation_statements = ["FOOBAR"]
+  couchbase {
+    hosts       = ["%s"]
+    username    = "%s"
+    password    = "%s"
+    bucket_name = "travel-sample"
+    base64_pem  = "%s"
+  }
+}
+`, path, name, host1, username, password, base64PEM)
 }
 
 func testAccDatabaseSecretBackendConnectionConfig_elasticsearch(name, path, host, username, password string) string {

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -174,7 +174,7 @@ func TestAccDatabaseSecretBackendConnection_couchbase(t *testing.T) {
 	host1TLS := fmt.Sprintf("couchbases://%s", host1)
 
 	getBase64PEM := func(host string) string {
-		resp, err := http.Get(fmt.Sprintf("http://%s:8091"))
+		resp, err := http.Get(fmt.Sprintf("http://%s:8091", host))
 		defer resp.Body.Close()
 
 		if err != nil {

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -261,7 +261,7 @@ func TestAccDatabaseSecretBackendConnection_couchbaseTLS(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "couchbase.0.username", username),
 					resource.TestCheckResourceAttr(resourceName, "couchbase.0.password", password),
 					resource.TestCheckResourceAttr(resourceName, "couchbase.0.tls", "true"),
-					resource.TestCheckResourceAttr(resourceName, "couchbase.0.insecure_tls", "false"),
+					resource.TestCheckResourceAttr(resourceName, "couchbase.0.insecure_tls", "true"),
 					resource.TestCheckResourceAttr(resourceName, "couchbase.0.base64_pem", host1Base64PEM),
 				),
 			},
@@ -1094,12 +1094,13 @@ resource "vault_database_secret_backend_connection" "test" {
   allowed_roles            = ["dev", "prod"]
   root_rotation_statements = ["FOOBAR"]
   couchbase {
-    hosts       = ["%s"]
-    username    = "%s"
-    password    = "%s"
-    tls         = true
-    base64_pem  = "%s"
-    bucket_name = "travel-sample"
+    hosts        = ["%s"]
+    username     = "%s"
+    password     = "%s"
+    tls          = true
+    insecure_tls = true
+    base64_pem   = "%s"
+    bucket_name  = "travel-sample"
   }
 }
 `, path, name, host1, username, password, base64PEM)

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -194,6 +194,7 @@ func TestAccDatabaseSecretBackendConnection_couchbase(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "couchbase.0.tls", "false"),
 					resource.TestCheckResourceAttr(resourceName, "couchbase.0.insecure_tls", "false"),
 					resource.TestCheckResourceAttr(resourceName, "couchbase.0.base64_pem", ""),
+					resource.TestCheckResourceAttr(resourceName, "couchbase.0.bucket_name", "travel-sample"),
 				),
 			},
 			{
@@ -996,15 +997,17 @@ resource "vault_mount" "db" {
   path = "%s"
   type = "database"
 }
+
 resource "vault_database_secret_backend_connection" "test" {
   backend                  = vault_mount.db.path
   name                     = "%s"
   allowed_roles            = ["dev", "prod"]
   root_rotation_statements = ["FOOBAR"]
   couchbase {
-    hosts    = ["%s", "%s"]
-    username = "%s"
-    password = "%s"
+    hosts       = ["%s", "%s"]
+    username    = "%s"
+    password    = "%s"
+    bucket_name = "travel-sample"
   }
 }
 `, path, name, host1, host2, username, password)

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -1099,6 +1099,7 @@ resource "vault_database_secret_backend_connection" "test" {
     password    = "%s"
     tls         = true
     base64_pem  = "%s"
+    bucket_name = "travel-sample"
   }
 }
 `, path, name, host1, username, password, base64PEM)


### PR DESCRIPTION
This PR fixes an issue where the `couchbase` database connection config provided an invalid parameter to Vault. In vault the param is `base64pem` not `base64_pem`. 

Other fixes/discovered  work:
- `username_template` was being cast to a `bool` but should have been a `string` : fixed
- missing Couchbase TLS tests : fixed
- no support for testing Couchbase in CI : fixed




<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #1275 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc-ent TESTARGS='-v -test.run TestAccDatabaseSecretBackendConnection_couchbase -test.count=1'
make testacc TF_ACC_ENTERPRISE=1
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -v -test.run TestAccDatabaseSecretBackendConnection_couchbase -test.count=1 -timeout 30m ./...

=== RUN   TestAccDatabaseSecretBackendConnection_couchbase
--- PASS: TestAccDatabaseSecretBackendConnection_couchbase (3.01s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     3.625s

```
