### PR TITLE
Add Redis database plugin support

### DIFF
--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -95,6 +95,10 @@ var (
 		name:              "snowflake",
 		defaultPluginName: "snowflake" + dbPluginSuffix,
 	}
+	dbEngineRedis = &dbEngine{
+		name:              "redis",
+		defaultPluginName: "redis" + dbPluginSuffix,
+	}
 	dbEngineRedisElastiCache = &dbEngine{
 		name:              "redis_elasticache",
 		defaultPluginName: "redis-elasticache" + dbPluginSuffix,
@@ -120,6 +124,7 @@ var (
 		dbEnginePostgres,
 		dbEngineOracle,
 		dbEngineSnowflake,
+		dbEngineRedis,
 		dbEngineRedisElastiCache,
 		dbEngineRedshift,
 	}
@@ -561,6 +566,57 @@ func getDatabaseSchema(typ schema.ValueType) schemaMap {
 			MaxItems:      1,
 			ConflictsWith: util.CalculateConflictsWith(dbEngineOracle.Name(), dbEngineTypes),
 		},
+		dbEngineRedis.name: {
+			Type:        typ,
+			Optional:    true,
+			Description: "Connection parameters for the redis-database-plugin plugin.",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"host": {
+						Type:        schema.TypeString,
+						Required:    true,
+						Description: "Redis host to connect to.",
+					},
+					"port": {
+						Type:         schema.TypeInt,
+						Optional:     true,
+						Description:  "The transport port to use to connect to Redis.",
+						Default:      6379,
+						ValidateFunc: validation.IsPortNumber,
+					},
+					"username": {
+						Type:        schema.TypeString,
+						Required:    true,
+						Description: "Specifies the username to use for admin access.",
+					},
+					"password": {
+						Type:        schema.TypeString,
+						Required:    true,
+						Description: "Specifies the password corresponding to the given admin username.",
+						Sensitive:   true,
+					},
+					"tls": {
+						Type:        schema.TypeBool,
+						Optional:    true,
+						Description: "Whether to use TLS when connecting to Redis.",
+						Default:     true,
+					},
+					"insecure_tls": {
+						Type:        schema.TypeBool,
+						Optional:    true,
+						Description: "Whether to ignore insecure TLS when connecting to Redis.",
+						Default:     false,
+					},
+					"ca_cert": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "The path to a PEM-encoded CA cert file to use to verify the Redis server's identity",
+					},
+				},
+			},
+			MaxItems:      1,
+			ConflictsWith: util.CalculateConflictsWith(dbEngineRedis.Name(), dbEngineTypes),
+		},
 		dbEngineRedisElastiCache.name: {
 			Type:        typ,
 			Optional:    true,
@@ -872,6 +928,8 @@ func getDatabaseAPIDataForEngine(engine *dbEngine, idx int, d *schema.ResourceDa
 		setDatabaseConnectionDataWithDisableEscaping(d, prefix, data)
 	case dbEngineElasticSearch:
 		setElasticsearchDatabaseConnectionData(d, prefix, data)
+	case dbEngineRedis:
+		setRedisDatabaseConnectionData(d, prefix, data)
 	case dbEngineRedisElastiCache:
 		setRedisElastiCacheDatabaseConnectionData(d, prefix, data)
 	case dbEngineSnowflake:
@@ -987,6 +1045,55 @@ func getMySQLConnectionDetailsFromResponse(d *schema.ResourceData, prefix string
 		if v, ok := data["tls_ca"]; ok {
 			result["tls_ca"] = v.(string)
 		}
+	}
+	return result
+}
+
+func getRedisConnectionDetailsFromResponse(d *schema.ResourceData, prefix string, resp *api.Secret) map[string]interface{} {
+	details := resp.Data["connection_details"]
+	data, ok := details.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	result := map[string]interface{}{}
+	if v, ok := data["host"]; ok {
+		result["host"] = v.(string)
+	} else if v, ok := d.GetOk(prefix + "host"); ok {
+		result["host"] = v.(string)
+	}
+	if v, ok := data["port"]; ok {
+		port, err := v.(json.Number).Int64()
+		result["port"] = port
+		if err != nil {
+			log.Printf("[WARN] Non-number %s returned from Vault server: %s", v, err)
+		} else {
+			result["port"] = port
+		}
+	}
+	if v, ok := data["username"]; ok {
+		result["username"] = v.(string)
+	} else if v, ok := d.GetOk(prefix + "username"); ok {
+		result["username"] = v.(string)
+	}
+	if v, ok := data["password"]; ok {
+		result["password"] = v.(string)
+	} else if v, ok := d.GetOk(prefix + "password"); ok {
+		result["password"] = v.(string)
+	}
+	if v, ok := data["tls"]; ok {
+		result["tls"] = v.(bool)
+	} else if v, ok := d.GetOk(prefix + "tls"); ok {
+		result["tls"] = v.(bool)
+	}
+	if v, ok := data["insecure_tls"]; ok {
+		result["insecure_tls"] = v.(bool)
+	} else if v, ok := d.GetOk(prefix + "insecure_tls"); ok {
+		result["insecure_tls"] = v.(bool)
+	}
+	if v, ok := data["ca_cert"]; ok {
+		result["ca_cert"] = v.(string)
+	} else if v, ok := d.GetOk(prefix + "ca_cert"); ok {
+		result["ca_cert"] = v.(string)
 	}
 	return result
 }
@@ -1251,6 +1358,30 @@ func setMySQLDatabaseConnectionData(d *schema.ResourceData, prefix string, data 
 	}
 	if v, ok := d.GetOk(prefix + "tls_ca"); ok {
 		data["tls_ca"] = v.(string)
+	}
+}
+
+func setRedisDatabaseConnectionData(d *schema.ResourceData, prefix string, data map[string]interface{}) {
+	if v, ok := d.GetOk(prefix + "host"); ok {
+		data["url"] = v.(string)
+	}
+	if v, ok := d.GetOkExists(prefix + "port"); ok {
+		data["port"] = v.(int)
+	}
+	if v, ok := d.GetOk(prefix + "username"); ok {
+		data["username"] = v.(string)
+	}
+	if v, ok := d.GetOk(prefix + "password"); ok {
+		data["password"] = v.(string)
+	}
+	if v, ok := d.GetOk(prefix + "tls"); ok {
+		data["tls"] = v.(bool)
+	}
+	if v, ok := d.GetOk(prefix + "insecure_tls"); ok {
+		data["insecure_tls"] = v.(bool)
+	}
+	if v, ok := d.GetOk(prefix + "ca_file"); ok {
+		data["ca_file"] = v.(string)
 	}
 }
 
