### PR TITLE
Fix data_source_azure_access_credentials US Government Cloud

### DIFF
--- a/vault/data_source_azure_access_credentials.go
+++ b/vault/data_source_azure_access_credentials.go
@@ -231,7 +231,7 @@ func azureAccessCredentialsDataSourceRead(d *schema.ResourceData, meta interface
 
 		switch env.Name {
 		case "AzureCloud":
-			clientOptions.Endpoint = arm.AzurePublic
+			clientOptions.Endpoint = arm.AzurePublicCloud
 		case "AzureChinaCloud":
 			clientOptions.Endpoint = arm.AzureChina
 		case "AzureUSGovernmentCloud":

--- a/vault/data_source_azure_access_credentials.go
+++ b/vault/data_source_azure_access_credentials.go
@@ -105,7 +105,7 @@ func azureAccessCredentialsDataSource() *schema.Resource {
 				Optional: true,
 				Description: `The Azure environment to use during credential validation.
 Defaults to the environment configured in the Vault backend.
-Some possible values: AzurePublicCloud, AzureGovernmentCloud`,
+Some possible values: AzureCloud, AzureUSGovernmentCloud`,
 			},
 		},
 	}
@@ -230,11 +230,11 @@ func azureAccessCredentialsDataSourceRead(d *schema.ResourceData, meta interface
 		}
 
 		switch env.Name {
-		case "AzurePublicCloud":
-			clientOptions.Endpoint = arm.AzurePublicCloud
+		case "AzureCloud":
+			clientOptions.Endpoint = arm.AzurePublic
 		case "AzureChinaCloud":
 			clientOptions.Endpoint = arm.AzureChina
-		case "AzureGovernmentCloud":
+		case "AzureUSGovernmentCloud":
 			clientOptions.Endpoint = arm.AzureGovernment
 		case "AzureGermanCloud":
 			// AzureGermanCloud appears to have been removed,

--- a/vault/data_source_azure_access_credentials.go
+++ b/vault/data_source_azure_access_credentials.go
@@ -105,7 +105,7 @@ func azureAccessCredentialsDataSource() *schema.Resource {
 				Optional: true,
 				Description: `The Azure environment to use during credential validation.
 Defaults to the environment configured in the Vault backend.
-Some possible values: AzureCloud, AzureUSGovernmentCloud`,
+Some possible values: AzurePublicCloud, AzureUSGovernmentCloud`,
 			},
 		},
 	}
@@ -230,7 +230,7 @@ func azureAccessCredentialsDataSourceRead(d *schema.ResourceData, meta interface
 		}
 
 		switch env.Name {
-		case "AzureCloud":
+		case "AzurePublicCloud":
 			clientOptions.Endpoint = arm.AzurePublicCloud
 		case "AzureChinaCloud":
 			clientOptions.Endpoint = arm.AzureChina


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1589

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
fix: data_source_azure_access_credentials environment support for government cloud
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -run=TestAccXXX -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/codegen   0.067s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    0.039s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    0.089s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    0.039s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        0.056s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    0.035s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      0.031s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  0.034s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/pki      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/provider 0.057s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/semver   0.032s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
ok      github.com/hashicorp/terraform-provider-vault/testutil  0.031s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util      0.030s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/vault     0.747s [no tests to run]
```