### PR TITLE
Add support for setting deletion_allowed on a transformation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ PKG_NAME = vault
 TF_ACC_TERRAFORM_VERSION ?= 1.2.2
 TESTARGS ?= -test.v
 TF_VAULT_VERSION ?=
+TEST_PATH ?= ./...
 
 default: build
 
@@ -12,10 +13,10 @@ build: fmtcheck
 	go install
 
 test: fmtcheck
-	TF_ACC= go test $(TESTARGS) -timeout 10m -parallel=4 ./...
+	TF_ACC= go test $(TESTARGS) -timeout 10m -parallel=4 $(TEST_PATH)
 
 testacc: fmtcheck
-	TF_ACC=1 go test $(TESTARGS) -timeout 30m ./...
+	TF_ACC=1 go test $(TESTARGS) -timeout 30m $(TEST_PATH)
 
 testacc-ent:
 	make testacc TF_ACC_ENTERPRISE=1

--- a/generated/datasources/transform/decode/role_name_test.go
+++ b/generated/datasources/transform/decode/role_name_test.go
@@ -48,23 +48,27 @@ resource "vault_mount" "transform" {
   path = "%s"
   type = "transform"
 }
+
 resource "vault_transform_transformation_name" "ccn-fpe" {
-  path = vault_mount.transform.path
-  name = "ccn-fpe"
-  type = "fpe"
-  template = "builtin/creditcardnumber"
-  tweak_source = "internal"
-  allowed_roles = ["payments"]
+  path             = vault_mount.transform.path
+  name             = "ccn-fpe"
+  type             = "fpe"
+  template         = "builtin/creditcardnumber"
+  tweak_source     = "internal"
+  allowed_roles    = ["payments"]
+  deletion_allowed = true
 }
+
 resource "vault_transform_role_name" "payments" {
-  path = vault_transform_transformation_name.ccn-fpe.path
-  name = "payments"
-  transformations = ["ccn-fpe"]
+  path            = vault_transform_transformation_name.ccn-fpe.path
+  name            = "payments"
+  transformations = [vault_transform_transformation_name.ccn-fpe.name]
 }
+
 data "vault_transform_decode_role_name" "test" {
-    path      = vault_transform_role_name.payments.path
-    role_name = "payments"
-    value     = "9300-3376-4943-8903"
+  path      = vault_transform_role_name.payments.path
+  role_name = "payments"
+  value     = "9300-3376-4943-8903"
 }
 `, path)
 }
@@ -94,23 +98,27 @@ resource "vault_mount" "transform" {
   path = "%s"
   type = "transform"
 }
+
 resource "vault_transform_transformation_name" "ccn-fpe" {
-  path = vault_mount.transform.path
-  name = "ccn-fpe"
-  type = "fpe"
-  template = "builtin/creditcardnumber"
-  tweak_source = "internal"
-  allowed_roles = ["payments"]
+  path             = vault_mount.transform.path
+  name             = "ccn-fpe"
+  type             = "fpe"
+  template         = "builtin/creditcardnumber"
+  tweak_source     = "internal"
+  allowed_roles    = ["payments"]
+  deletion_allowed = true
 }
+
 resource "vault_transform_role_name" "payments" {
-  path = vault_transform_transformation_name.ccn-fpe.path
-  name = "payments"
-  transformations = ["ccn-fpe"]
+  path            = vault_transform_transformation_name.ccn-fpe.path
+  name            = "payments"
+  transformations = [vault_transform_transformation_name.ccn-fpe.name]
 }
+
 data "vault_transform_decode_role_name" "test" {
-    path      = vault_transform_role_name.payments.path
-    role_name = "payments"
-    batch_input = [{"value":"9300-3376-4943-8903"}]
+  path        = vault_transform_role_name.payments.path
+  role_name   = "payments"
+  batch_input = [{ "value" : "9300-3376-4943-8903" }]
 }
 `, path)
 }

--- a/generated/datasources/transform/encode/role_name_test.go
+++ b/generated/datasources/transform/encode/role_name_test.go
@@ -48,23 +48,27 @@ resource "vault_mount" "transform" {
   path = "%s"
   type = "transform"
 }
