### PR TITLE
Persist namespace to state on  import

### DIFF
--- a/generated/datasources/transform/decode/role_name.go
+++ b/generated/datasources/transform/decode/role_name.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
+	"github.com/hashicorp/terraform-provider-vault/vault"
 )
 
 const roleNameEndpoint = "/transform/decode/{role_name}"

--- a/generated/datasources/transform/decode/role_name.go
+++ b/generated/datasources/transform/decode/role_name.go
@@ -18,7 +18,7 @@ const roleNameEndpoint = "/transform/decode/{role_name}"
 
 func RoleNameDataSource() *schema.Resource {
 	return &schema.Resource{
-		Read: readRoleNameResource,
+		Read: vault.ReadWrapper(readRoleNameResource),
 		Schema: map[string]*schema.Schema{
 			"path": {
 				Type:        schema.TypeString,

--- a/generated/datasources/transform/encode/role_name.go
+++ b/generated/datasources/transform/encode/role_name.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
+	"github.com/hashicorp/terraform-provider-vault/vault"
 )
 
 const roleNameEndpoint = "/transform/encode/{role_name}"

--- a/generated/datasources/transform/encode/role_name.go
+++ b/generated/datasources/transform/encode/role_name.go
@@ -18,7 +18,7 @@ const roleNameEndpoint = "/transform/encode/{role_name}"
 
 func RoleNameDataSource() *schema.Resource {
 	return &schema.Resource{
-		Read: readRoleNameResource,
+		Read: vault.ReadWrapper(readRoleNameResource),
 		Schema: map[string]*schema.Schema{
 			"path": {
 				Type:        schema.TypeString,

--- a/generated/resources/transform/alphabet/name.go
+++ b/generated/resources/transform/alphabet/name.go
@@ -42,7 +42,7 @@ func NameResource() *schema.Resource {
 	return &schema.Resource{
 		Create: createNameResource,
 		Update: updateNameResource,
-		Read:   readNameResource,
+		Read:   vault.ReadWrapper(readNameResource),
 		Exists: resourceNameExists,
 		Delete: deleteNameResource,
 		Importer: &schema.ResourceImporter{

--- a/generated/resources/transform/alphabet/name.go
+++ b/generated/resources/transform/alphabet/name.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
+	"github.com/hashicorp/terraform-provider-vault/vault"
 )
 
 const nameEndpoint = "/transform/alphabet/{name}"

--- a/generated/resources/transform/role/name.go
+++ b/generated/resources/transform/role/name.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
+	"github.com/hashicorp/terraform-provider-vault/vault"
 )
 
 const nameEndpoint = "/transform/role/{name}"
@@ -43,7 +44,7 @@ func NameResource() *schema.Resource {
 	return &schema.Resource{
 		Create: createNameResource,
 		Update: updateNameResource,
-		Read:   readNameResource,
+		Read:   vault.ReadWrapper(readNameResource),
 		Exists: resourceNameExists,
 		Delete: deleteNameResource,
 		Importer: &schema.ResourceImporter{

--- a/generated/resources/transform/template/name.go
+++ b/generated/resources/transform/template/name.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
+	"github.com/hashicorp/terraform-provider-vault/vault"
 )
 
 const (
@@ -85,7 +86,7 @@ Only applicable to FPE transformations.`,
 	return &schema.Resource{
 		Create: createNameResource,
 		Update: updateNameResource,
-		Read:   readNameResource,
+		Read:   vault.ReadWrapper(readNameResource),
 		Exists: resourceNameExists,
 		Delete: deleteNameResource,
 		Importer: &schema.ResourceImporter{

--- a/generated/resources/transform/transformation/name.go
+++ b/generated/resources/transform/transformation/name.go
@@ -70,7 +70,7 @@ func NameResource() *schema.Resource {
 	return &schema.Resource{
 		Create: createNameResource,
 		Update: updateNameResource,
-		Read:   readNameResource,
+		Read:   vault.ReadWrapper(readNameResource),
 		Exists: resourceNameExists,
 		Delete: deleteNameResource,
 		Importer: &schema.ResourceImporter{

--- a/generated/resources/transform/transformation/name.go
+++ b/generated/resources/transform/transformation/name.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
+	"github.com/hashicorp/terraform-provider-vault/vault"
 )
 
 const nameEndpoint = "/transform/transformation/{name}"

--- a/internal/identity/entity/entity_test.go
+++ b/internal/identity/entity/entity_test.go
@@ -249,7 +249,7 @@ func TestFindAliases(t *testing.T) {
 						},
 					},
 				},
-				wantErrOnRead: readWrapper(true),
+				wantErrOnRead: true,
 			},
 			want:    nil,
 			wantErr: true,
@@ -460,7 +460,7 @@ func TestLookupEntityAlias(t *testing.T) {
 			},
 			findHandler: &testLookupEntityAliasHandler{
 				entities:      defaultEntities,
-				wantErrOnRead: readWrapper(true),
+				wantErrOnRead: true,
 			},
 			want:    nil,
 			wantErr: true,

--- a/internal/identity/entity/entity_test.go
+++ b/internal/identity/entity/entity_test.go
@@ -249,7 +249,7 @@ func TestFindAliases(t *testing.T) {
 						},
 					},
 				},
-				wantErrOnRead: true,
+				wantErrOnRead: readWrapper(true),
 			},
 			want:    nil,
 			wantErr: true,
@@ -460,7 +460,7 @@ func TestLookupEntityAlias(t *testing.T) {
 			},
 			findHandler: &testLookupEntityAliasHandler{
 				entities:      defaultEntities,
-				wantErrOnRead: true,
+				wantErrOnRead: readWrapper(true),
 			},
 			want:    nil,
 			wantErr: true,

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -21,6 +21,8 @@ import (
 	"github.com/mitchellh/go-homedir"
 
 	goversion "github.com/hashicorp/go-version"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 )
 
 const (
@@ -659,5 +661,18 @@ func GetImportTestStep(resourceName string, skipVerify bool, ignoreFields ...str
 		ImportState:             true,
 		ImportStateVerify:       !skipVerify,
 		ImportStateVerifyIgnore: ignoreFields,
+	}
+}
+
+// GetNamespaceImportStateCheck checks that the namespace was properly imported into the state.
+func GetNamespaceImportStateCheck(ns string) resource.ImportStateCheckFunc {
+	return func(states []*terraform.InstanceState) error {
+		for _, s := range states {
+			if actual := s.Attributes[consts.FieldNamespace]; actual != ns {
+				return fmt.Errorf("expected %q for %s, actual %q",
+					ns, consts.FieldNamespace, actual)
+			}
+		}
+		return nil
 	}
 }

--- a/vault/data_identity_entity.go
+++ b/vault/data_identity_entity.go
@@ -89,7 +89,7 @@ var (
 
 func identityEntityDataSource() *schema.Resource {
 	return &schema.Resource{
-		Read: identityEntityDataSourceRead,
+		Read: ReadWrapper(identityEntityDataSourceRead),
 
 		Schema: map[string]*schema.Schema{
 			"entity_name": {

--- a/vault/data_identity_group.go
+++ b/vault/data_identity_group.go
@@ -43,7 +43,7 @@ var (
 
 func identityGroupDataSource() *schema.Resource {
 	return &schema.Resource{
-		Read: identityGroupDataSourceRead,
+		Read: ReadWrapper(identityGroupDataSourceRead),
 
 		Schema: map[string]*schema.Schema{
 			"group_name": {

--- a/vault/data_identity_oidc_client_creds.go
+++ b/vault/data_identity_oidc_client_creds.go
@@ -11,7 +11,7 @@ import (
 
 func identityOIDCClientCredsDataSource() *schema.Resource {
 	return &schema.Resource{
-		Read: readOIDCClientCredsResource,
+		Read: ReadWrapper(readOIDCClientCredsResource),
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:        schema.TypeString,

--- a/vault/data_identity_oidc_openid_config.go
+++ b/vault/data_identity_oidc_openid_config.go
@@ -15,7 +15,7 @@ const identityOIDCOpenIDConfigPathSuffix = "/.well-known/openid-configuration"
 
 func identityOIDCOpenIDConfigDataSource() *schema.Resource {
 	return &schema.Resource{
-		Read: readOIDCOpenIDConfigResource,
+		Read: ReadWrapper(readOIDCOpenIDConfigResource),
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:        schema.TypeString,

--- a/vault/data_identity_oidc_public_keys.go
+++ b/vault/data_identity_oidc_public_keys.go
@@ -15,7 +15,7 @@ const identityOIDCPublicKeysPathSuffix = "/.well-known/keys"
 
 func identityOIDCPublicKeysDataSource() *schema.Resource {
 	return &schema.Resource{
-		Read: readOIDCPublicKeysResource,
+		Read: ReadWrapper(readOIDCPublicKeysResource),
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:        schema.TypeString,

--- a/vault/data_source_ad_credentials.go
+++ b/vault/data_source_ad_credentials.go
@@ -11,7 +11,7 @@ import (
 
 func adAccessCredentialsDataSource() *schema.Resource {
 	return &schema.Resource{
-		Read: readCredsResource,
+		Read: ReadWrapper(readCredsResource),
 		Schema: map[string]*schema.Schema{
 			"backend": {
 				Type:        schema.TypeString,

--- a/vault/data_source_approle_auth_backend_role_id.go
+++ b/vault/data_source_approle_auth_backend_role_id.go
@@ -12,7 +12,7 @@ import (
 
 func approleAuthBackendRoleIDDataSource() *schema.Resource {
 	return &schema.Resource{
-		Read: approleAuthBackendRoleIDRead,
+		Read: ReadWrapper(approleAuthBackendRoleIDRead),
 
 		Schema: map[string]*schema.Schema{
 			"role_name": {

--- a/vault/data_source_auth_backend.go
+++ b/vault/data_source_auth_backend.go
@@ -11,7 +11,7 @@ import (
 
 func authBackendDataSource() *schema.Resource {
 	return &schema.Resource{
-		Read: authBackendDataSourceRead,
+		Read: ReadWrapper(authBackendDataSourceRead),
 		Schema: map[string]*schema.Schema{
 			"path": {
 				Type:        schema.TypeString,

--- a/vault/data_source_aws_access_credentials.go
+++ b/vault/data_source_aws_access_credentials.go
@@ -40,7 +40,7 @@ const (
 
 func awsAccessCredentialsDataSource() *schema.Resource {
 	return &schema.Resource{
-		Read: awsAccessCredentialsDataSourceRead,
+		Read: ReadWrapper(awsAccessCredentialsDataSourceRead),
 
 		Schema: map[string]*schema.Schema{
 			"backend": {

--- a/vault/data_source_azure_access_credentials.go
+++ b/vault/data_source_azure_access_credentials.go
@@ -21,7 +21,7 @@ import (
 
 func azureAccessCredentialsDataSource() *schema.Resource {
 	return &schema.Resource{
-		Read: azureAccessCredentialsDataSourceRead,
+		Read: ReadWrapper(azureAccessCredentialsDataSourceRead),
 
 		Schema: map[string]*schema.Schema{
 			"backend": {

--- a/vault/data_source_gcp_auth_backend_role.go
+++ b/vault/data_source_gcp_auth_backend_role.go
@@ -103,7 +103,7 @@ func gcpAuthBackendRoleDataSource() *schema.Resource {
 	addTokenFields(fields, &addTokenFieldsConfig{})
 
 	return &schema.Resource{
-		Read:   gcpAuthBackendRoleRead,
+		Read:   ReadWrapper(gcpAuthBackendRoleRead),
 		Schema: fields,
 	}
 }

--- a/vault/data_source_generic_secret.go
+++ b/vault/data_source_generic_secret.go
@@ -14,7 +14,7 @@ import (
 
 func genericSecretDataSource() *schema.Resource {
 	return &schema.Resource{
-		Read: genericSecretDataSourceRead,
+		Read: ReadWrapper(genericSecretDataSourceRead),
 
 		Schema: map[string]*schema.Schema{
 			consts.FieldPath: {

--- a/vault/data_source_kubernetes_auth_backend_config.go
+++ b/vault/data_source_kubernetes_auth_backend_config.go
@@ -12,7 +12,7 @@ import (
 
 func kubernetesAuthBackendConfigDataSource() *schema.Resource {
 	return &schema.Resource{
-		Read: kubernetesAuthBackendConfigDataSourceRead,
+		Read: ReadWrapper(kubernetesAuthBackendConfigDataSourceRead),
 		Schema: map[string]*schema.Schema{
 			"backend": {
 				Type:        schema.TypeString,

--- a/vault/data_source_kubernetes_auth_backend_role.go
+++ b/vault/data_source_kubernetes_auth_backend_role.go
@@ -58,7 +58,7 @@ func kubernetesAuthBackendRoleDataSource() *schema.Resource {
 	addTokenFields(fields, &addTokenFieldsConfig{})
 
 	return &schema.Resource{
-		Read:   kubernetesAuthBackendRoleDataSourceRead,
+		Read:   ReadWrapper(kubernetesAuthBackendRoleDataSourceRead),
 		Schema: fields,
 	}
 }

--- a/vault/data_source_kubernetes_credentials.go
+++ b/vault/data_source_kubernetes_credentials.go
@@ -19,7 +19,7 @@ const (
 
 func kubernetesServiceAccountTokenDataSource() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: readKubernetesServiceAccountToken,
+		ReadContext: ReadContextWrapper(readKubernetesServiceAccountToken),
 		Schema: map[string]*schema.Schema{
 			consts.FieldBackend: {
 				Type: schema.TypeString,

--- a/vault/data_source_kv_secret.go
+++ b/vault/data_source_kv_secret.go
@@ -14,7 +14,7 @@ import (
 
 func kvSecretDataSource() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: kvSecretDataSourceRead,
+		ReadContext: ReadContextWrapper(kvSecretDataSourceRead),
 
 		Schema: map[string]*schema.Schema{
 			consts.FieldPath: {

--- a/vault/data_source_kv_secret_v2.go
+++ b/vault/data_source_kv_secret_v2.go
@@ -15,7 +15,7 @@ import (
 
 func kvSecretV2DataSource() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: kvSecretV2DataSourceRead,
+		ReadContext: ReadContextWrapper(kvSecretV2DataSourceRead),
 
 		Schema: map[string]*schema.Schema{
 			consts.FieldMount: {

--- a/vault/data_source_kv_secrets_list.go
+++ b/vault/data_source_kv_secrets_list.go
@@ -12,7 +12,7 @@ import (
 
 func kvSecretListDataSource() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: kvSecretListDataSourceRead,
+		ReadContext: ReadContextWrapper(kvSecretListDataSourceRead),
 
 		Schema: map[string]*schema.Schema{
 			consts.FieldPath: {

--- a/vault/data_source_kv_secrets_list_v2.go
+++ b/vault/data_source_kv_secrets_list_v2.go
@@ -12,7 +12,7 @@ import (
 
 func kvSecretListDataSourceV2() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: kvSecretV2ListDataSourceRead,
+		ReadContext: ReadContextWrapper(kvSecretV2ListDataSourceRead),
 
 		Schema: map[string]*schema.Schema{
 			consts.FieldMount: {

--- a/vault/data_source_kv_subkeys_v2.go
+++ b/vault/data_source_kv_subkeys_v2.go
@@ -15,7 +15,7 @@ import (
 
 func kvSecretSubkeysV2DataSource() *schema.Resource {
 	return &schema.Resource{
-		ReadContext: kvSecretSubkeysDataSourceRead,
+		ReadContext: ReadContextWrapper(kvSecretSubkeysDataSourceRead),
 
 		Schema: map[string]*schema.Schema{
 			consts.FieldMount: {

--- a/vault/data_source_nomad_credentials.go
+++ b/vault/data_source_nomad_credentials.go
@@ -11,7 +11,7 @@ import (
 
 func nomadAccessCredentialsDataSource() *schema.Resource {
 	return &schema.Resource{
-		Read: readNomadCredsResource,
+		Read: ReadWrapper(readNomadCredsResource),
 		Schema: map[string]*schema.Schema{
 			"backend": {
 				Type:        schema.TypeString,

--- a/vault/data_source_policy_document.go
+++ b/vault/data_source_policy_document.go
@@ -41,7 +41,7 @@ var allowedCapabilities = []string{
 
 func policyDocumentDataSource() *schema.Resource {
 	return &schema.Resource{
-		Read: policyDocumentDataSourceRead,
+		Read: ReadWrapper(policyDocumentDataSourceRead),
 		Schema: map[string]*schema.Schema{
 			"rule": {
 				Type:        schema.TypeList,

--- a/vault/data_source_transit_decrypt.go
+++ b/vault/data_source_transit_decrypt.go
@@ -11,7 +11,7 @@ import (
 
 func transitDecryptDataSource() *schema.Resource {
 	return &schema.Resource{
-		Read: transitDecryptDataSourceRead,
+		Read: ReadWrapper(transitDecryptDataSourceRead),
 
 		Schema: map[string]*schema.Schema{
 			"key": {

--- a/vault/data_source_transit_encrypt.go
+++ b/vault/data_source_transit_encrypt.go
@@ -11,7 +11,7 @@ import (
 
 func transitEncryptDataSource() *schema.Resource {
 	return &schema.Resource{
-		Read: transitEncryptDataSourceRead,
+		Read: ReadWrapper(transitEncryptDataSourceRead),
 
 		Schema: map[string]*schema.Schema{
 			"key": {

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -1,9 +1,13 @@
 package vault
 
 import (
+	"context"
 	"fmt"
+	"log"
+	"os"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
 
@@ -833,4 +837,42 @@ func UpdateSchemaResource(r *schema.Resource) *schema.Resource {
 	mustAddSchema(r, getNamespaceSchema())
 
 	return r
+}
+
+// ReadWrapper provides common read operations to the wrapped schema.ReadFunc.
+func ReadWrapper(f schema.ReadFunc) schema.ReadFunc {
+	return func(d *schema.ResourceData, i interface{}) error {
+		if err := importNamespace(d); err != nil {
+			return err
+		}
+
+		return f(d, i)
+	}
+}
+
+// ReadContextWrapper provides common read operations to the wrapped schema.ReadContextFunc.
+func ReadContextWrapper(f schema.ReadContextFunc) schema.ReadContextFunc {
+	return func(ctx context.Context, d *schema.ResourceData, i interface{}) diag.Diagnostics {
+		if err := importNamespace(d); err != nil {
+			return diag.FromErr(err)
+		}
+		return f(ctx, d, i)
+	}
+}
+
+func importNamespace(d *schema.ResourceData) error {
+	if ns := os.Getenv(consts.EnvVarVaultNamespaceImport); ns != "" {
+		s := d.State()
+		if _, ok := s.Attributes[consts.FieldNamespace]; !ok {
+			log.Printf(`[INFO] Environment variable %s set, `+
+				`attempting TF state import "%s=%s"`,
+				consts.EnvVarVaultNamespaceImport, consts.FieldNamespace, ns)
+			if err := d.Set(consts.FieldNamespace, ns); err != nil {
+				return fmt.Errorf("failed to import %q, err=%w",
+					consts.EnvVarVaultNamespaceImport, err)
+			}
+		}
+	}
+
+	return nil
 }

--- a/vault/resource_ad_secret_backend.go
+++ b/vault/resource_ad_secret_backend.go
@@ -212,7 +212,7 @@ func adSecretBackendResource() *schema.Resource {
 	return &schema.Resource{
 		Create: createConfigResource,
 		Update: updateConfigResource,
-		Read:   readConfigResource,
+		Read:   ReadWrapper(readConfigResource),
 		Delete: deleteConfigResource,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,

--- a/vault/resource_ad_secret_library.go
+++ b/vault/resource_ad_secret_library.go
@@ -62,7 +62,7 @@ func adSecretBackendLibraryResource() *schema.Resource {
 	return &schema.Resource{
 		Create: createLibraryResource,
 		Update: updateLibraryResource,
-		Read:   readLibraryResource,
+		Read:   ReadWrapper(readLibraryResource),
 		Delete: deleteLibraryResource,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,

--- a/vault/resource_ad_secret_roles.go
+++ b/vault/resource_ad_secret_roles.go
@@ -58,7 +58,7 @@ func adSecretBackendRoleResource() *schema.Resource {
 	return &schema.Resource{
 		Create: createRoleResource,
 		Update: updateRoleResource,
-		Read:   readRoleResource,
+		Read:   ReadWrapper(readRoleResource),
 		Delete: deleteRoleResource,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,

--- a/vault/resource_alicloud_auth_backend_role.go
+++ b/vault/resource_alicloud_auth_backend_role.go
@@ -42,7 +42,7 @@ func alicloudAuthBackendRoleResource() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: alicloudAuthBackendRoleCreate,
 		UpdateContext: alicloudAuthBackendRoleUpdate,
-		ReadContext:   alicloudAuthBackendRoleRead,
+		ReadContext:   ReadContextWrapper(alicloudAuthBackendRoleRead),
 		DeleteContext: alicloudAuthBackendRoleDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,

--- a/vault/resource_approle_auth_backend_login.go
+++ b/vault/resource_approle_auth_backend_login.go
@@ -17,7 +17,7 @@ import (
 func approleAuthBackendLoginResource() *schema.Resource {
 	return &schema.Resource{
 		Create: approleAuthBackendLoginCreate,
-		Read:   approleAuthBackendLoginRead,
+		Read:   ReadWrapper(approleAuthBackendLoginRead),
 		Delete: approleAuthBackendLoginDelete,
 		Exists: approleAuthBackendLoginExists,
 

--- a/vault/resource_approle_auth_backend_role.go
+++ b/vault/resource_approle_auth_backend_role.go
@@ -74,7 +74,7 @@ func approleAuthBackendRoleResource() *schema.Resource {
 
 	return &schema.Resource{
 		CreateContext: approleAuthBackendRoleCreate,
-		ReadContext:   approleAuthBackendRoleRead,
+		ReadContext:   ReadContextWrapper(approleAuthBackendRoleRead),
 		UpdateContext: approleAuthBackendRoleUpdate,
 		DeleteContext: approleAuthBackendRoleDelete,
 		Importer: &schema.ResourceImporter{

--- a/vault/resource_approle_auth_backend_role_secret_id.go
+++ b/vault/resource_approle_auth_backend_role_secret_id.go
@@ -19,7 +19,7 @@ var approleAuthBackendRoleSecretIDIDRegex = regexp.MustCompile("^backend=(.+)::r
 func approleAuthBackendRoleSecretIDResource(name string) *schema.Resource {
 	return &schema.Resource{
 		Create: approleAuthBackendRoleSecretIDCreate,
-		Read:   approleAuthBackendRoleSecretIDRead,
+		Read:   ReadWrapper(approleAuthBackendRoleSecretIDRead),
 		Delete: approleAuthBackendRoleSecretIDDelete,
 		Exists: approleAuthBackendRoleSecretIDExists,
 

--- a/vault/resource_audit.go
+++ b/vault/resource_audit.go
@@ -14,7 +14,7 @@ import (
 func auditResource() *schema.Resource {
 	return &schema.Resource{
 		Create: auditWrite,
-		Read:   auditRead,
+		Read:   ReadWrapper(auditRead),
 		Delete: auditDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,

--- a/vault/resource_auth_backend.go
+++ b/vault/resource_auth_backend.go
@@ -17,7 +17,7 @@ func AuthBackendResource() *schema.Resource {
 
 		Create: authBackendWrite,
 		Delete: authBackendDelete,
-		Read:   authBackendRead,
+		Read:   ReadWrapper(authBackendRead),
 		Update: authBackendUpdate,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,

--- a/vault/resource_aws_auth_backend_cert.go
+++ b/vault/resource_aws_auth_backend_cert.go
@@ -21,7 +21,7 @@ var (
 func awsAuthBackendCertResource() *schema.Resource {
 	return &schema.Resource{
 		Create: awsAuthBackendCertCreate,
-		Read:   awsAuthBackendCertRead,
+		Read:   ReadWrapper(awsAuthBackendCertRead),
 		Delete: awsAuthBackendCertDelete,
 		Exists: awsAuthBackendCertExists,
 		Importer: &schema.ResourceImporter{

--- a/vault/resource_aws_auth_backend_client.go
+++ b/vault/resource_aws_auth_backend_client.go
@@ -14,7 +14,7 @@ import (
 func awsAuthBackendClientResource() *schema.Resource {
 	return &schema.Resource{
 		Create: awsAuthBackendWrite,
-		Read:   awsAuthBackendRead,
+		Read:   ReadWrapper(awsAuthBackendRead),
 		Update: awsAuthBackendWrite,
 		Delete: awsAuthBackendDelete,
 		Exists: awsAuthBackendExists,

--- a/vault/resource_aws_auth_backend_identity_whitelist.go
+++ b/vault/resource_aws_auth_backend_identity_whitelist.go
@@ -16,7 +16,7 @@ var awsAuthBackendIdentityWhitelistBackendFromPathRegex = regexp.MustCompile("^a
 func awsAuthBackendIdentityWhitelistResource() *schema.Resource {
 	return &schema.Resource{
 		Create: awsAuthBackendIdentityWhitelistWrite,
-		Read:   awsAuthBackendIdentityWhitelistRead,
+		Read:   ReadWrapper(awsAuthBackendIdentityWhitelistRead),
 		Update: awsAuthBackendIdentityWhitelistWrite,
 		Delete: awsAuthBackendIdentityWhitelistDelete,
 		Exists: awsAuthBackendIdentityWhitelistExists,

--- a/vault/resource_aws_auth_backend_login.go
+++ b/vault/resource_aws_auth_backend_login.go
@@ -15,7 +15,7 @@ import (
 func awsAuthBackendLoginResource() *schema.Resource {
 	return &schema.Resource{
 		Create: awsAuthBackendLoginCreate,
-		Read:   awsAuthBackendLoginRead,
+		Read:   ReadWrapper(awsAuthBackendLoginRead),
 		Delete: awsAuthBackendLoginDelete,
 
 		Schema: map[string]*schema.Schema{

--- a/vault/resource_aws_auth_backend_role.go
+++ b/vault/resource_aws_auth_backend_role.go
@@ -161,7 +161,7 @@ func awsAuthBackendRoleResource() *schema.Resource {
 	return &schema.Resource{
 		CustomizeDiff: resourceVaultAwsAuthBackendRoleCustomizeDiff,
 		CreateContext: awsAuthBackendRoleCreate,
-		ReadContext:   awsAuthBackendRoleRead,
+		ReadContext:   ReadContextWrapper(awsAuthBackendRoleRead),
 		UpdateContext: awsAuthBackendRoleUpdate,
 		DeleteContext: awsAuthBackendRoleDelete,
 		Importer: &schema.ResourceImporter{

--- a/vault/resource_aws_auth_backend_role_tag.go
+++ b/vault/resource_aws_auth_backend_role_tag.go
@@ -13,7 +13,7 @@ import (
 func awsAuthBackendRoleTagResource() *schema.Resource {
 	return &schema.Resource{
 		Create: awsAuthBackendRoleTagResourceCreate,
-		Read:   awsAuthBackendRoleTagResourceRead,
+		Read:   ReadWrapper(awsAuthBackendRoleTagResourceRead),
 		Delete: awsAuthBackendRoleTagResourceDelete,
 
 		Schema: map[string]*schema.Schema{

--- a/vault/resource_aws_auth_backend_roletag_blacklist.go
+++ b/vault/resource_aws_auth_backend_roletag_blacklist.go
@@ -16,7 +16,7 @@ var awsAuthBackendRoleTagBlacklistBackendFromPathRegex = regexp.MustCompile("^au
 func awsAuthBackendRoleTagBlacklistResource() *schema.Resource {
 	return &schema.Resource{
 		Create: awsAuthBackendRoleTagBlacklistWrite,
-		Read:   awsAuthBackendRoleTagBlacklistRead,
+		Read:   ReadWrapper(awsAuthBackendRoleTagBlacklistRead),
 		Update: awsAuthBackendRoleTagBlacklistWrite,
 		Delete: awsAuthBackendRoleTagBlacklistDelete,
 		Exists: awsAuthBackendRoleTagBlacklistExists,

--- a/vault/resource_aws_auth_backend_sts_role.go
+++ b/vault/resource_aws_auth_backend_sts_role.go
@@ -19,7 +19,7 @@ var (
 func awsAuthBackendSTSRoleResource() *schema.Resource {
 	return &schema.Resource{
 		Create: awsAuthBackendSTSRoleCreate,
-		Read:   awsAuthBackendSTSRoleRead,
+		Read:   ReadWrapper(awsAuthBackendSTSRoleRead),
 		Update: awsAuthBackendSTSRoleUpdate,
 		Delete: awsAuthBackendSTSRoleDelete,
 		Exists: awsAuthBackendSTSRoleExists,

--- a/vault/resource_aws_secret_backend.go
+++ b/vault/resource_aws_secret_backend.go
@@ -15,7 +15,7 @@ import (
 func awsSecretBackendResource() *schema.Resource {
 	return &schema.Resource{
 		Create: awsSecretBackendCreate,
-		Read:   awsSecretBackendRead,
+		Read:   ReadWrapper(awsSecretBackendRead),
 		Update: awsSecretBackendUpdate,
 		Delete: awsSecretBackendDelete,
 		Exists: awsSecretBackendExists,

--- a/vault/resource_aws_secret_backend_role.go
+++ b/vault/resource_aws_secret_backend_role.go
@@ -15,7 +15,7 @@ import (
 func awsSecretBackendRoleResource(name string) *schema.Resource {
 	return &schema.Resource{
 		Create: awsSecretBackendRoleWrite,
-		Read:   awsSecretBackendRoleRead,
+		Read:   ReadWrapper(awsSecretBackendRoleRead),
 		Update: awsSecretBackendRoleWrite,
 		Delete: awsSecretBackendRoleDelete,
 		Exists: awsSecretBackendRoleExists,

--- a/vault/resource_azure_auth_backend_config.go
+++ b/vault/resource_azure_auth_backend_config.go
@@ -13,7 +13,7 @@ import (
 func azureAuthBackendConfigResource() *schema.Resource {
 	return &schema.Resource{
 		Create: azureAuthBackendWrite,
-		Read:   azureAuthBackendRead,
+		Read:   ReadWrapper(azureAuthBackendRead),
 		Update: azureAuthBackendWrite,
 		Delete: azureAuthBackendDelete,
 		Exists: azureAuthBackendExists,

--- a/vault/resource_azure_auth_backend_role.go
+++ b/vault/resource_azure_auth_backend_role.go
@@ -91,7 +91,7 @@ func azureAuthBackendRoleResource() *schema.Resource {
 
 	return &schema.Resource{
 		CreateContext: azureAuthBackendRoleCreate,
-		ReadContext:   azureAuthBackendRoleRead,
+		ReadContext:   ReadContextWrapper(azureAuthBackendRoleRead),
 		UpdateContext: azureAuthBackendRoleUpdate,
 		DeleteContext: azureAuthBackendRoleDelete,
 		Importer: &schema.ResourceImporter{

--- a/vault/resource_azure_secret_backend.go
+++ b/vault/resource_azure_secret_backend.go
@@ -14,7 +14,7 @@ import (
 func azureSecretBackendResource() *schema.Resource {
 	return &schema.Resource{
 		Create: azureSecretBackendCreate,
-		Read:   azureSecretBackendRead,
+		Read:   ReadWrapper(azureSecretBackendRead),
 		Update: azureSecretBackendUpdate,
 		Delete: azureSecretBackendDelete,
 		Exists: azureSecretBackendExists,

--- a/vault/resource_azure_secret_backend_role.go
+++ b/vault/resource_azure_secret_backend_role.go
@@ -14,7 +14,7 @@ import (
 func azureSecretBackendRoleResource() *schema.Resource {
 	return &schema.Resource{
 		Create: azureSecretBackendRoleCreate,
-		Read:   azureSecretBackendRoleRead,
+		Read:   ReadWrapper(azureSecretBackendRoleRead),
 		Update: azureSecretBackendRoleCreate,
 		Delete: azureSecretBackendRoleDelete,
 		Importer: &schema.ResourceImporter{

--- a/vault/resource_cert_auth_backend_role.go
+++ b/vault/resource_cert_auth_backend_role.go
@@ -112,7 +112,7 @@ func certAuthBackendRoleResource() *schema.Resource {
 
 		CreateContext: certAuthResourceWrite,
 		UpdateContext: certAuthResourceUpdate,
-		ReadContext:   certAuthResourceRead,
+		ReadContext:   ReadContextWrapper(certAuthResourceRead),
 		DeleteContext: certAuthResourceDelete,
 		Schema:        fields,
 	}

--- a/vault/resource_consul_secret_backend.go
+++ b/vault/resource_consul_secret_backend.go
@@ -14,7 +14,7 @@ import (
 func consulSecretBackendResource() *schema.Resource {
 	return &schema.Resource{
 		Create: consulSecretBackendCreate,
-		Read:   consulSecretBackendRead,
+		Read:   ReadWrapper(consulSecretBackendRead),
 		Update: consulSecretBackendUpdate,
 		Delete: consulSecretBackendDelete,
 		Exists: consulSecretBackendExists,

--- a/vault/resource_consul_secret_backend_role.go
+++ b/vault/resource_consul_secret_backend_role.go
@@ -20,7 +20,7 @@ var (
 func consulSecretBackendRoleResource() *schema.Resource {
 	return &schema.Resource{
 		Create: consulSecretBackendRoleWrite,
-		Read:   consulSecretBackendRoleRead,
+		Read:   ReadWrapper(consulSecretBackendRoleRead),
 		Update: consulSecretBackendRoleWrite,
 		Delete: consulSecretBackendRoleDelete,
 		Exists: consulSecretBackendRoleExists,

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -597,7 +597,7 @@ func databaseSecretBackendConnectionResource() *schema.Resource {
 
 	return &schema.Resource{
 		Create: databaseSecretBackendConnectionCreateOrUpdate,
-		Read:   databaseSecretBackendConnectionRead,
+		Read:   ReadWrapper(databaseSecretBackendConnectionRead),
 		Update: databaseSecretBackendConnectionCreateOrUpdate,
 		Delete: databaseSecretBackendConnectionDelete,
 		Exists: databaseSecretBackendConnectionExists,

--- a/vault/resource_database_secret_backend_role.go
+++ b/vault/resource_database_secret_backend_role.go
@@ -20,7 +20,7 @@ var (
 func databaseSecretBackendRoleResource() *schema.Resource {
 	return &schema.Resource{
 		Create: databaseSecretBackendRoleWrite,
-		Read:   databaseSecretBackendRoleRead,
+		Read:   ReadWrapper(databaseSecretBackendRoleRead),
 		Update: databaseSecretBackendRoleWrite,
 		Delete: databaseSecretBackendRoleDelete,
 		Exists: databaseSecretBackendRoleExists,

--- a/vault/resource_database_secret_backend_static_role.go
+++ b/vault/resource_database_secret_backend_static_role.go
@@ -20,7 +20,7 @@ var (
 func databaseSecretBackendStaticRoleResource() *schema.Resource {
 	return &schema.Resource{
 		Create: databaseSecretBackendStaticRoleWrite,
-		Read:   databaseSecretBackendStaticRoleRead,
+		Read:   ReadWrapper(databaseSecretBackendStaticRoleRead),
 		Update: databaseSecretBackendStaticRoleWrite,
 		Delete: databaseSecretBackendStaticRoleDelete,
 		Exists: databaseSecretBackendStaticRoleExists,

--- a/vault/resource_database_secrets_mount.go
+++ b/vault/resource_database_secrets_mount.go
@@ -105,7 +105,7 @@ func databaseSecretsMountCustomizeDiff(ctx context.Context, d *schema.ResourceDi
 func databaseSecretsMountResource() *schema.Resource {
 	return &schema.Resource{
 		Create:        databaseSecretsMountCreateOrUpdate,
-		Read:          databaseSecretsMountRead,
+		Read:          ReadWrapper(databaseSecretsMountRead),
 		Update:        databaseSecretsMountCreateOrUpdate,
 		Delete:        databaseSecretsMountDelete,
 		CustomizeDiff: databaseSecretsMountCustomizeDiff,

--- a/vault/resource_egp_policy.go
+++ b/vault/resource_egp_policy.go
@@ -11,7 +11,7 @@ func egpPolicyResource() *schema.Resource {
 		Create: egpPolicyWrite,
 		Update: egpPolicyWrite,
 		Delete: egpPolicyDelete,
-		Read:   egpPolicyRead,
+		Read:   ReadWrapper(egpPolicyRead),
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/vault/resource_gcp_auth_backend.go
+++ b/vault/resource_gcp_auth_backend.go
@@ -21,7 +21,7 @@ func gcpAuthBackendResource() *schema.Resource {
 	return &schema.Resource{
 		Create: gcpAuthBackendWrite,
 		Update: gcpAuthBackendUpdate,
-		Read:   gcpAuthBackendRead,
+		Read:   ReadWrapper(gcpAuthBackendRead),
 		Delete: gcpAuthBackendDelete,
 		Exists: gcpAuthBackendExists,
 		Importer: &schema.ResourceImporter{

--- a/vault/resource_gcp_auth_backend_role.go
+++ b/vault/resource_gcp_auth_backend_role.go
@@ -111,7 +111,7 @@ func gcpAuthBackendRoleResource() *schema.Resource {
 
 		CreateContext: gcpAuthResourceCreate,
 		UpdateContext: gcpAuthResourceUpdate,
-		ReadContext:   gcpAuthResourceRead,
+		ReadContext:   ReadContextWrapper(gcpAuthResourceRead),
 		DeleteContext: gcpAuthResourceDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,

--- a/vault/resource_gcp_secret_backend.go
+++ b/vault/resource_gcp_secret_backend.go
@@ -14,7 +14,7 @@ import (
 func gcpSecretBackendResource(name string) *schema.Resource {
 	return &schema.Resource{
 		Create: gcpSecretBackendCreate,
-		Read:   gcpSecretBackendRead,
+		Read:   ReadWrapper(gcpSecretBackendRead),
 		Update: gcpSecretBackendUpdate,
 		Delete: gcpSecretBackendDelete,
 		Exists: gcpSecretBackendExists,

--- a/vault/resource_gcp_secret_roleset.go
+++ b/vault/resource_gcp_secret_roleset.go
@@ -21,7 +21,7 @@ var (
 func gcpSecretRolesetResource() *schema.Resource {
 	return &schema.Resource{
 		Create: gcpSecretRolesetCreate,
-		Read:   gcpSecretRolesetRead,
+		Read:   ReadWrapper(gcpSecretRolesetRead),
 		Update: gcpSecretRolesetUpdate,
 		Delete: gcpSecretRolesetDelete,
 		Exists: gcpSecretRolesetExists,

--- a/vault/resource_gcp_secret_static_account.go
+++ b/vault/resource_gcp_secret_static_account.go
@@ -19,7 +19,7 @@ var (
 func gcpSecretStaticAccountResource() *schema.Resource {
 	return &schema.Resource{
 		Create: gcpSecretStaticAccountCreate,
-		Read:   gcpSecretStaticAccountRead,
+		Read:   ReadWrapper(gcpSecretStaticAccountRead),
 		Update: gcpSecretStaticAccountUpdate,
 		Delete: gcpSecretStaticAccountDelete,
 		Exists: gcpSecretStaticAccountExists,

--- a/vault/resource_generic_endpoint.go
+++ b/vault/resource_generic_endpoint.go
@@ -18,7 +18,7 @@ func genericEndpointResource(name string) *schema.Resource {
 		Create: genericEndpointResourceWrite,
 		Update: genericEndpointResourceWrite,
 		Delete: genericEndpointResourceDelete,
-		Read:   genericEndpointResourceRead,
+		Read:   ReadWrapper(genericEndpointResourceRead),
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/vault/resource_generic_secret.go
+++ b/vault/resource_generic_secret.go
@@ -20,7 +20,7 @@ func genericSecretResource(name string) *schema.Resource {
 		Create: genericSecretResourceWrite,
 		Update: genericSecretResourceWrite,
 		Delete: genericSecretResourceDelete,
-		Read:   genericSecretResourceRead,
+		Read:   ReadWrapper(genericSecretResourceRead),
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/vault/resource_generic_secret_test.go
+++ b/vault/resource_generic_secret_test.go
@@ -67,8 +67,9 @@ func TestResourceGenericSecretNS(t *testing.T) {
 				PreConfig: func() {
 					t.Setenv(consts.EnvVarVaultNamespaceImport, ns)
 				},
-				ImportState:  true,
-				ResourceName: resourceName,
+				ImportState:      true,
+				ResourceName:     resourceName,
+				ImportStateCheck: testutil.GetNamespaceImportStateCheck(ns),
 			},
 			{
 				// needed for the import step above :(

--- a/vault/resource_github_auth_backend.go
+++ b/vault/resource_github_auth_backend.go
@@ -60,7 +60,7 @@ func githubAuthBackendResource() *schema.Resource {
 
 	return &schema.Resource{
 		Create: githubAuthBackendCreate,
-		Read:   githubAuthBackendRead,
+		Read:   ReadWrapper(githubAuthBackendRead),
 		Update: githubAuthBackendUpdate,
 		Delete: githubAuthBackendDelete,
 		Importer: &schema.ResourceImporter{

--- a/vault/resource_github_team.go
+++ b/vault/resource_github_team.go
@@ -13,7 +13,7 @@ import (
 func githubTeamResource() *schema.Resource {
 	return &schema.Resource{
 		Create: githubTeamCreate,
-		Read:   githubTeamRead,
+		Read:   ReadWrapper(githubTeamRead),
 		Update: githubTeamUpdate,
 		Delete: githubTeamDelete,
 		Importer: &schema.ResourceImporter{

--- a/vault/resource_github_user.go
+++ b/vault/resource_github_user.go
@@ -13,7 +13,7 @@ import (
 func githubUserResource() *schema.Resource {
 	return &schema.Resource{
 		Create: githubUserCreate,
-		Read:   githubUserRead,
+		Read:   ReadWrapper(githubUserRead),
 		Update: githubUserUpdate,
 		Delete: githubUserDelete,
 		Importer: &schema.ResourceImporter{

--- a/vault/resource_identity_entity.go
+++ b/vault/resource_identity_entity.go
@@ -20,7 +20,7 @@ func identityEntityResource() *schema.Resource {
 	return &schema.Resource{
 		Create: identityEntityCreate,
 		Update: identityEntityUpdate,
-		Read:   identityEntityRead,
+		Read:   ReadWrapper(identityEntityRead),
 		Delete: identityEntityDelete,
 		Exists: identityEntityExists,
 		Importer: &schema.ResourceImporter{

--- a/vault/resource_identity_entity_alias.go
+++ b/vault/resource_identity_entity_alias.go
@@ -19,7 +19,7 @@ func identityEntityAliasResource() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: identityEntityAliasCreate,
 		UpdateContext: identityEntityAliasUpdate,
-		ReadContext:   identityEntityAliasRead,
+		ReadContext:   ReadContextWrapper(identityEntityAliasRead),
 		DeleteContext: identityEntityAliasDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,

--- a/vault/resource_identity_entity_policies.go
+++ b/vault/resource_identity_entity_policies.go
@@ -15,7 +15,7 @@ func identityEntityPoliciesResource() *schema.Resource {
 	return &schema.Resource{
 		Create: identityEntityPoliciesUpdate,
 		Update: identityEntityPoliciesUpdate,
-		Read:   identityEntityPoliciesRead,
+		Read:   ReadWrapper(identityEntityPoliciesRead),
 		Delete: identityEntityPoliciesDelete,
 
 		Schema: map[string]*schema.Schema{

--- a/vault/resource_identity_group.go
+++ b/vault/resource_identity_group.go
@@ -19,7 +19,7 @@ func identityGroupResource() *schema.Resource {
 	return &schema.Resource{
 		Create: identityGroupCreate,
 		Update: identityGroupUpdate,
-		Read:   identityGroupRead,
+		Read:   ReadWrapper(identityGroupRead),
 		Delete: identityGroupDelete,
 		Exists: identityGroupExists,
 		Importer: &schema.ResourceImporter{

--- a/vault/resource_identity_group_alias.go
+++ b/vault/resource_identity_group_alias.go
@@ -16,7 +16,7 @@ func identityGroupAliasResource() *schema.Resource {
 	return &schema.Resource{
 		Create: identityGroupAliasCreate,
 		Update: identityGroupAliasUpdate,
-		Read:   identityGroupAliasRead,
+		Read:   ReadWrapper(identityGroupAliasRead),
 		Delete: identityGroupAliasDelete,
 		Exists: identityGroupAliasExists,
 		Importer: &schema.ResourceImporter{

--- a/vault/resource_identity_group_member_entity_ids.go
+++ b/vault/resource_identity_group_member_entity_ids.go
@@ -13,7 +13,7 @@ func identityGroupMemberEntityIdsResource() *schema.Resource {
 	return &schema.Resource{
 		Create: identityGroupMemberEntityIdsUpdate,
 		Update: identityGroupMemberEntityIdsUpdate,
-		Read:   identityGroupMemberEntityIdsRead,
+		Read:   ReadWrapper(identityGroupMemberEntityIdsRead),
 		Delete: identityGroupMemberEntityIdsDelete,
 
 		Schema: map[string]*schema.Schema{

--- a/vault/resource_identity_group_policies.go
+++ b/vault/resource_identity_group_policies.go
@@ -14,7 +14,7 @@ func identityGroupPoliciesResource() *schema.Resource {
 	return &schema.Resource{
 		Create: identityGroupPoliciesUpdate,
 		Update: identityGroupPoliciesUpdate,
-		Read:   identityGroupPoliciesRead,
+		Read:   ReadWrapper(identityGroupPoliciesRead),
 		Delete: identityGroupPoliciesDelete,
 
 		Schema: map[string]*schema.Schema{

--- a/vault/resource_identity_oidc.go
+++ b/vault/resource_identity_oidc.go
@@ -15,7 +15,7 @@ func identityOidc() *schema.Resource {
 	return &schema.Resource{
 		Create: identityOidcCreate,
 		Update: identityOidcUpdate,
-		Read:   identityOidcRead,
+		Read:   ReadWrapper(identityOidcRead),
 		Delete: identityOidcDelete,
 		Exists: identityOidcExists,
 

--- a/vault/resource_identity_oidc_assignment.go
+++ b/vault/resource_identity_oidc_assignment.go
@@ -15,7 +15,7 @@ func identityOIDCAssignmentResource() *schema.Resource {
 	return &schema.Resource{
 		Create: identityOIDCAssignmentCreateUpdate,
 		Update: identityOIDCAssignmentCreateUpdate,
-		Read:   identityOIDCAssignmentRead,
+		Read:   ReadWrapper(identityOIDCAssignmentRead),
 		Delete: identityOIDCAssignmentDelete,
 
 		Schema: map[string]*schema.Schema{

--- a/vault/resource_identity_oidc_client.go
+++ b/vault/resource_identity_oidc_client.go
@@ -15,7 +15,7 @@ func identityOIDCClientResource() *schema.Resource {
 	return &schema.Resource{
 		Create: identityOIDCClientCreateUpdate,
 		Update: identityOIDCClientCreateUpdate,
-		Read:   identityOIDCClientRead,
+		Read:   ReadWrapper(identityOIDCClientRead),
 		Delete: identityOIDCClientDelete,
 
 		Schema: map[string]*schema.Schema{

--- a/vault/resource_identity_oidc_key.go
+++ b/vault/resource_identity_oidc_key.go
@@ -24,7 +24,7 @@ func identityOidcKey() *schema.Resource {
 	return &schema.Resource{
 		Create: identityOidcKeyCreate,
 		Update: identityOidcKeyUpdate,
-		Read:   identityOidcKeyRead,
+		Read:   ReadWrapper(identityOidcKeyRead),
 		Delete: identityOidcKeyDelete,
 		Exists: identityOidcKeyExists,
 		Importer: &schema.ResourceImporter{

--- a/vault/resource_identity_oidc_key_allowed_client_id.go
+++ b/vault/resource_identity_oidc_key_allowed_client_id.go
@@ -13,7 +13,7 @@ import (
 func identityOidcKeyAllowedClientId() *schema.Resource {
 	return &schema.Resource{
 		Create: identityOidcKeyAllowedClientIdWrite,
-		Read:   identityOidcKeyAllowedClientIdRead,
+		Read:   ReadWrapper(identityOidcKeyAllowedClientIdRead),
 		Delete: identityOidcKeyAllowedClientIdDelete,
 
 		Schema: map[string]*schema.Schema{

--- a/vault/resource_identity_oidc_provider.go
+++ b/vault/resource_identity_oidc_provider.go
@@ -15,7 +15,7 @@ func identityOIDCProviderResource() *schema.Resource {
 	return &schema.Resource{
 		Create: identityOIDCProviderCreateUpdate,
 		Update: identityOIDCProviderCreateUpdate,
-		Read:   identityOIDCProviderRead,
+		Read:   ReadWrapper(identityOIDCProviderRead),
 		Delete: identityOIDCProviderDelete,
 
 		Schema: map[string]*schema.Schema{

--- a/vault/resource_identity_oidc_role.go
+++ b/vault/resource_identity_oidc_role.go
@@ -15,7 +15,7 @@ func identityOidcRole() *schema.Resource {
 	return &schema.Resource{
 		Create: identityOidcRoleCreate,
 		Update: identityOidcRoleUpdate,
-		Read:   identityOidcRoleRead,
+		Read:   ReadWrapper(identityOidcRoleRead),
 		Delete: identityOidcRoleDelete,
 		Exists: identityOidcRoleExists,
 		Importer: &schema.ResourceImporter{

--- a/vault/resource_identity_oidc_scope.go
+++ b/vault/resource_identity_oidc_scope.go
@@ -16,7 +16,7 @@ func identityOIDCScopeResource() *schema.Resource {
 	return &schema.Resource{
 		Create: identityOIDCScopeCreateUpdate,
 		Update: identityOIDCScopeCreateUpdate,
-		Read:   identityOIDCScopeRead,
+		Read:   ReadWrapper(identityOIDCScopeRead),
 		Delete: identityOIDCScopeDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,

--- a/vault/resource_jwt_auth_backend.go
+++ b/vault/resource_jwt_auth_backend.go
@@ -21,7 +21,7 @@ func jwtAuthBackendResource() *schema.Resource {
 		},
 		Create: jwtAuthBackendWrite,
 		Delete: jwtAuthBackendDelete,
-		Read:   jwtAuthBackendRead,
+		Read:   ReadWrapper(jwtAuthBackendRead),
 		Update: jwtAuthBackendUpdate,
 
 		CustomizeDiff: jwtCustomizeDiff,

--- a/vault/resource_jwt_auth_backend_role.go
+++ b/vault/resource_jwt_auth_backend_role.go
@@ -147,7 +147,7 @@ func jwtAuthBackendRoleResource() *schema.Resource {
 
 	return &schema.Resource{
 		CreateContext: jwtAuthBackendRoleCreate,
-		ReadContext:   jwtAuthBackendRoleRead,
+		ReadContext:   ReadContextWrapper(jwtAuthBackendRoleRead),
 		UpdateContext: jwtAuthBackendRoleUpdate,
 		DeleteContext: jwtAuthBackendRoleDelete,
 		Importer: &schema.ResourceImporter{

--- a/vault/resource_kmip_secret_backend.go
+++ b/vault/resource_kmip_secret_backend.go
@@ -28,7 +28,7 @@ var kmipAPIFields = []string{
 func kmipSecretBackendResource() *schema.Resource {
 	return &schema.Resource{
 		Create: kmipSecretBackendCreate,
-		Read:   kmipSecretBackendRead,
+		Read:   ReadWrapper(kmipSecretBackendRead),
 		Update: kmipSecretBackendUpdate,
 		Delete: kmipSecretBackendDelete,
 		Importer: &schema.ResourceImporter{

--- a/vault/resource_kmip_secret_role.go
+++ b/vault/resource_kmip_secret_role.go
@@ -50,7 +50,7 @@ var kmipRoleAPIBooleanFields = []string{
 func kmipSecretRoleResource() *schema.Resource {
 	return &schema.Resource{
 		Create: kmipSecretRoleCreate,
-		Read:   kmipSecretRoleRead,
+		Read:   ReadWrapper(kmipSecretRoleRead),
 		Update: kmipSecretRoleUpdate,
 		Delete: kmipSecretRoleDelete,
 		Importer: &schema.ResourceImporter{

--- a/vault/resource_kmip_secret_scope.go
+++ b/vault/resource_kmip_secret_scope.go
@@ -16,7 +16,7 @@ var errKMIPScopeNotFound = errors.New("KMIP scope not found")
 func kmipSecretScopeResource() *schema.Resource {
 	return &schema.Resource{
 		Create: kmipSecretScopeCreate,
-		Read:   kmipSecretScopeRead,
+		Read:   ReadWrapper(kmipSecretScopeRead),
 		Update: kmipSecretScopeUpdate,
 		Delete: kmipSecretScopeDelete,
 		Importer: &schema.ResourceImporter{

--- a/vault/resource_kubernetes_auth_backend_config.go
+++ b/vault/resource_kubernetes_auth_backend_config.go
@@ -16,7 +16,7 @@ var kubernetesAuthBackendConfigFromPathRegex = regexp.MustCompile("^auth/(.+)/co
 func kubernetesAuthBackendConfigResource() *schema.Resource {
 	return &schema.Resource{
 		Create: kubernetesAuthBackendConfigCreate,
-		Read:   kubernetesAuthBackendConfigRead,
+		Read:   ReadWrapper(kubernetesAuthBackendConfigRead),
 		Update: kubernetesAuthBackendConfigUpdate,
 		Delete: kubernetesAuthBackendConfigDelete,
 		Exists: kubernetesAuthBackendConfigExists,

--- a/vault/resource_kubernetes_auth_backend_role.go
+++ b/vault/resource_kubernetes_auth_backend_role.go
@@ -68,7 +68,7 @@ func kubernetesAuthBackendRoleResource() *schema.Resource {
 
 	return &schema.Resource{
 		CreateContext: kubernetesAuthBackendRoleCreate,
-		ReadContext:   kubernetesAuthBackendRoleRead,
+		ReadContext:   ReadContextWrapper(kubernetesAuthBackendRoleRead),
 		UpdateContext: kubernetesAuthBackendRoleUpdate,
 		DeleteContext: kubernetesAuthBackendRoleDelete,
 		Importer: &schema.ResourceImporter{

--- a/vault/resource_kubernetes_secret_backend.go
+++ b/vault/resource_kubernetes_secret_backend.go
@@ -22,7 +22,7 @@ const (
 func kubernetesSecretBackendResource() *schema.Resource {
 	resource := &schema.Resource{
 		CreateContext: kubernetesSecretBackendCreateUpdate,
-		ReadContext:   kubernetesSecretBackendRead,
+		ReadContext:   ReadContextWrapper(kubernetesSecretBackendRead),
 		UpdateContext: kubernetesSecretBackendCreateUpdate,
 		DeleteContext: kubernetesSecretBackendDelete,
 		Importer: &schema.ResourceImporter{

--- a/vault/resource_kubernetes_secret_backend_role.go
+++ b/vault/resource_kubernetes_secret_backend_role.go
@@ -13,9 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
-var (
-	kubernetesSecretBackendFromPathRegex = regexp.MustCompile("^(.+)/roles/.+$")
-)
+var kubernetesSecretBackendFromPathRegex = regexp.MustCompile("^(.+)/roles/.+$")
 
 const (
 	fieldAllowedKubernetesNamespaces = "allowed_kubernetes_namespaces"
@@ -33,7 +31,7 @@ const (
 func kubernetesSecretBackendRoleResource() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: kubernetesSecretBackendRoleCreateUpdate,
-		ReadContext:   kubernetesSecretBackendRoleRead,
+		ReadContext:   ReadContextWrapper(kubernetesSecretBackendRoleRead),
 		UpdateContext: kubernetesSecretBackendRoleCreateUpdate,
 		DeleteContext: kubernetesSecretBackendRoleDelete,
 		Importer: &schema.ResourceImporter{

--- a/vault/resource_kv_secret.go
+++ b/vault/resource_kv_secret.go
@@ -17,7 +17,7 @@ func kvSecretResource(name string) *schema.Resource {
 		CreateContext: kvSecretWrite,
 		UpdateContext: kvSecretWrite,
 		DeleteContext: kvSecretDelete,
-		ReadContext:   kvSecretRead,
+		ReadContext:   ReadContextWrapper(ReadContextWrapper(kvSecretRead)),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/vault/resource_kv_secret_backend_v2.go
+++ b/vault/resource_kv_secret_backend_v2.go
@@ -17,7 +17,7 @@ func kvSecretBackendV2Resource() *schema.Resource {
 		CreateContext: kvSecretBackendV2CreateUpdate,
 		UpdateContext: kvSecretBackendV2CreateUpdate,
 		DeleteContext: kvSecretBackendV2Delete,
-		ReadContext:   kvSecretBackendV2Read,
+		ReadContext:   ReadContextWrapper(kvSecretBackendV2Read),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/vault/resource_kv_secret_v2.go
+++ b/vault/resource_kv_secret_v2.go
@@ -18,7 +18,7 @@ func kvSecretV2Resource(name string) *schema.Resource {
 		CreateContext: kvSecretV2Write,
 		UpdateContext: kvSecretV2Write,
 		DeleteContext: kvSecretV2Delete,
-		ReadContext:   kvSecretV2Read,
+		ReadContext:   ReadContextWrapper(kvSecretV2Read),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/vault/resource_ldap_auth_backend.go
+++ b/vault/resource_ldap_auth_backend.go
@@ -169,7 +169,7 @@ func ldapAuthBackendResource() *schema.Resource {
 
 		CreateContext: ldapAuthBackendWrite,
 		UpdateContext: ldapAuthBackendUpdate,
-		ReadContext:   ldapAuthBackendRead,
+		ReadContext:   ReadContextWrapper(ldapAuthBackendRead),
 		DeleteContext: ldapAuthBackendDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,

--- a/vault/resource_ldap_auth_backend_group.go
+++ b/vault/resource_ldap_auth_backend_group.go
@@ -22,7 +22,7 @@ func ldapAuthBackendGroupResource() *schema.Resource {
 
 		Create: ldapAuthBackendGroupResourceWrite,
 		Update: ldapAuthBackendGroupResourceWrite,
-		Read:   ldapAuthBackendGroupResourceRead,
+		Read:   ReadWrapper(ldapAuthBackendGroupResourceRead),
 		Delete: ldapAuthBackendGroupResourceDelete,
 		Exists: ldapAuthBackendGroupResourceExists,
 		Importer: &schema.ResourceImporter{

--- a/vault/resource_ldap_auth_backend_user.go
+++ b/vault/resource_ldap_auth_backend_user.go
@@ -23,7 +23,7 @@ func ldapAuthBackendUserResource() *schema.Resource {
 
 		Create: ldapAuthBackendUserResourceWrite,
 		Update: ldapAuthBackendUserResourceWrite,
-		Read:   ldapAuthBackendUserResourceRead,
+		Read:   ReadWrapper(ldapAuthBackendUserResourceRead),
 		Delete: ldapAuthBackendUserResourceDelete,
 		Exists: ldapAuthBackendUserResourceExists,
 		Importer: &schema.ResourceImporter{

--- a/vault/resource_mfa_duo.go
+++ b/vault/resource_mfa_duo.go
@@ -16,7 +16,7 @@ func mfaDuoResource() *schema.Resource {
 		Create: mfaDuoWrite,
 		Update: mfaDuoWrite,
 		Delete: mfaDuoDelete,
-		Read:   mfaDuoRead,
+		Read:   ReadWrapper(mfaDuoRead),
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/vault/resource_mfa_okta.go
+++ b/vault/resource_mfa_okta.go
@@ -16,7 +16,7 @@ func mfaOktaResource() *schema.Resource {
 		Create: mfaOktaWrite,
 		Update: mfaOktaUpdate,
 		Delete: mfaOktaDelete,
-		Read:   mfaOktaRead,
+		Read:   ReadWrapper(mfaOktaRead),
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/vault/resource_mfa_pingid.go
+++ b/vault/resource_mfa_pingid.go
@@ -16,7 +16,7 @@ func mfaPingIDResource() *schema.Resource {
 		Create: mfaPingIDWrite,
 		Update: mfaPingIDUpdate,
 		Delete: mfaPingIDDelete,
-		Read:   mfaPingIDRead,
+		Read:   ReadWrapper(mfaPingIDRead),
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/vault/resource_mfa_totp.go
+++ b/vault/resource_mfa_totp.go
@@ -15,7 +15,7 @@ func mfaTOTPResource() *schema.Resource {
 		Create: mfaTOTPWrite,
 		Update: mfaTOTPUpdate,
 		Delete: mfaTOTPDelete,
-		Read:   mfaTOTPRead,
+		Read:   ReadWrapper(mfaTOTPRead),
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/vault/resource_mount.go
+++ b/vault/resource_mount.go
@@ -120,7 +120,7 @@ func MountResource() *schema.Resource {
 		Create: mountWrite,
 		Update: mountUpdate,
 		Delete: mountDelete,
-		Read:   mountRead,
+		Read:   ReadWrapper(mountRead),
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/vault/resource_namespace.go
+++ b/vault/resource_namespace.go
@@ -25,7 +25,7 @@ func namespaceResource() *schema.Resource {
 		Create: namespaceCreate,
 		Update: namespaceCreate,
 		Delete: namespaceDelete,
-		Read:   namespaceRead,
+		Read:   ReadWrapper(namespaceRead),
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/vault/resource_nomad_secret_backend.go
+++ b/vault/resource_nomad_secret_backend.go
@@ -98,7 +98,7 @@ func nomadSecretAccessBackendResource() *schema.Resource {
 	return &schema.Resource{
 		Create: createNomadAccessConfigResource,
 		Update: updateNomadAccessConfigResource,
-		Read:   readNomadAccessConfigResource,
+		Read:   ReadWrapper(readNomadAccessConfigResource),
 		Delete: deleteNomadAccessConfigResource,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,

--- a/vault/resource_nomad_secret_role.go
+++ b/vault/resource_nomad_secret_role.go
@@ -57,7 +57,7 @@ func nomadSecretBackendRoleResource() *schema.Resource {
 	return &schema.Resource{
 		Create: createNomadRoleResource,
 		Update: updateNomadRoleResource,
-		Read:   readNomadRoleResource,
+		Read:   ReadWrapper(readNomadRoleResource),
 		Delete: deleteNomadRoleResource,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,

--- a/vault/resource_okta_auth_backend.go
+++ b/vault/resource_okta_auth_backend.go
@@ -23,7 +23,7 @@ func oktaAuthBackendResource() *schema.Resource {
 	return &schema.Resource{
 		Create: oktaAuthBackendWrite,
 		Delete: oktaAuthBackendDelete,
-		Read:   oktaAuthBackendRead,
+		Read:   ReadWrapper(oktaAuthBackendRead),
 		Update: oktaAuthBackendUpdate,
 		Exists: oktaAuthBackendExists,
 		Importer: &schema.ResourceImporter{

--- a/vault/resource_okta_auth_backend_group.go
+++ b/vault/resource_okta_auth_backend_group.go
@@ -16,7 +16,7 @@ import (
 func oktaAuthBackendGroupResource() *schema.Resource {
 	return &schema.Resource{
 		Create: oktaAuthBackendGroupWrite,
-		Read:   oktaAuthBackendGroupRead,
+		Read:   ReadWrapper(oktaAuthBackendGroupRead),
 		Update: oktaAuthBackendGroupWrite,
 		Delete: oktaAuthBackendGroupDelete,
 		Exists: oktaAuthBackendGroupExists,

--- a/vault/resource_okta_auth_backend_user.go
+++ b/vault/resource_okta_auth_backend_user.go
@@ -15,7 +15,7 @@ import (
 func oktaAuthBackendUserResource() *schema.Resource {
 	return &schema.Resource{
 		Create: oktaAuthBackendUserWrite,
-		Read:   oktaAuthBackendUserRead,
+		Read:   ReadWrapper(oktaAuthBackendUserRead),
 		Update: oktaAuthBackendUserWrite,
 		Delete: oktaAuthBackendUserDelete,
 

--- a/vault/resource_password_policy.go
+++ b/vault/resource_password_policy.go
@@ -11,7 +11,7 @@ func passwordPolicyResource() *schema.Resource {
 		Create: resourcePasswordPolicyWrite,
 		Update: resourcePasswordPolicyWrite,
 		Delete: resourcePasswordPolicyDelete,
-		Read:   resourcePasswordPolicyRead,
+		Read:   ReadWrapper(resourcePasswordPolicyRead),
 
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,

--- a/vault/resource_pki_secret_backend_cert.go
+++ b/vault/resource_pki_secret_backend_cert.go
@@ -17,7 +17,7 @@ import (
 func pkiSecretBackendCertResource() *schema.Resource {
 	return &schema.Resource{
 		Create:        pkiSecretBackendCertCreate,
-		Read:          pkiSecretBackendCertRead,
+		Read:          ReadWrapper(pkiSecretBackendCertRead),
 		Update:        pkiSecretBackendCertUpdate,
 		Delete:        pkiSecretBackendCertDelete,
 		CustomizeDiff: pkiCertAutoRenewCustomizeDiff,

--- a/vault/resource_pki_secret_backend_config_ca.go
+++ b/vault/resource_pki_secret_backend_config_ca.go
@@ -13,7 +13,7 @@ import (
 func pkiSecretBackendConfigCAResource() *schema.Resource {
 	return &schema.Resource{
 		Create: pkiSecretBackendConfigCACreate,
-		Read:   pkiSecretBackendConfigCARead,
+		Read:   ReadWrapper(pkiSecretBackendConfigCARead),
 		Delete: pkiSecretBackendConfigCADelete,
 
 		Schema: map[string]*schema.Schema{

--- a/vault/resource_pki_secret_backend_config_urls.go
+++ b/vault/resource_pki_secret_backend_config_urls.go
@@ -15,7 +15,7 @@ import (
 func pkiSecretBackendConfigUrlsResource() *schema.Resource {
 	return &schema.Resource{
 		Create: pkiSecretBackendConfigUrlsCreateUpdate,
-		Read:   pkiSecretBackendConfigUrlsRead,
+		Read:   ReadWrapper(pkiSecretBackendConfigUrlsRead),
 		Update: pkiSecretBackendConfigUrlsCreateUpdate,
 		Delete: pkiSecretBackendConfigUrlsDelete,
 		Importer: &schema.ResourceImporter{

--- a/vault/resource_pki_secret_backend_crl_config.go
+++ b/vault/resource_pki_secret_backend_crl_config.go
@@ -13,7 +13,7 @@ import (
 func pkiSecretBackendCrlConfigResource() *schema.Resource {
 	return &schema.Resource{
 		Create: pkiSecretBackendCrlConfigCreate,
-		Read:   pkiSecretBackendCrlConfigRead,
+		Read:   ReadWrapper(pkiSecretBackendCrlConfigRead),
 		Update: pkiSecretBackendCrlConfigUpdate,
 		Delete: pkiSecretBackendCrlConfigDelete,
 

--- a/vault/resource_pki_secret_backend_intermediate_cert_request.go
+++ b/vault/resource_pki_secret_backend_intermediate_cert_request.go
@@ -14,7 +14,7 @@ import (
 func pkiSecretBackendIntermediateCertRequestResource() *schema.Resource {
 	return &schema.Resource{
 		Create: pkiSecretBackendIntermediateCertRequestCreate,
-		Read:   pkiSecretBackendIntermediateCertRequestRead,
+		Read:   ReadWrapper(pkiSecretBackendIntermediateCertRequestRead),
 		Delete: pkiSecretBackendIntermediateCertRequestDelete,
 
 		Schema: map[string]*schema.Schema{

--- a/vault/resource_pki_secret_backend_intermediate_set_signed.go
+++ b/vault/resource_pki_secret_backend_intermediate_set_signed.go
@@ -13,7 +13,7 @@ import (
 func pkiSecretBackendIntermediateSetSignedResource() *schema.Resource {
 	return &schema.Resource{
 		Create: pkiSecretBackendIntermediateSetSignedCreate,
-		Read:   pkiSecretBackendCertRead,
+		Read:   ReadWrapper(pkiSecretBackendCertRead),
 		Delete: pkiSecretBackendIntermediateSetSignedDelete,
 
 		Schema: map[string]*schema.Schema{

--- a/vault/resource_pki_secret_backend_role.go
+++ b/vault/resource_pki_secret_backend_role.go
@@ -21,7 +21,7 @@ var (
 func pkiSecretBackendRoleResource() *schema.Resource {
 	return &schema.Resource{
 		Create: pkiSecretBackendRoleCreate,
-		Read:   pkiSecretBackendRoleRead,
+		Read:   ReadWrapper(pkiSecretBackendRoleRead),
 		Update: pkiSecretBackendRoleUpdate,
 		Delete: pkiSecretBackendRoleDelete,
 		Exists: pkiSecretBackendRoleExists,

--- a/vault/resource_pki_secret_backend_root_cert.go
+++ b/vault/resource_pki_secret_backend_root_cert.go
@@ -26,7 +26,7 @@ func pkiSecretBackendRootCertResource() *schema.Resource {
 		Update: func(data *schema.ResourceData, i interface{}) error {
 			return nil
 		},
-		Read: pkiSecretBackendCertRead,
+		Read: ReadWrapper(pkiSecretBackendCertRead),
 		StateUpgraders: []schema.StateUpgrader{
 			{
 				Version: 0,

--- a/vault/resource_pki_secret_backend_root_sign_intermediate.go
+++ b/vault/resource_pki_secret_backend_root_sign_intermediate.go
@@ -17,7 +17,7 @@ import (
 func pkiSecretBackendRootSignIntermediateResource() *schema.Resource {
 	return &schema.Resource{
 		Create: pkiSecretBackendRootSignIntermediateCreate,
-		Read:   pkiSecretBackendRootSignIntermediateRead,
+		Read:   ReadWrapper(pkiSecretBackendRootSignIntermediateRead),
 		Update: pkiSecretBackendRootSignIntermediateUpdate,
 		Delete: pkiSecretBackendCertDelete,
 		StateUpgraders: []schema.StateUpgrader{

--- a/vault/resource_pki_secret_backend_sign.go
+++ b/vault/resource_pki_secret_backend_sign.go
@@ -18,7 +18,7 @@ func pkiSecretBackendSignResource() *schema.Resource {
 		Update: func(data *schema.ResourceData, i interface{}) error {
 			return nil
 		},
-		Read: pkiSecretBackendCertRead,
+		Read: ReadWrapper(pkiSecretBackendCertRead),
 		StateUpgraders: []schema.StateUpgrader{
 			{
 				Version: 0,

--- a/vault/resource_policy.go
+++ b/vault/resource_policy.go
@@ -14,7 +14,7 @@ func policyResource() *schema.Resource {
 		Create: policyWrite,
 		Update: policyWrite,
 		Delete: policyDelete,
-		Read:   policyRead,
+		Read:   ReadWrapper(policyRead),
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/vault/resource_quota_lease_count.go
+++ b/vault/resource_quota_lease_count.go
@@ -18,7 +18,7 @@ func quotaLeaseCountPath(name string) string {
 func quotaLeaseCountResource() *schema.Resource {
 	return &schema.Resource{
 		Create: quotaLeaseCountCreate,
-		Read:   quotaLeaseCountRead,
+		Read:   ReadWrapper(quotaLeaseCountRead),
 		Update: quotaLeaseCountUpdate,
 		Delete: quotaLeaseCountDelete,
 		Exists: quotaLeaseCountExists,

--- a/vault/resource_quota_rate_limit.go
+++ b/vault/resource_quota_rate_limit.go
@@ -17,7 +17,7 @@ func quotaRateLimitPath(name string) string {
 func quotaRateLimitResource() *schema.Resource {
 	return &schema.Resource{
 		Create: quotaRateLimitCreate,
-		Read:   quotaRateLimitRead,
+		Read:   ReadWrapper(quotaRateLimitRead),
 		Update: quotaRateLimitUpdate,
 		Delete: quotaRateLimitDelete,
 		Exists: quotaRateLimitExists,

--- a/vault/resource_rabbitmq_secret_backend.go
+++ b/vault/resource_rabbitmq_secret_backend.go
@@ -15,7 +15,7 @@ import (
 func rabbitMQSecretBackendResource() *schema.Resource {
 	return &schema.Resource{
 		Create: rabbitMQSecretBackendCreate,
-		Read:   rabbitMQSecretBackendRead,
+		Read:   ReadWrapper(rabbitMQSecretBackendRead),
 		Update: rabbitMQSecretBackendUpdate,
 		Delete: rabbitMQSecretBackendDelete,
 		Exists: rabbitMQSecretBackendExists,

--- a/vault/resource_rabbitmq_secret_backend_role.go
+++ b/vault/resource_rabbitmq_secret_backend_role.go
@@ -14,7 +14,7 @@ import (
 func rabbitMQSecretBackendRoleResource() *schema.Resource {
 	return &schema.Resource{
 		Create: rabbitMQSecretBackendRoleWrite,
-		Read:   rabbitMQSecretBackendRoleRead,
+		Read:   ReadWrapper(rabbitMQSecretBackendRoleRead),
 		Update: rabbitMQSecretBackendRoleWrite,
 		Delete: rabbitMQSecretBackendRoleDelete,
 		Exists: rabbitMQSecretBackendRoleExists,

--- a/vault/resource_raft_autopilot.go
+++ b/vault/resource_raft_autopilot.go
@@ -63,7 +63,7 @@ func raftAutopilotConfigResource() *schema.Resource {
 	return &schema.Resource{
 		Create: createOrUpdateAutopilotConfigResource,
 		Update: createOrUpdateAutopilotConfigResource,
-		Read:   readAutopilotConfigResource,
+		Read:   ReadWrapper(readAutopilotConfigResource),
 		Delete: deleteAutopilotConfigResource,
 		Schema: fields,
 	}

--- a/vault/resource_raft_snapshot_agent_config.go
+++ b/vault/resource_raft_snapshot_agent_config.go
@@ -162,7 +162,7 @@ func raftSnapshotAgentConfigResource() *schema.Resource {
 	return &schema.Resource{
 		Create: createOrUpdateSnapshotAgentConfigResource,
 		Update: createOrUpdateSnapshotAgentConfigResource,
-		Read:   readSnapshotAgentConfigResource,
+		Read:   ReadWrapper(readSnapshotAgentConfigResource),
 		Delete: deleteSnapshotAgentConfigResource,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,

--- a/vault/resource_rgp_policy.go
+++ b/vault/resource_rgp_policy.go
@@ -11,7 +11,7 @@ func rgpPolicyResource() *schema.Resource {
 		Create: rgpPolicyWrite,
 		Update: rgpPolicyWrite,
 		Delete: rgpPolicyDelete,
-		Read:   rgpPolicyRead,
+		Read:   ReadWrapper(rgpPolicyRead),
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/vault/resource_ssh_secret_backend_ca.go
+++ b/vault/resource_ssh_secret_backend_ca.go
@@ -14,7 +14,7 @@ import (
 func sshSecretBackendCAResource() *schema.Resource {
 	return &schema.Resource{
 		Create: sshSecretBackendCACreate,
-		Read:   sshSecretBackendCARead,
+		Read:   ReadWrapper(sshSecretBackendCARead),
 		Delete: sshSecretBackendCADelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,

--- a/vault/resource_ssh_secret_backend_role.go
+++ b/vault/resource_ssh_secret_backend_role.go
@@ -179,7 +179,7 @@ func sshSecretBackendRoleResource() *schema.Resource {
 
 	return &schema.Resource{
 		Create: sshSecretBackendRoleWrite,
-		Read:   sshSecretBackendRoleRead,
+		Read:   ReadWrapper(sshSecretBackendRoleRead),
 		Update: sshSecretBackendRoleWrite,
 		Delete: sshSecretBackendRoleDelete,
 		Exists: sshSecretBackendRoleExists,

--- a/vault/resource_terraform_cloud_secret_backend.go
+++ b/vault/resource_terraform_cloud_secret_backend.go
@@ -14,7 +14,7 @@ import (
 func terraformCloudSecretBackendResource() *schema.Resource {
 	return &schema.Resource{
 		Create: terraformCloudSecretBackendCreate,
-		Read:   terraformCloudSecretBackendRead,
+		Read:   ReadWrapper(terraformCloudSecretBackendRead),
 		Update: terraformCloudSecretBackendUpdate,
 		Delete: terraformCloudSecretBackendDelete,
 		Exists: terraformCloudSecretBackendExists,

--- a/vault/resource_terraform_cloud_secret_creds.go
+++ b/vault/resource_terraform_cloud_secret_creds.go
@@ -14,7 +14,7 @@ import (
 func terraformCloudSecretCredsResource() *schema.Resource {
 	return &schema.Resource{
 		Create: createTerraformCloudSecretCredsResource,
-		Read:   readTerraformCloudSecretCredsResource,
+		Read:   ReadWrapper(readTerraformCloudSecretCredsResource),
 		Update: updateTerraformCloudSecretCredsResource,
 		Delete: deleteTerraformCloudSecretCredsResource,
 		Schema: map[string]*schema.Schema{

--- a/vault/resource_terraform_cloud_secret_role.go
+++ b/vault/resource_terraform_cloud_secret_role.go
@@ -19,7 +19,7 @@ var (
 func terraformCloudSecretRoleResource() *schema.Resource {
 	return &schema.Resource{
 		Create: terraformCloudSecretRoleWrite,
-		Read:   terraformCloudSecretRoleRead,
+		Read:   ReadWrapper(terraformCloudSecretRoleRead),
 		Update: terraformCloudSecretRoleWrite,
 		Delete: terraformCloudSecretRoleDelete,
 		Exists: terraformCloudSecretRoleExists,

--- a/vault/resource_token.go
+++ b/vault/resource_token.go
@@ -16,7 +16,7 @@ import (
 func tokenResource() *schema.Resource {
 	return &schema.Resource{
 		Create: tokenCreate,
-		Read:   tokenRead,
+		Read:   ReadWrapper(tokenRead),
 		Update: tokenUpdate,
 		Delete: tokenDelete,
 		Exists: tokenExists,

--- a/vault/resource_token_auth_backend_role.go
+++ b/vault/resource_token_auth_backend_role.go
@@ -106,7 +106,7 @@ func tokenAuthBackendRoleResource() *schema.Resource {
 
 	return &schema.Resource{
 		CreateContext: tokenAuthBackendRoleCreate,
-		ReadContext:   tokenAuthBackendRoleRead,
+		ReadContext:   ReadContextWrapper(tokenAuthBackendRoleRead),
 		UpdateContext: tokenAuthBackendRoleUpdate,
 		DeleteContext: tokenAuthBackendRoleDelete,
 		Importer: &schema.ResourceImporter{

--- a/vault/resource_transit_cache_config.go
+++ b/vault/resource_transit_cache_config.go
@@ -14,7 +14,7 @@ func transitSecretBackendCacheConfig() *schema.Resource {
 	return &schema.Resource{
 		Create: transitSecretBackendCacheConfigUpdate,
 		Update: transitSecretBackendCacheConfigUpdate,
-		Read:   transitSecretBackendCacheConfigRead,
+		Read:   ReadWrapper(transitSecretBackendCacheConfigRead),
 		Delete: transitSecretBackendCacheConfigDelete,
 
 		Schema: map[string]*schema.Schema{

--- a/vault/resource_transit_secret_backend_key.go
+++ b/vault/resource_transit_secret_backend_key.go
@@ -23,7 +23,7 @@ var (
 func transitSecretBackendKeyResource() *schema.Resource {
 	return &schema.Resource{
 		Create: transitSecretBackendKeyCreate,
-		Read:   transitSecretBackendKeyRead,
+		Read:   ReadWrapper(transitSecretBackendKeyRead),
 		Update: transitSecretBackendKeyUpdate,
 		Delete: transitSecretBackendKeyDelete,
 		Exists: transitSecretBackendKeyExists,


### PR DESCRIPTION
Whenever a namespaced resource was being imported with the `TERRAFORM_VAULT_NAMESPACE_IMPORT` the `namespace` field was not being stored in the TF state. This would cause the imported resource to be flagged as needing recreation on `terraform apply`, since a change to the `namespace` was being detected.

The fix is to detect the import on any resource read, and set the imported namespace in the state. This is done by wrapping a schema's `Read` or `ReadContext` function on all resources.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
