### PR TITLE
Fix GCP auth with service account credentials

### DIFF
--- a/internal/provider/auth_gcp.go
+++ b/internal/provider/auth_gcp.go
@@ -99,6 +99,8 @@ func (l *AuthLoginGCP) Login(client *api.Client) (*api.Secret, error) {
 		consts.FieldNamespace,
 		consts.FieldMount,
 		consts.FieldJWT,
+		consts.FieldCredentials,
+		consts.FieldServiceAccount,
 	)
 	if err != nil {
 		return nil, err
@@ -123,7 +125,7 @@ func (l *AuthLoginGCP) getJWT(ctx context.Context) (string, error) {
 
 	if v, ok := l.params[consts.FieldCredentials]; ok && v.(string) != "" {
 		// get the token from IAM
-		creds, err := getGCPOauthCredentials(ctx, v.(string))
+		creds, err := getGCPOauthCredentials(ctx, v.(string), "https://www.googleapis.com/auth/cloud-platform")
 		if err != nil {
 			return "", fmt.Errorf(
 				"JSON credentials are not valid, err=%w", err)

--- a/internal/provider/auth_gcp.go
+++ b/internal/provider/auth_gcp.go
@@ -21,6 +21,8 @@ import (
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 )
 
+const defaultGCPScope = "https://www.googleapis.com/auth/cloud-platform"
+
 // GetGCPLoginSchema for the gcp authentication engine.
 func GetGCPLoginSchema(authField string) *schema.Schema {
 	return getLoginSchema(
@@ -125,7 +127,7 @@ func (l *AuthLoginGCP) getJWT(ctx context.Context) (string, error) {
 
 	if v, ok := l.params[consts.FieldCredentials]; ok && v.(string) != "" {
 		// get the token from IAM
-		creds, err := getGCPOauthCredentials(ctx, v.(string), "https://www.googleapis.com/auth/cloud-platform")
+		creds, err := getGCPOauthCredentials(ctx, v.(string), defaultGCPScope)
 		if err != nil {
 			return "", fmt.Errorf(
 				"JSON credentials are not valid, err=%w", err)

--- a/internal/provider/auth_gcp_test.go
+++ b/internal/provider/auth_gcp_test.go
@@ -167,6 +167,7 @@ func TestAuthLoginGCP_Login(t *testing.T) {
 						consts.FieldCredentials:    os.Getenv(consts.EnvVarGoogleApplicationCreds),
 						consts.FieldServiceAccount: os.Getenv(envVarGCPServiceAccount),
 					},
+					initialized: true,
 				},
 			},
 			handler: &testLoginHandler{
@@ -178,9 +179,7 @@ func TestAuthLoginGCP_Login(t *testing.T) {
 				"/v1/auth/qux/login",
 			},
 			expectReqParams: []map[string]interface{}{{
-				consts.FieldRole:           "bob",
-				consts.FieldCredentials:    os.Getenv(consts.EnvVarGoogleApplicationCreds),
-				consts.FieldServiceAccount: os.Getenv(envVarGCPServiceAccount),
+				consts.FieldRole: "bob",
 			}},
 			want: &api.Secret{
 				Auth: &api.SecretAuth{


### PR DESCRIPTION
We are trying to use the provider with SA credentials, but the authentication does not succeed because the required scope is not present in the JWT request: "https://www.googleapis.com/auth/cloud-platform"

This scope is mandatory according to the documentation https://developer.hashicorp.com/vault/docs/auth/gcp#gcp-credentials.

The JWT sign request fails with the following error:
```
{"error":"invalid_scope","error_description":"Invalid OAuth scope or ID token audience provided."}
```

I was able to reproduce this in the `TestAuthLoginGCP_Login` test, but only after setting the initialized:true setting on the `AuthLoginGCP.AuthLoginCommon` object. I guess the test is not ran when this value is not positioned.

This fixes the JWT token generation, but the provider's call to Vault is rejected because the `credentials` and `service_account` parameters are not expected by the endpoint. I added them to the `copyParamsExcluding` call and changed the expected parameters in the test.

I can now run this test with valid credentials (see below).


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix GCP authentication backend when using Service Account credentials
```

Output from acceptance testing:

```
$ GOOGLE_APPLICATION_CREDENTIALS="/tmp/creds.json"
TF_ACC_GOOGLE_SERVICE_ACCOUNT="xxx@yyyy.iam.gserviceaccount.com" go test -run TestAuthLoginGCP_Login
PASS
ok      github.com/hashicorp/terraform-provider-vault/internal/provider 0.491s
...
```
