### PR TITLE
Accept data source values in the token field for Consul secrets backend

### DIFF
--- a/vault/resource_consul_secret_backend.go
+++ b/vault/resource_consul_secret_backend.go
@@ -294,20 +294,21 @@ func consulSecretBackendConfigPath(backend string) string {
 
 func consulSecretsBackendCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
 	newToken := diff.Get("token").(string)
-	newBootstrap := diff.Get("bootstrap").(bool)
-
-	// Disallow the following:
-	//   1. Bootstrap is false, the token field is empty, and we know this is the final value of token.
-	if !newBootstrap && newToken == "" && diff.NewValueKnown("token") {
-		return fmt.Errorf("field 'bootstrap' must be set to true when 'token' is unspecified")
-	}
+	isTokenValueKnown := diff.NewValueKnown("token")
 
 	// Disallow the following:
 	//   1. Bootstrap is true and the token field is set to something.
 	//   2. Bootstrap is true and the token field is empty, but we don't know the final value of token.
-	if newBootstrap && newToken != "" ||
-		(newBootstrap && newToken == "" && !diff.NewValueKnown("token")) {
-		return fmt.Errorf("field 'bootstrap' must be set to false when 'token' is specified")
+	//   3. Bootstrap is false, the token field is empty, and we know this is the final value of token.
+	if newBootstrap := diff.Get("bootstrap").(bool); newBootstrap {
+		if newToken != "" ||
+			(newToken == "" && !isTokenValueKnown) {
+			return fmt.Errorf("field 'bootstrap' must be set to false when 'token' is specified")
+		}
+	} else {
+		if newToken == "" && isTokenValueKnown {
+			return fmt.Errorf("field 'bootstrap' must be set to true when 'token' is unspecified")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
With the recent update to the Consul secret backend, we force users to set the field `bootstrap` to true when they do not provide a token. This was mistakenly triggering when the token is set to a data source, as the provider initially sees it as an empty value.

This bug fix determines that the empty value from a data source is not the known final value, and so allows the provider to continue. 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BUG FIXES:
* Correctly allow data source values for Consul tokens
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
ok      github.com/hashicorp/terraform-provider-vault/vault     5.025s
```

Closes #1595