+
 resource "vault_transform_transformation_name" "ccn-fpe" {
-  path = vault_mount.transform.path
-  name = "ccn-fpe"
-  type = "fpe"
-  template = "builtin/creditcardnumber"
-  tweak_source = "internal"
-  allowed_roles = ["payments"]
+  path             = vault_mount.transform.path
+  name             = "ccn-fpe"
+  type             = "fpe"
+  template         = "builtin/creditcardnumber"
+  tweak_source     = "internal"
+  allowed_roles    = ["payments"]
+  deletion_allowed = true
 }
+
 resource "vault_transform_role_name" "payments" {
-  path = vault_transform_transformation_name.ccn-fpe.path
-  name = "payments"
-  transformations = ["ccn-fpe"]
+  path            = vault_transform_transformation_name.ccn-fpe.path
+  name            = "payments"
+  transformations = [vault_transform_transformation_name.ccn-fpe.name]
 }
+
 data "vault_transform_encode_role_name" "test" {
-    path      = vault_transform_role_name.payments.path
-    role_name = "payments"
-    value     = "1111-2222-3333-4444"
+  path      = vault_transform_role_name.payments.path
+  role_name = "payments"
+  value     = "1111-2222-3333-4444"
 }
 `, path)
 }
@@ -94,23 +98,27 @@ resource "vault_mount" "transform" {
   path = "%s"
   type = "transform"
 }
+
 resource "vault_transform_transformation_name" "ccn-fpe" {
-  path = vault_mount.transform.path
-  name = "ccn-fpe"
-  type = "fpe"
-  template = "builtin/creditcardnumber"
-  tweak_source = "internal"
-  allowed_roles = ["payments"]
+  path             = vault_mount.transform.path
+  name             = "ccn-fpe"
+  type             = "fpe"
+  template         = "builtin/creditcardnumber"
+  tweak_source     = "internal"
+  allowed_roles    = ["payments"]
+  deletion_allowed = true
 }
+
 resource "vault_transform_role_name" "payments" {
-  path = vault_transform_transformation_name.ccn-fpe.path
-  name = "payments"
-  transformations = ["ccn-fpe"]
+  path            = vault_transform_transformation_name.ccn-fpe.path
+  name            = "payments"
+  transformations = [vault_transform_transformation_name.ccn-fpe.name]
 }
+
 data "vault_transform_encode_role_name" "test" {
-    path      = vault_transform_role_name.payments.path
-    role_name = "payments"
-    batch_input = [{"value":"1111-2222-3333-4444"}]
+  path        = vault_transform_role_name.payments.path
+  role_name   = "payments"
+  batch_input = [{ "value" : "1111-2222-3333-4444" }]
 }
 `, path)
 }

--- a/generated/resources/transform/alphabet/name_test.go
+++ b/generated/resources/transform/alphabet/name_test.go
@@ -81,9 +81,10 @@ resource "vault_mount" "mount_transform" {
   path = "%s"
   type = "transform"
 }
