### PR TITLE
Add Vault 1.12 PKI crl settings to pki_secret_backend_crl_config

### DIFF
--- a/vault/resource_pki_secret_backend_crl_config.go
+++ b/vault/resource_pki_secret_backend_crl_config.go
@@ -38,6 +38,36 @@ func pkiSecretBackendCrlConfigResource() *schema.Resource {
 				Optional:    true,
 				Description: "Disables or enables CRL building",
 			},
+			"ocsp_disable": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Disables or enables the OCSP responder.",
+			},
+			"ocsp_expiry": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the OCSP expiry time.",
+			},
+			"auto_rebuild": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Disables or enables the CRL automatic rebuild.",
+			},
+			"auto_rebuild_grace_period": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the CRL automatic require grace period.",
+			},
+			"enable_delta": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Disables or enables the delta CRL.",
+			},
+			"delta_rebuild_interval": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the delta CRL rebuild interval.",
+			},
 		},
 	}
 }
@@ -57,6 +87,24 @@ func pkiSecretBackendCrlConfigCreate(d *schema.ResourceData, meta interface{}) e
 	}
 	if disable, ok := d.GetOk("disable"); ok {
 		data["disable"] = disable
+	}
+	if ocsp_disable, ok := d.GetOk("ocsp_disable"); ok {
+		data["ocsp_disable"] = ocsp_disable
+	}
+	if ocsp_expiry, ok := d.GetOk("ocsp_expiry"); ok {
+		data["ocsp_expiry"] = ocsp_expiry
+	}
+	if auto_rebuild, ok := d.GetOk("auto_rebuild"); ok {
+		data["auto_rebuild"] = auto_rebuild
+	}
+	if auto_rebuild_grace_period, ok := d.GetOk("auto_rebuild_grace_period"); ok {
+		data["auto_rebuild_grace_period"] = auto_rebuild_grace_period
+	}
+	if enable_delta, ok := d.GetOk("enable_delta"); ok {
+		data["enable_delta"] = enable_delta
+	}
+	if delta_rebuild_interval, ok := d.GetOk("delta_rebuild_interval"); ok {
+		data["delta_rebuild_interval"] = delta_rebuild_interval
 	}
 
 	log.Printf("[DEBUG] Creating CRL config on PKI secret backend %q", backend)
@@ -94,6 +142,12 @@ func pkiSecretBackendCrlConfigRead(d *schema.ResourceData, meta interface{}) err
 
 	d.Set("expiry", config.Data["expiry"])
 	d.Set("disable", config.Data["disable"])
+	d.Set("ocsp_disable", config.Data["ocsp_disable"])
+	d.Set("ocsp_expiry", config.Data["ocsp_expiry"])
+	d.Set("auto_rebuild", config.Data["auto_rebuild"])
+	d.Set("auto_rebuild_grace_period", config.Data["auto_rebuild_grace_period"])
+	d.Set("enable_delta", config.Data["enable_delta"])
+	d.Set("delta_rebuild_interval", config.Data["delta_rebuild_interval"])
 
 	return nil
 }
@@ -113,6 +167,24 @@ func pkiSecretBackendCrlConfigUpdate(d *schema.ResourceData, meta interface{}) e
 	}
 	if disable, ok := d.GetOk("disable"); ok {
 		data["disable"] = disable
+	}
+	if ocsp_disable, ok := d.GetOk("ocsp_disable"); ok {
+		data["ocsp_disable"] = ocsp_disable
+	}
+	if ocsp_expiry, ok := d.GetOk("ocsp_expiry"); ok {
+		data["ocsp_expiry"] = ocsp_expiry
+	}
+	if auto_rebuild, ok := d.GetOk("auto_rebuild"); ok {
+		data["auto_rebuild"] = auto_rebuild
+	}
+	if auto_rebuild_grace_period, ok := d.GetOk("auto_rebuild_grace_period"); ok {
+		data["auto_rebuild_grace_period"] = auto_rebuild_grace_period
+	}
+	if enable_delta, ok := d.GetOk("enable_delta"); ok {
+		data["enable_delta"] = enable_delta
+	}
+	if delta_rebuild_interval, ok := d.GetOk("delta_rebuild_interval"); ok {
+		data["delta_rebuild_interval"] = delta_rebuild_interval
 	}
 
 	log.Printf("[DEBUG] Updating CRL config on PKI secret backend %q", backend)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add Vault 1.12 PKI crl settings to pki_secret_backend_crl_config
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
