### PR TITLE
Add version conditional skip for breaking 1.11 k8s test

### DIFF
--- a/vault/resource_kubernetes_auth_backend_config_test.go
+++ b/vault/resource_kubernetes_auth_backend_config_test.go
@@ -347,7 +347,10 @@ func TestAccKubernetesAuthBackendConfig_fullUpdate(t *testing.T) {
 }
 
 func TestAccKubernetesAuthBackendConfig_localCA(t *testing.T) {
-	t.Skip("Skip until VAULT-6698 is resolved")
+	isAboveVersionCutoff := testutil.CheckTestVaultVersion(t, "1.11")
+	if isAboveVersionCutoff {
+		t.Skip("Skip until test is fixed for 1.11")
+	}
 
 	backend := acctest.RandomWithPrefix("kubernetes")
 	jwt := kubernetesJWT


### PR DESCRIPTION
Currently `TestAccKubernetesAuthBackendConfig_localCA` is failing for 1.11; this needs to be investigated at a later date and resolved when we have the ability to mount test CA within a vault service k8s container. At present, we are disabling the test for 1.11 version builds in CI until the fix is in.