### PR TITLE
Temporarily skip azure secrets tests on vault-1.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,10 @@ jobs:
       - name: Build
         run: |
           make build
+      - name: Run unit tests
+        # here to short-circuit the acceptance tests, in the case of a failure.
+        run: |
+          make test
   acceptance:
     needs: [go-version, build]
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,9 +116,6 @@ jobs:
           COUCHBASE_PASSWORD: password
           CONSUL_HTTP_ADDR: "consul:8500"
         run: |
-          export TF_VAULT_VERSION=$(echo ${{ matrix.image }} | \
-            awk -F: '{match($NF, /^([0-9]+\.[0-9]+\.[0-9]+)/); printf("%s", substr($NF, RSTART, RLENGTH))}')
-          [ -n "${TF_VAULT_VERSION}" ] || (echo "could not get vault version from matrix.image: ${{ matrix.image }}" >&2 ; exit 1)
           make testacc-ent TESTARGS='-test.v -test.parallel=10' SKIP_MSSQL_MULTI_CI=true SKIP_RAFT_TESTS=true SKIP_VAULT_NEXT_TESTS=true
       - name: "Generate Vault API Path Coverage Report"
         run: |

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ WEBSITE_REPO = github.com/hashicorp/terraform-website
 PKG_NAME = vault
 TF_ACC_TERRAFORM_VERSION ?= 1.2.2
 TESTARGS ?= -test.v
-TF_VAULT_VERSION ?=
 TEST_PATH ?= ./...
 
 default: build