+
 resource "vault_transform_alphabet_name" "test" {
-  path = vault_mount.mount_transform.path
-  name = "%s"
+  path     = vault_mount.mount_transform.path
+  name     = "%s"
   alphabet = "%s"
 }
 `, path, name, alphabet)

--- a/generated/resources/transform/transformation/name.go
+++ b/generated/resources/transform/transformation/name.go
@@ -89,8 +89,7 @@ func NameResource() *schema.Resource {
 }
 
 func createNameResource(d *schema.ResourceData, meta interface{}) error {
-	m := meta.(*provider.ProviderMeta)
-	client, e := provider.GetClient(d, m)
+	client, e := provider.GetClient(d, meta)
 	if e != nil {
 		return e
 	}
@@ -117,7 +116,7 @@ func createNameResource(d *schema.ResourceData, meta interface{}) error {
 		data["type"] = v
 	}
 
-	if m.IsAPISupported(provider.VaultVersion112) {
+	if provider.IsAPISupported(meta, provider.VaultVersion112) {
 		data["deletion_allowed"] = d.Get("deletion_allowed")
 	}
 
@@ -131,8 +130,7 @@ func createNameResource(d *schema.ResourceData, meta interface{}) error {
 }
 
 func readNameResource(d *schema.ResourceData, meta interface{}) error {
-	m := meta.(*provider.ProviderMeta)
-	client, e := provider.GetClient(d, m)
+	client, e := provider.GetClient(d, meta)
 	if e != nil {
 		return e
 	}
@@ -189,7 +187,7 @@ func readNameResource(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("error setting state key 'type': %s", err)
 		}
 	}
-	if m.IsAPISupported(provider.VaultVersion112) {
+	if provider.IsAPISupported(meta, provider.VaultVersion112) {
 		if err := d.Set("deletion_allowed", resp.Data["deletion_allowed"]); err != nil {
 			return fmt.Errorf("error setting state key 'deletion_allowed': %s", err)
 		}
@@ -198,8 +196,7 @@ func readNameResource(d *schema.ResourceData, meta interface{}) error {
 }
 
 func updateNameResource(d *schema.ResourceData, meta interface{}) error {
-	m := meta.(*provider.ProviderMeta)
-	client, e := provider.GetClient(d, m)
+	client, e := provider.GetClient(d, meta)
 	if e != nil {
 		return e
 	}
@@ -224,7 +221,7 @@ func updateNameResource(d *schema.ResourceData, meta interface{}) error {
 		data["type"] = raw
 	}
 
-	if m.IsAPISupported(provider.VaultVersion112) {
+	if provider.IsAPISupported(meta, provider.VaultVersion112) {
 		data["deletion_allowed"] = d.Get("deletion_allowed")
 	}
 

--- a/generated/resources/transform/transformation/name_test.go
+++ b/generated/resources/transform/transformation/name_test.go
@@ -50,7 +50,6 @@ func TestTransformationName(t *testing.T) {
 				ResourceName: resourceName,
 				ImportState:  true,
 				ImportStateCheck: func(states []*terraform.InstanceState) error {
-					m := nameTestProvider.SchemaProvider().Meta().(*provider.ProviderMeta)
 					if len(states) != 1 {
 						return fmt.Errorf("expected 1 state but received %+v", states)
 					}
@@ -86,7 +85,7 @@ func TestTransformationName(t *testing.T) {
 						t.Fatalf("expected %q, received %q", "ccn-fpw", state.Attributes["name"])
 					}
 					var expectDeletionAllowed string
-					if m.IsAPISupported(provider.VaultVersion112) {
+					if provider.IsAPISupported(nameTestProvider.SchemaProvider().Meta(), provider.VaultVersion112) {
 						expectDeletionAllowed = "true"
 					}
 					if state.Attributes["deletion_allowed"] != expectDeletionAllowed {

--- a/generated/resources/transform/transformation/name_test.go
+++ b/generated/resources/transform/transformation/name_test.go
@@ -25,6 +25,7 @@ var nameTestProvider = func() *schema.Provider {
 func TestTransformationName(t *testing.T) {
 	path := acctest.RandomWithPrefix("transform")
 
+	resourceName := "vault_transform_transformation_name.test"
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() { testutil.TestEntPreCheck(t) },
 		Providers: map[string]*sdk_schema.Provider{
@@ -35,26 +36,26 @@ func TestTransformationName(t *testing.T) {
 			{
 				Config: basicConfig(path, "ccn-fpe", "fpe", "ccn", "internal", "payments", "*"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_transform_transformation_name.test", "path", path),
-					resource.TestCheckResourceAttr("vault_transform_transformation_name.test", "name", "ccn-fpe"),
-					resource.TestCheckResourceAttr("vault_transform_transformation_name.test", "type", "fpe"),
-					resource.TestCheckResourceAttr("vault_transform_transformation_name.test", "template", "ccn"),
-					resource.TestCheckResourceAttr("vault_transform_transformation_name.test", "tweak_source", "internal"),
-					resource.TestCheckResourceAttr("vault_transform_transformation_name.test", "allowed_roles.0", "payments"),
-					resource.TestCheckResourceAttr("vault_transform_transformation_name.test", "allowed_roles.#", "1"),
-					resource.TestCheckResourceAttr("vault_transform_transformation_name.test", "masking_character", "*"),
+					resource.TestCheckResourceAttr(resourceName, "path", path),
+					resource.TestCheckResourceAttr(resourceName, "name", "ccn-fpe"),
+					resource.TestCheckResourceAttr(resourceName, "type", "fpe"),
+					resource.TestCheckResourceAttr(resourceName, "template", "ccn"),
+					resource.TestCheckResourceAttr(resourceName, "tweak_source", "internal"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "payments"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "masking_character", "*"),
 				),
 			},
 			{
-				ResourceName: "vault_transform_transformation_name.test",
+				ResourceName: resourceName,
 				ImportState:  true,
 				ImportStateCheck: func(states []*terraform.InstanceState) error {
 					if len(states) != 1 {
 						return fmt.Errorf("expected 1 state but received %+v", states)
 					}
 					state := states[0]
-					if state.Attributes["%"] != "10" {
-						t.Fatalf("expected 10 attributes but received %s", state.Attributes["%"])
+					if state.Attributes["%"] != "11" {
+						t.Fatalf("expected 11 attributes but received %s", state.Attributes["%"])
 					}
 					if state.Attributes["templates.#"] != "1" {
 						t.Fatalf("expected %q, received %q", "1", state.Attributes["templates.#"])
@@ -83,20 +84,23 @@ func TestTransformationName(t *testing.T) {
 					if state.Attributes["name"] != "ccn-fpe" {
 						t.Fatalf("expected %q, received %q", "ccn-fpw", state.Attributes["name"])
 					}
+					if state.Attributes["deletion_allowed"] != "true" {
+						t.Fatalf("expected %q, received %q", "true", state.Attributes["deletion_allowed"])
+					}
 					return nil
 				},
 			},
 			{
 				Config: basicConfig(path, "ccn-fpe", "fpe", "ccn-1", "generated", "payments-1", "-"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_transform_transformation_name.test", "path", path),
-					resource.TestCheckResourceAttr("vault_transform_transformation_name.test", "name", "ccn-fpe"),
-					resource.TestCheckResourceAttr("vault_transform_transformation_name.test", "type", "fpe"),
-					resource.TestCheckResourceAttr("vault_transform_transformation_name.test", "template", "ccn-1"),
-					resource.TestCheckResourceAttr("vault_transform_transformation_name.test", "tweak_source", "generated"),
-					resource.TestCheckResourceAttr("vault_transform_transformation_name.test", "allowed_roles.0", "payments-1"),
-					resource.TestCheckResourceAttr("vault_transform_transformation_name.test", "allowed_roles.#", "1"),
-					resource.TestCheckResourceAttr("vault_transform_transformation_name.test", "masking_character", "-"),
+					resource.TestCheckResourceAttr(resourceName, "path", path),
+					resource.TestCheckResourceAttr(resourceName, "name", "ccn-fpe"),
+					resource.TestCheckResourceAttr(resourceName, "type", "fpe"),
+					resource.TestCheckResourceAttr(resourceName, "template", "ccn-1"),
+					resource.TestCheckResourceAttr(resourceName, "tweak_source", "generated"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.0", "payments-1"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_roles.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "masking_character", "-"),
 				),
 			},
 		},
@@ -127,14 +131,16 @@ resource "vault_mount" "mount_transform" {
   path = "%s"
   type = "transform"
 }
+
 resource "vault_transform_transformation_name" "test" {
-  path = vault_mount.mount_transform.path
-  name = "%s"
-  type = "%s"
-  template = "%s"
-  tweak_source = "%s"
-  allowed_roles = ["%s"]
+  path              = vault_mount.mount_transform.path
+  name              = "%s"
+  type              = "%s"
+  template          = "%s"
+  tweak_source      = "%s"
+  allowed_roles     = ["%s"]
   masking_character = "%s"
+  deletion_allowed  = true
 }
 `, path, name, tp, template, tweakSource, allowedRoles, maskingChar)
 }

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -241,9 +241,10 @@ const (
 	/*
 		Vault version constants
 	*/
-	VaultVersion111 = "1.11.0"
-	VaultVersion110 = "1.10.0"
 	VaultVersion190 = "1.9.0"
+	VaultVersion110 = "1.10.0"
+	VaultVersion111 = "1.11.0"
+	VaultVersion112 = "1.12.0"
 
 	/*
 		Vault auth methods

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -27,15 +27,13 @@ const DefaultMaxHTTPRetries = 2
 var (
 	MaxHTTPRetriesCCC int
 
-	VaultVersion190 *version.Version
-	VaultVersion110 *version.Version
-	VaultVersion111 *version.Version
-)
-
-func init() {
 	VaultVersion190 = version.Must(version.NewSemver(consts.VaultVersion190))
 	VaultVersion110 = version.Must(version.NewSemver(consts.VaultVersion110))
 	VaultVersion111 = version.Must(version.NewSemver(consts.VaultVersion111))
+	VaultVersion112 = version.Must(version.NewSemver(consts.VaultVersion112))
+)
+
+func init() {
 }
 
 // ProviderMeta provides resources with access to the Vault client and

--- a/website/docs/r/transform_transformation.html.md
+++ b/website/docs/r/transform_transformation.html.md
@@ -16,12 +16,13 @@ it will be created. If the transformation exists, it will be updated with the ne
 ## Example Usage
 
 ```hcl
-resource "vault_mount" "mount_transform" {
+resource "vault_mount" "example" {
   path = "transform"
   type = "transform"
 }
-resource "vault_transform_transformation" "test" {
-  path          = vault_mount.mount_transform.path
+
+resource "vault_transform_transformation" "example" {
+  path          = vault_mount.example.path
   name          = "ccn-fpe"
   type          = "fpe"
   template      = "ccn"
@@ -47,7 +48,9 @@ The following arguments are supported:
 * `templates` - (Optional) Templates configured for transformation.
 * `tweak_source` - (Optional) The source of where the tweak value comes from. Only valid when in FPE mode.
 * `type` - (Optional) The type of transformation to perform.
-
+* `deletion_allowed` - (Optional) If true, this transform can be deleted.
+  Otherwise, deletion is blocked while this value remains false. Default: `false`
+  *Only supported on vault-1.12+*
 
 ## Tutorials
 

--- a/website/vault.erb
+++ b/website/vault.erb
@@ -42,11 +42,11 @@
                         </li>
 
                         <li<%= sidebar_current("docs-vault-datasource-transform-decode") %>>
-                            <a href="/docs/providers/vault/generated/datasources/transform/decode/role_name.html">vault_transform_decode</a>
+                            <a href="/docs/providers/vault/d/transform_decode.html">vault_transform_decode</a>
                         </li>
 
                         <li<%= sidebar_current("docs-vault-datasource-transform-encode") %>>
-                            <a href="/docs/providers/vault/generated/datasources/transform/encode/role_name.html">vault_transform_encode</a>
+                            <a href="/docs/providers/vault/d/transform_encode.html">vault_transform_encode</a>
                         </li>
 
                         <li<%= sidebar_current("docs-vault-datasource-generic-secret") %>>
@@ -538,11 +538,11 @@
                         </li>
 
                         <li<%= sidebar_current("docs-vault-resource-transform-alphabet") %>>
-                            <a href="/docs/providers/vault/generated/resources/transform/alphabet/name.html">vault_transform_alphabet</a>
+                            <a href="/docs/providers/vault/r/transform_alphabet.html">vault_transform_alphabet</a>
                         </li>
 
                         <li<%= sidebar_current("docs-vault-resource-transform-role") %>>
-                            <a href="/docs/providers/vault/generated/resources/transform/role/name.html">vault_transform_role</a>
+                            <a href="/docs/providers/vault/r/transform_role.html">vault_transform_role</a>
                         </li>
 
                         <li<%= sidebar_current("docs-vault-resource-transform-template") %>>
@@ -550,7 +550,7 @@
                         </li>
 
                         <li<%= sidebar_current("docs-vault-resource-transform-transformation") %>>
-                          <a href="/docs/providers/vault/generated/resources/transform/transformation/name.html">vault_transform_transformation</a>
+                          <a href="/docs/providers/vault/r/transform_transformation.html">vault_transform_transformation</a>
                         </li>
 
                         <li<%= sidebar_current("docs-vault-resource-transit-secret-backend-key") %>>


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

```
$ make testacc-ent TESTARGS='-v -test.count=1' TEST_PATH=./generated/...
make testacc TF_ACC_ENTERPRISE=1
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -test.count=1 -timeout 30m ./generated/...
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
=== RUN   TestDecodeBasic
--- PASS: TestDecodeBasic (1.04s)
=== RUN   TestDecodeBatch
--- PASS: TestDecodeBatch (0.95s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    3.601s
=== RUN   TestEncodeBasic
--- PASS: TestEncodeBasic (1.18s)
=== RUN   TestEncodeBatch
--- PASS: TestEncodeBatch (1.01s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    2.748s
=== RUN   TestAlphabetName
--- PASS: TestAlphabetName (1.92s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    3.249s
=== RUN   TestRoleName
--- PASS: TestRoleName (1.94s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        3.557s
=== RUN   TestTemplateName
--- PASS: TestTemplateName (1.90s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    3.502s
=== RUN   TestTransformationName
--- PASS: TestTransformationName (1.87s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      3.560s

...
```
