### PR TITLE
fix: do not validate json on oidc scope template

### DIFF
--- a/vault/resource_identity_oidc_scope.go
+++ b/vault/resource_identity_oidc_scope.go
@@ -26,10 +26,9 @@ func identityOIDCScopeResource() *schema.Resource {
 				Required:    true,
 			},
 			"template": {
-				Type:         schema.TypeString,
-				Description:  "The template string for the scope. This may be provided as escaped JSON or base64 encoded JSON.",
-				Optional:     true,
-				ValidateFunc: ValidateDataJSONFunc("vault_identity_oidc_scope"),
+				Type:        schema.TypeString,
+				Description: "The template string for the scope. This may be provided as escaped JSON or base64 encoded JSON.",
+				Optional:    true,
 			},
 			"description": {
 				Type:        schema.TypeString,

--- a/website/docs/r/identity_oidc_scope.html.md
+++ b/website/docs/r/identity_oidc_scope.html.md
@@ -16,11 +16,7 @@ for more information.
 ```hcl
 resource "vault_identity_oidc_scope" "groups" {
   name        = "groups"
-  template    = jsonencode(
-  {
-    groups = "{{identity.entity.groups.names}}",
-  }
-  )
+  template    = "{\"groups\":{{identity.entity.groups.names}}}"
   description = "Vault OIDC Groups Scope"
 }
 ```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

This fixes an issue where the json encoded template was passing in a value for the template that would have vault render a string of the list, rather than a json list.  In the example, https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/identity_oidc_scope:

```
resource "vault_identity_oidc_scope" "groups" {
  name        = "groups"
  template    = jsonencode(
  {
    groups = "{{identity.entity.groups.names}}",
  }
  )
  description = "Vault OIDC Groups Scope"
}
```

`groups = "{{identity.entity.groups.names}}",` would render a string rather than a list of group names.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
remove json validation for `vault_identity_oidc_scope` `template`
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -run=TestAccXXX -timeout 30m ./...
?   	github.com/hashicorp/terraform-provider-vault	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/generate	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/codegen	0.756s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/generated	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode	1.082s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode	0.799s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet	0.788s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role	1.494s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template	1.257s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation	0.887s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/helper	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/consts	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/internal/identity/entity	0.826s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/group	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/pki	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/internal/provider	0.553s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/schema	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/testutil	0.849s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/util	1.333s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/vault	0.509s [no tests to run]
```
