### PR TITLE
Move lookupEntityAliasId() to the entity package

### DIFF
--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -32,6 +32,7 @@ const (
 	FieldLocal                    = "local"
 	FieldSealWrap                 = "seal_wrap"
 	FieldExternalEntropyAccess    = "external_entropy_access"
+	FieldMountAccessor            = "mount_accessor"
 
 	/*
 		common environment variables

--- a/internal/identity/entity/entity_test.go
+++ b/internal/identity/entity/entity_test.go
@@ -3,6 +3,7 @@ package entity
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"reflect"
 	"regexp"
@@ -15,7 +16,6 @@ import (
 
 type testFindAliasHandler struct {
 	requests      int
-	retryStatus   int
 	wantErrOnList bool
 	wantErrOnRead bool
 	entities      []*Entity
@@ -275,6 +275,217 @@ func TestFindAliases(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("FindAliases() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+type testLookupEntityAliasHandler struct {
+	requests      int
+	wantErrOnRead bool
+	entities      []*Entity
+}
+
+func (t *testLookupEntityAliasHandler) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		t.requests++
+
+		if req.Method != http.MethodPut {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		wantPath := "/v1/" + LookupPath
+		if wantPath != req.URL.Path {
+			w.WriteHeader(http.StatusNotImplemented)
+			return
+
+		}
+
+		if t.wantErrOnRead {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		b, err := ioutil.ReadAll(req.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		type reqParams struct {
+			Name               string `json:"name,omitempty"`
+			ID                 string `json:"id,omitempty"`
+			AliasID            string `json:"alias_id,omitempty"`
+			AliasName          string `json:"alias_name,omitempty"`
+			AliasMountAccessor string `json:"alias_mount_accessor,omitempty"`
+		}
+
+		var reqData reqParams
+		if err := json.Unmarshal(b, &reqData); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		var data map[string]interface{}
+		for _, e := range t.entities {
+			for _, a := range e.Aliases {
+				if a.Name == reqData.AliasName && a.MountAccessor == reqData.AliasMountAccessor {
+					b, err := json.Marshal(e)
+					if err != nil {
+						w.WriteHeader(http.StatusInternalServerError)
+						return
+					}
+					if err := json.Unmarshal(b, &data); err != nil {
+						w.WriteHeader(http.StatusInternalServerError)
+						return
+					}
+					break
+				}
+			}
+		}
+
+		m, err := json.Marshal(
+			&api.Secret{
+				Data: data,
+			},
+		)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write(m)
+	}
+}
+
+func TestLookupEntityAlias(t *testing.T) {
+	t.Parallel()
+
+	aliasBob := &Alias{
+		Name:          "bob",
+		MountAccessor: "CC417368-0C63-407A-93AD-2D76A72F58E2",
+	}
+
+	aliasAlice := &Alias{
+		Name:          "alice",
+		MountAccessor: "CC417368-0C63-407A-93AD-2D76A72F58E3",
+	}
+
+	defaultEntities := []*Entity{
+		{
+			ID: "C6D3410E-86AF-4A10-9282-4B1E9773932A",
+			Aliases: []*Alias{
+				aliasBob,
+			},
+		},
+		{
+			ID: "C6D3410E-86AF-4A10-9282-4B1E9773932B",
+			Aliases: []*Alias{
+				aliasAlice,
+			},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		params      *FindAliasParams
+		want        *Alias
+		findHandler *testLookupEntityAliasHandler
+		wantErr     bool
+	}{
+		{
+			name: "alice",
+			params: &FindAliasParams{
+				Name:          aliasAlice.Name,
+				MountAccessor: aliasAlice.MountAccessor,
+			},
+			findHandler: &testLookupEntityAliasHandler{
+				entities: defaultEntities,
+			},
+			want:    aliasAlice,
+			wantErr: false,
+		},
+		{
+			name: "bob",
+			params: &FindAliasParams{
+				Name:          aliasBob.Name,
+				MountAccessor: aliasBob.MountAccessor,
+			},
+			findHandler: &testLookupEntityAliasHandler{
+				entities: defaultEntities,
+			},
+			want:    aliasBob,
+			wantErr: false,
+		},
+		{
+			name: "none",
+			params: &FindAliasParams{
+				Name:          "other",
+				MountAccessor: "other_accesor",
+			},
+			findHandler: &testLookupEntityAliasHandler{
+				entities: defaultEntities,
+			},
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name: "error-empty-name",
+			params: &FindAliasParams{
+				MountAccessor: aliasBob.MountAccessor,
+			},
+			findHandler: &testLookupEntityAliasHandler{
+				entities: defaultEntities,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "error-empty-mount-accessor",
+			params: &FindAliasParams{
+				Name: aliasBob.Name,
+			},
+			findHandler: &testLookupEntityAliasHandler{
+				entities: defaultEntities,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "error-on-read",
+			params: &FindAliasParams{
+				Name: aliasBob.Name,
+			},
+			findHandler: &testLookupEntityAliasHandler{
+				entities:      defaultEntities,
+				wantErrOnRead: true,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := tt.findHandler
+
+			config, ln := testutil.TestHTTPServer(t, r.handler())
+			defer ln.Close()
+
+			config.Address = fmt.Sprintf("http://%s", ln.Addr())
+			c, err := api.NewClient(config)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := LookupEntityAlias(c, tt.params)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LookupEntityAlias() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("LookupEntityAlias() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/vault/data_identity_entity.go
+++ b/vault/data_identity_entity.go
@@ -6,10 +6,11 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/vault/api"
+
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/identity/entity"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
-	"github.com/hashicorp/vault/api"
 )
 
 var (
@@ -33,7 +34,7 @@ var (
 		"last_update_time",
 		"merged_from_canonical_ids",
 		"metadata",
-		"mount_accessor",
+		consts.FieldMountAccessor,
 		"mount_path",
 		"mount_type",
 		"name",
@@ -67,7 +68,7 @@ var (
 			Type:     schema.TypeMap,
 			Computed: true,
 		},
-		"mount_accessor": {
+		consts.FieldMountAccessor: {
 			Type:     schema.TypeString,
 			Computed: true,
 		},

--- a/vault/data_identity_group.go
+++ b/vault/data_identity_group.go
@@ -34,7 +34,7 @@ var (
 		"last_update_time",
 		"merged_from_canonical_ids",
 		"metadata",
-		"mount_accessor",
+		consts.FieldMountAccessor,
 		"mount_path",
 		"mount_type",
 		"name",

--- a/vault/resource_identity_entity_alias_test.go
+++ b/vault/resource_identity_entity_alias_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/identity/entity"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
@@ -31,7 +32,7 @@ func TestAccIdentityEntityAlias(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(nameEntityAlias, "name", nameEntity, "name"),
 					resource.TestCheckResourceAttrPair(nameEntityAlias, "canonical_id", nameEntity, "id"),
-					resource.TestCheckResourceAttrPair(nameEntityAlias, "mount_accessor", nameGithubA, "accessor"),
+					resource.TestCheckResourceAttrPair(nameEntityAlias, consts.FieldMountAccessor, nameGithubA, "accessor"),
 				),
 			},
 			{
@@ -136,8 +137,8 @@ resource "vault_identity_entity_alias" "test2" {
 				Config: fmt.Sprintf(configTmpl, alias+"-1", alias+"-2"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(
-						aliasResource1, "mount_accessor",
-						aliasResource2, "mount_accessor"),
+						aliasResource1, consts.FieldMountAccessor,
+						aliasResource2, consts.FieldMountAccessor),
 					resource.TestCheckResourceAttr(
 						aliasResource1, "name", alias+"-1"),
 					resource.TestCheckResourceAttr(
@@ -165,8 +166,8 @@ resource "vault_identity_entity_alias" "test2" {
 				Config: fmt.Sprintf(configTmpl, alias, alias+"-2"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(
-						aliasResource1, "mount_accessor",
-						aliasResource2, "mount_accessor"),
+						aliasResource1, consts.FieldMountAccessor,
+						aliasResource2, consts.FieldMountAccessor),
 					resource.TestCheckResourceAttr(
 						aliasResource1, "name", alias),
 					resource.TestCheckResourceAttr(
@@ -207,8 +208,8 @@ resource "vault_identity_entity_alias" "test2" {
 				Config: fmt.Sprintf(configTmpl, alias, alias+"-2"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(
-						aliasResource1, "mount_accessor",
-						aliasResource2, "mount_accessor"),
+						aliasResource1, consts.FieldMountAccessor,
+						aliasResource2, consts.FieldMountAccessor),
 					resource.TestCheckResourceAttr(
 						aliasResource1, "name", alias),
 					resource.TestCheckResourceAttr(
@@ -244,7 +245,7 @@ func TestAccIdentityEntityAlias_Update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(nameEntityAlias, "name", nameEntityA, "name"),
 					resource.TestCheckResourceAttrPair(nameEntityAlias, "canonical_id", nameEntityA, "id"),
-					resource.TestCheckResourceAttrPair(nameEntityAlias, "mount_accessor", nameGithubA, "accessor"),
+					resource.TestCheckResourceAttrPair(nameEntityAlias, consts.FieldMountAccessor, nameGithubA, "accessor"),
 				),
 			},
 			{
@@ -252,7 +253,7 @@ func TestAccIdentityEntityAlias_Update(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(nameEntityAlias, "name", nameEntityB, "name"),
 					resource.TestCheckResourceAttrPair(nameEntityAlias, "canonical_id", nameEntityB, "id"),
-					resource.TestCheckResourceAttrPair(nameEntityAlias, "mount_accessor", nameGithubB, "accessor"),
+					resource.TestCheckResourceAttrPair(nameEntityAlias, consts.FieldMountAccessor, nameGithubB, "accessor"),
 				),
 			},
 		},
@@ -302,7 +303,7 @@ func TestAccIdentityEntityAlias_Metadata(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(nameEntityAlias, "name", nameEntityA, "name"),
 					resource.TestCheckResourceAttrPair(nameEntityAlias, "canonical_id", nameEntityA, "id"),
-					resource.TestCheckResourceAttrPair(nameEntityAlias, "mount_accessor", nameGithubA, "accessor"),
+					resource.TestCheckResourceAttrPair(nameEntityAlias, consts.FieldMountAccessor, nameGithubA, "accessor"),
 					resource.TestCheckResourceAttr(nameEntityAlias, "custom_metadata.%", "1"),
 					resource.TestCheckResourceAttrPair(nameEntityAlias, "custom_metadata.version", nameEntityA, "metadata.version"),
 				),
@@ -312,7 +313,7 @@ func TestAccIdentityEntityAlias_Metadata(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair(nameEntityAlias, "name", nameEntityB, "name"),
 					resource.TestCheckResourceAttrPair(nameEntityAlias, "canonical_id", nameEntityB, "id"),
-					resource.TestCheckResourceAttrPair(nameEntityAlias, "mount_accessor", nameGithubB, "accessor"),
+					resource.TestCheckResourceAttrPair(nameEntityAlias, consts.FieldMountAccessor, nameGithubB, "accessor"),
 					resource.TestCheckResourceAttr(nameEntityAlias, "custom_metadata.%", "1"),
 					resource.TestCheckResourceAttrPair(nameEntityAlias, "custom_metadata.version", nameEntityB, "metadata.version"),
 				),

--- a/vault/resource_identity_group_alias.go
+++ b/vault/resource_identity_group_alias.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
@@ -29,7 +30,7 @@ func identityGroupAliasResource() *schema.Resource {
 				Description: "Name of the group alias.",
 			},
 
-			"mount_accessor": {
+			consts.FieldMountAccessor: {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Mount accessor to which this alias belongs to.",
@@ -51,15 +52,15 @@ func identityGroupAliasCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	name := d.Get("name").(string)
-	mountAccessor := d.Get("mount_accessor").(string)
+	mountAccessor := d.Get(consts.FieldMountAccessor).(string)
 	canonicalID := d.Get("canonical_id").(string)
 
 	path := identityGroupAliasPath
 
 	data := map[string]interface{}{
-		"name":           name,
-		"mount_accessor": mountAccessor,
-		"canonical_id":   canonicalID,
+		"name":                    name,
+		consts.FieldMountAccessor: mountAccessor,
+		"canonical_id":            canonicalID,
 	}
 
 	resp, err := client.Logical().Write(path, data)
@@ -89,16 +90,16 @@ func identityGroupAliasUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	data := map[string]interface{}{
-		"name":           resp.Data["name"],
-		"mount_accessor": resp.Data["mount_accessor"],
-		"canonical_id":   resp.Data["canonical_id"],
+		"name":                    resp.Data["name"],
+		consts.FieldMountAccessor: resp.Data[consts.FieldMountAccessor],
+		"canonical_id":            resp.Data["canonical_id"],
 	}
 
 	if name, ok := d.GetOk("name"); ok {
 		data["name"] = name
 	}
-	if mountAccessor, ok := d.GetOk("mount_accessor"); ok {
-		data["mount_accessor"] = mountAccessor
+	if mountAccessor, ok := d.GetOk(consts.FieldMountAccessor); ok {
+		data[consts.FieldMountAccessor] = mountAccessor
 	}
 	if canonicalID, ok := d.GetOk("canonical_id"); ok {
 		data["canonical_id"] = canonicalID
@@ -137,7 +138,7 @@ func identityGroupAliasRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId(resp.Data["id"].(string))
-	for _, k := range []string{"name", "mount_accessor", "canonical_id"} {
+	for _, k := range []string{"name", consts.FieldMountAccessor, "canonical_id"} {
 		if err := d.Set(k, resp.Data[k]); err != nil {
 			return fmt.Errorf("error setting state key \"%s\" on IdentityGroupAlias %q: %s", k, id, err)
 		}

--- a/vault/resource_identity_group_alias_test.go
+++ b/vault/resource_identity_group_alias_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
@@ -29,7 +30,7 @@ func TestAccIdentityGroupAlias(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(nameGroupAlias, "name", group),
 					resource.TestCheckResourceAttrPair(nameGroupAlias, "canonical_id", nameGroup, "id"),
-					resource.TestCheckResourceAttrPair(nameGroupAlias, "mount_accessor", nameGithubA, "accessor"),
+					resource.TestCheckResourceAttrPair(nameGroupAlias, consts.FieldMountAccessor, nameGithubA, "accessor"),
 				),
 			},
 		},
@@ -57,7 +58,7 @@ func TestAccIdentityGroupAliasUpdate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(nameGroupAlias, "name", aliasA),
 					resource.TestCheckResourceAttrPair(nameGroupAlias, "canonical_id", nameGroupA, "id"),
-					resource.TestCheckResourceAttrPair(nameGroupAlias, "mount_accessor", nameGithubA, "accessor"),
+					resource.TestCheckResourceAttrPair(nameGroupAlias, consts.FieldMountAccessor, nameGithubA, "accessor"),
 				),
 			},
 			{
@@ -65,7 +66,7 @@ func TestAccIdentityGroupAliasUpdate(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(nameGroupAlias, "name", aliasB),
 					resource.TestCheckResourceAttrPair(nameGroupAlias, "canonical_id", nameGroupB, "id"),
-					resource.TestCheckResourceAttrPair(nameGroupAlias, "mount_accessor", nameGithubB, "accessor"),
+					resource.TestCheckResourceAttrPair(nameGroupAlias, consts.FieldMountAccessor, nameGithubB, "accessor"),
 				),
 			},
 		},

--- a/vault/resource_mfa_duo.go
+++ b/vault/resource_mfa_duo.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
@@ -27,7 +28,7 @@ func mfaDuoResource() *schema.Resource {
 				Description:  "Name of the MFA method.",
 				ValidateFunc: validateNoTrailingSlash,
 			},
-			"mount_accessor": {
+			consts.FieldMountAccessor: {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "The mount to tie this method to for use in automatic mappings. The mapping will use the Name field of Aliases associated with this mount as the username in the mapping.",
@@ -119,7 +120,7 @@ func mfaDuoRead(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Read MFA Duo config %q", mfaDuoPath(name))
 
-	d.Set("mount_accessor", resp.Data["mount_accessor"])
+	d.Set(consts.FieldMountAccessor, resp.Data[consts.FieldMountAccessor])
 	d.Set("username_format", resp.Data["username_format"])
 	d.Set("api_hostname", resp.Data["api_hostname"])
 
@@ -136,8 +137,8 @@ func mfaDuoRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func mfaDuoUpdateFields(d *schema.ResourceData, data map[string]interface{}) {
-	if v, ok := d.GetOk("mount_accessor"); ok {
-		data["mount_accessor"] = v.(string)
+	if v, ok := d.GetOk(consts.FieldMountAccessor); ok {
+		data[consts.FieldMountAccessor] = v.(string)
 	}
 
 	if v, ok := d.GetOk("username_format"); ok {

--- a/vault/resource_mfa_okta.go
+++ b/vault/resource_mfa_okta.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
@@ -28,7 +29,7 @@ func mfaOktaResource() *schema.Resource {
 				Description:  "Name of the MFA method.",
 				ValidateFunc: validateNoTrailingSlash,
 			},
-			"mount_accessor": {
+			consts.FieldMountAccessor: {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
@@ -90,7 +91,7 @@ func mfaOktaRequestData(d *schema.ResourceData) map[string]interface{} {
 	}
 
 	fields := []string{
-		"name", "api_token", "mount_accessor",
+		"name", "api_token", consts.FieldMountAccessor,
 		"username_format", "org_name", "base_url",
 	}
 
@@ -136,7 +137,7 @@ func mfaOktaRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	fields := []string{
-		"name", "mount_accessor", "username_format",
+		"name", consts.FieldMountAccessor, "username_format",
 		"org_name", "base_url", "primary_email",
 		"id",
 	}

--- a/vault/resource_mfa_pingid.go
+++ b/vault/resource_mfa_pingid.go
@@ -29,7 +29,7 @@ func mfaPingIDResource() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validateNoTrailingSlash,
 			},
-			"mount_accessor": {
+			consts.FieldMountAccessor: {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
@@ -101,7 +101,7 @@ func mfaPingIDRequestData(d *schema.ResourceData) map[string]interface{} {
 	data := map[string]interface{}{}
 
 	fields := []string{
-		"name", "mount_accessor", "settings_file_base64",
+		"name", consts.FieldMountAccessor, "settings_file_base64",
 		"username_format",
 	}
 
@@ -146,7 +146,7 @@ func mfaPingIDRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("error reading from Vault at %s, err=%w", path, err)
 	}
 
-	if err := d.Set("mount_accessor", d.Get("mount_accessor")); err != nil {
+	if err := d.Set(consts.FieldMountAccessor, d.Get(consts.FieldMountAccessor)); err != nil {
 		return err
 	}
 

--- a/vault/resource_mfa_pingid_test.go
+++ b/vault/resource_mfa_pingid_test.go
@@ -37,7 +37,7 @@ func TestMFAPingIDBasic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"mount_accessor", "username_format", "settings_file_base64"},
+				ImportStateVerifyIgnore: []string{consts.FieldMountAccessor, "username_format", "settings_file_base64"},
 			},
 		},
 	})


### PR DESCRIPTION
Updates the `lookupEntityAliasId()` to be more like `entity.FindAliases()`,
and adds unit tests.

Renamed to `LookupEntityAlias()`

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #1517 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc-ent TESTARGS='-v -test.run TestAccIdenti -test.count=1'
make testacc TF_ACC_ENTERPRISE=1
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -v -test.run TestAccIdenti -test.count=1 -timeout 30m ./...

=== RUN   TestAccIdentityEntityAlias
--- PASS: TestAccIdentityEntityAlias (2.27s)
=== RUN   TestAccIdentityEntityAliasDuplicateFlow
--- PASS: TestAccIdentityEntityAliasDuplicateFlow (5.15s)
=== RUN   TestAccIdentityEntityAlias_Update
--- PASS: TestAccIdentityEntityAlias_Update (2.11s)
=== RUN   TestAccIdentityEntityAlias_Metadata
--- PASS: TestAccIdentityEntityAlias_Metadata (2.15s)
=== RUN   TestAccIdentityEntityPoliciesExclusive
--- PASS: TestAccIdentityEntityPoliciesExclusive (1.97s)
=== RUN   TestAccIdentityEntityPoliciesNonExclusive
--- PASS: TestAccIdentityEntityPoliciesNonExclusive (2.04s)
=== RUN   TestAccIdentityEntity
--- PASS: TestAccIdentityEntity (1.06s)
=== RUN   TestAccIdentityEntityUpdate
--- PASS: TestAccIdentityEntityUpdate (1.93s)
=== RUN   TestAccIdentityEntityUpdateRemoveValues
--- PASS: TestAccIdentityEntityUpdateRemoveValues (1.88s)
=== RUN   TestAccIdentityEntityUpdateRemovePolicies
--- PASS: TestAccIdentityEntityUpdateRemovePolicies (1.89s)
=== RUN   TestAccIdentityGroupAlias
--- PASS: TestAccIdentityGroupAlias (1.25s)
=== RUN   TestAccIdentityGroupAliasUpdate
--- PASS: TestAccIdentityGroupAliasUpdate (2.16s)
=== RUN   TestAccIdentityGroupMemberEntityIdsExclusiveEmpty
--- PASS: TestAccIdentityGroupMemberEntityIdsExclusiveEmpty (2.92s)
=== RUN   TestAccIdentityGroupMemberEntityIdsExclusive
--- PASS: TestAccIdentityGroupMemberEntityIdsExclusive (2.09s)
=== RUN   TestAccIdentityGroupMemberEntityIdsNonExclusiveEmpty
--- PASS: TestAccIdentityGroupMemberEntityIdsNonExclusiveEmpty (3.04s)
=== RUN   TestAccIdentityGroupMemberEntityIdsNonExclusive
--- PASS: TestAccIdentityGroupMemberEntityIdsNonExclusive (3.00s)
=== RUN   TestAccIdentityGroupMemberEntityIdsDynamic
--- PASS: TestAccIdentityGroupMemberEntityIdsDynamic (5.65s)
=== RUN   TestAccIdentityGroupPoliciesExclusive
--- PASS: TestAccIdentityGroupPoliciesExclusive (1.98s)
=== RUN   TestAccIdentityGroupPoliciesNonExclusive
--- PASS: TestAccIdentityGroupPoliciesNonExclusive (2.00s)
=== RUN   TestAccIdentityGroup
--- PASS: TestAccIdentityGroup (1.05s)
=== RUN   TestAccIdentityGroupUpdate
--- PASS: TestAccIdentityGroupUpdate (4.60s)
=== RUN   TestAccIdentityGroupExternal
--- PASS: TestAccIdentityGroupExternal (1.07s)
=== RUN   TestAccIdentityGroup_DuplicateCreate
--- PASS: TestAccIdentityGroup_DuplicateCreate (0.66s)
=== RUN   TestAccIdentityOIDCAssignment
--- PASS: TestAccIdentityOIDCAssignment (2.71s)
=== RUN   TestAccIdentityOIDCClient
--- PASS: TestAccIdentityOIDCClient (2.23s)
=== RUN   TestAccIdentityOidcKeyAllowedClientId
--- PASS: TestAccIdentityOidcKeyAllowedClientId (3.64s)
=== RUN   TestAccIdentityOidcKey
--- PASS: TestAccIdentityOidcKey (1.98s)
=== RUN   TestAccIdentityOidcKeyUpdate
--- PASS: TestAccIdentityOidcKeyUpdate (3.77s)
=== RUN   TestAccIdentityOIDCProvider
--- PASS: TestAccIdentityOIDCProvider (1.38s)
=== RUN   TestAccIdentityOidcRole
--- PASS: TestAccIdentityOidcRole (1.98s)
=== RUN   TestAccIdentityOidcRoleWithClientId
--- PASS: TestAccIdentityOidcRoleWithClientId (1.77s)
=== RUN   TestAccIdentityOidcRoleUpdate
--- PASS: TestAccIdentityOidcRoleUpdate (3.28s)
=== RUN   TestAccIdentityOIDCScope
--- PASS: TestAccIdentityOIDCScope (1.91s)
=== RUN   TestAccIdentityOidc
--- PASS: TestAccIdentityOidc (1.89s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     82.724s

$ go test -v ./internal/identity/entity            
=== RUN   TestFindAliases
=== PAUSE TestFindAliases
=== RUN   TestLookupEntityAlias
=== PAUSE TestLookupEntityAlias
=== CONT  TestFindAliases
=== RUN   TestFindAliases/empty
=== CONT  TestLookupEntityAlias
=== RUN   TestLookupEntityAlias/alice
=== RUN   TestFindAliases/all
=== RUN   TestLookupEntityAlias/bob
=== RUN   TestLookupEntityAlias/none
=== RUN   TestFindAliases/name-only
=== RUN   TestLookupEntityAlias/error-empty-name
=== RUN   TestLookupEntityAlias/error-empty-mount-accessor
=== RUN   TestLookupEntityAlias/error-on-read
--- PASS: TestLookupEntityAlias (0.01s)
    --- PASS: TestLookupEntityAlias/alice (0.00s)
    --- PASS: TestLookupEntityAlias/bob (0.00s)
    --- PASS: TestLookupEntityAlias/none (0.00s)
    --- PASS: TestLookupEntityAlias/error-empty-name (0.00s)
    --- PASS: TestLookupEntityAlias/error-empty-mount-accessor (0.00s)
    --- PASS: TestLookupEntityAlias/error-on-read (0.00s)
=== RUN   TestFindAliases/name-and-mount-accessor
=== RUN   TestFindAliases/mount-accessor-mismatch
=== RUN   TestFindAliases/error-on-list
=== RUN   TestFindAliases/error-on-read
--- PASS: TestFindAliases (7.98s)
    --- PASS: TestFindAliases/empty (0.00s)
    --- PASS: TestFindAliases/all (0.00s)
    --- PASS: TestFindAliases/name-only (0.00s)
    --- PASS: TestFindAliases/name-and-mount-accessor (0.00s)
    --- PASS: TestFindAliases/mount-accessor-mismatch (0.00s)
    --- PASS: TestFindAliases/error-on-list (4.06s)
    --- PASS: TestFindAliases/error-on-read (3.91s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  8.219s



```
