### PR TITLE
vault_pki_secret_backend_cert: Report when renewal is pending

### DIFF
--- a/vault/resource_pki_secret_backend_cert.go
+++ b/vault/resource_pki_secret_backend_cert.go
@@ -151,7 +151,13 @@ func pkiSecretBackendCertResource() *schema.Resource {
 			"expiration": {
 				Type:        schema.TypeInt,
 				Computed:    true,
-				Description: "The certificate expiration.",
+				Description: "The certificate expiration as a Unix-style timestamp.",
+			},
+			"renew_pending": {
+				Type:     schema.TypeBool,
+				Computed: true,
+				Description: "Initially false, and then set to true during refresh once " +
+					"the expiration is less than min_seconds_remaining in the future.",
 			},
 			"revoke": {
 				Type:        schema.TypeBool,
@@ -245,30 +251,34 @@ func pkiSecretBackendCertCreate(d *schema.ResourceData, meta interface{}) error 
 	d.Set("serial_number", resp.Data["serial_number"])
 	d.Set("expiration", resp.Data["expiration"])
 
+	if err := pkiSecretBackendCertSynchronizeRenewPending(d); err != nil {
+		return err
+	}
+
 	d.SetId(fmt.Sprintf("%s/%s/%s", backend, name, commonName))
 	return pkiSecretBackendCertRead(d, meta)
 }
 
-func checkPKICertExpiry(expiration int64) bool {
-	expiry := time.Unix(expiration, 0)
-	now := time.Now()
-
-	return now.After(expiry)
-}
-
 func pkiCertAutoRenewCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	// The Create and Read functions will both set renew_pending if
+	// the current time is after the min_seconds_remaining timestamp. During
+	// planning we respond to that by proposing automatic renewal, if enabled.
 	if d.Id() == "" || !d.Get("auto_renew").(bool) {
 		return nil
 	}
-
-	expiration := int64(d.Get("expiration").(int) - d.Get("min_seconds_remaining").(int))
-	if checkPKICertExpiry(expiration) {
+	if d.Get("renew_pending").(bool) {
 		log.Printf("[DEBUG] certificate %q is due for renewal", d.Id())
 		if err := d.SetNewComputed("certificate"); err != nil {
 			return err
 		}
 
 		if err := d.ForceNew("certificate"); err != nil {
+			return err
+		}
+
+		// Renewing the certificate will reset the value of renew_pending
+		d.SetNewComputed("renew_pending")
+		if err := d.ForceNew("renew_pending"); err != nil {
 			return err
 		}
 
@@ -295,8 +305,12 @@ func pkiSecretBackendCertRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	// trigger a resource re-creation whenever the engine's mount has disappeared
-	if !enabled {
+	if enabled {
+		if err := pkiSecretBackendCertSynchronizeRenewPending(d); err != nil {
+			return err
+		}
+	} else {
+		// trigger a resource re-creation whenever the engine's mount has disappeared
 		log.Printf("[WARN] Mount %q does not exist, setting resource for re-creation", path)
 		d.SetId("")
 	}
@@ -342,6 +356,32 @@ func pkiSecretBackendCertDelete(d *schema.ResourceData, meta interface{}) error 
 
 func pkiSecretBackendCertPath(backend string, name string) string {
 	return strings.Trim(backend, "/") + "/issue/" + strings.Trim(name, "/")
+}
+
+// pkiSecretBackendCertSynchronizeRenewPending calculates whether the
+// expiration time of the certificate is fewer than min_seconds_remaining
+// seconds in the future (relative to the current system time), and then
+// updates the renew_pending attribute accordingly.
+func pkiSecretBackendCertSynchronizeRenewPending(d *schema.ResourceData) error {
+	if _, ok := d.Get("renew_pending").(bool); !ok {
+		// pkiSecretBackendCertRead is shared between vault_pki_secret_backend_cert
+		// and vault_pki_secret_backend_root_cert, and the latter doesn't have
+		// an auto-renew mechanism so doesn't have a "renew_pending" attribute
+		// to update.
+		return nil
+	}
+
+	expiration := d.Get("expiration").(int)
+	earlyRenew := d.Get("min_seconds_remaining").(int)
+	effectiveExpiration := int64(expiration - earlyRenew)
+	return d.Set("renew_pending", checkPKICertExpiry(effectiveExpiration))
+}
+
+func checkPKICertExpiry(expiration int64) bool {
+	expiry := time.Unix(expiration, 0)
+	now := time.Now()
+
+	return now.After(expiry)
 }
 
 func convertIntoSliceOfString(slice interface{}) []string {

--- a/vault/resource_pki_secret_backend_cert_test.go
+++ b/vault/resource_pki_secret_backend_cert_test.go
@@ -183,6 +183,7 @@ func TestPkiSecretBackendCert_renew(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceName, "revoke", "false"),
 		resource.TestCheckResourceAttrSet(resourceName, "expiration"),
 		resource.TestCheckResourceAttrSet(resourceName, "serial_number"),
+		resource.TestCheckResourceAttrSet(resourceName, "renew_pending"),
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -200,6 +201,13 @@ func TestPkiSecretBackendCert_renew(t *testing.T) {
 			},
 			{
 				// test renewal based on cert expiry
+				// NOTE: Ideally we'd also directly test that the refreshed
+				// state has renew_pending set to true before creating the plan,
+				// but the test harness only exposes the state after applying
+				// the plan so we can't make assertions against the intermediate
+				// refresh and planning steps. Therefore we're only testing
+				// that renew_pending got set to true indirectly by observing
+				// that it then caused the certificate to get re-issued.
 				PreConfig: testWaitCertExpiry(store),
 				Config:    testPkiSecretBackendCertConfig_renew(path),
 				Check: resource.ComposeTestCheckFunc(

--- a/vault/resource_pki_secret_backend_sign_test.go
+++ b/vault/resource_pki_secret_backend_sign_test.go
@@ -155,6 +155,7 @@ func TestPkiSecretBackendSign_renew(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceName, "min_seconds_remaining", "3595"),
 		resource.TestCheckResourceAttrSet(resourceName, "expiration"),
 		resource.TestCheckResourceAttrSet(resourceName, "serial"),
+		resource.TestCheckResourceAttrSet(resourceName, "renew_pending"),
 		testValidateCSR(resourceName),
 	}
 	resource.Test(t, resource.TestCase{

--- a/website/docs/r/pki_secret_backend_cert.html.md
+++ b/website/docs/r/pki_secret_backend_cert.html.md
@@ -84,3 +84,5 @@ In addition to the fields above, the following attributes are exported:
 * `serial_number` - The serial number
 
 * `expiration` - The expiration date of the certificate in unix epoch format
+
+* `renew_pending` - `true` if the current time (during refresh) is after the start of the early renewal window declared by `min_seconds_remaining`, and `false` otherwise; if `auto_renew` is set to `true` then the provider will plan to replace the certificate once renewal is pending.

--- a/website/docs/r/pki_secret_backend_sign.html.md
+++ b/website/docs/r/pki_secret_backend_sign.html.md
@@ -106,6 +106,8 @@ In addition to the fields above, the following attributes are exported:
 
 * `expiration` - The expiration date of the certificate in unix epoch format
 
+* `renew_pending` - `true` if the current time (during refresh) is after the start of the early renewal window declared by `min_seconds_remaining`, and `false` otherwise; if `auto_renew` is set to `true` then the provider will plan to replace the certificate once renewal is pending.
+
 ## Deprecations
 
 * `serial` - Use `serial_number` instead.


### PR DESCRIPTION
(This actually affects both `vault_pki_secret_backend_cert` and `vault_pki_secret_backend_sign` in the same way, because they share the same logic for refreshing and planning.)

This exports an additional boolean attribute `renew_pending`, which will start set to `false` but will transition to `true` during refresh if the current time is less than `min_seconds_remaining` seconds before the certificate's expiration time. The auto renew behavior is then triggered by this new attribute becoming `true`, ensuring that these two behaviors will always agree with one another about when renewal is pending.

This adds a little extra information to the plan output to explain why the provider is proposing to replace the object, and also adds a useful hook for postconditions that wish to detect (e.g. during a refresh-only plan) that a renewal is pending.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


---

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
IMPROVEMENTS:
* Add attribute `renew_pending` to `vault_pki_secret_backend_cert` and `vault_pki_secret_backend_sign` to expose the provider's decision about whether the object is within its renewal period.
```

Output from acceptance testing:

```
# (using vault 1.11.3 on linux_amd64 with a server in dev mode)

$ TF_ACC=1 go test -v -run=TestPkiSecretBackendCert -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/codegen   0.079s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    0.212s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    0.471s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    0.375s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        0.220s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    0.442s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      0.213s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  0.173s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/pki      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/provider 0.491s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/semver   0.131s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
ok      github.com/hashicorp/terraform-provider-vault/testutil  0.105s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util      0.115s [no tests to run]
2022/09/07 09:15:30 [INFO] Using Vault token with the following policies: root
=== RUN   TestPkiSecretBackendCert_basic
--- PASS: TestPkiSecretBackendCert_basic (6.05s)
=== RUN   TestPkiSecretBackendCert_renew
--- PASS: TestPkiSecretBackendCert_renew (13.74s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     20.015s

$ TF_ACC=1 go test -v -run=TestPkiSecretBackendSign -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/codegen   0.092s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    0.505s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    0.496s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    0.202s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        0.233s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    0.567s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      0.257s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  0.153s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/pki      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/provider 0.204s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/semver   0.129s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
ok      github.com/hashicorp/terraform-provider-vault/testutil  0.218s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util      0.109s [no tests to run]
2022/09/07 09:28:16 [INFO] Using Vault token with the following policies: root
=== RUN   TestPkiSecretBackendSign_basic
--- PASS: TestPkiSecretBackendSign_basic (5.34s)
=== RUN   TestPkiSecretBackendSign_renew
--- PASS: TestPkiSecretBackendSign_renew (11.67s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     17.235s
```
