### PR TITLE
Remove redundant `depends_on` from documentation

### DIFF
--- a/website/docs/d/ad_access_credentials.html.md
+++ b/website/docs/d/ad_access_credentials.html.md
@@ -40,7 +40,6 @@ resource "vault_ad_secret_role" "bob" {
 data "vault_ad_access_credentials" "creds" {
   backend = vault_ad_secret_backend.config.backend
   role    = vault_ad_secret_role.bob.role}
-  depends_on = [vault_ad_secret_role.bob]
 }
 ```
 

--- a/website/docs/d/nomad_access_token.html.md
+++ b/website/docs/d/nomad_access_token.html.md
@@ -40,7 +40,6 @@ resource "vault_nomad_secret_role" "test" {
 data "vault_nomad_access_token" "token" {
   backend = vault_nomad_secret_backend.config.backend
   role    = vault_nomad_secret_role.test.role
-  depends_on = [vault_nomad_secret_role.test]
 }
 ```
 

--- a/website/docs/r/pki_secret_backend_config_ca.html.md
+++ b/website/docs/r/pki_secret_backend_config_ca.html.md
@@ -21,8 +21,6 @@ for more details.
 
 ```hcl
 resource "vault_pki_secret_backend_config_ca" "intermediate" {
-  depends_on = [vault_mount.intermediate]
-
   backend = vault_mount.intermediate.path
   
   pem_bundle = <<EOT

--- a/website/docs/r/pki_secret_backend_intermediate_cert_request.html.md
+++ b/website/docs/r/pki_secret_backend_intermediate_cert_request.html.md
@@ -21,7 +21,6 @@ for more details.
 
 ```hcl
 resource "vault_pki_secret_backend_intermediate_cert_request" "test" {
-  depends_on  = [vault_mount.pki]
   backend     = vault_mount.pki.path
   type        = "internal"
   common_name = "app.my.domain"
@@ -81,7 +80,6 @@ The following arguments are supported:
 
 * `managed_key_id` - (Optional) The ID of the previously configured managed key. This field is
   required if `type` is `kms` and it conflicts with `managed_key_name`
-
 
 ## Attributes Reference
 

--- a/website/docs/r/pki_secret_backend_root_cert.html.md
+++ b/website/docs/r/pki_secret_backend_root_cert.html.md
@@ -21,7 +21,6 @@ for more details.
 
 ```hcl
 resource "vault_pki_secret_backend_root_cert" "test" {
-  depends_on            = [vault_mount.pki]
   backend               = vault_mount.pki.path
   type                  = "internal"
   common_name           = "Root CA"
@@ -95,7 +94,6 @@ The following arguments are supported:
 
 * `managed_key_id` - (Optional) The ID of the previously configured managed key. This field is
   required if `type` is `kms` and it conflicts with `managed_key_name`
-
 
 ## Attributes Reference
 

--- a/website/docs/r/pki_secret_backend_root_sign_intermediate.html.md
+++ b/website/docs/r/pki_secret_backend_root_sign_intermediate.html.md
@@ -14,7 +14,6 @@ Creates PKI certificate.
 
 ```hcl
 resource "vault_pki_secret_backend_root_sign_intermediate" "root" {
-  depends_on           = [vault_pki_secret_backend_intermediate_cert_request.intermediate]
   backend              = vault_mount.root.path
   csr                  = vault_pki_secret_backend_intermediate_cert_request.intermediate.csr
   common_name          = "Intermediate CA"

--- a/website/docs/r/pki_secret_backend_sign.html.md
+++ b/website/docs/r/pki_secret_backend_sign.html.md
@@ -21,7 +21,6 @@ for more details.
 
 ```hcl
 resource "vault_pki_secret_backend_sign" "test" {
-  depends_on = [vault_pki_secret_backend_role.admin]
   backend    = vault_mount.pki.path
   name       = vault_pki_secret_backend_role.admin.name
   csr        = <<EOT


### PR DESCRIPTION
I was confused by the prolific use of `depends_on` in the provider examples. In many cases, they are not needed because an output from the same resource is referenced, creating the dependency implicitly.

Cut down on the information load by removing these cases.

Signed-off-by: Matthias Rampke <matthias@rampke.de>

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```