### PR TITLE
Fix Import for OIDC Scope resource

### DIFF
--- a/vault/resource_identity_oidc_scope.go
+++ b/vault/resource_identity_oidc_scope.go
@@ -17,6 +17,9 @@ func identityOIDCScopeResource() *schema.Resource {
 		Update: identityOIDCScopeCreateUpdate,
 		Read:   identityOIDCScopeRead,
 		Delete: identityOIDCScopeDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -106,6 +109,9 @@ func identityOIDCScopeRead(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("error setting state key %q on OIDC Scope %q, err=%w", k, path, err)
 		}
 	}
+
+	// @TODO parse name from path and set it to TF state
+	// if err := d.Set("name", d.Get())
 
 	return nil
 }

--- a/vault/resource_identity_oidc_scope.go
+++ b/vault/resource_identity_oidc_scope.go
@@ -3,6 +3,7 @@ package vault
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -110,8 +111,10 @@ func identityOIDCScopeRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	// @TODO parse name from path and set it to TF state
-	// if err := d.Set("name", d.Get())
+	name := strings.Trim(strings.TrimPrefix(path, identityOIDCScopePathPrefix), "/")
+	if err := d.Set("name", name); err != nil {
+		return fmt.Errorf("error setting state key %q on OIDC Scope %q, err=%w", "name", path, err)
+	}
 
 	return nil
 }

--- a/vault/resource_identity_oidc_scope_test.go
+++ b/vault/resource_identity_oidc_scope_test.go
@@ -43,10 +43,9 @@ func TestAccIdentityOIDCScope(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"name"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/vault/resource_identity_oidc_scope_test.go
+++ b/vault/resource_identity_oidc_scope_test.go
@@ -42,6 +42,12 @@ func TestAccIdentityOIDCScope(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "template", updatedScope),
 				),
 			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name"},
+			},
 		},
 	})
 }


### PR DESCRIPTION
The OIDC Scope was previously missing an Import. This PR fixes that.

Fixes #1473 


```
$ make testacc TESTARGS='-v -run TestAccIdentityOIDCScope'
=== RUN   TestAccIdentityOIDCScope
--- PASS: TestAccIdentityOIDCScope (3.31s)
PASS
```