### PR TITLE
Update PR "Add Basic Constraints attribute to vault_pki_secret_backend_intermediate_cert_request"

### DIFF
--- a/vault/resource_pki_secret_backend_intermediate_cert_request.go
+++ b/vault/resource_pki_secret_backend_intermediate_cert_request.go
@@ -185,7 +185,7 @@ func pkiSecretBackendIntermediateCertRequestResource() *schema.Resource {
 			},
 			"add_basic_constraints": {
 				Type:        schema.TypeBool,
-				Description: "Whether to add a Basic Constraints extension with CA: true",
+				Description: "Set 'CA: true' in basic constraints to the CSR to allow signing with ADCS.",
 				ForceNew:    true,
 				Default:     false,
 				Optional:    true,

--- a/vault/resource_pki_secret_backend_intermediate_cert_request.go
+++ b/vault/resource_pki_secret_backend_intermediate_cert_request.go
@@ -183,6 +183,13 @@ func pkiSecretBackendIntermediateCertRequestResource() *schema.Resource {
 				ForceNew:      true,
 				ConflictsWith: []string{"managed_key_name"},
 			},
+			"add_basic_constraints": {
+				Type:        schema.TypeBool,
+				Description: "Whether to add a Basic Constraints extension with CA: true",
+				ForceNew:    true,
+				Default:     false,
+				Optional:    true,
+			},
 		},
 	}
 }
@@ -223,19 +230,20 @@ func pkiSecretBackendIntermediateCertRequestCreate(ctx context.Context, d *schem
 	}
 
 	data := map[string]interface{}{
-		"common_name":          d.Get("common_name").(string),
-		"format":               d.Get("format").(string),
-		"private_key_format":   d.Get("private_key_format").(string),
-		"exclude_cn_from_sans": d.Get("exclude_cn_from_sans").(bool),
-		"ou":                   d.Get("ou").(string),
-		"organization":         d.Get("organization").(string),
-		"country":              d.Get("country").(string),
-		"locality":             d.Get("locality").(string),
-		"province":             d.Get("province").(string),
-		"street_address":       d.Get("street_address").(string),
-		"postal_code":          d.Get("postal_code").(string),
-		"managed_key_name":     d.Get("managed_key_name").(string),
-		"managed_key_id":       d.Get("managed_key_id").(string),
+		"common_name":           d.Get("common_name").(string),
+		"format":                d.Get("format").(string),
+		"private_key_format":    d.Get("private_key_format").(string),
+		"exclude_cn_from_sans":  d.Get("exclude_cn_from_sans").(bool),
+		"ou":                    d.Get("ou").(string),
+		"organization":          d.Get("organization").(string),
+		"country":               d.Get("country").(string),
+		"locality":              d.Get("locality").(string),
+		"province":              d.Get("province").(string),
+		"street_address":        d.Get("street_address").(string),
+		"postal_code":           d.Get("postal_code").(string),
+		"managed_key_name":      d.Get("managed_key_name").(string),
+		"managed_key_id":        d.Get("managed_key_id").(string),
+		"add_basic_constraints": d.Get("add_basic_constraints").(bool),
 	}
 
 	if intermediateType != "kms" {

--- a/vault/resource_pki_secret_backend_intermediate_cert_request.go
+++ b/vault/resource_pki_secret_backend_intermediate_cert_request.go
@@ -184,11 +184,12 @@ func pkiSecretBackendIntermediateCertRequestResource() *schema.Resource {
 				ConflictsWith: []string{"managed_key_name"},
 			},
 			"add_basic_constraints": {
-				Type:        schema.TypeBool,
-				Description: "Set 'CA: true' in basic constraints to the CSR to allow signing with ADCS.",
-				ForceNew:    true,
-				Default:     false,
-				Optional:    true,
+				Type: schema.TypeBool,
+				Description: `Set 'CA: true' in a Basic Constraints extension. Only needed as
+a workaround in some compatibility scenarios with Active Directory Certificate Services.`,
+				ForceNew: true,
+				Default:  false,
+				Optional: true,
 			},
 		},
 	}

