### PR TITLE
Fix: support updating backend descriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ website/node_modules
 *.iml
 *.test
 .vscode
+*.orig
 
 website/vendor
 

--- a/vault/import_mount_test.go
+++ b/vault/import_mount_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAccMount_importBasic(t *testing.T) {
 	path := "test-" + acctest.RandString(10)
-	cfg := mountConfig{
+	cfg := testMountConfig{
 		path:      path,
 		mountType: "kv",
 		version:   "1",

--- a/vault/resource_azure_secret_backend_role.go
+++ b/vault/resource_azure_secret_backend_role.go
@@ -42,7 +42,6 @@ func azureSecretBackendRoleResource() *schema.Resource {
 			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				ForceNew:    true,
 				Description: "Human-friendly description of the mount for the backend.",
 			},
 			"azure_roles": {

--- a/vault/resource_jwt_auth_backend.go
+++ b/vault/resource_jwt_auth_backend.go
@@ -48,7 +48,6 @@ func jwtAuthBackendResource() *schema.Resource {
 			"description": {
 				Type:        schema.TypeString,
 				Required:    false,
-				ForceNew:    true,
 				Optional:    true,
 				Description: "The description of the auth backend",
 			},

--- a/vault/resource_kubernetes_secret_backend_test.go
+++ b/vault/resource_kubernetes_secret_backend_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )

--- a/vault/resource_mount.go
+++ b/vault/resource_mount.go
@@ -32,7 +32,6 @@ func getMountSchema(excludes ...string) schemaMap {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Required:    false,
-			ForceNew:    false,
 			Description: "Human-friendly description of the mount",
 		},
 		"default_lease_ttl_seconds": {

--- a/vault/resource_okta_auth_backend.go
+++ b/vault/resource_okta_auth_backend.go
@@ -48,7 +48,6 @@ func oktaAuthBackendResource() *schema.Resource {
 			"description": {
 				Type:        schema.TypeString,
 				Required:    false,
-				ForceNew:    true,
 				Optional:    true,
 				Description: "The description of the auth backend",
 			},

--- a/vault/resource_rabbitmq_secret_backend.go
+++ b/vault/resource_rabbitmq_secret_backend.go
@@ -38,7 +38,6 @@ func rabbitMQSecretBackendResource() *schema.Resource {
 			"description": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				ForceNew:    true,
 				Description: "Human-friendly description of the mount for the backend.",
 			},
 			"default_lease_ttl_seconds": {


### PR DESCRIPTION
Updating the description auth-backend resource should not result in the
resource being recreated.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
