### PR TITLE
docs: Fix vault_kv_secret_backend_v2 delete_version_after example

### DIFF
--- a/website/docs/r/kv_secret_backend_v2.html.md
+++ b/website/docs/r/kv_secret_backend_v2.html.md
@@ -26,10 +26,10 @@ resource "vault_mount" "kvv2" {
 }
 
 resource "vault_kv_secret_backend_v2" "config" {
-  mount                      = vault_mount.kvv2.path
-  max_versions               = 5
-  delete_version_after_input = "3.5h"
-  cas_required               = true
+  mount                = vault_mount.kvv2.path
+  max_versions         = 5
+  delete_version_after = "3.5h"
+  cas_required         = true
 }
 ```
 

--- a/website/docs/r/kv_secret_backend_v2.html.md
+++ b/website/docs/r/kv_secret_backend_v2.html.md
@@ -28,7 +28,7 @@ resource "vault_mount" "kvv2" {
 resource "vault_kv_secret_backend_v2" "config" {
   mount                = vault_mount.kvv2.path
   max_versions         = 5
-  delete_version_after = "3.5h"
+  delete_version_after = 12600
   cas_required         = true
 }
 ```


### PR DESCRIPTION
`delete_version_after_input` is not a valid argument for `vault_kv_secret_backend_v2` -- it is called `delete_version_after`. Additionally, the value is an integer number of seconds. This PR fixes the example.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
