### PR TITLE
Add first-class auth login config support

### DIFF
--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -64,12 +64,32 @@ const (
 	FieldAnyMount                 = "any_mount"
 	FieldUUID                     = "uuid"
 	FieldMountAccessor            = "mount_accessor"
+	FieldUsername                 = "username"
+	FieldPassword                 = "password"
+	FieldPasswordFile             = "password_file"
+	FieldAuthLoginDefault         = "auth_login"
+	FieldAuthLoginUserpass        = "auth_login_userpass"
+	FieldAuthLoginAWS             = "auth_login_aws"
+	FieldIdentity                 = "identity"
+	FieldSignature                = "signature"
+	FieldPKCS7                    = "pkcs7"
+	FieldNonce                    = "nonce"
+	FieldIAMHttpRequestMethod     = "iam_http_request_method"
+	FieldIAMHttpRequestURL        = "iam_http_request_url"
+	FieldIAMHttpRequestBody       = "iam_http_request_body"
+	FieldIAMHttpRequestHeaders    = "iam_http_request_headers"
 
 	/*
 		common environment variables
 	*/
 	EnvVarVaultNamespaceImport = "TERRAFORM_VAULT_NAMESPACE_IMPORT"
 	EnvVarSkipChildToken       = "TERRAFORM_VAULT_SKIP_CHILD_TOKEN"
+	// EnvVarUsername to get the username for the userpass auth method
+	EnvVarUsername = "TERRAFORM_VAULT_USERNAME"
+	// EnvVarPassword to get the password for the userpass auth method
+	EnvVarPassword = "TERRAFORM_VAULT_PASSWORD"
+	// EnvVarPasswordFile to get the password for the userpass auth method
+	EnvVarPasswordFile = "TERRAFORM_VAULT_PASSWORD_FILE"
 
 	/*
 		common mount types
@@ -88,6 +108,12 @@ const (
 	VaultVersion11 = "1.11.0"
 	VaultVersion10 = "1.10.0"
 	VaultVersion9  = "1.9.0"
+
+	/*
+		Vault auth methods
+	*/
+	AuthMethodAWS      = "aws"
+	AuthMethodUserpass = "userpass"
 
 	/*
 		misc. path related constants

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -101,6 +101,7 @@ const (
 	MountTypeRabbitMQ   = "rabbitmq"
 	MountTypeNomad      = "nomad"
 	MountTypeKubernetes = "kubernetes"
+	MountTypeUserpass   = "userpass"
 
 	/*
 		Vault version constants

--- a/internal/provider/auth.go
+++ b/internal/provider/auth.go
@@ -54,6 +54,17 @@ func (l *AuthLoginCommon) Namespace() string {
 	return ""
 }
 
+func (l *AuthLoginCommon) MountPath() string {
+	if l.mount == "" {
+		return l.Method()
+	}
+	return l.mount
+}
+
+func (l *AuthLoginCommon) Method() string {
+	return ""
+}
+
 func (l *AuthLoginCommon) copyParams() map[string]interface{} {
 	params := make(map[string]interface{}, len(l.params))
 	for k, v := range l.params {

--- a/internal/provider/auth.go
+++ b/internal/provider/auth.go
@@ -1,0 +1,147 @@
+package provider
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+)
+
+var AuthLoginFields = []string{
+	consts.FieldAuthLoginDefault,
+	consts.FieldAuthLoginUserpass,
+	consts.FieldAuthLoginAWS,
+}
+
+type AuthLogin interface {
+	Init(data *schema.ResourceData, authFiled string) error
+	Schema() *schema.Resource
+	LoginPath() string
+	MountPath() string
+	Method() string
+	Login(client *api.Client) (*api.Secret, error)
+	Namespace() string
+}
+
+type AuthLoginCommon struct {
+	authField string
+	mount     string
+	params    map[string]interface{}
+}
+
+func (l *AuthLoginCommon) Init(d *schema.ResourceData, authField string) error {
+	l.authField = authField
+	path, params, err := l.init(d)
+	if err != nil {
+		return err
+	}
+
+	l.mount = path
+	l.params = params
+
+	return nil
+}
+
+func (l *AuthLoginCommon) Namespace() string {
+	if l.params != nil {
+		ns, ok := l.params[consts.FieldNamespace].(string)
+		if ok {
+			return ns
+		}
+	}
+	return ""
+}
+
+func (l *AuthLoginCommon) copyParams() map[string]interface{} {
+	params := make(map[string]interface{}, len(l.params))
+	for k, v := range l.params {
+		params[k] = v
+	}
+	return params
+}
+
+func (l *AuthLoginCommon) login(client *api.Client, path string, params map[string]interface{}) (*api.Secret, error) {
+	return client.Logical().Write(path, params)
+}
+
+func (l *AuthLoginCommon) init(d *schema.ResourceData) (string, map[string]interface{}, error) {
+	v, ok := d.GetOk(l.authField)
+	if !ok {
+		return "", nil, fmt.Errorf("resource data missing %q", l.authField)
+	}
+
+	config := v.([]interface{})
+	if len(config) != 1 {
+		// this should never happen
+		return "", nil, fmt.Errorf("empty config for %q", l.authField)
+	}
+
+	var path string
+	if v, ok := l.getOk(d, consts.FieldPath); ok {
+		path = v.(string)
+	} else if v, ok := l.getOk(d, consts.FieldMount); ok {
+		path = v.(string)
+	} else {
+		return "", nil, fmt.Errorf("no valid path configured in %#v", d)
+	}
+
+	var params map[string]interface{}
+	if v, ok := l.getOk(d, consts.FieldParameters); ok {
+		params = v.(map[string]interface{})
+	} else {
+		params = config[0].(map[string]interface{})
+	}
+
+	return path, params, nil
+}
+
+func (l *AuthLoginCommon) getOk(d *schema.ResourceData, field string) (interface{}, bool) {
+	return d.GetOk(fmt.Sprintf("%s.0.%s", l.authField, field))
+}
+
+func GetAuthLogin(r *schema.ResourceData) (AuthLogin, error) {
+	for _, authField := range AuthLoginFields {
+		_, ok := r.GetOk(authField)
+		if !ok {
+			continue
+		}
+
+		var l AuthLogin
+		switch authField {
+		case consts.FieldAuthLoginDefault:
+			l = &AuthLoginGeneric{}
+		case consts.FieldAuthLoginAWS:
+			l = &AuthLoginAWS{}
+		case consts.FieldAuthLoginUserpass:
+			l = &AuthLoginUserpass{}
+		default:
+			return nil, nil
+		}
+
+		if err := l.Init(r, authField); err != nil {
+			return nil, err
+		}
+
+		return l, nil
+	}
+
+	return nil, nil
+}
+
+func mustAddLoginSchema(r *schema.Resource) *schema.Resource {
+	MustAddSchema(r, map[string]*schema.Schema{
+		consts.FieldNamespace: {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		consts.FieldMount: {
+			Type:     schema.TypeString,
+			Optional: true,
+			Default:  consts.AuthMethodUserpass,
+		},
+	})
+
+	return r
+}

--- a/internal/provider/auth.go
+++ b/internal/provider/auth.go
@@ -15,6 +15,7 @@ type (
 	getSchemaResource func(string) *schema.Resource
 )
 
+// AuthLoginFields supported by the provider.
 var AuthLoginFields = []string{
 	consts.FieldAuthLoginDefault,
 	consts.FieldAuthLoginUserpass,
@@ -30,6 +31,7 @@ type AuthLogin interface {
 	Namespace() string
 }
 
+// AuthLoginCommon providing common methods for other AuthLogin* implementations.
 type AuthLoginCommon struct {
 	authField string
 	mount     string
@@ -151,7 +153,7 @@ func GetAuthLogin(r *schema.ResourceData) (AuthLogin, error) {
 	return nil, nil
 }
 
-func mustAddLoginSchema(r *schema.Resource) *schema.Resource {
+func mustAddLoginSchema(r *schema.Resource, defaultMount string) *schema.Resource {
 	MustAddSchema(r, map[string]*schema.Schema{
 		consts.FieldNamespace: {
 			Type:        schema.TypeString,
@@ -162,7 +164,7 @@ func mustAddLoginSchema(r *schema.Resource) *schema.Resource {
 			Type:        schema.TypeString,
 			Optional:    true,
 			Description: "The path where the authentication engine is mounted.",
-			Default:     consts.AuthMethodUserpass,
+			Default:     defaultMount,
 		},
 	})
 

--- a/internal/provider/auth.go
+++ b/internal/provider/auth.go
@@ -154,13 +154,15 @@ func GetAuthLogin(r *schema.ResourceData) (AuthLogin, error) {
 func mustAddLoginSchema(r *schema.Resource) *schema.Resource {
 	MustAddSchema(r, map[string]*schema.Schema{
 		consts.FieldNamespace: {
-			Type:     schema.TypeString,
-			Optional: true,
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The authentication engine's namespace.",
 		},
 		consts.FieldMount: {
-			Type:     schema.TypeString,
-			Optional: true,
-			Default:  consts.AuthMethodUserpass,
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The path where the authentication engine is mounted.",
+			Default:     consts.AuthMethodUserpass,
 		},
 	})
 

--- a/internal/provider/auth_aws.go
+++ b/internal/provider/auth_aws.go
@@ -1,0 +1,186 @@
+package provider
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-secure-stdlib/awsutil"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+)
+
+var SchemaLoginAWS = mustAddLoginSchema(&schema.Resource{
+	Schema: map[string]*schema.Schema{
+		consts.FieldRole: {
+			Type:     schema.TypeString,
+			Optional: true,
+			Description: `name of the role against which the login is being attempted. 
+If role is not specified, then the login endpoint looks for a 
+role bearing the name of the AMI ID of the EC2 instance that is trying 
+to login if using the ec2 auth method, 
+or the "friendly name" (i.e., role name or username) 
+of the IAM principal authenticated. If a matching role is not found, login fails.`,
+		},
+		consts.FieldIdentity: {
+			Type: schema.TypeString,
+			Description: `base64 encoded EC2 instance identity document, which can usually be obtained from 
+the http://169.254.169.254/latest/dynamic/instance-identity/document endpoint. 
+When using curl for fetching the identity document, consider using the option -w 0 while piping the 
+output to base64 binary. Either both of this and signature must be set OR pkcs7 must be set when using the 
+ec2 auth method.`,
+			Optional: true,
+		},
+		consts.FieldSignature: {
+			Type: schema.TypeString,
+			Description: `base64-encoded SHA256 RSA signature of the instance identity document, 
+which can usually be obtained from the http://169.254.169.254/latest/dynamic/instance-identity/document endpoint. 
+Either both this AND identity must be set OR pkcs7 must be set when using the ec2 auth method.`,
+			Optional: true,
+		},
+		consts.FieldPKCS7: {
+			Type: schema.TypeString,
+			Description: `PKCS#7 signature of the identity document with all \n characters removed. 
+This supports signatures from the AWS http://169.254.169.254/latest/dynamic/instance-identity/rsa2048 
+or http://169.254.169.254/latest/dynamic/instance-identity/pkcs7 endpoints.
+Either this needs to be set OR both identity and signature need to be set when using the ec2 auth method.`,
+			Optional: true,
+		},
+		consts.FieldNonce: {
+			Type: schema.TypeString,
+			Description: `The nonce to be used for subsequent login requests. If this parameter is not 
+specified at all and if reauthentication is allowed, then the method will generate a random nonce, 
+attaches it to the instance's identity-accesslist entry and returns the nonce back as part of auth metadata.
+This value should be used with further login requests, to establish client authenticity.
+Clients can choose to set a custom nonce if preferred, in which case, 
+it is recommended that clients provide a strong nonce.
+If a nonce is provided but with an empty value, 
+it indicates intent to disable reauthentication. 
+Note that, when disallow_reauthentication option is enabled on either the role or the role tag, 
+the nonce holds no significance. This is ignored unless using the ec2 auth method.`,
+			Optional: true,
+		},
+		consts.FieldIAMHttpRequestMethod: {
+			Type: schema.TypeString,
+			Description: `HTTP method used in the signed request.
+Currently only POST is supported, but other methods may be supported in the future.
+This is required when using the iam auth method.`,
+			Optional: true,
+		},
+		consts.FieldIAMHttpRequestURL: {
+			Type: schema.TypeString,
+			Description: `base64-encoded HTTP URL used in the signed request. 
+Most likely just aHR0cHM6Ly9zdHMuYW1hem9uYXdzLmNvbS8= (base64-encoding of https://sts.amazonaws.
+com/) as most requests will probably use POST with an empty URI. 
+This is required when using the iam auth method.`,
+			Optional: true,
+		},
+		consts.FieldIAMHttpRequestBody: {
+			Type: schema.TypeString,
+			Description: `base64-encoded body of the signed request. 
+Most likely QWN0aW9uPUdldENhbGxlcklkZW50aXR5JlZlcnNpb249MjAxMS0wNi0xNQ==, 
+which is the base64 encoding of Action=GetCallerIdentity&Version=2011-06-15.
+This is required when using the iam auth method.`,
+			Optional: true,
+		},
+		consts.FieldIAMHttpRequestHeaders: {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Description: `key/value pairs of headers for use in the sts:GetCallerIdentity HTTP requests headers. 
+Can be either a Base64-encoded, JSON-serialized string, or a JSON object of key/value pairs. 
+The JSON serialization assumes that each header key maps to either a string value or an array of string values 
+(though the length of that array will probably only be one). 
+If the iam_server_id_header_value is configured in Vault for the aws auth mount, 
+then the headers must include the X-Vault-AWS-IAM-Server-ID header, 
+its value must match the value configured, and the header must be included in the signed headers. 
+This is required when using the iam auth method.`,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+	},
+})
+
+// AuthLoginAWS for handling the Vault AWS authentication engine.
+type AuthLoginAWS struct {
+	AuthLoginCommon
+}
+
+func (l *AuthLoginAWS) Schema() *schema.Resource {
+	return SchemaLoginAWS
+}
+
+func (l *AuthLoginAWS) MountPath() string {
+	if l.mount == "" {
+		return consts.AuthMethodUserpass
+	}
+	return l.mount
+}
+
+func (l *AuthLoginAWS) LoginPath() string {
+	// TODO: add params validation
+	return fmt.Sprintf("auth/%s/login", l.MountPath())
+}
+
+func (l *AuthLoginAWS) Method() string {
+	return consts.AuthMethodAWS
+}
+
+func (l *AuthLoginAWS) Login(client *api.Client) (*api.Secret, error) {
+	params := l.copyParams()
+
+	logger := hclog.Default()
+	if logging.IsDebugOrHigher() {
+		logger.SetLevel(hclog.Debug)
+	} else {
+		logger.SetLevel(hclog.Error)
+	}
+	if err := signAWSLogin(l.params, logger); err != nil {
+		return nil, fmt.Errorf("error signing AWS login request: %s", err)
+	}
+
+	return l.login(client, l.LoginPath(), params)
+}
+
+func signAWSLogin(parameters map[string]interface{}, logger hclog.Logger) error {
+	var accessKey, secretKey, securityToken string
+	if val, ok := parameters["aws_access_key_id"].(string); ok {
+		accessKey = val
+	}
+
+	if val, ok := parameters["aws_secret_access_key"].(string); ok {
+		secretKey = val
+	}
+
+	if val, ok := parameters["aws_security_token"].(string); ok {
+		securityToken = val
+	}
+
+	creds, err := awsutil.RetrieveCreds(accessKey, secretKey, securityToken, logger)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve AWS credentials: %s", err)
+	}
+
+	var headerValue, stsRegion string
+	if val, ok := parameters["header_value"].(string); ok {
+		headerValue = val
+	}
+
+	if val, ok := parameters["sts_region"].(string); ok {
+		stsRegion = val
+	}
+
+	loginData, err := awsutil.GenerateLoginData(creds, headerValue, stsRegion, logger)
+	if err != nil {
+		return fmt.Errorf("failed to generate AWS login data: %s", err)
+	}
+
+	parameters["iam_http_request_method"] = loginData["iam_http_request_method"]
+	parameters["iam_request_url"] = loginData["iam_request_url"]
+	parameters["iam_request_headers"] = loginData["iam_request_headers"]
+	parameters["iam_request_body"] = loginData["iam_request_body"]
+
+	return nil
+}

--- a/internal/provider/auth_aws.go
+++ b/internal/provider/auth_aws.go
@@ -112,13 +112,6 @@ func (l *AuthLoginAWS) Schema() *schema.Resource {
 	return SchemaLoginAWS
 }
 
-func (l *AuthLoginAWS) MountPath() string {
-	if l.mount == "" {
-		return consts.AuthMethodUserpass
-	}
-	return l.mount
-}
-
 func (l *AuthLoginAWS) LoginPath() string {
 	// TODO: add params validation
 	return fmt.Sprintf("auth/%s/login", l.MountPath())

--- a/internal/provider/auth_aws.go
+++ b/internal/provider/auth_aws.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-secure-stdlib/awsutil"
@@ -12,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 )
 
+// GetAWSLoginSchema for the AWS authentication engine.
 func GetAWSLoginSchema(authField string) *schema.Schema {
 	return getLoginSchema(
 		authField,
@@ -20,97 +22,61 @@ func GetAWSLoginSchema(authField string) *schema.Schema {
 	)
 }
 
+// GetAWSLoginSchemaResource for the AWS authentication engine.
 func GetAWSLoginSchemaResource(_ string) *schema.Resource {
 	return mustAddLoginSchema(&schema.Resource{
 		Schema: map[string]*schema.Schema{
 			consts.FieldRole: {
-				Type:     schema.TypeString,
-				Optional: true,
-				Description: `name of the role against which the login is being attempted. 
-If role is not specified, then the login endpoint looks for a 
-role bearing the name of the AMI ID of the EC2 instance that is trying 
-to login if using the ec2 auth method, 
-or the "friendly name" (i.e., role name or username) 
-of the IAM principal authenticated. If a matching role is not found, login fails.`,
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `The IAM role to use when logging into Vault.`,
 			},
 			consts.FieldIdentity: {
-				Type: schema.TypeString,
-				Description: `base64 encoded EC2 instance identity document, which can usually be obtained from 
-the http://169.254.169.254/latest/dynamic/instance-identity/document endpoint. 
-When using curl for fetching the identity document, consider using the option -w 0 while piping the 
-output to base64 binary. Either both of this and signature must be set OR pkcs7 must be set when using the 
-ec2 auth method.`,
-				Optional: true,
+				Type:        schema.TypeString,
+				Description: `The base64 encoded EC2 instance identity document.`,
+				Optional:    true,
 			},
 			consts.FieldSignature: {
-				Type: schema.TypeString,
-				Description: `base64-encoded SHA256 RSA signature of the instance identity document, 
-which can usually be obtained from the http://169.254.169.254/latest/dynamic/instance-identity/document endpoint. 
-Either both this AND identity must be set OR pkcs7 must be set when using the ec2 auth method.`,
-				Optional: true,
+				Type:        schema.TypeString,
+				Description: `The base64 encoded SHA256 RSA signature of the instance identity document.`,
+				Optional:    true,
 			},
 			consts.FieldPKCS7: {
-				Type: schema.TypeString,
-				Description: `PKCS#7 signature of the identity document with all \n characters removed. 
-This supports signatures from the AWS http://169.254.169.254/latest/dynamic/instance-identity/rsa2048 
-or http://169.254.169.254/latest/dynamic/instance-identity/pkcs7 endpoints.
-Either this needs to be set OR both identity and signature need to be set when using the ec2 auth method.`,
-				Optional: true,
+				Type:        schema.TypeString,
+				Description: `PKCS#7 signature of the identity document.`,
+				Optional:    true,
 			},
 			consts.FieldNonce: {
-				Type: schema.TypeString,
-				Description: `The nonce to be used for subsequent login requests. If this parameter is not 
-specified at all and if reauthentication is allowed, then the method will generate a random nonce, 
-attaches it to the instance's identity-accesslist entry and returns the nonce back as part of auth metadata.
-This value should be used with further login requests, to establish client authenticity.
-Clients can choose to set a custom nonce if preferred, in which case, 
-it is recommended that clients provide a strong nonce.
-If a nonce is provided but with an empty value, 
-it indicates intent to disable reauthentication. 
-Note that, when disallow_reauthentication option is enabled on either the role or the role tag, 
-the nonce holds no significance. This is ignored unless using the ec2 auth method.`,
-				Optional: true,
+				Type:        schema.TypeString,
+				Description: `The nonce to be used for subsequent login requests.`,
+				Optional:    true,
 			},
 			consts.FieldIAMHttpRequestMethod: {
-				Type: schema.TypeString,
-				Description: `HTTP method used in the signed request.
-Currently only POST is supported, but other methods may be supported in the future.
-This is required when using the iam auth method.`,
-				Optional: true,
+				Type:        schema.TypeString,
+				Description: `The HTTP method used in the signed request.`,
+				Optional:    true,
+				Default:     http.MethodPost,
 			},
 			consts.FieldIAMHttpRequestURL: {
-				Type: schema.TypeString,
-				Description: `base64-encoded HTTP URL used in the signed request. 
-Most likely just aHR0cHM6Ly9zdHMuYW1hem9uYXdzLmNvbS8= (base64-encoding of https://sts.amazonaws.
-com/) as most requests will probably use POST with an empty URI. 
-This is required when using the iam auth method.`,
-				Optional: true,
+				Type:        schema.TypeString,
+				Description: `The base64 encoded HTTP URL used in the signed request.`,
+				Optional:    true,
 			},
 			consts.FieldIAMHttpRequestBody: {
-				Type: schema.TypeString,
-				Description: `base64-encoded body of the signed request. 
-Most likely QWN0aW9uPUdldENhbGxlcklkZW50aXR5JlZlcnNpb249MjAxMS0wNi0xNQ==, 
-which is the base64 encoding of Action=GetCallerIdentity&Version=2011-06-15.
-This is required when using the iam auth method.`,
-				Optional: true,
+				Type:        schema.TypeString,
+				Description: `The base64 encoded body of the signed request.`,
+				Optional:    true,
 			},
 			consts.FieldIAMHttpRequestHeaders: {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Description: `key/value pairs of headers for use in the sts:GetCallerIdentity HTTP requests headers. 
-Can be either a Base64-encoded, JSON-serialized string, or a JSON object of key/value pairs. 
-The JSON serialization assumes that each header key maps to either a string value or an array of string values 
-(though the length of that array will probably only be one). 
-If the iam_server_id_header_value is configured in Vault for the aws auth mount, 
-then the headers must include the X-Vault-AWS-IAM-Server-ID header, 
-its value must match the value configured, and the header must be included in the signed headers. 
-This is required when using the iam auth method.`,
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Description: `Mapping of extra IAM specific HTTP request login headers.`,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
 			},
 		},
-	})
+	}, consts.MountTypeAWS)
 }
 
 // AuthLoginAWS for handling the Vault AWS authentication engine.
@@ -119,15 +85,18 @@ type AuthLoginAWS struct {
 	AuthLoginCommon
 }
 
+// LoginPath for the AWS authentication engine.
 func (l *AuthLoginAWS) LoginPath() string {
 	// TODO: add params validation
 	return fmt.Sprintf("auth/%s/login", l.MountPath())
 }
 
+// Method name for the AWS authentication engine.
 func (l *AuthLoginAWS) Method() string {
 	return consts.AuthMethodAWS
 }
 
+// Login using the AWS authentication engine.
 func (l *AuthLoginAWS) Login(client *api.Client) (*api.Secret, error) {
 	params := l.copyParams(
 		consts.FieldNamespace,

--- a/internal/provider/auth_aws.go
+++ b/internal/provider/auth_aws.go
@@ -12,45 +12,54 @@ import (
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 )
 
-var SchemaLoginAWS = mustAddLoginSchema(&schema.Resource{
-	Schema: map[string]*schema.Schema{
-		consts.FieldRole: {
-			Type:     schema.TypeString,
-			Optional: true,
-			Description: `name of the role against which the login is being attempted. 
+func GetAWSLoginSchema(authField string) *schema.Schema {
+	return getLoginSchema(
+		authField,
+		"Login to vault using the AWS method",
+		GetAWSLoginSchemaResource,
+	)
+}
+
+func GetAWSLoginSchemaResource(_ string) *schema.Resource {
+	return mustAddLoginSchema(&schema.Resource{
+		Schema: map[string]*schema.Schema{
+			consts.FieldRole: {
+				Type:     schema.TypeString,
+				Optional: true,
+				Description: `name of the role against which the login is being attempted. 
 If role is not specified, then the login endpoint looks for a 
 role bearing the name of the AMI ID of the EC2 instance that is trying 
 to login if using the ec2 auth method, 
 or the "friendly name" (i.e., role name or username) 
 of the IAM principal authenticated. If a matching role is not found, login fails.`,
-		},
-		consts.FieldIdentity: {
-			Type: schema.TypeString,
-			Description: `base64 encoded EC2 instance identity document, which can usually be obtained from 
+			},
+			consts.FieldIdentity: {
+				Type: schema.TypeString,
+				Description: `base64 encoded EC2 instance identity document, which can usually be obtained from 
 the http://169.254.169.254/latest/dynamic/instance-identity/document endpoint. 
 When using curl for fetching the identity document, consider using the option -w 0 while piping the 
 output to base64 binary. Either both of this and signature must be set OR pkcs7 must be set when using the 
 ec2 auth method.`,
-			Optional: true,
-		},
-		consts.FieldSignature: {
-			Type: schema.TypeString,
-			Description: `base64-encoded SHA256 RSA signature of the instance identity document, 
+				Optional: true,
+			},
+			consts.FieldSignature: {
+				Type: schema.TypeString,
+				Description: `base64-encoded SHA256 RSA signature of the instance identity document, 
 which can usually be obtained from the http://169.254.169.254/latest/dynamic/instance-identity/document endpoint. 
 Either both this AND identity must be set OR pkcs7 must be set when using the ec2 auth method.`,
-			Optional: true,
-		},
-		consts.FieldPKCS7: {
-			Type: schema.TypeString,
-			Description: `PKCS#7 signature of the identity document with all \n characters removed. 
+				Optional: true,
+			},
+			consts.FieldPKCS7: {
+				Type: schema.TypeString,
+				Description: `PKCS#7 signature of the identity document with all \n characters removed. 
 This supports signatures from the AWS http://169.254.169.254/latest/dynamic/instance-identity/rsa2048 
 or http://169.254.169.254/latest/dynamic/instance-identity/pkcs7 endpoints.
 Either this needs to be set OR both identity and signature need to be set when using the ec2 auth method.`,
-			Optional: true,
-		},
-		consts.FieldNonce: {
-			Type: schema.TypeString,
-			Description: `The nonce to be used for subsequent login requests. If this parameter is not 
+				Optional: true,
+			},
+			consts.FieldNonce: {
+				Type: schema.TypeString,
+				Description: `The nonce to be used for subsequent login requests. If this parameter is not 
 specified at all and if reauthentication is allowed, then the method will generate a random nonce, 
 attaches it to the instance's identity-accesslist entry and returns the nonce back as part of auth metadata.
 This value should be used with further login requests, to establish client authenticity.
@@ -60,35 +69,35 @@ If a nonce is provided but with an empty value,
 it indicates intent to disable reauthentication. 
 Note that, when disallow_reauthentication option is enabled on either the role or the role tag, 
 the nonce holds no significance. This is ignored unless using the ec2 auth method.`,
-			Optional: true,
-		},
-		consts.FieldIAMHttpRequestMethod: {
-			Type: schema.TypeString,
-			Description: `HTTP method used in the signed request.
+				Optional: true,
+			},
+			consts.FieldIAMHttpRequestMethod: {
+				Type: schema.TypeString,
+				Description: `HTTP method used in the signed request.
 Currently only POST is supported, but other methods may be supported in the future.
 This is required when using the iam auth method.`,
-			Optional: true,
-		},
-		consts.FieldIAMHttpRequestURL: {
-			Type: schema.TypeString,
-			Description: `base64-encoded HTTP URL used in the signed request. 
+				Optional: true,
+			},
+			consts.FieldIAMHttpRequestURL: {
+				Type: schema.TypeString,
+				Description: `base64-encoded HTTP URL used in the signed request. 
 Most likely just aHR0cHM6Ly9zdHMuYW1hem9uYXdzLmNvbS8= (base64-encoding of https://sts.amazonaws.
 com/) as most requests will probably use POST with an empty URI. 
 This is required when using the iam auth method.`,
-			Optional: true,
-		},
-		consts.FieldIAMHttpRequestBody: {
-			Type: schema.TypeString,
-			Description: `base64-encoded body of the signed request. 
+				Optional: true,
+			},
+			consts.FieldIAMHttpRequestBody: {
+				Type: schema.TypeString,
+				Description: `base64-encoded body of the signed request. 
 Most likely QWN0aW9uPUdldENhbGxlcklkZW50aXR5JlZlcnNpb249MjAxMS0wNi0xNQ==, 
 which is the base64 encoding of Action=GetCallerIdentity&Version=2011-06-15.
 This is required when using the iam auth method.`,
-			Optional: true,
-		},
-		consts.FieldIAMHttpRequestHeaders: {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Description: `key/value pairs of headers for use in the sts:GetCallerIdentity HTTP requests headers. 
+				Optional: true,
+			},
+			consts.FieldIAMHttpRequestHeaders: {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Description: `key/value pairs of headers for use in the sts:GetCallerIdentity HTTP requests headers. 
 Can be either a Base64-encoded, JSON-serialized string, or a JSON object of key/value pairs. 
 The JSON serialization assumes that each header key maps to either a string value or an array of string values 
 (though the length of that array will probably only be one). 
@@ -96,20 +105,18 @@ If the iam_server_id_header_value is configured in Vault for the aws auth mount,
 then the headers must include the X-Vault-AWS-IAM-Server-ID header, 
 its value must match the value configured, and the header must be included in the signed headers. 
 This is required when using the iam auth method.`,
-			Elem: &schema.Schema{
-				Type: schema.TypeString,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
 			},
 		},
-	},
-})
-
-// AuthLoginAWS for handling the Vault AWS authentication engine.
-type AuthLoginAWS struct {
-	AuthLoginCommon
+	})
 }
 
-func (l *AuthLoginAWS) Schema() *schema.Resource {
-	return SchemaLoginAWS
+// AuthLoginAWS for handling the Vault AWS authentication engine.
+// Requires configuration provided by SchemaLoginAWS.
+type AuthLoginAWS struct {
+	AuthLoginCommon
 }
 
 func (l *AuthLoginAWS) LoginPath() string {
@@ -122,7 +129,11 @@ func (l *AuthLoginAWS) Method() string {
 }
 
 func (l *AuthLoginAWS) Login(client *api.Client) (*api.Secret, error) {
-	params := l.copyParams()
+	params := l.copyParams(
+		consts.FieldNamespace,
+		consts.FieldMount,
+		consts.FieldPasswordFile,
+	)
 
 	logger := hclog.Default()
 	if logging.IsDebugOrHigher() {

--- a/internal/provider/auth_generic.go
+++ b/internal/provider/auth_generic.go
@@ -1,0 +1,108 @@
+package provider
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+)
+
+var SchemaLoginGeneric = &schema.Resource{
+	Schema: map[string]*schema.Schema{
+		consts.FieldPath: {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+		consts.FieldNamespace: {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+		consts.FieldParameters: {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		consts.FieldMethod: {
+			Type:     schema.TypeString,
+			Optional: true,
+		},
+	},
+}
+
+// AuthLoginGeneric provides a raw interface for authenticating to most
+// authentication engines.
+type AuthLoginGeneric struct {
+	AuthLoginCommon
+	path      string
+	namespace string
+	method    string
+}
+
+func (l *AuthLoginGeneric) Schema() *schema.Resource {
+	return nil
+}
+
+func (l *AuthLoginGeneric) Namespace() string {
+	return l.namespace
+}
+
+func (l *AuthLoginGeneric) MountPath() string {
+	return ""
+}
+
+func (l *AuthLoginGeneric) Init(d *schema.ResourceData, authField string) error {
+	l.authField = authField
+
+	path, params, err := l.init(d)
+	if err != nil {
+		return err
+	}
+
+	l.path = path
+	l.params = params
+
+	if v, ok := l.getOk(d, consts.FieldNamespace); ok {
+		l.namespace = v.(string)
+	}
+
+	if v, ok := l.getOk(d, consts.FieldMethod); ok {
+		l.method = v.(string)
+	}
+
+	return nil
+}
+
+func (l *AuthLoginGeneric) LoginPath() string {
+	return l.path
+}
+
+func (l *AuthLoginGeneric) Method() string {
+	return l.method
+}
+
+func (l *AuthLoginGeneric) Login(client *api.Client) (*api.Secret, error) {
+	params := l.copyParams()
+
+	switch l.Method() {
+	// the AWS auth method was previously handled by the auth_login generic
+	// resource.
+	case consts.AuthMethodAWS:
+		logger := hclog.Default()
+		if logging.IsDebugOrHigher() {
+			logger.SetLevel(hclog.Debug)
+		} else {
+			logger.SetLevel(hclog.Error)
+		}
+		if err := signAWSLogin(params, logger); err != nil {
+			return nil, fmt.Errorf("error signing AWS login request: %s", err)
+		}
+	}
+
+	return l.login(client, l.LoginPath(), params)
+}

--- a/internal/provider/auth_generic.go
+++ b/internal/provider/auth_generic.go
@@ -11,32 +11,43 @@ import (
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 )
 
-var SchemaLoginGeneric = &schema.Resource{
-	Schema: map[string]*schema.Schema{
-		consts.FieldPath: {
-			Type:     schema.TypeString,
-			Required: true,
-		},
-		consts.FieldNamespace: {
-			Type:     schema.TypeString,
-			Optional: true,
-		},
-		consts.FieldParameters: {
-			Type:     schema.TypeMap,
-			Optional: true,
-			Elem: &schema.Schema{
-				Type: schema.TypeString,
+func GetGenericLoginSchema(authField string) *schema.Schema {
+	return getLoginSchema(
+		authField,
+		"Login to vault with an existing auth method using auth/<mount>/login",
+		GetGenericLoginSchemaResource,
+	)
+}
+
+func GetGenericLoginSchemaResource(_ string) *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			consts.FieldPath: {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			consts.FieldNamespace: {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			consts.FieldParameters: {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			consts.FieldMethod: {
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 		},
-		consts.FieldMethod: {
-			Type:     schema.TypeString,
-			Optional: true,
-		},
-	},
+	}
 }
 
 // AuthLoginGeneric provides a raw interface for authenticating to most
 // authentication engines.
+// Requires configuration provided by SchemaLoginGeneric.
 type AuthLoginGeneric struct {
 	AuthLoginCommon
 	path      string
@@ -44,16 +55,8 @@ type AuthLoginGeneric struct {
 	method    string
 }
 
-func (l *AuthLoginGeneric) Schema() *schema.Resource {
-	return nil
-}
-
 func (l *AuthLoginGeneric) Namespace() string {
 	return l.namespace
-}
-
-func (l *AuthLoginGeneric) MountPath() string {
-	return ""
 }
 
 func (l *AuthLoginGeneric) Init(d *schema.ResourceData, authField string) error {

--- a/internal/provider/auth_test.go
+++ b/internal/provider/auth_test.go
@@ -1,0 +1,117 @@
+package provider
+
+import (
+	"io/ioutil"
+	"path"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+)
+
+func Test_setupUserpassAuthParams(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  map[string]interface{}
+		env     map[string]string
+		wantErr bool
+		want    map[string]interface{}
+	}{
+		{
+			name: "username-from-env",
+			params: map[string]interface{}{
+				consts.FieldPassword: "foobar",
+			},
+			env: map[string]string{
+				consts.EnvVarUsername: "bob",
+			},
+			want: map[string]interface{}{
+				consts.FieldUsername: "bob",
+				consts.FieldPassword: "foobar",
+			},
+			wantErr: false,
+		},
+		{
+			name: "password-from-env",
+			params: map[string]interface{}{
+				consts.FieldUsername: "bob",
+			},
+			env: map[string]string{
+				consts.EnvVarPassword: "foobar",
+			},
+			want: map[string]interface{}{
+				consts.FieldUsername: "bob",
+				consts.FieldPassword: "foobar",
+			},
+			wantErr: false,
+		},
+		{
+			name: "password-file-from-env",
+			params: map[string]interface{}{
+				consts.FieldUsername: "bob",
+			},
+			env: map[string]string{
+				// setup in testrun
+				consts.EnvVarPasswordFile: "",
+			},
+			want: map[string]interface{}{
+				consts.FieldUsername: "bob",
+				consts.FieldPassword: "foobar",
+			},
+			wantErr: false,
+		},
+		{
+			name: "password-file-from-params",
+			params: map[string]interface{}{
+				consts.FieldUsername:     "bob",
+				consts.FieldPasswordFile: "",
+			},
+			want: map[string]interface{}{
+				consts.FieldUsername: "bob",
+				consts.FieldPassword: "foobar",
+			},
+			wantErr: false,
+		},
+		{
+			name: "error-no-username",
+			params: map[string]interface{}{
+				"canary": "baz",
+			},
+			want: map[string]interface{}{
+				"canary": "baz",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var filename string
+			if tt.env != nil {
+				if _, ok := tt.env[consts.EnvVarPasswordFile]; ok {
+					filename = path.Join(t.TempDir(), "password")
+					tt.env[consts.EnvVarPasswordFile] = filename
+				}
+			}
+
+			if _, ok := tt.params[consts.FieldPasswordFile]; ok {
+				filename = path.Join(t.TempDir(), "password")
+				tt.params[consts.FieldPasswordFile] = filename
+			}
+
+			if filename != "" {
+				if err := ioutil.WriteFile(
+					filename, []byte(tt.want[consts.FieldPassword].(string)), 0o440); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			if err := setupUserpassAuthParams(tt.params, tt.env); (err != nil) != tt.wantErr {
+				t.Errorf("setupUserpassAuthParams() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if !reflect.DeepEqual(tt.want, tt.params) {
+				t.Errorf("setupUserpassAuthParams() want = %v, actual %v", tt.want, tt.params)
+			}
+		})
+	}
+}

--- a/internal/provider/auth_userpass.go
+++ b/internal/provider/auth_userpass.go
@@ -1,0 +1,137 @@
+package provider
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+)
+
+var SchemaLoginUserpass = mustAddLoginSchema(&schema.Resource{
+	Schema: map[string]*schema.Schema{
+		consts.FieldUsername: {
+			Type:        schema.TypeString,
+			Required:    true,
+			DefaultFunc: schema.EnvDefaultFunc(consts.EnvVarUsername, ""),
+		},
+		consts.FieldPassword: {
+			Type:        schema.TypeString,
+			Optional:    true,
+			DefaultFunc: schema.EnvDefaultFunc(consts.EnvVarPassword, ""),
+		},
+		consts.FieldPasswordFile: {
+			Type:        schema.TypeString,
+			Optional:    true,
+			DefaultFunc: schema.EnvDefaultFunc(consts.EnvVarPasswordFile, ""),
+			// ConflictsWith: []string{consts.FieldPassword},
+		},
+	},
+})
+
+// AuthLoginUserpass provides an interface for authenticating to the
+// userpass authentication engine.
+type AuthLoginUserpass struct {
+	AuthLoginCommon
+}
+
+func (l *AuthLoginUserpass) Schema() *schema.Resource {
+	return SchemaLoginUserpass
+}
+
+func (l *AuthLoginUserpass) Login(client *api.Client) (*api.Secret, error) {
+	params := l.copyParams()
+	if err := setupUserpassAuthParams(params, nil); err != nil {
+		return nil, err
+	}
+
+	return l.login(client, l.LoginPath(), params)
+}
+
+func (l *AuthLoginUserpass) MountPath() string {
+	if l.mount == "" {
+		return consts.AuthMethodUserpass
+	}
+	return l.mount
+}
+
+func (l *AuthLoginUserpass) LoginPath() string {
+	return fmt.Sprintf("auth/%s/login/%s", l.MountPath(), l.params[consts.FieldUsername])
+}
+
+func (l *AuthLoginUserpass) Method() string {
+	return consts.AuthMethodUserpass
+}
+
+func setupUserpassAuthParams(params map[string]interface{}, env map[string]string) error {
+	method := consts.AuthMethodUserpass
+
+	// largely here for tests
+	getEnv := func(k string) string {
+		if env != nil {
+			return env[k]
+		}
+		return os.Getenv(k)
+	}
+
+	username := getEnv(consts.EnvVarUsername)
+	if username == "" {
+		if v, ok := params["username"]; ok {
+			username = v.(string)
+		}
+	}
+
+	if username == "" {
+		return fmt.Errorf("auth method %q, %q not set in %q",
+			method,
+			consts.FieldUsername,
+			consts.FieldParameters,
+		)
+	}
+
+	// the password can be had from various sources
+	p := getEnv(consts.EnvVarPassword)
+	if p == "" {
+		var passwordFile string
+		if v := getEnv(consts.EnvVarPasswordFile); v != "" {
+			passwordFile = v
+		} else if v, ok := params[consts.FieldPasswordFile]; ok && v != nil {
+			passwordFile = v.(string)
+			delete(params, consts.FieldPasswordFile)
+		}
+
+		if v := getEnv(consts.EnvVarPassword); v != "" {
+			p = v
+		} else if v, ok := params[consts.FieldPassword]; ok && v != nil {
+			p = v.(string)
+		}
+
+		if passwordFile != "" && p != "" {
+			return fmt.Errorf("auth method %q, mutually exclusive auth params provided: %s",
+				method,
+				strings.Join([]string{consts.FieldPassword, consts.FieldPasswordFile}, ", "))
+		}
+
+		if passwordFile != "" {
+			f, err := os.Open(passwordFile)
+			if err != nil {
+				return err
+			}
+
+			v, err := ioutil.ReadAll(f)
+			if err != nil {
+				return err
+			}
+			p = string(v)
+		}
+	}
+
+	params[consts.FieldPassword] = p
+	params[consts.FieldUsername] = username
+
+	return nil
+}

--- a/internal/provider/auth_userpass.go
+++ b/internal/provider/auth_userpass.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 )
 
+// GetUserpassLoginSchema for the userpass authentication engine.
 func GetUserpassLoginSchema(authField string) *schema.Schema {
 	return getLoginSchema(
 		authField,
@@ -20,6 +21,7 @@ func GetUserpassLoginSchema(authField string) *schema.Schema {
 	)
 }
 
+// GetUserpassLoginSchemaResource for the userpass authentication engine.
 func GetUserpassLoginSchemaResource(authField string) *schema.Resource {
 	return mustAddLoginSchema(&schema.Resource{
 		Schema: map[string]*schema.Schema{
@@ -48,7 +50,7 @@ func GetUserpassLoginSchemaResource(authField string) *schema.Resource {
 				},
 			},
 		},
-	})
+	}, consts.MountTypeUserpass)
 }
 
 // AuthLoginUserpass provides an interface for authenticating to the
@@ -58,14 +60,17 @@ type AuthLoginUserpass struct {
 	AuthLoginCommon
 }
 
+// LoginPath for the userpass authentication engine.
 func (l *AuthLoginUserpass) LoginPath() string {
 	return fmt.Sprintf("auth/%s/login/%s", l.MountPath(), l.params[consts.FieldUsername])
 }
 
+// Method name for the userpass authentication engine.
 func (l *AuthLoginUserpass) Method() string {
 	return consts.AuthMethodUserpass
 }
 
+// Login using the userpass authentication engine.
 func (l *AuthLoginUserpass) Login(client *api.Client) (*api.Secret, error) {
 	params := l.copyParams(
 		consts.FieldNamespace,

--- a/internal/provider/auth_userpass.go
+++ b/internal/provider/auth_userpass.go
@@ -52,13 +52,6 @@ func (l *AuthLoginUserpass) Login(client *api.Client) (*api.Secret, error) {
 	return l.login(client, l.LoginPath(), params)
 }
 
-func (l *AuthLoginUserpass) MountPath() string {
-	if l.mount == "" {
-		return consts.AuthMethodUserpass
-	}
-	return l.mount
-}
-
 func (l *AuthLoginUserpass) LoginPath() string {
 	return fmt.Sprintf("auth/%s/login/%s", l.MountPath(), l.params[consts.FieldUsername])
 }

--- a/internal/provider/auth_userpass_test.go
+++ b/internal/provider/auth_userpass_test.go
@@ -18,50 +18,7 @@ func Test_setupUserpassAuthParams(t *testing.T) {
 		want    map[string]interface{}
 	}{
 		{
-			name: "username-from-env",
-			params: map[string]interface{}{
-				consts.FieldPassword: "foobar",
-			},
-			env: map[string]string{
-				consts.EnvVarUsername: "bob",
-			},
-			want: map[string]interface{}{
-				consts.FieldUsername: "bob",
-				consts.FieldPassword: "foobar",
-			},
-			wantErr: false,
-		},
-		{
-			name: "password-from-env",
-			params: map[string]interface{}{
-				consts.FieldUsername: "bob",
-			},
-			env: map[string]string{
-				consts.EnvVarPassword: "foobar",
-			},
-			want: map[string]interface{}{
-				consts.FieldUsername: "bob",
-				consts.FieldPassword: "foobar",
-			},
-			wantErr: false,
-		},
-		{
-			name: "password-file-from-env",
-			params: map[string]interface{}{
-				consts.FieldUsername: "bob",
-			},
-			env: map[string]string{
-				// setup in testrun
-				consts.EnvVarPasswordFile: "",
-			},
-			want: map[string]interface{}{
-				consts.FieldUsername: "bob",
-				consts.FieldPassword: "foobar",
-			},
-			wantErr: false,
-		},
-		{
-			name: "password-file-from-params",
+			name: "password-file",
 			params: map[string]interface{}{
 				consts.FieldUsername:     "bob",
 				consts.FieldPasswordFile: "",
@@ -86,13 +43,6 @@ func Test_setupUserpassAuthParams(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var filename string
-			if tt.env != nil {
-				if _, ok := tt.env[consts.EnvVarPasswordFile]; ok {
-					filename = path.Join(t.TempDir(), "password")
-					tt.env[consts.EnvVarPasswordFile] = filename
-				}
-			}
-
 			if _, ok := tt.params[consts.FieldPasswordFile]; ok {
 				filename = path.Join(t.TempDir(), "password")
 				tt.params[consts.FieldPasswordFile] = filename
@@ -105,7 +55,7 @@ func Test_setupUserpassAuthParams(t *testing.T) {
 				}
 			}
 
-			if err := setupUserpassAuthParams(tt.params, tt.env); (err != nil) != tt.wantErr {
+			if err := setupUserpassAuthParams(tt.params); (err != nil) != tt.wantErr {
 				t.Errorf("setupUserpassAuthParams() error = %v, wantErr %v", err, tt.wantErr)
 			}
 

--- a/internal/provider/auth_userpass_test.go
+++ b/internal/provider/auth_userpass_test.go
@@ -1,12 +1,19 @@
 package provider
 
 import (
+	"encoding/json"
+	"fmt"
 	"io/ioutil"
+	"net/http"
 	"path"
 	"reflect"
+	"strings"
 	"testing"
 
+	"github.com/hashicorp/vault/api"
+
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
 func Test_setupUserpassAuthParams(t *testing.T) {
@@ -61,6 +68,201 @@ func Test_setupUserpassAuthParams(t *testing.T) {
 
 			if !reflect.DeepEqual(tt.want, tt.params) {
 				t.Errorf("setupUserpassAuthParams() want = %v, actual %v", tt.want, tt.params)
+			}
+		})
+	}
+}
+
+func TestAuthLoginUserpass_LoginPath(t *testing.T) {
+	type fields struct {
+		AuthLoginCommon AuthLoginCommon
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "basic",
+			fields: fields{
+				AuthLoginCommon: AuthLoginCommon{
+					authField: "",
+					mount:     "foo",
+					params: map[string]interface{}{
+						consts.FieldUsername: "bob",
+					},
+				},
+			},
+			want: "auth/foo/login/bob",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := &AuthLoginUserpass{
+				AuthLoginCommon: tt.fields.AuthLoginCommon,
+			}
+			if got := l.LoginPath(); got != tt.want {
+				t.Errorf("LoginPath() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+type testLoginHandler struct {
+	requestCount int
+	paths        []string
+	params       []map[string]interface{}
+}
+
+func (t *testLoginHandler) userpassHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		t.requestCount++
+
+		t.paths = append(t.paths, req.URL.Path)
+
+		if req.Method != http.MethodPut {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
+		b, err := ioutil.ReadAll(req.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		var params map[string]interface{}
+		if err := json.Unmarshal(b, &params); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		t.params = append(t.params, params)
+
+		parts := strings.Split(req.URL.Path, "/")
+		m, err := json.Marshal(
+			&api.Secret{
+				Auth: &api.SecretAuth{
+					Metadata: map[string]string{
+						"username": parts[len(parts)-1],
+					},
+				},
+			},
+		)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write(m)
+	}
+}
+
+func TestAuthLoginUserpass_Login(t *testing.T) {
+	type fields struct {
+		AuthLoginCommon AuthLoginCommon
+	}
+	tests := []struct {
+		name            string
+		fields          fields
+		handler         *testLoginHandler
+		want            *api.Secret
+		expectReqCount  int
+		expectReqParams []map[string]interface{}
+		expectReqPaths  []string
+		wantErr         bool
+	}{
+		{
+			name: "basic",
+			fields: fields{
+				AuthLoginCommon: AuthLoginCommon{
+					authField: "baz",
+					mount:     "foo",
+					params: map[string]interface{}{
+						consts.FieldUsername: "bob",
+						consts.FieldPassword: "baz",
+					},
+				},
+			},
+			handler:        &testLoginHandler{},
+			expectReqCount: 1,
+			expectReqPaths: []string{
+				"/v1/auth/foo/login/bob",
+			},
+			expectReqParams: []map[string]interface{}{
+				{
+					consts.FieldUsername: "bob",
+					consts.FieldPassword: "baz",
+				},
+			},
+			want: &api.Secret{
+				Auth: &api.SecretAuth{
+					Metadata: map[string]string{
+						"username": "bob",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "error-no-username",
+			fields: fields{
+				AuthLoginCommon: AuthLoginCommon{
+					authField: "baz",
+					mount:     "foo",
+					params: map[string]interface{}{
+						consts.FieldPassword: "baz",
+					},
+				},
+			},
+			handler:         &testLoginHandler{},
+			expectReqCount:  0,
+			expectReqPaths:  nil,
+			expectReqParams: nil,
+			want:            nil,
+			wantErr:         true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := tt.handler
+
+			config, ln := testutil.TestHTTPServer(t, r.userpassHandler())
+			defer ln.Close()
+
+			config.Address = fmt.Sprintf("http://%s", ln.Addr())
+			c, err := api.NewClient(config)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			l := &AuthLoginUserpass{
+				AuthLoginCommon: tt.fields.AuthLoginCommon,
+			}
+
+			got, err := l.Login(c)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Login() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.expectReqCount != tt.handler.requestCount {
+				t.Errorf("Login() expected %d requests, actual %d", tt.expectReqCount, tt.handler.requestCount)
+			}
+
+			if !reflect.DeepEqual(tt.expectReqPaths, tt.handler.paths) {
+				t.Errorf("Login() request paths do not match expected %#v, actual %#v", tt.expectReqPaths,
+					tt.handler.paths)
+			}
+
+			if !reflect.DeepEqual(tt.expectReqParams, tt.handler.params) {
+				t.Errorf("Login() request params do not match expected %#v, actual %#v", tt.expectReqParams,
+					tt.handler.params)
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Login() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -9,9 +9,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-secure-stdlib/awsutil"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/vault/api"
@@ -172,41 +169,21 @@ func NewProviderMeta(d *schema.ResourceData) (interface{}, error) {
 		return nil, err
 	}
 
-	// Attempt to use auth/<mount>login if 'auth_login' is provided in provider config
-	authLoginI := d.Get("auth_login").([]interface{})
-	if len(authLoginI) > 1 {
-		return "", fmt.Errorf("auth_login block may appear only once")
+	authLogin, err := GetAuthLogin(d)
+	if err != nil {
+		return nil, err
 	}
 
-	if len(authLoginI) == 1 {
-		authLogin := authLoginI[0].(map[string]interface{})
-		authLoginPath := authLogin[consts.FieldPath].(string)
-		authLoginNamespace := ""
-		if authLoginNamespaceI, ok := authLogin[consts.FieldNamespace]; ok {
-			authLoginNamespace = authLoginNamespaceI.(string)
-			client.SetNamespace(authLoginNamespace)
-		}
-		authLoginParameters := authLogin[consts.FieldParameters].(map[string]interface{})
-
-		method := authLogin[consts.FieldMethod].(string)
-		if method == "aws" {
-			logger := hclog.Default()
-			if logging.IsDebugOrHigher() {
-				logger.SetLevel(hclog.Debug)
-			} else {
-				logger.SetLevel(hclog.Error)
-			}
-			if err := signAWSLogin(authLoginParameters, logger); err != nil {
-				return nil, fmt.Errorf("error signing AWS login request: %s", err)
-			}
-		}
-
-		secret, err := client.Logical().Write(authLoginPath, authLoginParameters)
+	if authLogin != nil {
+		client.SetNamespace(authLogin.Namespace())
+		secret, err := authLogin.Login(client)
 		if err != nil {
 			return nil, err
 		}
+
 		token = secret.Auth.ClientToken
 	}
+
 	if token != "" {
 		client.SetToken(token)
 	}
@@ -331,47 +308,6 @@ func setChildToken(d *schema.ResourceData, c *api.Client) error {
 
 	// Set the token to the generated child token
 	c.SetToken(childToken)
-
-	return nil
-}
-
-func signAWSLogin(parameters map[string]interface{}, logger hclog.Logger) error {
-	var accessKey, secretKey, securityToken string
-	if val, ok := parameters["aws_access_key_id"].(string); ok {
-		accessKey = val
-	}
-
-	if val, ok := parameters["aws_secret_access_key"].(string); ok {
-		secretKey = val
-	}
-
-	if val, ok := parameters["aws_security_token"].(string); ok {
-		securityToken = val
-	}
-
-	creds, err := awsutil.RetrieveCreds(accessKey, secretKey, securityToken, logger)
-	if err != nil {
-		return fmt.Errorf("failed to retrieve AWS credentials: %s", err)
-	}
-
-	var headerValue, stsRegion string
-	if val, ok := parameters["header_value"].(string); ok {
-		headerValue = val
-	}
-
-	if val, ok := parameters["sts_region"].(string); ok {
-		stsRegion = val
-	}
-
-	loginData, err := awsutil.GenerateLoginData(creds, headerValue, stsRegion, logger)
-	if err != nil {
-		return fmt.Errorf("failed to generate AWS login data: %s", err)
-	}
-
-	parameters["iam_http_request_method"] = loginData["iam_http_request_method"]
-	parameters["iam_request_url"] = loginData["iam_request_url"]
-	parameters["iam_request_headers"] = loginData["iam_request_headers"]
-	parameters["iam_request_body"] = loginData["iam_request_body"]
 
 	return nil
 }

--- a/internal/provider/schema_util.go
+++ b/internal/provider/schema_util.go
@@ -1,0 +1,17 @@
+package provider
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func MustAddSchema(r *schema.Resource, m map[string]*schema.Schema) {
+	for k, s := range m {
+		if _, ok := r.Schema[k]; ok {
+			panic(fmt.Sprintf("cannot add schema field %q,  already exists in the Schema map", k))
+		}
+
+		r.Schema[k] = s
+	}
+}

--- a/util/util.go
+++ b/util/util.go
@@ -56,18 +56,22 @@ func ErrorContainsHTTPCode(err error, codes ...int) bool {
 	return false
 }
 
+// CalculateConflictsWith returns a slice of field names that conflict with
+// a single field (self).
 func CalculateConflictsWith(self string, group []string) []string {
-	if len(group) < 2 {
-		return []string{}
+	result := make([]string, 0)
+	seen := map[string]bool{
+		self: true,
 	}
-	results := make([]string, 0, len(group)-2)
 	for _, item := range group {
-		if item == self {
+		if _, ok := seen[item]; ok {
 			continue
 		}
-		results = append(results, item)
+
+		seen[item] = true
+		result = append(result, item)
 	}
-	return results
+	return result
 }
 
 func ArrayToTerraformList(values []string) string {

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -365,3 +365,56 @@ func TestGetAPIRequestData(t *testing.T) {
 		})
 	}
 }
+
+func TestCalculateConflictsWith(t *testing.T) {
+	tests := []struct {
+		name  string
+		self  string
+		group []string
+		want  []string
+	}{
+		{
+			name:  "empty",
+			self:  "basic",
+			group: []string{},
+			want:  []string{},
+		},
+		{
+			name:  "empty-self",
+			self:  "basic",
+			group: []string{"basic"},
+			want:  []string{},
+		},
+		{
+			name:  "single",
+			self:  "single",
+			group: []string{"foo"},
+			want:  []string{"foo"},
+		},
+		{
+			name:  "single-self",
+			self:  "single",
+			group: []string{"foo", "single"},
+			want:  []string{"foo"},
+		},
+		{
+			name:  "multiple-self",
+			self:  "multiple",
+			group: []string{"multiple", "foo", "multiple"},
+			want:  []string{"foo"},
+		},
+		{
+			name:  "duplicates-other",
+			self:  "multiple",
+			group: []string{"foo", "bar", "foo", "bar"},
+			want:  []string{"foo", "bar"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CalculateConflictsWith(tt.self, tt.group); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("CalculateConflictsWith() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -97,33 +97,29 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("VAULT_CAPATH", ""),
 				Description: "Path to directory containing CA certificate files to validate the server's certificate.",
 			},
-			"auth_login": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Login to vault with an existing auth method using auth/<mount>/login",
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						consts.FieldPath: {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-						consts.FieldNamespace: {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-						consts.FieldParameters: {
-							Type:     schema.TypeMap,
-							Optional: true,
-							Elem: &schema.Schema{
-								Type: schema.TypeString,
-							},
-						},
-						consts.FieldMethod: {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-					},
-				},
+			consts.FieldAuthLoginDefault: {
+				Type:          schema.TypeList,
+				Optional:      true,
+				MaxItems:      1,
+				ConflictsWith: []string{consts.FieldAuthLoginAWS, consts.FieldAuthLoginUserpass},
+				Description:   "Login to vault with an existing auth method using auth/<mount>/login",
+				Elem:          provider.SchemaLoginGeneric,
+			},
+			consts.FieldAuthLoginUserpass: {
+				Type:          schema.TypeList,
+				Optional:      true,
+				MaxItems:      1,
+				ConflictsWith: []string{consts.FieldAuthLoginDefault, consts.FieldAuthLoginAWS},
+				Description:   "Login to vault using the userpass method",
+				Elem:          provider.SchemaLoginUserpass,
+			},
+			consts.FieldAuthLoginAWS: {
+				Type:          schema.TypeList,
+				Optional:      true,
+				MaxItems:      1,
+				ConflictsWith: []string{consts.FieldAuthLoginDefault, consts.FieldAuthLoginUserpass},
+				Description:   "Login to vault using the AWS method",
+				Elem:          provider.SchemaLoginAWS,
 			},
 			"client_auth": {
 				Type:        schema.TypeList,
@@ -828,18 +824,8 @@ func getNamespaceSchema() map[string]*schema.Schema {
 	}
 }
 
-func mustAddSchema(r *schema.Resource, m map[string]*schema.Schema) {
-	for k, s := range m {
-		if _, ok := r.Schema[k]; ok {
-			panic(fmt.Sprintf("cannot add schema field %q,  already exists in the Schema map", k))
-		}
-
-		r.Schema[k] = s
-	}
-}
-
 func UpdateSchemaResource(r *schema.Resource) *schema.Resource {
-	mustAddSchema(r, getNamespaceSchema())
+	provider.MustAddSchema(r, getNamespaceSchema())
 
 	return r
 }

--- a/vault/provider_test.go
+++ b/vault/provider_test.go
@@ -272,7 +272,7 @@ func testResourceApproleLoginCheckAttrs(t *testing.T) resource.TestCheckFunc {
 			Schema: approleProvider.Schema,
 		}
 		approleProviderData := approleProviderResource.TestResourceData()
-		approleProviderData.Set("auth_login", authLoginData)
+		approleProviderData.Set(consts.FieldAuthLoginDefault, authLoginData)
 		_, err := provider.NewProviderMeta(approleProviderData)
 		if err != nil {
 			t.Fatal(err)

--- a/vault/resource_kubernetes_secret_backend.go
+++ b/vault/resource_kubernetes_secret_backend.go
@@ -61,7 +61,7 @@ func kubernetesSecretBackendResource() *schema.Resource {
 	}
 
 	// Add common mount schema to the resource
-	mustAddSchema(resource, getMountSchema("type"))
+	provider.MustAddSchema(resource, getMountSchema("type"))
 
 	return resource
 }


### PR DESCRIPTION
This fix provides first-class auth specific configuration for logging into Vault. Initial auth engines supported are userpass and aws.

This is an additive change, which means that the current auth_login functionality remains unchanged.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
