### PR TITLE
Add anonymous_group_search to ldap_auth_backend

### DIFF
--- a/vault/resource_ldap_auth_backend.go
+++ b/vault/resource_ldap_auth_backend.go
@@ -121,6 +121,11 @@ func ldapAuthBackendResource() *schema.Resource {
 			Optional: true,
 			Computed: true,
 		},
+		"anonymous_group_search": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Computed: true,
+		},
 
 		"description": {
 			Type:     schema.TypeString,
@@ -295,6 +300,10 @@ func ldapAuthBackendUpdate(ctx context.Context, d *schema.ResourceData, meta int
 		data["use_token_groups"] = v.(bool)
 	}
 
+	if v, ok := d.GetOkExists("anonymous_group_search"); ok {
+		data["anonymous_group_search"] = v.(bool)
+	}
+
 	if v, ok := d.GetOk("client_tls_cert"); ok {
 		data["client_tls_cert"] = v.(string)
 	}
@@ -377,6 +386,7 @@ func ldapAuthBackendRead(_ context.Context, d *schema.ResourceData, meta interfa
 	d.Set("groupattr", resp.Data["groupattr"])
 	d.Set("username_as_alias", resp.Data["username_as_alias"])
 	d.Set("use_token_groups", resp.Data["use_token_groups"])
+	d.Set("anonymous_group_search", resp.Data["anonymous_group_search"])
 
 	// `bindpass`, `client_tls_cert` and `client_tls_key` cannot be read out from the API
 	// So... if they drift, they drift.

--- a/website/docs/r/ldap_auth_backend.html.md
+++ b/website/docs/r/ldap_auth_backend.html.md
@@ -76,6 +76,8 @@ The following arguments are supported:
 
 * `use_token_groups` - (Optional) Use the Active Directory tokenGroups constructed attribute of the user to find the group memberships
 
+* `anonymous_group_search` - (Optional) Use anonymous binds when performing LDAP group searches (note: even when true, the initial credentials will still be used for the initial connection test)
+
 * `path` - (Optional) Path to mount the LDAP auth backend under
 
 * `description` - (Optional) Description for the LDAP auth backend mount


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):


```release-note
Add missing argument to anonymous_group_search ldap_auth_backend
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
