### PR TITLE
Add vault_audit_request_header resource

### DIFF
--- a/vault/provider.go
+++ b/vault/provider.go
@@ -606,6 +606,10 @@ var (
 			Resource:      UpdateSchemaResource(auditResource()),
 			PathInventory: []string{"/sys/audit/{path}"},
 		},
+		"vault_audit_request_header": {
+			Resource:      UpdateSchemaResource(auditRequestHeaderResource()),
+			PathInventory: []string{"/sys/config/auditing/request-headers/{path}"},
+		},
 		"vault_ssh_secret_backend_ca": {
 			Resource:      UpdateSchemaResource(sshSecretBackendCAResource()),
 			PathInventory: []string{"/ssh/config/ca"},

--- a/vault/resource_audit_request_header.go
+++ b/vault/resource_audit_request_header.go
@@ -1,0 +1,178 @@
+package vault
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+
+	"github.com/hashicorp/vault/api"
+)
+
+func auditRequestHeaderPath(name string) string {
+	return "sys/config/auditing/request-headers/" + name
+}
+
+func auditRequestHeaderResource() *schema.Resource {
+	return &schema.Resource{
+		Create: auditRequestHeaderCreate,
+		Read:   ReadWrapper(auditRequestHeaderRead),
+		Update: auditRequestHeaderUpdate,
+		Delete: auditRequestHeaderDelete,
+		Exists: auditRequestHeaderExists,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of the request header to audit.",
+			},
+			"hmac": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Whether this header's value should be HMAC'd in the audit logs.",
+			},
+		},
+	}
+}
+
+func auditRequestHeaderCreate(d *schema.ResourceData, meta interface{}) error {
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
+	name := d.Get("name").(string)
+	path := auditRequestHeaderPath(name)
+	d.SetId(name)
+
+	log.Printf("[DEBUG] Creating Resource Audit Request Header %s", name)
+
+	data := map[string]interface{}{}
+
+	if v, ok := d.GetOk("hmac"); ok {
+		data["hmac"] = v
+	}
+
+	_, err := client.Logical().Write(path, data)
+	if err != nil {
+		d.SetId("")
+		return fmt.Errorf("error creating Resource Audit Request Header %s: %w", name, err)
+	}
+	log.Printf("[DEBUG] Created Resource Audit Request Header %s", name)
+
+	return auditRequestHeaderRead(d, meta)
+}
+
+func auditRequestHeaderRead(d *schema.ResourceData, meta interface{}) error {
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
+	name := d.Id()
+	path := auditRequestHeaderPath(name)
+
+	log.Printf("[DEBUG] Reading Resource Audit Request Header %s", name)
+	resp, err := client.Logical().Read(path)
+	if err != nil {
+		// This endpoint returns a 400 if the header does not exist, rather than
+		// a 404/empty response.
+		if apiErr, ok := err.(*api.ResponseError); !ok || apiErr.StatusCode != 400 ||
+			len(apiErr.Errors) != 1 || apiErr.Errors[0] != "Could not find header in config" {
+
+			return fmt.Errorf("error reading Resource Audit Request Header %s: %w", name, err)
+		}
+	}
+
+	if resp == nil {
+		log.Printf("[WARN] Resource Audit Request Header %s not found, removing from state", name)
+		d.SetId("")
+		return nil
+	}
+
+	if hmac, ok := resp.Data[name].(map[string]interface{})["hmac"]; ok {
+		if err := d.Set("hmac", hmac); err != nil {
+			return fmt.Errorf("error setting hmac for Resource Audit Request Header %s: %w", name, err)
+		}
+	}
+
+	return nil
+}
+
+func auditRequestHeaderUpdate(d *schema.ResourceData, meta interface{}) error {
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
+	name := d.Id()
+	path := auditRequestHeaderPath(name)
+
+	log.Printf("[DEBUG] Updating Resource Audit Request Header %s", name)
+
+	data := map[string]interface{}{}
+
+	if v, ok := d.GetOk("hmac"); ok {
+		data["hmac"] = v
+	}
+
+	_, err := client.Logical().Write(path, data)
+	if err != nil {
+		d.SetId("")
+		return fmt.Errorf("error updating Resource Audit Request Header %s: %w", name, err)
+	}
+	log.Printf("[DEBUG] Updated Resource Audit Request Header %s", name)
+
+	return auditRequestHeaderRead(d, meta)
+}
+
+func auditRequestHeaderDelete(d *schema.ResourceData, meta interface{}) error {
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
+	name := d.Id()
+	path := auditRequestHeaderPath(name)
+
+	log.Printf("[DEBUG] Deleting Resource Audit Request Header %s", name)
+	_, err := client.Logical().Delete(path)
+	if err != nil {
+		return fmt.Errorf("error deleting Resource Audit Request Header %s: %w", name, err)
+	}
+	log.Printf("[DEBUG] Deleted Resource Audit Request Header %s", name)
+
+	return nil
+}
+
+func auditRequestHeaderExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return false, e
+	}
+
+	name := d.Id()
+	path := auditRequestHeaderPath(name)
+
+	log.Printf("[DEBUG] Checking if Resource Audit Request Header %s exists", name)
+
+	secret, err := client.Logical().Read(path)
+	if err != nil {
+		// This endpoint returns a 400 if the header does not exist, rather than
+		// a 404/empty response.
+		if apiErr, ok := err.(*api.ResponseError); ok && apiErr.StatusCode == 400 &&
+			len(apiErr.Errors) == 1 && apiErr.Errors[0] == "Could not find header in config" {
+
+			return false, nil
+		}
+
+		return true, fmt.Errorf("error checking if Resource Audit Request Header %s exists: %w", name, err)
+	}
+
+	log.Printf("[DEBUG] Checked if Resource Audit Request Header %s exists", name)
+	return secret != nil, nil
+}

