### PR TITLE
fix: remove unnecessary nesting of secret data for KV-V1 secrets

### DIFF
--- a/vault/resource_kv_secret.go
+++ b/vault/resource_kv_secret.go
@@ -65,11 +65,7 @@ func kvSecretWrite(ctx context.Context, d *schema.ResourceData, meta interface{}
 		return diag.Errorf("data_json syntax error: %s", err)
 	}
 
-	data := map[string]interface{}{
-		"data": secretData,
-	}
-
-	if _, err := client.Logical().Write(path, data); err != nil {
+	if _, err := client.Logical().Write(path, secretData); err != nil {
 		return diag.Errorf("error writing secret data to %q, err=%s", path, err)
 	}
 
@@ -103,12 +99,10 @@ func kvSecretRead(_ context.Context, d *schema.ResourceData, meta interface{}) d
 
 	log.Printf("[DEBUG] secret: %#v", secret)
 
-	data := secret.Data["data"]
+	data := secret.Data
 
-	if v, ok := data.(map[string]interface{}); ok {
-		if err := d.Set(consts.FieldData, serializeDataMapToString(v)); err != nil {
-			return diag.FromErr(err)
-		}
+	if err := d.Set(consts.FieldData, serializeDataMapToString(data)); err != nil {
+		return diag.FromErr(err)
 	}
 
 	return nil

--- a/vault/resource_kv_secret_test.go
+++ b/vault/resource_kv_secret_test.go
@@ -123,7 +123,6 @@ func testResourceKVSecret_apiAcessCheck(s *terraform.State, want string) error {
 	}
 
 	return nil
-
 }
 
 func testResourceKVSecret_basic_apiAcessCheck(s *terraform.State) error {

--- a/vault/resource_kv_secret_test.go
+++ b/vault/resource_kv_secret_test.go
@@ -28,7 +28,7 @@ func TestAccKVSecret(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, fmt.Sprintf("%s/%s", mount, name)),
 					resource.TestCheckResourceAttr(resourceName, "data.zip", "zap"),
 					resource.TestCheckResourceAttr(resourceName, "data.foo", "bar"),
-					testResourceKVSecret_basic_apiAcessCheck,
+					testResourceKVSecret_apiAcessCheck("zap"),
 				),
 			},
 			{
@@ -37,7 +37,7 @@ func TestAccKVSecret(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, fmt.Sprintf("%s/%s", mount, name)),
 					resource.TestCheckResourceAttr(resourceName, "data.zip", "zoop"),
 					resource.TestCheckResourceAttr(resourceName, "data.foo", "bar"),
-					testResourceKVSecret_updated_apiAcessCheck,
+					testResourceKVSecret_apiAcessCheck("zoop"),
 				),
 			},
 			{
@@ -102,33 +102,27 @@ resource "vault_kv_secret" "test" {
 	return ret
 }
 
-func testResourceKVSecret_apiAcessCheck(s *terraform.State, want string) error {
-	resourceState := s.Modules[0].Resources["vault_kv_secret.test"]
-	state := resourceState.Primary
+func testResourceKVSecret_apiAcessCheck(want string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourceState := s.Modules[0].Resources["vault_kv_secret.test"]
+		state := resourceState.Primary
 
-	path := state.ID
+		path := state.ID
 
-	client, err := provider.GetClient(state, testProvider.Meta())
-	if err != nil {
-		return err
+		client, err := provider.GetClient(state, testProvider.Meta())
+		if err != nil {
+			return err
+		}
+
+		secret, err := client.Logical().Read(path)
+		if err != nil {
+			return fmt.Errorf("error reading back secret: %s", err)
+		}
+
+		if got := secret.Data["zip"]; got != want {
+			return fmt.Errorf("'zip' data is %q; want %q", got, want)
+		}
+
+		return nil
 	}
-
-	secret, err := client.Logical().Read(path)
-	if err != nil {
-		return fmt.Errorf("error reading back secret: %s", err)
-	}
-
-	if got := secret.Data["zip"]; got != want {
-		return fmt.Errorf("'zip' data is %q; want %q", got, want)
-	}
-
-	return nil
-}
-
-func testResourceKVSecret_basic_apiAcessCheck(s *terraform.State) error {
-	return testResourceKVSecret_apiAcessCheck(s, "zap")
-}
-
-func testResourceKVSecret_updated_apiAcessCheck(s *terraform.State) error {
-	return testResourceKVSecret_apiAcessCheck(s, "zoop")
 }

--- a/vault/resource_kv_secret_test.go
+++ b/vault/resource_kv_secret_test.go
@@ -28,7 +28,7 @@ func TestAccKVSecret(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, fmt.Sprintf("%s/%s", mount, name)),
 					resource.TestCheckResourceAttr(resourceName, "data.zip", "zap"),
 					resource.TestCheckResourceAttr(resourceName, "data.foo", "bar"),
-					testResourceKVSecret_apiAcessCheck,
+					testResourceKVSecret_basic_apiAcessCheck,
 				),
 			},
 			{
@@ -37,6 +37,7 @@ func TestAccKVSecret(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, fmt.Sprintf("%s/%s", mount, name)),
 					resource.TestCheckResourceAttr(resourceName, "data.zip", "zoop"),
 					resource.TestCheckResourceAttr(resourceName, "data.foo", "bar"),
+					testResourceKVSecret_updated_apiAcessCheck,
 				),
 			},
 			{
@@ -101,7 +102,7 @@ resource "vault_kv_secret" "test" {
 	return ret
 }
 
-func testResourceKVSecret_apiAcessCheck(s *terraform.State) error {
+func testResourceKVSecret_apiAcessCheck(s *terraform.State, want string) error {
 	resourceState := s.Modules[0].Resources["vault_kv_secret.test"]
 	state := resourceState.Primary
 
@@ -117,9 +118,18 @@ func testResourceKVSecret_apiAcessCheck(s *terraform.State) error {
 		return fmt.Errorf("error reading back secret: %s", err)
 	}
 
-	if got, want := secret.Data["zip"], "zap"; got != want {
+	if got := secret.Data["zip"]; got != want {
 		return fmt.Errorf("'zip' data is %q; want %q", got, want)
 	}
 
 	return nil
+
+}
+
+func testResourceKVSecret_basic_apiAcessCheck(s *terraform.State) error {
+	return testResourceKVSecret_apiAcessCheck(s, "zap")
+}
+
+func testResourceKVSecret_updated_apiAcessCheck(s *terraform.State) error {
+	return testResourceKVSecret_apiAcessCheck(s, "zoop")
 }

--- a/vault/resource_kv_secret_test.go
+++ b/vault/resource_kv_secret_test.go
@@ -28,7 +28,7 @@ func TestAccKVSecret(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, fmt.Sprintf("%s/%s", mount, name)),
 					resource.TestCheckResourceAttr(resourceName, "data.zip", "zap"),
 					resource.TestCheckResourceAttr(resourceName, "data.foo", "bar"),
-					testResourceKVSecret_apiAcessCheck("zap"),
+					testResourceKVSecret_apiAccessCheck("zap"),
 				),
 			},
 			{
@@ -37,7 +37,7 @@ func TestAccKVSecret(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, fmt.Sprintf("%s/%s", mount, name)),
 					resource.TestCheckResourceAttr(resourceName, "data.zip", "zoop"),
 					resource.TestCheckResourceAttr(resourceName, "data.foo", "bar"),
-					testResourceKVSecret_apiAcessCheck("zoop"),
+					testResourceKVSecret_apiAccessCheck("zoop"),
 				),
 			},
 			{
@@ -102,7 +102,7 @@ resource "vault_kv_secret" "test" {
 	return ret
 }
 
-func testResourceKVSecret_apiAcessCheck(want string) resource.TestCheckFunc {
+func testResourceKVSecret_apiAccessCheck(want string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		resourceState := s.Modules[0].Resources["vault_kv_secret.test"]
 		state := resourceState.Primary

--- a/vault/resource_kv_secret_test.go
+++ b/vault/resource_kv_secret_test.go
@@ -23,7 +23,7 @@ func TestAccKVSecret(t *testing.T) {
 		PreCheck:  func() { testutil.TestAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
-				Config: testKVSecretConfig(mount, name),
+				Config: testKVSecretConfig_basic(mount, name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, fmt.Sprintf("%s/%s", mount, name)),
 					resource.TestCheckResourceAttr(resourceName, "data.zip", "zap"),
@@ -31,7 +31,7 @@ func TestAccKVSecret(t *testing.T) {
 				),
 			},
 			{
-				Config: testKVSecretConfigUpdate(mount, name),
+				Config: testKVSecretConfig_updated(mount, name),
 				Check:  testResourceKVSecret_updateCheck,
 			},
 			{
@@ -56,7 +56,7 @@ resource "vault_mount" "kvv1" {
 	return ret
 }
 
-func testKVSecretConfig(mount, name string) string {
+func testKVSecretConfig_basic(mount, name string) string {
 	ret := fmt.Sprintf(`
 %s
 
@@ -76,7 +76,7 @@ resource "vault_kv_secret" "test" {
 	return ret
 }
 
-func testKVSecretConfigUpdate(mount, name string) string {
+func testKVSecretConfig_updated(mount, name string) string {
 	ret := fmt.Sprintf(`
 %s
 

--- a/vault/resource_kv_secret_test.go
+++ b/vault/resource_kv_secret_test.go
@@ -31,8 +31,16 @@ func TestAccKVSecret(t *testing.T) {
 				),
 			},
 			{
+				Config: testKVSecretConfig_basic(mount, name),
+				Check:  testResourceKVSecret_apiAcessCheck,
+			},
+			{
 				Config: testKVSecretConfig_updated(mount, name),
-				Check:  testResourceKVSecret_updateCheck,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, fmt.Sprintf("%s/%s", mount, name)),
+					resource.TestCheckResourceAttr(resourceName, "data.zip", "zoop"),
+					resource.TestCheckResourceAttr(resourceName, "data.foo", "bar"),
+				),
 			},
 			{
 				ResourceName:            resourceName,
@@ -96,7 +104,7 @@ resource "vault_kv_secret" "test" {
 	return ret
 }
 
-func testResourceKVSecret_updateCheck(s *terraform.State) error {
+func testResourceKVSecret_apiAcessCheck(s *terraform.State) error {
 	resourceState := s.Modules[0].Resources["vault_kv_secret.test"]
 	state := resourceState.Primary
 
@@ -112,7 +120,7 @@ func testResourceKVSecret_updateCheck(s *terraform.State) error {
 		return fmt.Errorf("error reading back secret: %s", err)
 	}
 
-	if got, want := secret.Data["zip"], "zoop"; got != want {
+	if got, want := secret.Data["zip"], "zoo"; got != want {
 		return fmt.Errorf("'zip' data is %q; want %q", got, want)
 	}
 

--- a/vault/resource_kv_secret_test.go
+++ b/vault/resource_kv_secret_test.go
@@ -28,11 +28,8 @@ func TestAccKVSecret(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, fmt.Sprintf("%s/%s", mount, name)),
 					resource.TestCheckResourceAttr(resourceName, "data.zip", "zap"),
 					resource.TestCheckResourceAttr(resourceName, "data.foo", "bar"),
+					testResourceKVSecret_apiAcessCheck,
 				),
-			},
-			{
-				Config: testKVSecretConfig_basic(mount, name),
-				Check:  testResourceKVSecret_apiAcessCheck,
 			},
 			{
 				Config: testKVSecretConfig_updated(mount, name),
@@ -120,7 +117,7 @@ func testResourceKVSecret_apiAcessCheck(s *terraform.State) error {
 		return fmt.Errorf("error reading back secret: %s", err)
 	}
 
-	if got, want := secret.Data["zip"], "zoo"; got != want {
+	if got, want := secret.Data["zip"], "zap"; got != want {
 		return fmt.Errorf("'zip' data is %q; want %q", got, want)
 	}
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1549

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
fix #1549
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccKVSecret'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -run=TestAccKVSecret -timeout 30m ./...
?   	github.com/hashicorp/terraform-provider-vault	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/generate	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/codegen	0.277s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/generated	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode	0.276s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode	1.362s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet	0.926s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role	0.483s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template	1.155s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation	0.699s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/helper	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/consts	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/internal/identity/entity	0.341s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/group	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/pki	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/internal/provider	1.429s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/schema	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/testutil	1.335s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/util	1.247s [no tests to run]
2022/08/07 09:57:30 [INFO] Using Vault token with the following policies: root
=== RUN   TestAccKVSecretBackendV2
--- PASS: TestAccKVSecretBackendV2 (1.86s)
=== RUN   TestAccKVSecret
--- PASS: TestAccKVSecret (1.71s)
=== RUN   TestAccKVSecretV2
--- PASS: TestAccKVSecretV2 (1.11s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/vault	5.369s
```
