### PR TITLE
Update kvv1 test to use AssertVaultState()

### DIFF
--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -448,9 +448,17 @@ func assertVaultState(resp *api.Secret, tfs *terraform.State, path string, tests
 			}
 		}
 
-		v, inVault := resp.Data[st.VaultAttr]
-		if v == nil && (s == "" || s == "0") {
-			continue
+		var v interface{}
+		var inVault bool
+		if st.VaultAttr == "" {
+			v = resp.Data
+			inVault = true
+		} else {
+			v, inVault = resp.Data[st.VaultAttr]
+			if v == nil && (s == "" || s == "0") {
+				continue
+			}
+
 		}
 
 		if !inVault && inState {
@@ -549,6 +557,28 @@ func assertVaultState(resp *api.Secret, tfs *terraform.State, path string, tests
 				if !reflect.DeepEqual(expected, actual) {
 					return fmt.Errorf(errFmt, st.StateAttr, expected, actual)
 				}
+			}
+		case map[string]interface{}:
+			expected := map[string]interface{}{}
+
+			prefix := fmt.Sprintf("%s.", st.StateAttr)
+			for attr := range attrs {
+				if strings.HasPrefix(attr, prefix) {
+					parts := strings.Split(attr, ".")
+					if len(parts) < 2 {
+						continue
+					}
+
+					switch parts[1] {
+					case "#", "%":
+						continue
+					}
+
+					expected[parts[1]] = attrs[attr]
+				}
+			}
+			if !reflect.DeepEqual(expected, v) {
+				return fmt.Errorf(errFmt, st.StateAttr, expected, v)
 			}
 		case []map[string]interface{}:
 			var expected []map[string]interface{}

--- a/vault/data_source_kv_secret.go
+++ b/vault/data_source_kv_secret.go
@@ -70,9 +70,7 @@ func kvSecretDataSourceRead(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.Errorf("no secret found at %q", path)
 	}
 
-	data := secret.Data["data"]
-
-	jsonData, err := json.Marshal(data)
+	jsonData, err := json.Marshal(secret.Data)
 	if err != nil {
 		return diag.Errorf("error marshaling JSON for %q: %s", path, err)
 	}


### PR DESCRIPTION
- update AssertVaultState* to support comparing map[string]interface{}

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #1570 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ go test -test.v -test.paniconexit0 -test.run ^\QTestAccKVSecret\E$
2022/08/10 13:32:27 [INFO] Using Vault token with the following policies: root
=== RUN   TestAccKVSecret
--- PASS: TestAccKVSecret (37.58s)
PASS

Debugger finished with the exit code 0
```
