### PR TITLE
Only initialize the testProvider for acceptance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
-TEST?=$$(go list ./...)
-GOFMT_FILES?=$$(find . -name '*.go')
-WEBSITE_REPO=github.com/hashicorp/terraform-website
-PKG_NAME=vault
-TF_ACC_TERRAFORM_VERSION?=1.2.2
+TEST ?= $$(go list ./...)
+GOFMT_FILES ?= $$(find . -name '*.go')
+WEBSITE_REPO = github.com/hashicorp/terraform-website
+PKG_NAME = vault
+TF_ACC_TERRAFORM_VERSION ?= 1.2.2
+TESTARGS ?= -test.v
 
 default: build
 
@@ -13,7 +14,7 @@ test: fmtcheck
 	TF_ACC= go test $(TESTARGS) -timeout 10m -parallel=4 ./...
 
 testacc: fmtcheck
-	TF_ACC=1 go test -v $(TESTARGS) -timeout 30m ./...
+	TF_ACC=1 go test $(TESTARGS) -timeout 30m ./...
 
 testacc-ent:
 	make testacc TF_ACC_ENTERPRISE=1

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -39,7 +39,7 @@ func TestEntPreCheck(t *testing.T) {
 }
 
 func SkipTestAcc(t *testing.T) {
-	SkipTestEnvUnset(t, resource.TestEnvVar)
+	SkipTestEnvUnset(t, resource.EnvTfAcc)
 }
 
 func SkipTestAccEnt(t *testing.T) {

--- a/vault/provider_test.go
+++ b/vault/provider_test.go
@@ -69,6 +69,11 @@ func init() {
 func initTestProvider() {
 	testInitOnce.Do(
 		func() {
+			// only required when running acceptance tests
+			if os.Getenv(resource.EnvTfAcc) == "" {
+				return
+			}
+
 			if testProvider == nil {
 				testProvider = Provider()
 				testProviders = map[string]*schema.Provider{


### PR DESCRIPTION
The `testProvider` was being initialized/configured in all cases. This should only happen when running the acceptance tests which require access to a Vault server. This PR should resolve that issue.