@@ -1649,6 +1780,8 @@ func getDBConnectionConfig(d *schema.ResourceData, engine *dbEngine, idx int,
 		result = getElasticsearchConnectionDetailsFromResponse(d, prefix, resp)
 	case dbEngineSnowflake:
 		result = getSnowflakeConnectionDetailsFromResponse(d, prefix, resp)
+	case dbEngineRedis:
+		result = getRedisConnectionDetailsFromResponse(d, prefix, resp)
 	case dbEngineRedisElastiCache:
 		result = getRedisElastiCacheConnectionDetailsFromResponse(d, prefix, resp)
 	case dbEngineRedshift:

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -599,7 +599,7 @@ func getDatabaseSchema(typ schema.ValueType) schemaMap {
 						Type:        schema.TypeBool,
 						Optional:    true,
 						Description: "Whether to use TLS when connecting to Redis.",
-						Default:     true,
+						Default:     false,
 					},
 					"insecure_tls": {
 						Type:        schema.TypeBool,
@@ -1092,8 +1092,6 @@ func getRedisConnectionDetailsFromResponse(d *schema.ResourceData, prefix string
 	}
 	if v, ok := data["ca_cert"]; ok {
 		result["ca_cert"] = v.(string)
-	} else if v, ok := d.GetOk(prefix + "ca_cert"); ok {
-		result["ca_cert"] = v.(string)
 	}
 	return result
 }
@@ -1363,7 +1361,7 @@ func setMySQLDatabaseConnectionData(d *schema.ResourceData, prefix string, data 
 
 func setRedisDatabaseConnectionData(d *schema.ResourceData, prefix string, data map[string]interface{}) {
 	if v, ok := d.GetOk(prefix + "host"); ok {
-		data["url"] = v.(string)
+		data["host"] = v.(string)
 	}
 	if v, ok := d.GetOkExists(prefix + "port"); ok {
 		data["port"] = v.(int)
@@ -1374,14 +1372,14 @@ func setRedisDatabaseConnectionData(d *schema.ResourceData, prefix string, data 
 	if v, ok := d.GetOk(prefix + "password"); ok {
 		data["password"] = v.(string)
 	}
-	if v, ok := d.GetOk(prefix + "tls"); ok {
+	if v, ok := d.GetOkExists(prefix + "tls"); ok {
 		data["tls"] = v.(bool)
 	}
-	if v, ok := d.GetOk(prefix + "insecure_tls"); ok {
+	if v, ok := d.GetOkExists(prefix + "insecure_tls"); ok {
 		data["insecure_tls"] = v.(bool)
 	}
-	if v, ok := d.GetOk(prefix + "ca_file"); ok {
-		data["ca_file"] = v.(string)
+	if v, ok := d.GetOkExists(prefix + "ca_cert"); ok {
+		data["ca_cert"] = v.(string)
 	}
 }
 

--- a/website/docs/r/database_secret_backend_connection.md
+++ b/website/docs/r/database_secret_backend_connection.md
@@ -171,19 +171,19 @@ Exactly one of the nested blocks of configuration options must be supplied.
 
 ### Redis Configuration Options
 
-* `host` - (Required) Redis server host.
+* `host` - (Required) Redis host to connect to.
+
+* `username` - (Required) Specifies the username to use for admin access.
+
+* `password` - (Required) Specifies the password corresponding to the given admin username.
 
 * `port` - (Optional) Redis server port (defaults to `6379`)
 
-* `username` - (Optional) ...
+* `tls` - (Optional) Whether to use TLS when connecting to Redis.
 
-* `password` - (Optional) ...
+* `insecure_tls` - (Optional) Whether to ignore insecure TLS when connecting to Redis.
 
-* `tls` - (Optional) ...
-
-* `insecure_tls` - (Optional) ...
-
-* `ca_cert` - (Optional) ...
+* `ca_cert` - (Optional) The path to a PEM-encoded CA cert file to use to verify the Redis server's identity.
 
 ### Redis ElastiCache Configuration Options
 

--- a/website/docs/r/database_secret_backend_connection.md
+++ b/website/docs/r/database_secret_backend_connection.md
@@ -92,6 +92,8 @@ The following arguments are supported:
 
 * `influxdb` - (Optional) A nested block containing configuration options for InfluxDB connections.
 
+* `redis` - (Optional) A nested block containing configuration options for Redis connections.
+
 * `redis_elasticache` - (Optional) A nested block containing configuration options for Redis ElastiCache connections.
 
 Exactly one of the nested blocks of configuration options must be supplied.
@@ -166,6 +168,22 @@ Exactly one of the nested blocks of configuration options must be supplied.
 
 * `connect_timeout` - (Optional) The number of seconds to use as a connection
   timeout.
+
+### Redis Configuration Options
+
+* `host` - (Required) Redis server host.
+
+* `port` - (Optional) Redis server port (defaults to `6379`)
+
+* `username` - (Optional) ...
+
+* `password` - (Optional) ...
+
+* `tls` - (Optional) ...
+
+* `insecure_tls` - (Optional) ...
+
+* `ca_cert` - (Optional) ...
 
 ### Redis ElastiCache Configuration Options
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1640 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Added Redis database secrets plugin support
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccDatabaseSecretBackendConnection_redis'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -run=TestAccDatabaseSecretBackendConnection_redis -timeout 30m ./...
?   	github.com/hashicorp/terraform-provider-vault	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/generate	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/codegen	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/generated	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/helper	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/consts	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/internal/identity/entity	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/group	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/mfa	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/pki	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/internal/provider	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/schema	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/testutil	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/util	(cached) [no tests to run]
panic: Error making API request.

URL: GET https://vault.service.blufor.cloud:8200/v1/auth/token/lookup-self
Code: 403. Errors:

* permission denied

goroutine 1 [running]:
github.com/hashicorp/terraform-provider-vault/vault.initTestProvider.func1()
	/home/blufor/@blu/terraform-provider-vault/vault/provider_test.go:88 +0x19c
sync.(*Once).doSlow(0x0?, 0x0?)
	/usr/lib/go/src/sync/once.go:74 +0xc2
sync.(*Once).Do(...)
	/usr/lib/go/src/sync/once.go:65
github.com/hashicorp/terraform-provider-vault/vault.initTestProvider()
	/home/blufor/@blu/terraform-provider-vault/vault/provider_test.go:70 +0x31
github.com/hashicorp/terraform-provider-vault/vault.init.0()
	/home/blufor/@blu/terraform-provider-vault/vault/provider_test.go:66 +0x17
FAIL	github.com/hashicorp/terraform-provider-vault/vault	0.037s
FAIL
make: *** [Makefile:19: testacc] Error 1
...
```

> Testing failed due to unset test environment and no more time to investigate. Other tests fail too for me. Maybe somebody else can run it? Thx! :)