### PR TITLE
docs: document the `disable_remount` field

### DIFF
--- a/website/docs/r/ad_secret_backend.html.md
+++ b/website/docs/r/ad_secret_backend.html.md
@@ -43,6 +43,9 @@ The following arguments are supported:
 * `backend` - (Optional) The unique path this backend should be mounted at. Must
 not begin or end with a `/`. Defaults to `ad`.
 
+* `disable_remount` - (Optional) If set, opts out of mount migration on path updates.
+  See here for more info on [Mount Migration](https://www.vaultproject.io/docs/concepts/mount-migration)
+
 * `anonymous_group_search` - (Optional) Use anonymous binds when performing LDAP group searches
 (if true the initial credentials will still be used for the initial connection test).
 

--- a/website/docs/r/auth_backend.html.md
+++ b/website/docs/r/auth_backend.html.md
@@ -35,6 +35,9 @@ The following arguments are supported:
 
 * `path` - (Optional) The path to mount the auth method — this defaults to the name of the type.
 
+* `disable_remount` - (Optional) If set, opts out of mount migration on path updates.
+  See here for more info on [Mount Migration](https://www.vaultproject.io/docs/concepts/mount-migration)
+
 * `description` - (Optional) A description of the auth method.
 
 * `local` - (Optional) Specifies if the auth method is local only.

--- a/website/docs/r/aws_secret_backend.html.md
+++ b/website/docs/r/aws_secret_backend.html.md
@@ -60,6 +60,9 @@ while newer versions of Vault will.
 * `path` - (Optional) The unique path this backend should be mounted at. Must
 not begin or end with a `/`. Defaults to `aws`.
 
+* `disable_remount` - (Optional) If set, opts out of mount migration on path updates.
+  See here for more info on [Mount Migration](https://www.vaultproject.io/docs/concepts/mount-migration)
+
 * `description` - (Optional) A human-friendly description for this backend.
 
 * `default_lease_ttl_seconds` - (Optional) The default TTL for credentials

--- a/website/docs/r/azure_secret_backend.html.md
+++ b/website/docs/r/azure_secret_backend.html.md
@@ -53,7 +53,7 @@ resource "vault_azure_secret_backend" "azure" {
 
 The following arguments are supported:
 
-* `namespace` - (Optional) The namespace to provision the resource in.
+- `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
   The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
    *Available only for Vault Enterprise*.
@@ -72,6 +72,9 @@ The following arguments are supported:
 - `environment` (`string:""`) - The Azure environment.
 
 - `path` (`string: <optional>`) - The unique path this backend should be mounted at. Defaults to `azure`.
+
+- `disable_remount` - (Optional) If set, opts out of mount migration on path updates.
+  See here for more info on [Mount Migration](https://www.vaultproject.io/docs/concepts/mount-migration)
 
 ## Attributes Reference
 

--- a/website/docs/r/consul_secret_backend.html.md
+++ b/website/docs/r/consul_secret_backend.html.md
@@ -64,6 +64,9 @@ and a [Consul reset may be required.](https://learn.hashicorp.com/tutorials/cons
 * `path` - (Optional) The unique location this backend should be mounted at. Must not begin or end with a `/`. Defaults
 to `consul`.
 
+* `disable_remount` - (Optional) If set, opts out of mount migration on path updates.
+  See here for more info on [Mount Migration](https://www.vaultproject.io/docs/concepts/mount-migration)
+
 * `description` - (Optional) A human-friendly description for this backend.
 
 * `address` - (Required) Specifies the address of the Consul instance, provided as "host:port" like "127.0.0.1:8500".

--- a/website/docs/r/gcp_auth_backend.html.md
+++ b/website/docs/r/gcp_auth_backend.html.md
@@ -38,6 +38,9 @@ The following arguments are supported:
 
 * `path` - (Optional) The path to mount the auth method — this defaults to 'gcp'.
 
+* `disable_remount` - (Optional) If set, opts out of mount migration on path updates.
+  See here for more info on [Mount Migration](https://www.vaultproject.io/docs/concepts/mount-migration)
+
 * `description` - (Optional) A description of the auth method.
 
 * `local` - (Optional) Specifies if the auth method is local only.

--- a/website/docs/r/gcp_secret_backend.html.md
+++ b/website/docs/r/gcp_secret_backend.html.md
@@ -45,6 +45,9 @@ previously stored values.
 * `path` - (Optional) The unique path this backend should be mounted at. Must
 not begin or end with a `/`. Defaults to `gcp`.
 
+* `disable_remount` - (Optional) If set, opts out of mount migration on path updates.
+  See here for more info on [Mount Migration](https://www.vaultproject.io/docs/concepts/mount-migration)
+
 * `description` - (Optional) A human-friendly description for this backend.
 
 * `default_lease_ttl_seconds` - (Optional) The default TTL for credentials

--- a/website/docs/r/github_auth_backend.html.md
+++ b/website/docs/r/github_auth_backend.html.md
@@ -32,6 +32,9 @@ The following arguments are supported:
 * `path` - (Optional) Path where the auth backend is mounted. Defaults to `auth/github`
   if not specified.
 
+* `disable_remount` - (Optional) If set, opts out of mount migration on path updates.
+  See here for more info on [Mount Migration](https://www.vaultproject.io/docs/concepts/mount-migration)
+
 * `organization` - (Required) The organization configured users must be part of.
 
 * `organization_id` (Optional) The ID of the organization users must be part of.

--- a/website/docs/r/jwt_auth_backend.html.md
+++ b/website/docs/r/jwt_auth_backend.html.md
@@ -70,6 +70,9 @@ The following arguments are supported:
 
 * `path` - (Required) Path to mount the JWT/OIDC auth backend
 
+* `disable_remount` - (Optional) If set, opts out of mount migration on path updates.
+  See here for more info on [Mount Migration](https://www.vaultproject.io/docs/concepts/mount-migration)
+
 * `type` - (Optional) Type of auth backend. Should be one of `jwt` or `oidc`. Default - `jwt`
 
 * `description` - (Optional) The description of the auth backend

--- a/website/docs/r/kmip_secret_backend.html.md
+++ b/website/docs/r/kmip_secret_backend.html.md
@@ -39,6 +39,9 @@ The following arguments are supported:
 * `path` - (Required) The unique path this backend should be mounted at. Must
   not begin or end with a `/`. Defaults to `kmip`.
 
+* `disable_remount` - (Optional) If set, opts out of mount migration on path updates.
+  See here for more info on [Mount Migration](https://www.vaultproject.io/docs/concepts/mount-migration)
+
 * `description` - (Optional) A human-friendly description for this backend.
 
 * `listen_addrs` - (Optional) Addresses the KMIP server should listen on (`host:port`).

--- a/website/docs/r/ldap_auth_backend.html.md
+++ b/website/docs/r/ldap_auth_backend.html.md
@@ -78,6 +78,9 @@ The following arguments are supported:
 
 * `path` - (Optional) Path to mount the LDAP auth backend under
 
+* `disable_remount` - (Optional) If set, opts out of mount migration on path updates.
+  See here for more info on [Mount Migration](https://www.vaultproject.io/docs/concepts/mount-migration)
+
 * `description` - (Optional) Description for the LDAP auth backend mount
 
 * `local` - (Optional) Specifies if the auth method is local only.

--- a/website/docs/r/nomad_secret_backend.html.md
+++ b/website/docs/r/nomad_secret_backend.html.md
@@ -45,6 +45,9 @@ The following arguments are supported:
 * `backend` - (Optional) The unique path this backend should be mounted at. Must
 not begin or end with a `/`. Defaults to `nomad`.
 
+* `disable_remount` - (Optional) If set, opts out of mount migration on path updates.
+  See here for more info on [Mount Migration](https://www.vaultproject.io/docs/concepts/mount-migration)
+
 * `address` - (Optional) Specifies the address of the Nomad instance, provided
 as "protocol://host:port" like "http://127.0.0.1:4646".
 

--- a/website/docs/r/okta_auth_backend.html.md
+++ b/website/docs/r/okta_auth_backend.html.md
@@ -42,6 +42,9 @@ The following arguments are supported:
 
 * `path` - (Required) Path to mount the Okta auth backend
 
+* `disable_remount` - (Optional) If set, opts out of mount migration on path updates.
+  See here for more info on [Mount Migration](https://www.vaultproject.io/docs/concepts/mount-migration)
+
 * `description` - (Optional) The description of the auth backend
 
 * `organization` - (Required) The Okta organization. This will be the first part of the url `https://XXX.okta.com`

--- a/website/docs/r/rabbitmq_secret_backend.html.md
+++ b/website/docs/r/rabbitmq_secret_backend.html.md
@@ -58,6 +58,9 @@ overwrite the previously stored values.
 * `path` - (Optional) The unique path this backend should be mounted at. Must
 not begin or end with a `/`. Defaults to `rabbitmq`.
 
+* `disable_remount` - (Optional) If set, opts out of mount migration on path updates.
+  See here for more info on [Mount Migration](https://www.vaultproject.io/docs/concepts/mount-migration)
+
 * `description` - (Optional) A human-friendly description for this backend.
 
 * `default_lease_ttl_seconds` - (Optional) The default TTL for credentials

--- a/website/docs/r/terraform_cloud_secret_backend.md
+++ b/website/docs/r/terraform_cloud_secret_backend.md
@@ -47,6 +47,9 @@ on `token`. Changing the value, however, _will_ overwrite the previously stored 
 
 * `backend` - (Optional) The unique location this backend should be mounted at. Must not begin or end with a `/`. Defaults to `terraform`.
 
+* `disable_remount` - (Optional) If set, opts out of mount migration on path updates.
+  See here for more info on [Mount Migration](https://www.vaultproject.io/docs/concepts/mount-migration)
+
 * `description` - (Optional) A human-friendly description for this backend.
 
 * `default_lease_ttl_seconds` - (Optional) The default TTL for credentials issued by this backend.


### PR DESCRIPTION
Adds documentation to Auth/Secret backends for the new `disable_remount` field added to disable mount migration.