### PR TITLE
Add provider argument: ca_cert_bytes

### DIFF
--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -110,9 +110,15 @@ func NewProviderMeta(d *schema.ResourceData) (interface{}, error) {
 		clientAuthKey = clientAuth["key_file"].(string)
 	}
 
+	caCertBytes := []byte("")
+	if d.Get("ca_cert_bytes").(string) != "" {
+		caCertBytes = []byte(d.Get("ca_cert_bytes").(string))
+	}
+
 	err := clientConfig.ConfigureTLS(&api.TLSConfig{
 		CACert:        d.Get("ca_cert_file").(string),
 		CAPath:        d.Get("ca_cert_dir").(string),
+		CACertBytes:   caCertBytes,
 		Insecure:      d.Get("skip_tls_verify").(bool),
 		TLSServerName: d.Get("tls_server_name").(string),
 

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -92,6 +92,12 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("VAULT_CAPATH", ""),
 				Description: "Path to directory containing CA certificate files to validate the server's certificate.",
 			},
+			"ca_cert_bytes": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("VAULT_CACERT_BYTES", ""),
+				Description: "CA certificate PEM string to validate the server's certificate.",
+			},
 			"auth_login": {
 				Type:        schema.TypeList,
 				Optional:    true,

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -125,6 +125,10 @@ variables in order to keep credential information out of the configuration.
   the certificate presented by the Vault server. May be set via the
   `VAULT_CAPATH` environment variable.
 
+* `ca_cert_bytes` - (Optional) PEM-encoded string that will be used to validate
+  the certificate presented by the Vault server. May be set via the
+  `VAULT_CACERT_BYTES` environment variable.
+
 * `auth_login` - (Optional) A configuration block, described below, that
   attempts to authenticate using the `auth/<method>/login` path to
   acquire a token which Terraform will use. Terraform still issues itself


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Closes #1453

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):

```
Added ability to specify Vault CA cert as a string argument in the provider configuration block
```

Output from acceptance testing: https://gist.github.com/czembower/a44b842c494c0de75433daecd71aef80

Made possible by: https://github.com/hashicorp/vault/pull/14753/commits/2130948f98378ef235b2dac1774d1ac495ceb0df
Followed naming precedent set in Vault core: VAULT_CACERT_BYTES

This feature makes it easier to use validated TLS in ephemeral run environments where the CA data is not installed locally, but available from a Terraform data source.
