### PR TITLE
Add data source for fetching the Vault address from the provider

### DIFF
--- a/vault/data_source_address.go
+++ b/vault/data_source_address.go
@@ -1,0 +1,34 @@
+package vault
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+)
+
+func addressDataSource() *schema.Resource {
+	return &schema.Resource{
+		Read: ReadWrapper(addressDataSourceRead),
+		Schema: map[string]*schema.Schema{
+			"address": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "URL of the root of the target Vault server.",
+			},
+		},
+	}
+}
+
+func addressDataSourceRead(d *schema.ResourceData, meta interface{}) error {
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
+	address := client.Address()
+
+	d.SetId(address)
+	d.Set("address", address)
+
+	return nil
+}

--- a/vault/data_source_address_test.go
+++ b/vault/data_source_address_test.go
@@ -1,0 +1,29 @@
+package vault
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	r "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/hashicorp/terraform-provider-vault/testutil"
+)
+
+func TestAccDataSourceAddress(t *testing.T) {
+	r.Test(t, r.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testutil.TestAccPreCheck(t) },
+		Steps: []r.TestStep{
+			{
+				Config: testDataSourceAddressBasic_config,
+				Check:  resource.TestCheckResourceAttrSet("data.vault_address.test", "address"),
+			},
+		},
+	})
+}
+
+var testDataSourceAddressBasic_config = `
+
+data "vault_address" "test" {}
+
+`

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -21,6 +21,10 @@ const (
 	// multiple endpoints in Vault.
 	GenericPath = "generic"
 
+	// MetaPath is used inventorying paths that do not represent any endpoints
+	// in Vault.
+	MetaPath = "meta"
+
 	// UnknownPath is used for inventorying paths that have no obvious
 	// current endpoint they serve in Vault, and may relate to previous
 	// versions of Vault.
@@ -236,6 +240,10 @@ type Description struct {
 
 var (
 	DataSourceRegistry = map[string]*Description{
+		"vault_address": {
+			Resource:      UpdateSchemaResource(addressDataSource()),
+			PathInventory: []string{MetaPath},
+		},
 		"vault_approle_auth_backend_role_id": {
 			Resource:      UpdateSchemaResource(approleAuthBackendRoleIDDataSource()),
 			PathInventory: []string{"/auth/approle/role/{role_name}/role-id"},

--- a/website/docs/d/address.html.md
+++ b/website/docs/d/address.html.md
@@ -1,0 +1,29 @@
+---
+layout: "vault"
+page_title: "Vault: vault_address data source"
+sidebar_current: "docs-vault-datasource-address"
+description: |-
+  Fetch the URL of the root of the target Vault server.
+---
+
+# vault\_address
+
+Fetch the URL of the root of the target Vault server. Allows getting the URL configured for the provider.
+
+The data source can be useful if the address is configured for the provider with the `VAULT_ADDR` environment variable, or if the URL is needed in a child module using the provider.
+
+## Example Usage
+
+```hcl
+data "vault_address" "current" {}
+```
+
+## Argument Reference
+
+There are no arguments.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `address` - URL of the root of the target Vault server.

--- a/website/vault.erb
+++ b/website/vault.erb
@@ -22,9 +22,14 @@
                 <a href="#">Data Sources</a>
                     <ul class="nav nav-visible">
 
+                        <li<%= sidebar_current("docs-vault-datasource-address") %>>
+                            <a href="/docs/providers/vault/d/address.html">vault_address>
+                        </li>
+
                         <li<%= sidebar_current("docs-vault-datasource-approle-auth-backend-role-id") %>>
                             <a href="/docs/providers/vault/d/approle_auth_backend_role_id.html">vault_approle_auth_backend_role_id</a>
                         </li>
+
                         <li<%= sidebar_current("docs-vault-datasource-auth-backend") %>>
                             <a href="/docs/providers/vault/d/auth_backend.html">vault_auth_backend</a>
                         </li>


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

---

Add `vault_address` data source for fetching the URL of the Vault server configured for the provider.

The data source can be useful if the address is configured for the provider with the `VAULT_ADDR` environment variable, or if the URL is needed in a child module using the provider. In my use case for configuring redirect URLs of an OIDC IdP.

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):

```release-note
Add `vault_address` data source for fetching the URL of the Vault server
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccDataSourceAddress'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -run=TestAccDataSourceAddress -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/codegen   (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/pki      [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/internal/provider (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/testutil  (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
2022/08/05 17:01:26 [INFO] Using Vault token with the following policies: admin, default
=== RUN   TestAccDataSourceAddress
--- PASS: TestAccDataSourceAddress (2.47s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     (cached)
```
