### PR TITLE
Additional changes like those in #1305/#1479

### DIFF
--- a/vault/resource_azure_auth_backend_config.go
+++ b/vault/resource_azure_auth_backend_config.go
@@ -66,7 +66,10 @@ func azureAuthBackendConfigResource() *schema.Resource {
 }
 
 func azureAuthBackendWrite(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*provider.ProviderMeta).GetClient()
+	config, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 
 	// if backend comes from the config, it won't have the StateFunc
 	// applied yet, so we need to apply it again.
@@ -100,8 +103,10 @@ func azureAuthBackendWrite(d *schema.ResourceData, meta interface{}) error {
 }
 
 func azureAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*provider.ProviderMeta).GetClient()
-
+	config, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	log.Printf("[DEBUG] Reading Azure auth backend config")
 	secret, err := config.Logical().Read(d.Id())
 	if err != nil {
@@ -130,8 +135,10 @@ func azureAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func azureAuthBackendDelete(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*provider.ProviderMeta).GetClient()
-
+	config, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
 	log.Printf("[DEBUG] Deleting Azure auth backend config from %q", d.Id())
 	_, err := config.Logical().Delete(d.Id())
 	if err != nil {
@@ -143,8 +150,10 @@ func azureAuthBackendDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func azureAuthBackendExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	config := meta.(*provider.ProviderMeta).GetClient()
-
+	config, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
 	log.Printf("[DEBUG] Checking if Azure auth backend is configured at %q", d.Id())
 	secret, err := config.Logical().Read(d.Id())
 	if err != nil {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #1305 and #1479

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fixing vault/resource_azure_auth_backend_config.go to make it work better with namespaces.
```

Output from acceptance testing:

```
The following fails even on a clean clone of main this test and all of the others in the MAKEFILE fail.
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