--- a/vault/resource_pki_secret_backend_intermediate_cert_request_test.go
+++ b/vault/resource_pki_secret_backend_intermediate_cert_request_test.go
@@ -31,11 +31,13 @@ func TestPkiSecretBackendIntermediateCertRequest_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testPkiSecretBackendIntermediateCertRequestConfig_basic(path, false),
-				Check:  resource.ComposeTestCheckFunc(testCheckFunc...),
+				Check: resource.ComposeTestCheckFunc(append(testCheckFunc,
+					resource.TestCheckResourceAttr(resourceName, "add_basic_constraints", "false"))...),
 			},
 			{
 				Config: testPkiSecretBackendIntermediateCertRequestConfig_basic(path, true),
-				Check:  resource.ComposeTestCheckFunc(testCheckFunc...),
+				Check: resource.ComposeTestCheckFunc(append(testCheckFunc,
+					resource.TestCheckResourceAttr(resourceName, "add_basic_constraints", "true"))...),
 			},
 		},
 	})

--- a/website/docs/r/pki_secret_backend_intermediate_cert_request.html.md
+++ b/website/docs/r/pki_secret_backend_intermediate_cert_request.html.md
@@ -82,6 +82,7 @@ The following arguments are supported:
 * `managed_key_id` - (Optional) The ID of the previously configured managed key. This field is
   required if `type` is `kms` and it conflicts with `managed_key_name`
 
+* `add_basic_constraints` - (Optional) Add CA basic constraints to the CSR to allow signing with ADCS
 
 ## Attributes Reference
 

--- a/website/docs/r/pki_secret_backend_intermediate_cert_request.html.md
+++ b/website/docs/r/pki_secret_backend_intermediate_cert_request.html.md
@@ -82,7 +82,7 @@ The following arguments are supported:
 * `managed_key_id` - (Optional) The ID of the previously configured managed key. This field is
   required if `type` is `kms` and it conflicts with `managed_key_name`
 
-* `add_basic_constraints` - (Optional) Add CA basic constraints to the CSR to allow signing with ADCS
+* `add_basic_constraints` - (Optional) Adds a Basic Constraints extension with 'CA: true'. Only needed as a workaround in some compatibility scenarios with Active Directory Certificate Services.
 
 ## Attributes Reference
 

--- a/website/docs/r/pki_secret_backend_intermediate_cert_request.html.md
+++ b/website/docs/r/pki_secret_backend_intermediate_cert_request.html.md
@@ -82,7 +82,9 @@ The following arguments are supported:
 * `managed_key_id` - (Optional) The ID of the previously configured managed key. This field is
   required if `type` is `kms` and it conflicts with `managed_key_name`
 
-* `add_basic_constraints` - (Optional) Adds a Basic Constraints extension with 'CA: true'. Only needed as a workaround in some compatibility scenarios with Active Directory Certificate Services.
+* `add_basic_constraints` - (Optional) Adds a Basic Constraints extension with 'CA: true'.
+  Only needed as a workaround in some compatibility scenarios with Active Directory
+  Certificate Services
 
 ## Attributes Reference
 


### PR DESCRIPTION
This is a new branch to update the community PR https://github.com/hashicorp/terraform-provider-vault/pull/1160 to resolve merge conflicts and add test coverage. 

Output from acceptance testing:

```
❯ make testacc TESTARGS='-run=^TestPki -count=1'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -run=^TestPki -count=1 -timeout 30m ./...
ok      github.com/hashicorp/terraform-provider-vault/vault     58.566s
```

```release-note
Improvement: `vault_pki_secret_backend_intermediate_cert_request` resource to include the `add_basic_constraints` argument. This adds extensions required when signing intermediate CSRs by Microsoft AD CS Root Authorities.
```

Relates #1160