### PR TITLE
Support configuring vault version handling.

### DIFF
--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -172,6 +172,8 @@ const (
 	FieldClientToken              = "client_token"
 	FieldWrappedToken             = "wrapped_token"
 	FieldOrphan                   = "orphan"
+	FieldVaultVersionOverride     = "vault_version_override"
+	FieldSkipGetVaultVersion      = "skip_get_vault_version"
 
 	/*
 		common environment variables

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -112,11 +112,6 @@ func (p *ProviderMeta) GetVaultVersion() *version.Version {
 	return p.vaultVersion
 }
 
-// SetVaultVersion for this instance.
-func (p *ProviderMeta) SetVaultVersion(v *version.Version) {
-	p.vaultVersion = v
-}
-
 func (p *ProviderMeta) validate() error {
 	if p.client == nil {
 		return fmt.Errorf("root api.Client not set, init with NewProviderMeta()")

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -99,13 +99,22 @@ func (p *ProviderMeta) GetNSClient(ns string) (*api.Client, error) {
 // ProviderMeta vaultVersion is above the
 // minimum version.
 func (p *ProviderMeta) IsAPISupported(minVersion *version.Version) bool {
-	return p.vaultVersion.GreaterThanOrEqual(minVersion)
+	ver := p.GetVaultVersion()
+	if ver == nil {
+		return false
+	}
+	return ver.GreaterThanOrEqual(minVersion)
 }
 
 // GetVaultVersion returns the providerMeta
 // vaultVersion attribute.
 func (p *ProviderMeta) GetVaultVersion() *version.Version {
 	return p.vaultVersion
+}
+
+// SetVaultVersion for this instance.
+func (p *ProviderMeta) SetVaultVersion(v *version.Version) {
+	p.vaultVersion = v
 }
 
 func (p *ProviderMeta) validate() error {
@@ -234,12 +243,22 @@ func NewProviderMeta(d *schema.ResourceData) (interface{}, error) {
 		}
 	}
 
-	// Set the Vault version to *ProviderMeta object
-	vaultVersion, err := getVaultVersion(client)
-	if err != nil {
-		return nil, err
+	var vaultVersion *version.Version
+	if v, ok := d.GetOk(consts.FieldVaultVersionOverride); ok {
+		ver, err := version.NewVersion(v.(string))
+		if err != nil {
+			return nil, fmt.Errorf("invalid value for %q, err=%w",
+				consts.FieldVaultVersionOverride, err)
+		}
+		vaultVersion = ver
+	} else if !d.Get(consts.FieldSkipGetVaultVersion).(bool) {
+		// Set the Vault version to *ProviderMeta object
+		ver, err := getVaultVersion(client)
+		if err != nil {
+			return nil, err
+		}
+		vaultVersion = ver
 	}
-
 	// Set the namespace to the requested namespace, if provided
 	namespace := d.Get(consts.FieldNamespace).(string)
 	if namespace != "" {
@@ -331,7 +350,7 @@ func IsAPISupported(meta interface{}, minVersion *version.Version) bool {
 func getVaultVersion(client *api.Client) (*version.Version, error) {
 	resp, err := client.Sys().SealStatus()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("could not determine the Vault server version, err=%s", err)
 	}
 
 	if resp == nil {

--- a/internal/provider/meta_test.go
+++ b/internal/provider/meta_test.go
@@ -378,13 +378,13 @@ func TestIsAPISupported(t *testing.T) {
 
 	testCases := []struct {
 		name       string
-		minVersion string
+		minVersion *version.Version
 		expected   bool
 		meta       interface{}
 	}{
 		{
-			name:       "server-greater-than",
-			minVersion: "1.8.0",
+			name:       "supported-greater-than",
+			minVersion: version.Must(version.NewSemver("1.8.0")),
 			expected:   true,
 			meta: &ProviderMeta{
 				client:       rootClient,
@@ -392,8 +392,8 @@ func TestIsAPISupported(t *testing.T) {
 			},
 		},
 		{
-			name:       "server-less-than",
-			minVersion: "1.12.0",
+			name:       "supported-less-than",
+			minVersion: version.Must(version.NewSemver("1.12.0")),
 			expected:   false,
 			meta: &ProviderMeta{
 				client:       rootClient,
@@ -401,12 +401,21 @@ func TestIsAPISupported(t *testing.T) {
 			},
 		},
 		{
-			name:       "server-equal",
-			minVersion: "1.10.0",
+			name:       "supported-equal",
+			minVersion: version.Must(version.NewSemver("1.10.0")),
 			expected:   true,
 			meta: &ProviderMeta{
 				client:       rootClient,
 				vaultVersion: VaultVersion10,
+			},
+		},
+		{
+			name:       "unsupported-unset",
+			minVersion: version.Must(version.NewSemver("1.12.0")),
+			expected:   false,
+			meta: &ProviderMeta{
+				client:       rootClient,
+				vaultVersion: nil,
 			},
 		},
 	}
@@ -427,12 +436,7 @@ func TestIsAPISupported(t *testing.T) {
 				tt.meta = m
 			}
 
-			mv, err := version.NewVersion(tt.minVersion)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			isTFVersionGreater := tt.meta.(*ProviderMeta).IsAPISupported(mv)
+			isTFVersionGreater := tt.meta.(*ProviderMeta).IsAPISupported(tt.minVersion)
 
 			if isTFVersionGreater != tt.expected {
 				t.Errorf("IsAPISupported() got = %v, want %v", isTFVersionGreater, tt.expected)

--- a/internal/provider/validators.go
+++ b/internal/provider/validators.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gosimple/slug"
 	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -181,6 +182,24 @@ func ValidateDiagUUID(i interface{}, path cty.Path) diag.Diagnostics {
 				Summary:  "Invalid UUID",
 				Detail: "Value must be in valid hexadecimal format, e.g. " +
 					"323e4572-a92c-13d3-a457-426614173990",
+				AttributePath: path,
+			},
+		}
+	}
+
+	return nil
+}
+
+// ValidateSemVer validates that the input string conforms to SemVer 2.0.0
+func ValidateDiagSemVer(i interface{}, path cty.Path) diag.Diagnostics {
+	have := i.(string)
+	if _, err := version.NewSemver(have); err != nil {
+		return diag.Diagnostics{
+			{
+				Severity: diag.Error,
+				Summary:  "Invalid semantic version",
+				Detail: "Value must be in valid semantic version string, e.g. " +
+					"1.12.0",
 				AttributePath: path,
 			},
 		}

--- a/internal/provider/validators_test.go
+++ b/internal/provider/validators_test.go
@@ -371,3 +371,54 @@ func TestValidateDiagUUID(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateDiagSemVer(t *testing.T) {
+	want := diag.Diagnostics{
+		{
+			Severity: diag.Error,
+			Summary:  "Invalid semantic version",
+			Detail: "Value must be in valid semantic version string, e.g. " +
+				"1.12.0",
+			AttributePath: nil,
+		},
+	}
+	type args struct{}
+	tests := []struct {
+		name string
+		i    interface{}
+		path cty.Path
+		want diag.Diagnostics
+	}{
+		{
+			name: "invalid",
+			i:    "v0. 2.0",
+			path: nil,
+			want: want,
+		},
+		{
+			name: "invalid-empty",
+			i:    "",
+			path: nil,
+			want: want,
+		},
+		{
+			name: "valid",
+			i:    "0.2.0",
+			path: nil,
+			want: nil,
+		},
+		{
+			name: "valid-with-v-prefix",
+			i:    "v0.2.0",
+			path: nil,
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ValidateDiagSemVer(tt.i, tt.path); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ValidateDiagSemVer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -192,6 +192,20 @@ func Provider() *schema.Provider {
 					},
 				},
 			},
+			consts.FieldSkipGetVaultVersion: {
+				Type:             schema.TypeBool,
+				Optional:         true,
+				Default:          false,
+				Description:      "Skip the dynamic fetching of the Vault server version.",
+				ValidateDiagFunc: provider.ValidateDiagSemVer,
+			},
+			consts.FieldVaultVersionOverride: {
+				Type:     schema.TypeString,
+				Optional: true,
+				Description: "Override the Vault server version, " +
+					"which is normally determined dynamically from the target Vault server",
+				ValidateDiagFunc: provider.ValidateDiagSemVer,
+			},
 		},
 		ConfigureFunc:  provider.NewProviderMeta,
 		DataSourcesMap: dataSourcesMap,

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -193,11 +193,10 @@ func Provider() *schema.Provider {
 				},
 			},
 			consts.FieldSkipGetVaultVersion: {
-				Type:             schema.TypeBool,
-				Optional:         true,
-				Default:          false,
-				Description:      "Skip the dynamic fetching of the Vault server version.",
-				ValidateDiagFunc: provider.ValidateDiagSemVer,
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Skip the dynamic fetching of the Vault server version.",
 			},
 			consts.FieldVaultVersionOverride: {
 				Type:     schema.TypeString,

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -203,6 +203,18 @@ variables in order to keep credential information out of the configuration.
   See [namespaces](https://www.vaultproject.io/docs/enterprise/namespaces) for more info.
   *Available only for Vault Enterprise*.
 
+* `skip_get_vault_version` - (Optional) Skip the dynamic fetching of the Vault server version. 
+  Set to `true` when the */sys/seal-status* API endpoint is not available. See (#vault_version_override) 
+  for related info
+
+* `vault_version_override` - (Optional) Override the target Vault server semantic version.
+  Normally the version is dynamically set from the */sys/seal-status* API endpoint. In the case where this endpoint
+  is not available an override can be specified here.
+
+~> Setting the `vault_version_override` determines Vault server's API compatability, so
+it's important that the value specified here matches the target server. It is recommended to
+only ever use this option in the case where the server version cannot be dynamically determined.
+
 * `headers` - (Optional) A configuration block, described below, that provides headers
 to be sent along with all requests to the Vault server.  This block can be specified
 multiple times.
@@ -220,6 +232,7 @@ The `headers` configuration block accepts the following arguments:
 * `name` - (Required) The name of the header.
 
 * `value` - (Required) The value of the header.
+
 
 ## Vault Authentication Configuration Options
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -204,7 +204,7 @@ variables in order to keep credential information out of the configuration.
   *Available only for Vault Enterprise*.
 
 * `skip_get_vault_version` - (Optional) Skip the dynamic fetching of the Vault server version. 
-  Set to `true` when the */sys/seal-status* API endpoint is not available. See (#vault_version_override) 
+  Set to `true` when the */sys/seal-status* API endpoint is not available. See [vault_version_override](#vault_version_override)
   for related info
 
 * `vault_version_override` - (Optional) Override the target Vault server semantic version.


### PR DESCRIPTION
Add two new provider fields for configuring way that the provider determines the target Vault server's version.

- `vault_version_override`: will set the vault version explicitly, no API requests will be made to retrieve the version
- `skip_get_vault_version`: enable to disable API version requests.

If no version can be determined, the lowest supported versioned API semantics will be applied to all resources.


Closes #1643
