### PR TITLE
add kv-v2 write retry

### DIFF
--- a/vault/resource_generic_secret.go
+++ b/vault/resource_generic_secret.go
@@ -4,10 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/vault/api"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
@@ -149,7 +151,11 @@ func genericSecretResourceWrite(d *schema.ResourceData, meta interface{}) error 
 
 	writeData := func() error {
 		if _, err := client.Logical().Write(path, data); err != nil {
-			return err
+			if respErr, ok := err.(*api.ResponseError); ok && (respErr.StatusCode == http.StatusBadRequest) {
+				return err
+			} else {
+				return backoff.Permanent(err)
+			}
 		}
 		return nil
 	}

--- a/vault/resource_kv_secret_v2.go
+++ b/vault/resource_kv_secret_v2.go
@@ -5,13 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"net/http"
-	"time"
 
-	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
@@ -140,6 +136,7 @@ func kvSecretV2Write(ctx context.Context, d *schema.ResourceData, meta interface
 
 	if _, err := client.Logical().Write(path, data); err != nil {
 		return diag.Errorf("error writing secret data to %s, err=%s", path, err)
+	}
 
 	d.SetId(path)
 


### PR DESCRIPTION
An error condition can occur if attempting to create a kv-v2 mount and write secrets to it in the same terraform run, resulting in the error:

```Upgrading from non-versioned to versioned data. This backend will be unavailable for a brief period and will resume service shortly```

It appears that this error is common on Vault running in a cluster, and less so when standalone. 

This PR adds retry with backoff on writes to vault_kv_secret_v2 as well as vault_generic_secret resources. Followed precedent set for retry in namespaceDelete().

Closes #677 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
```
Fixed failed writes to newly-created kv-v2 mount by adding retry/backoff
```

Output from acceptance testing:
```
TESTARGS="--run TestAccKVSecretV2 --run TestResourceGenericSecret" make testacc-ent
make testacc TF_ACC_ENTERPRISE=1
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v --run TestAccKVSecretV2 --run TestResourceGenericSecret -timeout 30m ./...

2022/08/11 11:24:20 [INFO] Using Vault token with the following policies: root
=== RUN   TestResourceGenericSecret
--- PASS: TestResourceGenericSecret (2.41s)
=== RUN   TestResourceGenericSecretNS
--- PASS: TestResourceGenericSecretNS (3.14s)
=== RUN   TestResourceGenericSecret_deleted
--- PASS: TestResourceGenericSecret_deleted (1.99s)
=== RUN   TestResourceGenericSecret_deleteAllVersions
--- PASS: TestResourceGenericSecret_deleteAllVersions (2.03s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/vault	9.999s
```

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request