--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ There may be additional variables for specific tests. Consult the specific test(
     - `ARM_CLIENT_ID`
     - `ARM_CLIENT_SECRET`
     - `ARM_RESOURCE_GROUP`
-    - `TF_VAULT_VERSION`
 4. Run `make testacc`
 
 If you wish to run specific tests, use the `TESTARGS` environment variable:

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -33,9 +33,6 @@ var (
 	VaultVersion112 = version.Must(version.NewSemver(consts.VaultVersion112))
 )
 
-func init() {
-}
-
 // ProviderMeta provides resources with access to the Vault client and
 // other bits
 type ProviderMeta struct {

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -15,14 +15,12 @@ import (
 
 	"github.com/coreos/pkg/multierror"
 	"github.com/hashicorp/go-retryablehttp"
-	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/vault/api"
 	"github.com/mitchellh/go-homedir"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
-	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 const (
@@ -705,48 +703,5 @@ func GetNamespaceImportStateCheck(ns string) resource.ImportStateCheckFunc {
 			}
 		}
 		return nil
-	}
-}
-
-// SkipIfAPIVersionLT skips of the running vault version is less-than ver.
-func SkipIfAPIVersionLT(t *testing.T, m interface{}, ver *version.Version) {
-	t.Helper()
-	SkipOnAPIVersion(t, m, ver.LessThan, "Vault version lt %q", ver)
-}
-
-// SkipIfAPIVersionLTE skips if the running vault version is less-than-or-equal to ver.
-func SkipIfAPIVersionLTE(t *testing.T, m interface{}, ver *version.Version) {
-	t.Helper()
-	SkipOnAPIVersion(t, m, ver.LessThanOrEqual, "Vault version lte %q", ver)
-}
-
-// SkipIfAPIVersionEQ skips if the running vault version is equal to ver.
-func SkipIfAPIVersionEQ(t *testing.T, m interface{}, ver *version.Version) {
-	t.Helper()
-	SkipOnAPIVersion(t, m, ver.Equal, "Vault version eq %q", ver)
-}
-
-// SkipIfAPIVersionGT skips if the running vault version is greater-than ver.
-func SkipIfAPIVersionGT(t *testing.T, m interface{}, ver *version.Version) {
-	t.Helper()
-	SkipOnAPIVersion(t, m, ver.GreaterThan, "Vault version gt %q", ver)
-}
-
-// SkipIfAPIVersionGTE skips if the running vault version is greater-than-or-equal to ver.
-func SkipIfAPIVersionGTE(t *testing.T, m interface{}, ver *version.Version) {
-	t.Helper()
-	SkipOnAPIVersion(t, m, ver.GreaterThanOrEqual, "Vault version gte %q", ver)
-}
-
-func SkipOnAPIVersion(t *testing.T, m interface{}, cmp func(*version.Version) bool, format string, args ...interface{}) {
-	t.Helper()
-
-	p := m.(*provider.ProviderMeta)
-	curVer := p.GetVaultVersion()
-	if curVer == nil {
-		t.Fatalf("vault version not set on %T", p)
-	}
-	if !cmp(curVer) {
-		t.Skipf(format, args...)
 	}
 }

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/coreos/pkg/multierror"
 	"github.com/hashicorp/go-retryablehttp"
-	goversion "github.com/hashicorp/go-version"
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/vault/api"
@@ -709,36 +709,36 @@ func GetNamespaceImportStateCheck(ns string) resource.ImportStateCheckFunc {
 }
 
 // SkipIfAPIVersionLT skips of the running vault version is less-than ver.
-func SkipIfAPIVersionLT(t *testing.T, m interface{}, ver *goversion.Version) {
+func SkipIfAPIVersionLT(t *testing.T, m interface{}, ver *version.Version) {
 	t.Helper()
 	SkipOnAPIVersion(t, m, ver.LessThan, "Vault version lt %q", ver)
 }
 
 // SkipIfAPIVersionLTE skips if the running vault version is less-than-or-equal to ver.
-func SkipIfAPIVersionLTE(t *testing.T, m interface{}, ver *goversion.Version) {
+func SkipIfAPIVersionLTE(t *testing.T, m interface{}, ver *version.Version) {
 	t.Helper()
 	SkipOnAPIVersion(t, m, ver.LessThanOrEqual, "Vault version lte %q", ver)
 }
 
 // SkipIfAPIVersionEQ skips if the running vault version is equal to ver.
-func SkipIfAPIVersionEQ(t *testing.T, m interface{}, ver *goversion.Version) {
+func SkipIfAPIVersionEQ(t *testing.T, m interface{}, ver *version.Version) {
 	t.Helper()
 	SkipOnAPIVersion(t, m, ver.Equal, "Vault version eq %q", ver)
 }
 
 // SkipIfAPIVersionGT skips if the running vault version is greater-than ver.
-func SkipIfAPIVersionGT(t *testing.T, m interface{}, ver *goversion.Version) {
+func SkipIfAPIVersionGT(t *testing.T, m interface{}, ver *version.Version) {
 	t.Helper()
 	SkipOnAPIVersion(t, m, ver.GreaterThan, "Vault version gt %q", ver)
 }
 
 // SkipIfAPIVersionGTE skips if the running vault version is greater-than-or-equal to ver.
-func SkipIfAPIVersionGTE(t *testing.T, m interface{}, ver *goversion.Version) {
+func SkipIfAPIVersionGTE(t *testing.T, m interface{}, ver *version.Version) {
 	t.Helper()
 	SkipOnAPIVersion(t, m, ver.GreaterThanOrEqual, "Vault version gte %q", ver)
 }
 
-func SkipOnAPIVersion(t *testing.T, m interface{}, cmp func(*goversion.Version) bool, format string, args ...interface{}) {
+func SkipOnAPIVersion(t *testing.T, m interface{}, cmp func(*version.Version) bool, format string, args ...interface{}) {
 	t.Helper()
 
 	p := m.(*provider.ProviderMeta)

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -15,12 +15,14 @@ import (
 
 	"github.com/coreos/pkg/multierror"
 	"github.com/hashicorp/go-retryablehttp"
+	goversion "github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/vault/api"
 	"github.com/mitchellh/go-homedir"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 const (
@@ -703,5 +705,48 @@ func GetNamespaceImportStateCheck(ns string) resource.ImportStateCheckFunc {
 			}
 		}
 		return nil
+	}
+}
+
+// SkipIfAPIVersionLT skips of the running vault version is less-than ver.
+func SkipIfAPIVersionLT(t *testing.T, m interface{}, ver *goversion.Version) {
+	t.Helper()
+	SkipOnAPIVersion(t, m, ver.LessThan, "Vault version lt %q", ver)
+}
+
+// SkipIfAPIVersionLTE skips if the running vault version is less-than-or-equal to ver.
+func SkipIfAPIVersionLTE(t *testing.T, m interface{}, ver *goversion.Version) {
+	t.Helper()
+	SkipOnAPIVersion(t, m, ver.LessThanOrEqual, "Vault version lte %q", ver)
+}
+
+// SkipIfAPIVersionEQ skips if the running vault version is equal to ver.
+func SkipIfAPIVersionEQ(t *testing.T, m interface{}, ver *goversion.Version) {
+	t.Helper()
+	SkipOnAPIVersion(t, m, ver.Equal, "Vault version eq %q", ver)
+}
+
+// SkipIfAPIVersionGT skips if the running vault version is greater-than ver.
+func SkipIfAPIVersionGT(t *testing.T, m interface{}, ver *goversion.Version) {
+	t.Helper()
+	SkipOnAPIVersion(t, m, ver.GreaterThan, "Vault version gt %q", ver)
+}
+
+// SkipIfAPIVersionGTE skips if the running vault version is greater-than-or-equal to ver.
+func SkipIfAPIVersionGTE(t *testing.T, m interface{}, ver *goversion.Version) {
+	t.Helper()
+	SkipOnAPIVersion(t, m, ver.GreaterThanOrEqual, "Vault version gte %q", ver)
+}
+
+func SkipOnAPIVersion(t *testing.T, m interface{}, cmp func(*goversion.Version) bool, format string, args ...interface{}) {
+	t.Helper()
+
+	p := m.(*provider.ProviderMeta)
+	curVer := p.GetVaultVersion()
+	if curVer == nil {
+		t.Fatalf("vault version not set on %T", p)
+	}
+	if !cmp(curVer) {
+		t.Skipf(format, args...)
 	}
 }

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -20,8 +20,6 @@ import (
 	"github.com/hashicorp/vault/api"
 	"github.com/mitchellh/go-homedir"
 
-	goversion "github.com/hashicorp/go-version"
-
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 )
 
@@ -192,21 +190,6 @@ func GetTestADCreds(t *testing.T) (string, string, string) {
 func GetTestNomadCreds(t *testing.T) (string, string) {
 	v := SkipTestEnvUnset(t, "NOMAD_ADDR", "NOMAD_TOKEN")
 	return v[0], v[1]
-}
-
-// Returns true if TF_VAULT_VERSION is greater than or equal to the given Vault version
-func CheckTestVaultVersion(t *testing.T, cutoff string) bool {
-	v := SkipTestEnvUnset(t, "TF_VAULT_VERSION")
-
-	cutoffVersion, _ := goversion.NewVersion(cutoff)
-	envVersion, err := goversion.NewVersion(v[0])
-	if err != nil {
-		t.Fatalf("error parsing vault version from TF_VAULT_VERSION environment variable: %v", err)
-	} else {
-		return envVersion.GreaterThanOrEqual(cutoffVersion)
-	}
-
-	return false
 }
 
 func TestCheckResourceAttrJSON(name, key, expectedValue string) resource.TestCheckFunc {

--- a/vault/resource_azure_secret_backend_test.go
+++ b/vault/resource_azure_secret_backend_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -16,8 +17,15 @@ func TestAzureSecretBackend(t *testing.T) {
 	resourceType := "vault_azure_secret_backend"
 	resourceName := resourceType + ".test"
 	resource.Test(t, resource.TestCase{
-		Providers:    testProviders,
-		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		Providers: testProviders,
+		PreCheck: func() {
+			testutil.TestAccPreCheck(t)
+
+			maxVer := provider.VaultVersion112
+			if provider.IsAPISupported(testProvider.Meta(), maxVer) {
+				t.Skipf("Skip until resource supports vault-%s", maxVer)
+			}
+		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeAzure, consts.FieldPath),
 		Steps: []resource.TestStep{
 			{
@@ -67,8 +75,15 @@ func TestAzureSecretBackend_remount(t *testing.T) {
 	resourceType := "vault_azure_secret_backend"
 	resourceName := resourceType + ".test"
 	resource.Test(t, resource.TestCase{
-		Providers:    testProviders,
-		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		Providers: testProviders,
+		PreCheck: func() {
+			testutil.TestAccPreCheck(t)
+
+			maxVer := provider.VaultVersion112
+			if provider.IsAPISupported(testProvider.Meta(), maxVer) {
+				t.Skipf("Skip until resource supports vault-%s", maxVer)
+			}
+		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeAzure, consts.FieldPath),
 		Steps: []resource.TestStep{
 			{

--- a/vault/resource_azure_secret_backend_test.go
+++ b/vault/resource_azure_secret_backend_test.go
@@ -20,7 +20,7 @@ func TestAzureSecretBackend(t *testing.T) {
 		Providers: testProviders,
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			testutil.SkipIfAPIVersionGTE(t, testProvider.Meta(), provider.VaultVersion112)
+			SkipIfAPIVersionGTE(t, testProvider.Meta(), provider.VaultVersion112)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeAzure, consts.FieldPath),
 		Steps: []resource.TestStep{
@@ -74,7 +74,7 @@ func TestAzureSecretBackend_remount(t *testing.T) {
 		Providers: testProviders,
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			testutil.SkipIfAPIVersionGTE(t, testProvider.Meta(), provider.VaultVersion112)
+			SkipIfAPIVersionGTE(t, testProvider.Meta(), provider.VaultVersion112)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeAzure, consts.FieldPath),
 		Steps: []resource.TestStep{

--- a/vault/resource_azure_secret_backend_test.go
+++ b/vault/resource_azure_secret_backend_test.go
@@ -20,11 +20,7 @@ func TestAzureSecretBackend(t *testing.T) {
 		Providers: testProviders,
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-
-			maxVer := provider.VaultVersion112
-			if provider.IsAPISupported(testProvider.Meta(), maxVer) {
-				t.Skipf("Skip until resource supports vault-%s", maxVer)
-			}
+			testutil.SkipIfAPIVersionGTE(t, testProvider.Meta(), provider.VaultVersion112)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeAzure, consts.FieldPath),
 		Steps: []resource.TestStep{
@@ -78,11 +74,7 @@ func TestAzureSecretBackend_remount(t *testing.T) {
 		Providers: testProviders,
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-
-			maxVer := provider.VaultVersion112
-			if provider.IsAPISupported(testProvider.Meta(), maxVer) {
-				t.Skipf("Skip until resource supports vault-%s", maxVer)
-			}
+			testutil.SkipIfAPIVersionGTE(t, testProvider.Meta(), provider.VaultVersion112)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeAzure, consts.FieldPath),
 		Steps: []resource.TestStep{

--- a/vault/resource_consul_secret_backend_role_test.go
+++ b/vault/resource_consul_secret_backend_role_test.go
@@ -178,7 +178,7 @@ func TestConsulSecretBackendRole_Legacy(t *testing.T) {
 		Providers: testProviders,
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionGT(t, testProvider.Meta(), provider.VaultVersion110)
+			SkipIfAPIVersionGTE(t, testProvider.Meta(), provider.VaultVersion111)
 		},
 		CheckDestroy: testAccConsulSecretBackendRoleCheckDestroy,
 		Steps: []resource.TestStep{

--- a/vault/resource_consul_secret_backend_role_test.go
+++ b/vault/resource_consul_secret_backend_role_test.go
@@ -70,7 +70,7 @@ func TestConsulSecretBackendRole(t *testing.T) {
 		Providers: testProviders,
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion111)
+			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion111)
 		},
 		CheckDestroy: testAccConsulSecretBackendRoleCheckDestroy,
 		Steps: []resource.TestStep{
@@ -178,7 +178,7 @@ func TestConsulSecretBackendRole_Legacy(t *testing.T) {
 		Providers: testProviders,
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			testutil.SkipIfAPIVersionGT(t, testProvider.Meta(), provider.VaultVersion110)
+			SkipIfAPIVersionGT(t, testProvider.Meta(), provider.VaultVersion110)
 		},
 		CheckDestroy: testAccConsulSecretBackendRoleCheckDestroy,
 		Steps: []resource.TestStep{

--- a/vault/resource_consul_secret_backend_role_test.go
+++ b/vault/resource_consul_secret_backend_role_test.go
@@ -70,9 +70,7 @@ func TestConsulSecretBackendRole(t *testing.T) {
 		Providers: testProviders,
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			if !provider.IsAPISupported(testProvider.Meta(), provider.VaultVersion111) {
-				t.Skipf("test requires Vault %s or newer", provider.VaultVersion111)
-			}
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion111)
 		},
 		CheckDestroy: testAccConsulSecretBackendRoleCheckDestroy,
 		Steps: []resource.TestStep{
@@ -180,9 +178,7 @@ func TestConsulSecretBackendRole_Legacy(t *testing.T) {
 		Providers: testProviders,
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			if provider.IsAPISupported(testProvider.Meta(), provider.VaultVersion111) {
-				t.Skipf("test is reserved for Vault %s and below", provider.VaultVersion110)
-			}
+			testutil.SkipIfAPIVersionGT(t, testProvider.Meta(), provider.VaultVersion110)
 		},
 		CheckDestroy: testAccConsulSecretBackendRoleCheckDestroy,
 		Steps: []resource.TestStep{

--- a/vault/resource_consul_secret_backend_role_test.go
+++ b/vault/resource_consul_secret_backend_role_test.go
@@ -15,10 +15,6 @@ import (
 )
 
 func TestConsulSecretBackendRole(t *testing.T) {
-	if testNewParameters := testutil.CheckTestVaultVersion(t, "1.11"); !testNewParameters {
-		t.Skipf("test requires Vault 1.11 or newer")
-	}
-
 	path := acctest.RandomWithPrefix("tf-test-consul")
 	name := acctest.RandomWithPrefix("tf-test-name")
 	token := "026a0c16-87cd-4c2d-b3f3-fb539f592b7e"
@@ -71,8 +67,13 @@ func TestConsulSecretBackendRole(t *testing.T) {
 		resource.TestCheckTypeSetElemAttr(resourceName, "node_identities.*", "client-0:dc1"))
 
 	resource.Test(t, resource.TestCase{
-		Providers:    testProviders,
-		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		Providers: testProviders,
+		PreCheck: func() {
+			testutil.TestAccPreCheck(t)
+			if !provider.IsAPISupported(testProvider.Meta(), provider.VaultVersion111) {
+				t.Skipf("test requires Vault %s or newer", provider.VaultVersion111)
+			}
+		},
 		CheckDestroy: testAccConsulSecretBackendRoleCheckDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -139,10 +140,6 @@ func TestConsulSecretBackendRole(t *testing.T) {
 }
 
 func TestConsulSecretBackendRole_Legacy(t *testing.T) {
-	if testNewParameters := testutil.CheckTestVaultVersion(t, "1.11"); testNewParameters {
-		t.Skipf("test is reserved for Vault 1.10 or older")
-	}
-
 	path := acctest.RandomWithPrefix("tf-test-consul")
 	name := acctest.RandomWithPrefix("tf-test-name")
 	token := "026a0c16-87cd-4c2d-b3f3-fb539f592b7e"
@@ -180,8 +177,13 @@ func TestConsulSecretBackendRole_Legacy(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceName, "policies.1", "far"))
 
 	resource.Test(t, resource.TestCase{
-		Providers:    testProviders,
-		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		Providers: testProviders,
+		PreCheck: func() {
+			testutil.TestAccPreCheck(t)
+			if !provider.IsAPISupported(testProvider.Meta(), provider.VaultVersion111) {
+				t.Skipf("test requires Vault %s or newer", provider.VaultVersion111)
+			}
+		},
 		CheckDestroy: testAccConsulSecretBackendRoleCheckDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/vault/resource_consul_secret_backend_role_test.go
+++ b/vault/resource_consul_secret_backend_role_test.go
@@ -180,8 +180,8 @@ func TestConsulSecretBackendRole_Legacy(t *testing.T) {
 		Providers: testProviders,
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			if !provider.IsAPISupported(testProvider.Meta(), provider.VaultVersion111) {
-				t.Skipf("test requires Vault %s or newer", provider.VaultVersion111)
+			if provider.IsAPISupported(testProvider.Meta(), provider.VaultVersion111) {
+				t.Skipf("test is reserved for Vault %s and below", provider.VaultVersion110)
 			}
 		},
 		CheckDestroy: testAccConsulSecretBackendRoleCheckDestroy,

--- a/vault/resource_consul_secret_backend_test.go
+++ b/vault/resource_consul_secret_backend_test.go
@@ -133,17 +133,18 @@ func TestConsulSecretBackend_Bootstrap(t *testing.T) {
 	resourceName := resourceType + ".test"
 	resourceRoleName := "vault_consul_secret_backend_role.test"
 
-	if !testutil.CheckTestVaultVersion(t, "1.11") {
-		t.Skipf("test requires Vault 1.11 or newer")
-	}
-
 	cleanup, consulConfig := consulhelper.PrepareTestContainer(t, "1.12.3", false, false)
 	t.Cleanup(cleanup)
 	consulAddr := consulConfig.Address()
 
 	resource.Test(t, resource.TestCase{
-		Providers:    testProviders,
-		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		Providers: testProviders,
+		PreCheck: func() {
+			testutil.TestAccPreCheck(t)
+			if !provider.IsAPISupported(testProvider.Meta(), provider.VaultVersion111) {
+				t.Skipf("test requires Vault %s or newer", provider.VaultVersion111)
+			}
+		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeConsul, consts.FieldPath),
 		Steps: []resource.TestStep{
 			{

--- a/vault/resource_consul_secret_backend_test.go
+++ b/vault/resource_consul_secret_backend_test.go
@@ -128,6 +128,8 @@ func TestConsulSecretBackend(t *testing.T) {
 }
 
 func TestConsulSecretBackend_Bootstrap(t *testing.T) {
+	testutil.SkipTestAcc(t)
+
 	path := acctest.RandomWithPrefix("tf-test-consul")
 	resourceType := "vault_consul_secret_backend"
 	resourceName := resourceType + ".test"

--- a/vault/resource_consul_secret_backend_test.go
+++ b/vault/resource_consul_secret_backend_test.go
@@ -141,9 +141,7 @@ func TestConsulSecretBackend_Bootstrap(t *testing.T) {
 		Providers: testProviders,
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			if !provider.IsAPISupported(testProvider.Meta(), provider.VaultVersion111) {
-				t.Skipf("test requires Vault %s or newer", provider.VaultVersion111)
-			}
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion111)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeConsul, consts.FieldPath),
 		Steps: []resource.TestStep{

--- a/vault/resource_consul_secret_backend_test.go
+++ b/vault/resource_consul_secret_backend_test.go
@@ -141,7 +141,7 @@ func TestConsulSecretBackend_Bootstrap(t *testing.T) {
 		Providers: testProviders,
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion111)
+			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion111)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeConsul, consts.FieldPath),
 		Steps: []resource.TestStep{

--- a/vault/resource_kubernetes_auth_backend_config_test.go
+++ b/vault/resource_kubernetes_auth_backend_config_test.go
@@ -353,10 +353,7 @@ func TestAccKubernetesAuthBackendConfig_localCA(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			maxVer := provider.VaultVersion111
-			if provider.IsAPISupported(testProvider.Meta(), maxVer) {
-				t.Skipf("Skip until test is fixed for vault-%s", maxVer)
-			}
+			testutil.SkipIfAPIVersionGTE(t, testProvider.Meta(), provider.VaultVersion111)
 		},
 		Providers:    testProviders,
 		CheckDestroy: testAccCheckKubernetesAuthBackendConfigDestroy,

--- a/vault/resource_kubernetes_auth_backend_config_test.go
+++ b/vault/resource_kubernetes_auth_backend_config_test.go
@@ -353,7 +353,7 @@ func TestAccKubernetesAuthBackendConfig_localCA(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			testutil.SkipIfAPIVersionGTE(t, testProvider.Meta(), provider.VaultVersion111)
+			SkipIfAPIVersionGTE(t, testProvider.Meta(), provider.VaultVersion111)
 		},
 		Providers:    testProviders,
 		CheckDestroy: testAccCheckKubernetesAuthBackendConfigDestroy,

--- a/vault/resource_kubernetes_auth_backend_config_test.go
+++ b/vault/resource_kubernetes_auth_backend_config_test.go
@@ -347,16 +347,17 @@ func TestAccKubernetesAuthBackendConfig_fullUpdate(t *testing.T) {
 }
 
 func TestAccKubernetesAuthBackendConfig_localCA(t *testing.T) {
-	isAboveVersionCutoff := testutil.CheckTestVaultVersion(t, "1.11")
-	if isAboveVersionCutoff {
-		t.Skip("Skip until test is fixed for 1.11")
-	}
-
 	backend := acctest.RandomWithPrefix("kubernetes")
 	jwt := kubernetesJWT
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		PreCheck: func() {
+			testutil.TestAccPreCheck(t)
+			maxVer := provider.VaultVersion111
+			if provider.IsAPISupported(testProvider.Meta(), maxVer) {
+				t.Skipf("Skip until test is fixed for vault-%s", maxVer)
+			}
+		},
 		Providers:    testProviders,
 		CheckDestroy: testAccCheckKubernetesAuthBackendConfigDestroy,
 		Steps: []resource.TestStep{

--- a/vault/testhelpers_test.go
+++ b/vault/testhelpers_test.go
@@ -79,7 +79,7 @@ func SkipIfAPIVersionLT(t *testing.T, m interface{}, ver *version.Version) {
 	f := func(curVer *version.Version) bool {
 		return curVer.LessThan(ver)
 	}
-	SkipOnAPIVersion(t, m, f, "Vault version lt %q", ver)
+	SkipOnAPIVersion(t, m, f, "Vault version < %q", ver)
 }
 
 // SkipIfAPIVersionLTE skips if the running vault version is less-than-or-equal to ver.
@@ -88,7 +88,7 @@ func SkipIfAPIVersionLTE(t *testing.T, m interface{}, ver *version.Version) {
 	f := func(curVer *version.Version) bool {
 		return curVer.LessThanOrEqual(ver)
 	}
-	SkipOnAPIVersion(t, m, f, "Vault version lte %q", ver)
+	SkipOnAPIVersion(t, m, f, "Vault version <= %q", ver)
 }
 
 // SkipIfAPIVersionEQ skips if the running vault version is equal to ver.
@@ -97,7 +97,7 @@ func SkipIfAPIVersionEQ(t *testing.T, m interface{}, ver *version.Version) {
 	f := func(curVer *version.Version) bool {
 		return curVer.Equal(ver)
 	}
-	SkipOnAPIVersion(t, m, f, "Vault version eq %q", ver)
+	SkipOnAPIVersion(t, m, f, "Vault version == %q", ver)
 }
 
 // SkipIfAPIVersionGT skips if the running vault version is greater-than ver.
@@ -106,7 +106,7 @@ func SkipIfAPIVersionGT(t *testing.T, m interface{}, ver *version.Version) {
 	f := func(curVer *version.Version) bool {
 		return curVer.GreaterThan(ver)
 	}
-	SkipOnAPIVersion(t, m, f, "Vault version gt %q", ver)
+	SkipOnAPIVersion(t, m, f, "Vault version > %q", ver)
 }
 
 // SkipIfAPIVersionGTE skips if the running vault version is greater-than-or-equal to ver.
@@ -115,7 +115,7 @@ func SkipIfAPIVersionGTE(t *testing.T, m interface{}, ver *version.Version) {
 	f := func(curVer *version.Version) bool {
 		return curVer.GreaterThanOrEqual(ver)
 	}
-	SkipOnAPIVersion(t, m, f, "Vault version gte %q", ver)
+	SkipOnAPIVersion(t, m, f, "Vault version >= %q", ver)
 }
 
 func SkipOnAPIVersion(t *testing.T, m interface{}, cmp func(*version.Version) bool, format string, args ...interface{}) {

--- a/vault/testhelpers_test.go
+++ b/vault/testhelpers_test.go
@@ -3,7 +3,9 @@ package vault
 import (
 	"fmt"
 	"regexp"
+	"testing"
 
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
@@ -68,5 +70,48 @@ func testCheckMountDestroyed(resourceType, mountType, pathField string) resource
 		}
 
 		return nil
+	}
+}
+
+// SkipIfAPIVersionLT skips of the running vault version is less-than ver.
+func SkipIfAPIVersionLT(t *testing.T, m interface{}, ver *version.Version) {
+	t.Helper()
+	SkipOnAPIVersion(t, m, ver.LessThan, "Vault version lt %q", ver)
+}
+
+// SkipIfAPIVersionLTE skips if the running vault version is less-than-or-equal to ver.
+func SkipIfAPIVersionLTE(t *testing.T, m interface{}, ver *version.Version) {
+	t.Helper()
+	SkipOnAPIVersion(t, m, ver.LessThanOrEqual, "Vault version lte %q", ver)
+}
+
+// SkipIfAPIVersionEQ skips if the running vault version is equal to ver.
+func SkipIfAPIVersionEQ(t *testing.T, m interface{}, ver *version.Version) {
+	t.Helper()
+	SkipOnAPIVersion(t, m, ver.Equal, "Vault version eq %q", ver)
+}
+
+// SkipIfAPIVersionGT skips if the running vault version is greater-than ver.
+func SkipIfAPIVersionGT(t *testing.T, m interface{}, ver *version.Version) {
+	t.Helper()
+	SkipOnAPIVersion(t, m, ver.GreaterThan, "Vault version gt %q", ver)
+}
+
+// SkipIfAPIVersionGTE skips if the running vault version is greater-than-or-equal to ver.
+func SkipIfAPIVersionGTE(t *testing.T, m interface{}, ver *version.Version) {
+	t.Helper()
+	SkipOnAPIVersion(t, m, ver.GreaterThanOrEqual, "Vault version gte %q", ver)
+}
+
+func SkipOnAPIVersion(t *testing.T, m interface{}, cmp func(*version.Version) bool, format string, args ...interface{}) {
+	t.Helper()
+
+	p := m.(*provider.ProviderMeta)
+	curVer := p.GetVaultVersion()
+	if curVer == nil {
+		t.Fatalf("vault version not set on %T", p)
+	}
+	if !cmp(curVer) {
+		t.Skipf(format, args...)
 	}
 }

--- a/vault/testhelpers_test.go
+++ b/vault/testhelpers_test.go
@@ -76,31 +76,46 @@ func testCheckMountDestroyed(resourceType, mountType, pathField string) resource
 // SkipIfAPIVersionLT skips of the running vault version is less-than ver.
 func SkipIfAPIVersionLT(t *testing.T, m interface{}, ver *version.Version) {
 	t.Helper()
-	SkipOnAPIVersion(t, m, ver.LessThan, "Vault version lt %q", ver)
+	f := func(curVer *version.Version) bool {
+		return curVer.LessThan(ver)
+	}
+	SkipOnAPIVersion(t, m, f, "Vault version lt %q", ver)
 }
 
 // SkipIfAPIVersionLTE skips if the running vault version is less-than-or-equal to ver.
 func SkipIfAPIVersionLTE(t *testing.T, m interface{}, ver *version.Version) {
 	t.Helper()
-	SkipOnAPIVersion(t, m, ver.LessThanOrEqual, "Vault version lte %q", ver)
+	f := func(curVer *version.Version) bool {
+		return curVer.LessThanOrEqual(ver)
+	}
+	SkipOnAPIVersion(t, m, f, "Vault version lte %q", ver)
 }
 
 // SkipIfAPIVersionEQ skips if the running vault version is equal to ver.
 func SkipIfAPIVersionEQ(t *testing.T, m interface{}, ver *version.Version) {
 	t.Helper()
-	SkipOnAPIVersion(t, m, ver.Equal, "Vault version eq %q", ver)
+	f := func(curVer *version.Version) bool {
+		return curVer.Equal(ver)
+	}
+	SkipOnAPIVersion(t, m, f, "Vault version eq %q", ver)
 }
 
 // SkipIfAPIVersionGT skips if the running vault version is greater-than ver.
 func SkipIfAPIVersionGT(t *testing.T, m interface{}, ver *version.Version) {
 	t.Helper()
-	SkipOnAPIVersion(t, m, ver.GreaterThan, "Vault version gt %q", ver)
+	f := func(curVer *version.Version) bool {
+		return curVer.GreaterThan(ver)
+	}
+	SkipOnAPIVersion(t, m, f, "Vault version gt %q", ver)
 }
 
 // SkipIfAPIVersionGTE skips if the running vault version is greater-than-or-equal to ver.
 func SkipIfAPIVersionGTE(t *testing.T, m interface{}, ver *version.Version) {
 	t.Helper()
-	SkipOnAPIVersion(t, m, ver.GreaterThanOrEqual, "Vault version gte %q", ver)
+	f := func(curVer *version.Version) bool {
+		return curVer.GreaterThanOrEqual(ver)
+	}
+	SkipOnAPIVersion(t, m, f, "Vault version gte %q", ver)
 }
 
 func SkipOnAPIVersion(t *testing.T, m interface{}, cmp func(*version.Version) bool, format string, args ...interface{}) {
@@ -111,7 +126,9 @@ func SkipOnAPIVersion(t *testing.T, m interface{}, cmp func(*version.Version) bo
 	if curVer == nil {
 		t.Fatalf("vault version not set on %T", p)
 	}
-	if !cmp(curVer) {
+
+	t.Logf("Vault server version %q", curVer)
+	if cmp(curVer) {
 		t.Skipf(format, args...)
 	}
 }


### PR DESCRIPTION
Drop CheckTestVaultVersion() in favour of provider.IsAPISupported()

