### PR TITLE
Ensure all AuthLogin instances are validated on call to Login().

### DIFF
--- a/internal/provider/auth_aws.go
+++ b/internal/provider/auth_aws.go
@@ -155,6 +155,10 @@ func (l *AuthLoginAWS) Method() string {
 
 // Login using the aws authentication engine.
 func (l *AuthLoginAWS) Login(client *api.Client) (*api.Secret, error) {
+	if err := l.validate(); err != nil {
+		return nil, err
+	}
+
 	params, err := l.copyParams(
 		consts.FieldRole,
 	)

--- a/internal/provider/auth_azure.go
+++ b/internal/provider/auth_azure.go
@@ -132,8 +132,8 @@ func (l *AuthLoginAzure) Method() string {
 
 // Login using the azure authentication engine.
 func (l *AuthLoginAzure) Login(client *api.Client) (*api.Secret, error) {
-	if !l.initialized {
-		return nil, fmt.Errorf("auth login not initialized")
+	if err := l.validate(); err != nil {
+		return nil, err
 	}
 
 	params, err := l.copyParams(l.requiredParams()...)

--- a/internal/provider/auth_azure_test.go
+++ b/internal/provider/auth_azure_test.go
@@ -255,11 +255,6 @@ func TestAuthLoginAzure_Login(t *testing.T) {
 			name: "error-uninitialized",
 			authLogin: &AuthLoginAzure{
 				AuthLoginCommon: AuthLoginCommon{
-					authField: consts.FieldAuthLoginAzure,
-					params: map[string]interface{}{
-						consts.FieldRole: "alice",
-						consts.FieldJWT:  "jwt1",
-					},
 					initialized: false,
 				},
 			},
@@ -269,7 +264,7 @@ func TestAuthLoginAzure_Login(t *testing.T) {
 			expectReqCount: 0,
 			want:           nil,
 			wantErr:        true,
-			expectErr:      fmt.Errorf("auth login not initialized"),
+			expectErr:      authLoginInitCheckError,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/provider/auth_cert.go
+++ b/internal/provider/auth_cert.go
@@ -86,6 +86,10 @@ func (l *AuthLoginCert) Method() string {
 
 // Login using the cert authentication engine.
 func (l *AuthLoginCert) Login(client *api.Client) (*api.Secret, error) {
+	if err := l.validate(); err != nil {
+		return nil, err
+	}
+
 	c, err := client.Clone()
 	if err != nil {
 		return nil, err

--- a/internal/provider/auth_cert_test.go
+++ b/internal/provider/auth_cert_test.go
@@ -236,8 +236,9 @@ func TestAuthLoginCert_Login(t *testing.T) {
 			name: "default",
 			authLogin: &AuthLoginCert{
 				AuthLoginCommon{
-					authField: "baz",
-					params:    map[string]interface{}{},
+					authField:   "baz",
+					params:      map[string]interface{}{},
+					initialized: true,
 				},
 			},
 			handler: &testLoginHandler{
@@ -266,6 +267,7 @@ func TestAuthLoginCert_Login(t *testing.T) {
 					params: map[string]interface{}{
 						consts.FieldName: "bob",
 					},
+					initialized: true,
 				},
 			},
 			handler: &testLoginHandler{
@@ -286,6 +288,20 @@ func TestAuthLoginCert_Login(t *testing.T) {
 				},
 			},
 			wantErr: false,
+		},
+		{
+			name: "error-uninitialized",
+			authLogin: &AuthLoginCert{
+				AuthLoginCommon{
+					initialized: false,
+				},
+			},
+			handler: &testLoginHandler{
+				handlerFunc: handlerFunc,
+			},
+			want:      nil,
+			wantErr:   true,
+			expectErr: authLoginInitCheckError,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/provider/auth_gcp.go
+++ b/internal/provider/auth_gcp.go
@@ -91,17 +91,24 @@ func (l *AuthLoginGCP) Method() string {
 
 // Login using the gcp authentication engine.
 func (l *AuthLoginGCP) Login(client *api.Client) (*api.Secret, error) {
+	if err := l.validate(); err != nil {
+		return nil, err
+	}
+
+	params, err := l.copyParamsExcluding(
+		consts.FieldNamespace,
+		consts.FieldMount,
+		consts.FieldJWT,
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	ctx := context.Background()
 	jwt, err := l.getJWT(ctx)
 	if err != nil {
 		return nil, err
 	}
-
-	params := l.copyParamsExcluding(
-		consts.FieldNamespace,
-		consts.FieldMount,
-		consts.FieldJWT,
-	)
 
 	params[consts.FieldJWT] = jwt
 

--- a/internal/provider/auth_gcp_test.go
+++ b/internal/provider/auth_gcp_test.go
@@ -133,6 +133,7 @@ func TestAuthLoginGCP_Login(t *testing.T) {
 						consts.FieldJWT:  "jwt",
 						consts.FieldRole: "bob",
 					},
+					initialized: true,
 				},
 			},
 			handler: &testLoginHandler{
@@ -208,6 +209,20 @@ func TestAuthLoginGCP_Login(t *testing.T) {
 			expectReqParams: nil,
 			want:            nil,
 			wantErr:         true,
+		},
+		{
+			name: "error-uninitialized",
+			authLogin: &AuthLoginGCP{
+				AuthLoginCommon{
+					initialized: false,
+				},
+			},
+			handler: &testLoginHandler{
+				handlerFunc: handlerFunc,
+			},
+			want:      nil,
+			wantErr:   true,
+			expectErr: authLoginInitCheckError,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/provider/auth_generic.go
+++ b/internal/provider/auth_generic.go
@@ -88,6 +88,10 @@ func (l *AuthLoginGeneric) Method() string {
 }
 
 func (l *AuthLoginGeneric) Login(client *api.Client) (*api.Secret, error) {
+	if err := l.validate(); err != nil {
+		return nil, err
+	}
+
 	params, err := l.copyParams()
 	if err != nil {
 		return nil, err

--- a/internal/provider/auth_jwt.go
+++ b/internal/provider/auth_jwt.go
@@ -73,9 +73,14 @@ func (l *AuthLoginJWT) Method() string {
 
 // Login using the jwt authentication engine.
 func (l *AuthLoginJWT) Login(client *api.Client) (*api.Secret, error) {
-	if !l.initialized {
-		return nil, fmt.Errorf("auth login not initialized")
+	if err := l.validate(); err != nil {
+		return nil, err
 	}
 
-	return l.login(client, l.LoginPath(), l.copyParamsExcluding(consts.FieldNamespace, consts.FieldMount))
+	params, err := l.copyParamsExcluding(consts.FieldNamespace, consts.FieldMount)
+	if err != nil {
+		return nil, err
+	}
+
+	return l.login(client, l.LoginPath(), params)
 }

--- a/internal/provider/auth_jwt_test.go
+++ b/internal/provider/auth_jwt_test.go
@@ -176,11 +176,6 @@ func TestAuthLoginJWT_Login(t *testing.T) {
 			name: "error-uninitialized",
 			authLogin: &AuthLoginJWT{
 				AuthLoginCommon: AuthLoginCommon{
-					authField: consts.FieldAuthLoginJWT,
-					params: map[string]interface{}{
-						consts.FieldRole: "alice",
-						consts.FieldJWT:  "jwt1",
-					},
 					initialized: false,
 				},
 			},
@@ -190,7 +185,7 @@ func TestAuthLoginJWT_Login(t *testing.T) {
 			expectReqCount: 0,
 			want:           nil,
 			wantErr:        true,
-			expectErr:      fmt.Errorf("auth login not initialized"),
+			expectErr:      authLoginInitCheckError,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/provider/auth_kerberos.go
+++ b/internal/provider/auth_kerberos.go
@@ -143,9 +143,10 @@ func (l *AuthLoginKerberos) Method() string {
 
 // Login using the kerberos authentication engine.
 func (l *AuthLoginKerberos) Login(client *api.Client) (*api.Secret, error) {
-	if !l.initialized {
-		return nil, fmt.Errorf("auth login not initialized")
+	if err := l.validate(); err != nil {
+		return nil, err
 	}
+
 	negInitToken, err := l.getNegInitToken()
 	if err != nil {
 		return nil, err

--- a/internal/provider/auth_oci.go
+++ b/internal/provider/auth_oci.go
@@ -86,8 +86,8 @@ func (l *AuthLoginOCI) Method() string {
 
 // Login using the OCI authentication engine.
 func (l *AuthLoginOCI) Login(client *api.Client) (*api.Secret, error) {
-	if !l.initialized {
-		return nil, fmt.Errorf("auth login not initialized")
+	if err := l.validate(); err != nil {
+		return nil, err
 	}
 
 	v := l.params[consts.FieldAuthType]

--- a/internal/provider/auth_oci_test.go
+++ b/internal/provider/auth_oci_test.go
@@ -214,11 +214,6 @@ func TestAuthLoginOCI_Login(t *testing.T) {
 			name: "error-uninitialized",
 			authLogin: &AuthLoginOCI{
 				AuthLoginCommon: AuthLoginCommon{
-					authField: consts.FieldAuthLoginOCI,
-					params: map[string]interface{}{
-						consts.FieldRole:     "alice",
-						consts.FieldAuthType: ociAuthTypeAPIKeys,
-					},
 					initialized: false,
 				},
 			},
@@ -228,7 +223,7 @@ func TestAuthLoginOCI_Login(t *testing.T) {
 			expectReqCount: 0,
 			want:           nil,
 			wantErr:        true,
-			expectErr:      fmt.Errorf("auth login not initialized"),
+			expectErr:      authLoginInitCheckError,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/provider/auth_oidc.go
+++ b/internal/provider/auth_oidc.go
@@ -98,8 +98,8 @@ func (l *AuthLoginOIDC) Method() string {
 
 // Login using the oidc authentication engine.
 func (l *AuthLoginOIDC) Login(client *api.Client) (*api.Secret, error) {
-	if !l.initialized {
-		return nil, fmt.Errorf("auth login not initiailized")
+	if err := l.validate(); err != nil {
+		return nil, err
 	}
 
 	params, err := l.getAuthParams()

--- a/internal/provider/auth_oidc_test.go
+++ b/internal/provider/auth_oidc_test.go
@@ -1,11 +1,14 @@
 package provider
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"reflect"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/vault/api"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 )
@@ -213,6 +216,55 @@ func TestAuthLoginOIDC_getAuthParams(t *testing.T) {
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getAuthParams() got = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestAuthLoginOIDC_Login(t *testing.T) {
+	handlerFunc := func(t *testLoginHandler, w http.ResponseWriter, req *http.Request) {
+		role := "default"
+		params := t.params[len(t.params)-1]
+		if v, ok := params[consts.FieldRole]; ok {
+			role = v.(string)
+		}
+
+		m, err := json.Marshal(
+			&api.Secret{
+				Auth: &api.SecretAuth{
+					Metadata: map[string]string{
+						"role": role,
+					},
+				},
+			},
+		)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write(m)
+	}
+
+	tests := []authLoginTest{
+		{
+			name: "error-uninitialized",
+			authLogin: &AuthLoginOIDC{
+				AuthLoginCommon{
+					initialized: false,
+				},
+			},
+			handler: &testLoginHandler{
+				handlerFunc: handlerFunc,
+			},
+			want:      nil,
+			wantErr:   true,
+			expectErr: authLoginInitCheckError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testAuthLogin(t, tt)
 		})
 	}
 }

--- a/internal/provider/auth_radius.go
+++ b/internal/provider/auth_radius.go
@@ -74,9 +74,14 @@ func (l *AuthLoginRadius) Method() string {
 
 // Login using the radius authentication engine.
 func (l *AuthLoginRadius) Login(client *api.Client) (*api.Secret, error) {
-	if !l.initialized {
-		return nil, fmt.Errorf("auth login not initialized")
+	if err := l.validate(); err != nil {
+		return nil, err
 	}
 
-	return l.login(client, l.LoginPath(), l.copyParamsExcluding(consts.FieldNamespace, consts.FieldMount))
+	params, err := l.copyParamsExcluding(consts.FieldNamespace, consts.FieldMount)
+	if err != nil {
+		return nil, err
+	}
+
+	return l.login(client, l.LoginPath(), params)
 }

--- a/internal/provider/auth_radius_test.go
+++ b/internal/provider/auth_radius_test.go
@@ -176,11 +176,6 @@ func TestAuthLoginRadius_Login(t *testing.T) {
 			name: "error-uninitialized",
 			authLogin: &AuthLoginRadius{
 				AuthLoginCommon: AuthLoginCommon{
-					authField: consts.FieldAuthLoginRadius,
-					params: map[string]interface{}{
-						consts.FieldUsername: "alice",
-						consts.FieldPassword: "password1",
-					},
 					initialized: false,
 				},
 			},
@@ -190,7 +185,7 @@ func TestAuthLoginRadius_Login(t *testing.T) {
 			expectReqCount: 0,
 			want:           nil,
 			wantErr:        true,
-			expectErr:      fmt.Errorf("auth login not initialized"),
+			expectErr:      authLoginInitCheckError,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/provider/auth_userpass.go
+++ b/internal/provider/auth_userpass.go
@@ -72,10 +72,18 @@ func (l *AuthLoginUserpass) Method() string {
 
 // Login using the userpass authentication engine.
 func (l *AuthLoginUserpass) Login(client *api.Client) (*api.Secret, error) {
-	params := l.copyParamsExcluding(
+	if err := l.validate(); err != nil {
+		return nil, err
+	}
+
+	params, err := l.copyParamsExcluding(
 		consts.FieldNamespace,
 		consts.FieldMount,
 	)
+	if err != nil {
+		return nil, err
+	}
+
 	if err := setupUserpassAuthParams(params); err != nil {
 		return nil, err
 	}

--- a/internal/provider/auth_userpass_test.go
+++ b/internal/provider/auth_userpass_test.go
@@ -140,6 +140,7 @@ func TestAuthLoginUserpass_Login(t *testing.T) {
 						consts.FieldUsername: "bob",
 						consts.FieldPassword: "baz",
 					},
+					initialized: true,
 				},
 			},
 			handler: &testLoginHandler{
@@ -173,6 +174,7 @@ func TestAuthLoginUserpass_Login(t *testing.T) {
 					params: map[string]interface{}{
 						consts.FieldPassword: "baz",
 					},
+					initialized: true,
 				},
 			},
 			handler: &testLoginHandler{
@@ -183,6 +185,20 @@ func TestAuthLoginUserpass_Login(t *testing.T) {
 			expectReqParams: nil,
 			want:            nil,
 			wantErr:         true,
+		},
+		{
+			name: "error-uninitialized",
+			authLogin: &AuthLoginUserpass{
+				AuthLoginCommon{
+					initialized: false,
+				},
+			},
+			handler: &testLoginHandler{
+				handlerFunc: handlerFunc,
+			},
+			want:      nil,
+			wantErr:   true,
+			expectErr: authLoginInitCheckError,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #1627 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc-ent SKIP_VAULT_NEXT_TESTS=1 TESTARGS='-v -test.run TestAuthLogin -test.count=1'
make testacc TF_ACC_ENTERPRISE=1
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -test.run TestAuthLogin -test.count=1 -timeout 30m ./...

=== RUN   TestAuthLoginAWS_Init
=== RUN   TestAuthLoginAWS_Init/basic
=== RUN   TestAuthLoginAWS_Init/error-missing-resource
=== RUN   TestAuthLoginAWS_Init/error-missing-required
--- PASS: TestAuthLoginAWS_Init (0.00s)
    --- PASS: TestAuthLoginAWS_Init/basic (0.00s)
    --- PASS: TestAuthLoginAWS_Init/error-missing-resource (0.00s)
    --- PASS: TestAuthLoginAWS_Init/error-missing-required (0.00s)
=== RUN   TestAuthLoginAWS_LoginPath
=== RUN   TestAuthLoginAWS_LoginPath/default
=== RUN   TestAuthLoginAWS_LoginPath/other
--- PASS: TestAuthLoginAWS_LoginPath (0.00s)
    --- PASS: TestAuthLoginAWS_LoginPath/default (0.00s)
    --- PASS: TestAuthLoginAWS_LoginPath/other (0.00s)
=== RUN   TestAuthLoginAWS_getCredentialsConfig
=== RUN   TestAuthLoginAWS_getCredentialsConfig/static-creds
=== RUN   TestAuthLoginAWS_getCredentialsConfig/static-creds-with-profile
=== RUN   TestAuthLoginAWS_getCredentialsConfig/all
--- PASS: TestAuthLoginAWS_getCredentialsConfig (0.00s)
    --- PASS: TestAuthLoginAWS_getCredentialsConfig/static-creds (0.00s)
    --- PASS: TestAuthLoginAWS_getCredentialsConfig/static-creds-with-profile (0.00s)
    --- PASS: TestAuthLoginAWS_getCredentialsConfig/all (0.00s)
=== RUN   TestAuthLoginAWS_Login
=== RUN   TestAuthLoginAWS_Login/error-uninitialized
--- PASS: TestAuthLoginAWS_Login (0.00s)
    --- PASS: TestAuthLoginAWS_Login/error-uninitialized (0.00s)
=== RUN   TestAuthLoginAzure_Init
=== RUN   TestAuthLoginAzure_Init/basic
=== RUN   TestAuthLoginAzure_Init/error-missing-resource
=== RUN   TestAuthLoginAzure_Init/error-missing-required
=== RUN   TestAuthLoginAzure_Init/error-missing-one-of
--- PASS: TestAuthLoginAzure_Init (0.00s)
    --- PASS: TestAuthLoginAzure_Init/basic (0.00s)
    --- PASS: TestAuthLoginAzure_Init/error-missing-resource (0.00s)
    --- PASS: TestAuthLoginAzure_Init/error-missing-required (0.00s)
    --- PASS: TestAuthLoginAzure_Init/error-missing-one-of (0.00s)
=== RUN   TestAuthLoginAzure_LoginPath
=== RUN   TestAuthLoginAzure_LoginPath/default
=== RUN   TestAuthLoginAzure_LoginPath/other
--- PASS: TestAuthLoginAzure_LoginPath (0.00s)
    --- PASS: TestAuthLoginAzure_LoginPath/default (0.00s)
    --- PASS: TestAuthLoginAzure_LoginPath/other (0.00s)
=== RUN   TestAuthLoginAzure_Login
=== RUN   TestAuthLoginAzure_Login/auth-with-jwt
=== RUN   TestAuthLoginAzure_Login/auth-with-az-identity
    auth_azure_test.go:249: "TF_ACC_AZURE_AUTH" must be set
=== RUN   TestAuthLoginAzure_Login/error-uninitialized
--- PASS: TestAuthLoginAzure_Login (0.00s)
    --- PASS: TestAuthLoginAzure_Login/auth-with-jwt (0.00s)
    --- SKIP: TestAuthLoginAzure_Login/auth-with-az-identity (0.00s)
    --- PASS: TestAuthLoginAzure_Login/error-uninitialized (0.00s)
=== RUN   TestAuthLoginCert_Init
=== RUN   TestAuthLoginCert_Init/without-role-name
=== RUN   TestAuthLoginCert_Init/with-role-name
=== RUN   TestAuthLoginCert_Init/with-namespace
=== RUN   TestAuthLoginCert_Init/all-params
=== RUN   TestAuthLoginCert_Init/error-missing-resource
--- PASS: TestAuthLoginCert_Init (0.00s)
    --- PASS: TestAuthLoginCert_Init/without-role-name (0.00s)
    --- PASS: TestAuthLoginCert_Init/with-role-name (0.00s)
    --- PASS: TestAuthLoginCert_Init/with-namespace (0.00s)
    --- PASS: TestAuthLoginCert_Init/all-params (0.00s)
    --- PASS: TestAuthLoginCert_Init/error-missing-resource (0.00s)
=== RUN   TestAuthLoginCert_LoginPath
=== RUN   TestAuthLoginCert_LoginPath/default
--- PASS: TestAuthLoginCert_LoginPath (0.00s)
    --- PASS: TestAuthLoginCert_LoginPath/default (0.00s)
=== RUN   TestAuthLoginCert_Login
=== RUN   TestAuthLoginCert_Login/default
=== RUN   TestAuthLoginCert_Login/named-role
=== RUN   TestAuthLoginCert_Login/error-uninitialized
--- PASS: TestAuthLoginCert_Login (0.00s)
    --- PASS: TestAuthLoginCert_Login/default (0.00s)
    --- PASS: TestAuthLoginCert_Login/named-role (0.00s)
    --- PASS: TestAuthLoginCert_Login/error-uninitialized (0.00s)
=== RUN   TestAuthLoginGCP_Init
=== RUN   TestAuthLoginGCP_Init/error-missing-resource
--- PASS: TestAuthLoginGCP_Init (0.00s)
    --- PASS: TestAuthLoginGCP_Init/error-missing-resource (0.00s)
=== RUN   TestAuthLoginGCP_LoginPath
=== RUN   TestAuthLoginGCP_LoginPath/default
--- PASS: TestAuthLoginGCP_LoginPath (0.00s)
    --- PASS: TestAuthLoginGCP_LoginPath/default (0.00s)
=== RUN   TestAuthLoginGCP_Login
=== RUN   TestAuthLoginGCP_Login/role-jwt
=== RUN   TestAuthLoginGCP_Login/role-credentials
    auth_gcp_test.go:194: "GOOGLE_APPLICATION_CREDENTIALS" must be set
=== RUN   TestAuthLoginGCP_Login/no-jwt
=== RUN   TestAuthLoginGCP_Login/error-uninitialized
--- PASS: TestAuthLoginGCP_Login (0.00s)
    --- PASS: TestAuthLoginGCP_Login/role-jwt (0.00s)
    --- SKIP: TestAuthLoginGCP_Login/role-credentials (0.00s)
    --- PASS: TestAuthLoginGCP_Login/no-jwt (0.00s)
    --- PASS: TestAuthLoginGCP_Login/error-uninitialized (0.00s)
=== RUN   TestAuthLoginJWT_Init
=== RUN   TestAuthLoginJWT_Init/basic
=== RUN   TestAuthLoginJWT_Init/error-missing-resource
=== RUN   TestAuthLoginJWT_Init/error-missing-required
--- PASS: TestAuthLoginJWT_Init (0.00s)
    --- PASS: TestAuthLoginJWT_Init/basic (0.00s)
    --- PASS: TestAuthLoginJWT_Init/error-missing-resource (0.00s)
    --- PASS: TestAuthLoginJWT_Init/error-missing-required (0.00s)
=== RUN   TestAuthLoginJWT_LoginPath
=== RUN   TestAuthLoginJWT_LoginPath/default
--- PASS: TestAuthLoginJWT_LoginPath (0.00s)
    --- PASS: TestAuthLoginJWT_LoginPath/default (0.00s)
=== RUN   TestAuthLoginJWT_Login
=== RUN   TestAuthLoginJWT_Login/basic
=== RUN   TestAuthLoginJWT_Login/error-uninitialized
--- PASS: TestAuthLoginJWT_Login (0.00s)
    --- PASS: TestAuthLoginJWT_Login/basic (0.00s)
    --- PASS: TestAuthLoginJWT_Login/error-uninitialized (0.00s)
=== RUN   TestAuthLoginKerberos_Init
=== RUN   TestAuthLoginKerberos_Init/with-token
=== RUN   TestAuthLoginKerberos_Init/error-missing-resource
=== RUN   TestAuthLoginKerberos_Init/error-missing-required
--- PASS: TestAuthLoginKerberos_Init (0.00s)
    --- PASS: TestAuthLoginKerberos_Init/with-token (0.00s)
    --- PASS: TestAuthLoginKerberos_Init/error-missing-resource (0.00s)
    --- PASS: TestAuthLoginKerberos_Init/error-missing-required (0.00s)
=== RUN   TestAuthLoginKerberos_LoginPath
=== RUN   TestAuthLoginKerberos_LoginPath/default
--- PASS: TestAuthLoginKerberos_LoginPath (0.00s)
    --- PASS: TestAuthLoginKerberos_LoginPath/default (0.00s)
=== RUN   TestAuthLoginKerberos_Login
=== RUN   TestAuthLoginKerberos_Login/with-token
=== RUN   TestAuthLoginKerberos_Login/no-token
--- PASS: TestAuthLoginKerberos_Login (0.00s)
    --- PASS: TestAuthLoginKerberos_Login/with-token (0.00s)
    --- PASS: TestAuthLoginKerberos_Login/no-token (0.00s)
=== RUN   TestAuthLoginOCI_Init
=== RUN   TestAuthLoginOCI_Init/basic
=== RUN   TestAuthLoginOCI_Init/error-missing-resource
=== RUN   TestAuthLoginOCI_Init/error-missing-required
--- PASS: TestAuthLoginOCI_Init (0.00s)
    --- PASS: TestAuthLoginOCI_Init/basic (0.00s)
    --- PASS: TestAuthLoginOCI_Init/error-missing-resource (0.00s)
    --- PASS: TestAuthLoginOCI_Init/error-missing-required (0.00s)
=== RUN   TestAuthLoginOCI_LoginPath
=== RUN   TestAuthLoginOCI_LoginPath/default
--- PASS: TestAuthLoginOCI_LoginPath (0.00s)
    --- PASS: TestAuthLoginOCI_LoginPath/default (0.00s)
=== RUN   TestAuthLoginOCI_Login
=== RUN   TestAuthLoginOCI_Login/api-keys
    auth_oci_test.go:192: "TF_ACC_OCI_AUTH" must be set
=== RUN   TestAuthLoginOCI_Login/error-uninitialized
--- PASS: TestAuthLoginOCI_Login (0.00s)
    --- SKIP: TestAuthLoginOCI_Login/api-keys (0.00s)
    --- PASS: TestAuthLoginOCI_Login/error-uninitialized (0.00s)
=== RUN   TestAuthLoginOIDC_Init
=== RUN   TestAuthLoginOIDC_Init/basic
=== RUN   TestAuthLoginOIDC_Init/error-missing-resource
=== RUN   TestAuthLoginOIDC_Init/error-missing-required
--- PASS: TestAuthLoginOIDC_Init (0.00s)
    --- PASS: TestAuthLoginOIDC_Init/basic (0.00s)
    --- PASS: TestAuthLoginOIDC_Init/error-missing-resource (0.00s)
    --- PASS: TestAuthLoginOIDC_Init/error-missing-required (0.00s)
=== RUN   TestAuthLoginOIDC_LoginPath
=== RUN   TestAuthLoginOIDC_LoginPath/default
--- PASS: TestAuthLoginOIDC_LoginPath (0.00s)
    --- PASS: TestAuthLoginOIDC_LoginPath/default (0.00s)
=== RUN   TestAuthLoginOIDC_getAuthParams
=== RUN   TestAuthLoginOIDC_getAuthParams/listener-addr-only
=== RUN   TestAuthLoginOIDC_getAuthParams/callback-addr-only
=== RUN   TestAuthLoginOIDC_getAuthParams/both-addrs
=== RUN   TestAuthLoginOIDC_getAuthParams/error-no-role
--- PASS: TestAuthLoginOIDC_getAuthParams (0.00s)
    --- PASS: TestAuthLoginOIDC_getAuthParams/listener-addr-only (0.00s)
    --- PASS: TestAuthLoginOIDC_getAuthParams/callback-addr-only (0.00s)
    --- PASS: TestAuthLoginOIDC_getAuthParams/both-addrs (0.00s)
    --- PASS: TestAuthLoginOIDC_getAuthParams/error-no-role (0.00s)
=== RUN   TestAuthLoginOIDC_Login
=== RUN   TestAuthLoginOIDC_Login/error-uninitialized
--- PASS: TestAuthLoginOIDC_Login (0.00s)
    --- PASS: TestAuthLoginOIDC_Login/error-uninitialized (0.00s)
=== RUN   TestAuthLoginRadius_Init
=== RUN   TestAuthLoginRadius_Init/basic
=== RUN   TestAuthLoginRadius_Init/error-missing-resource
=== RUN   TestAuthLoginRadius_Init/error-missing-required
--- PASS: TestAuthLoginRadius_Init (0.00s)
    --- PASS: TestAuthLoginRadius_Init/basic (0.00s)
    --- PASS: TestAuthLoginRadius_Init/error-missing-resource (0.00s)
    --- PASS: TestAuthLoginRadius_Init/error-missing-required (0.00s)
=== RUN   TestAuthLoginRadius_LoginPath
=== RUN   TestAuthLoginRadius_LoginPath/default
--- PASS: TestAuthLoginRadius_LoginPath (0.00s)
    --- PASS: TestAuthLoginRadius_LoginPath/default (0.00s)
=== RUN   TestAuthLoginRadius_Login
=== RUN   TestAuthLoginRadius_Login/basic
=== RUN   TestAuthLoginRadius_Login/error-uninitialized
--- PASS: TestAuthLoginRadius_Login (0.00s)
    --- PASS: TestAuthLoginRadius_Login/basic (0.00s)
    --- PASS: TestAuthLoginRadius_Login/error-uninitialized (0.00s)
=== RUN   TestAuthLoginUserpass_LoginPath
=== RUN   TestAuthLoginUserpass_LoginPath/basic
--- PASS: TestAuthLoginUserpass_LoginPath (0.00s)
    --- PASS: TestAuthLoginUserpass_LoginPath/basic (0.00s)
=== RUN   TestAuthLoginUserpass_Login
=== RUN   TestAuthLoginUserpass_Login/basic
=== RUN   TestAuthLoginUserpass_Login/error-no-username
=== RUN   TestAuthLoginUserpass_Login/error-uninitialized
--- PASS: TestAuthLoginUserpass_Login (0.00s)
    --- PASS: TestAuthLoginUserpass_Login/basic (0.00s)
    --- PASS: TestAuthLoginUserpass_Login/error-no-username (0.00s)
    --- PASS: TestAuthLoginUserpass_Login/error-uninitialized (0.00s)
PASS
```