--- a/vault/resource_audit_request_header_test.go
+++ b/vault/resource_audit_request_header_test.go
@@ -1,0 +1,82 @@
+package vault
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+	"github.com/hashicorp/terraform-provider-vault/testutil"
+)
+
+func TestAuditRequestHeader(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-test")
+	newName := acctest.RandomWithPrefix("tf-test-new")
+	resource.Test(t, resource.TestCase{
+		Providers:    testProviders,
+		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		CheckDestroy: testAuditRequestHeaderCheckDestroy(name, newName),
+		Steps: []resource.TestStep{
+			{
+				Config: testAuditRequestHeader_Config(name, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_audit_request_header.header", "name", name),
+					resource.TestCheckResourceAttr("vault_audit_request_header.header", "hmac", "false"),
+				),
+			},
+			{
+				Config: testAuditRequestHeader_Config(name, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_audit_request_header.header", "name", name),
+					resource.TestCheckResourceAttr("vault_audit_request_header.header", "hmac", "true"),
+				),
+			},
+			{
+				Config: testAuditRequestHeader_Config(newName, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_audit_request_header.header", "name", newName),
+					resource.TestCheckResourceAttr("vault_audit_request_header.header", "hmac", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAuditRequestHeaderCheckDestroy(names ...string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+
+		for _, name := range names {
+			resp, err := client.Logical().Read(auditRequestHeaderPath(name))
+			if err != nil {
+				// This endpoint returns a 400 if the header does not exist, rather than
+				// a 404/empty response.
+				if apiErr, ok := err.(*api.ResponseError); !ok ||
+					apiErr.StatusCode != 400 || len(apiErr.Errors) != 1 ||
+					apiErr.Errors[0] != "Could not find header in config" {
+
+					return err
+				}
+			}
+
+			if resp != nil {
+				return fmt.Errorf("Resource Audit Request Header %s still exists", name)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAuditRequestHeader_Config(name string, hmac bool) string {
+	return fmt.Sprintf(`
+resource "vault_audit_request_header" "header" {
+  name = "%s"
+  hmac = %v
+}
+`, name, hmac)
+}

--- a/website/docs/r/audit_request_header.html.md
+++ b/website/docs/r/audit_request_header.html.md
@@ -1,0 +1,37 @@
+---
+layout: "vault"
+page_title: "Vault: vault_audit_request_header resource"
+sidebar_current: "docs-vault-resource-audit-request-header"
+description: |-
+  Manages audited request headers in Vault
+---
+
+# vault\_audit\_request\_header
+
+Manages additional request headers that appear in audited requests.
+
+~> **Note**
+Because of the way the [sys/config/auditing/request-headers API](https://www.vaultproject.io/api-docs/system/config-auditing)
+is implemented in Vault, this resource will manage existing audited headers with
+matching names without requiring import.
+
+## Example Usage
+
+```hcl
+resource "vault_audit_request_header" "x_forwarded_for" {
+  name = "X-Forwarded-For"
+  hmac = false
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the request header to audit.
+
+* `hmac` - (Optional) Whether this header's value should be HMAC'd in the audit logs.
+
+## Attributes Reference
+
+No additional attributes are exported by this resource.

--- a/website/vault.erb
+++ b/website/vault.erb
@@ -130,6 +130,10 @@
                             <a href="/docs/providers/vault/r/audit.html">vault_audit</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-vault-resource-audit-request-header") %>>
+                            <a href="/docs/providers/vault/r/audit_request_header.html">vault_audit_request_header</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-vault-resource-auth-backend") %>>
                             <a href="/docs/providers/vault/r/auth_backend.html">vault_auth_backend</a>
                         </li>


### PR DESCRIPTION
Supports the sys/config/auditing/request-headers APIs.

Closes #1465

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1465 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* **New Resource:** `vault_audit_request_header` ([#1610](https://github.com/terraform-providers/terraform-provider-vault/pull/1610)).
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAuditRequestHeader'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -run=TestAuditRequestHeader -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/codegen   0.021s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    0.042s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    0.023s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    0.019s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        0.030s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    0.024s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      0.024s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  0.025s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/pki      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/provider 0.026s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/semver   0.017s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
ok      github.com/hashicorp/terraform-provider-vault/testutil  0.042s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util      0.019s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/vault     2.105s

...
```
