### PR TITLE
Support allowed_domains_template on ssh_secret_backend_role. Fixes hashicorp#1675

### DIFF
--- a/vault/resource_ssh_secret_backend_role.go
+++ b/vault/resource_ssh_secret_backend_role.go
@@ -67,6 +67,11 @@ func sshSecretBackendRoleResource() *schema.Resource {
 			Type:     schema.TypeString,
 			Optional: true,
 		},
+		"allowed_domains_template": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Computed: true,
+		},
 		"allowed_domains": {
 			Type:     schema.TypeString,
 			Optional: true,
@@ -203,12 +208,13 @@ func sshSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) error {
 	path := sshRoleResourcePath(backend, name)
 
 	data := map[string]interface{}{
-		"key_type":                d.Get("key_type").(string),
-		"allow_bare_domains":      d.Get("allow_bare_domains").(bool),
-		"allow_host_certificates": d.Get("allow_host_certificates").(bool),
-		"allow_subdomains":        d.Get("allow_subdomains").(bool),
-		"allow_user_certificates": d.Get("allow_user_certificates").(bool),
-		"allow_user_key_ids":      d.Get("allow_user_key_ids").(bool),
+		"key_type":                 d.Get("key_type").(string),
+		"allow_bare_domains":       d.Get("allow_bare_domains").(bool),
+		"allow_host_certificates":  d.Get("allow_host_certificates").(bool),
+		"allow_subdomains":         d.Get("allow_subdomains").(bool),
+		"allow_user_certificates":  d.Get("allow_user_certificates").(bool),
+		"allow_user_key_ids":       d.Get("allow_user_key_ids").(bool),
+		"allowed_domains_template": d.Get("allowed_domains_template").(bool),
 	}
 
 	if v, ok := d.GetOk("allowed_critical_options"); ok {
@@ -360,7 +366,7 @@ func sshSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 	fields := []string{
 		"key_type", "allow_bare_domains", "allow_host_certificates",
 		"allow_subdomains", "allow_user_certificates", "allow_user_key_ids",
-		"allowed_critical_options", "allowed_domains",
+		"allowed_critical_options", "allowed_domains_template", "allowed_domains",
 		"cidr_list", "allowed_extensions", "default_extensions",
 		"default_critical_options", "allowed_users_template",
 		"allowed_users", "default_user", "key_id_format",

--- a/vault/resource_ssh_secret_backend_role_test.go
+++ b/vault/resource_ssh_secret_backend_role_test.go
@@ -32,6 +32,7 @@ func TestAccSSHSecretBackendRole(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceName, "allow_user_certificates", "true"),
 		resource.TestCheckResourceAttr(resourceName, "allow_user_key_ids", "false"),
 		resource.TestCheckResourceAttr(resourceName, "allowed_critical_options", ""),
+		resource.TestCheckResourceAttr(resourceName, "allowed_domains_template", "false"),
 		resource.TestCheckResourceAttr(resourceName, "allowed_domains", ""),
 		resource.TestCheckResourceAttr(resourceName, "allowed_extensions", ""),
 		resource.TestCheckResourceAttr(resourceName, "default_extensions.%", "0"),
@@ -54,6 +55,7 @@ func TestAccSSHSecretBackendRole(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceName, "allow_user_certificates", "false"),
 		resource.TestCheckResourceAttr(resourceName, "allow_user_key_ids", "true"),
 		resource.TestCheckResourceAttr(resourceName, "allowed_critical_options", "foo,bar"),
+		resource.TestCheckResourceAttr(resourceName, "allowed_domains_template", "true"),
 		resource.TestCheckResourceAttr(resourceName, "allowed_domains", "example.com,foo.com"),
 		resource.TestCheckResourceAttr(resourceName, "allowed_extensions", "ext1,ext2"),
 		resource.TestCheckResourceAttr(resourceName, "default_extensions.ext1", ""),
@@ -215,6 +217,7 @@ resource "vault_ssh_secret_backend_role" "test_role" {
   allow_user_certificates  = false
   allow_user_key_ids       = true
   allowed_critical_options = "foo,bar"
+  allowed_domains_template = true
   allowed_domains          = "example.com,foo.com"
   allowed_extensions       = "ext1,ext2"
   default_extensions       = { "ext1" = "" }

--- a/website/docs/r/ssh_secret_backend_role.html.md
+++ b/website/docs/r/ssh_secret_backend_role.html.md
@@ -62,7 +62,8 @@ The following arguments are supported:
 
 * `allowed_critical_options` - (Optional) Specifies a comma-separated list of critical options that certificates can have when signed.
 
-* `allowed_domains_template` - (Optional) Specifies if `allowed_domains` can be declared using identity template policies. Non-templated domains are also permitted.
+* `allowed_domains_template` - (Optional) Specifies if `allowed_domains` can be declared using
+  identity template policies. Non-templated domains are also permitted.
 
 * `allowed_domains` - (Optional) The list of domains for which a client can request a host certificate.
 

--- a/website/docs/r/ssh_secret_backend_role.html.md
+++ b/website/docs/r/ssh_secret_backend_role.html.md
@@ -62,6 +62,8 @@ The following arguments are supported:
 
 * `allowed_critical_options` - (Optional) Specifies a comma-separated list of critical options that certificates can have when signed.
 
+* `allowed_domains_template` - (Optional) Specifies if `allowed_domains` can be declared using identity template policies. Non-templated domains are also permitted.
+
 * `allowed_domains` - (Optional) The list of domains for which a client can request a host certificate.
 
 * `cidr_list` - (Optional) The comma-separated string of CIDR blocks for which this role is applicable.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-vault/issues/1675

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Support allowed_domains_template on ssh_secret_backend_role. Fixes hashicorp#1675
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
[...]
?   	github.com/hashicorp/terraform-provider-vault	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/generate	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/codegen	0.011s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/generated	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode	0.050s [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode	0.074s [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet	0.068s [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role	0.050s [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template	0.047s [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation	0.065s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/helper	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/consts	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/internal/identity/entity	0.047s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/group	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/mfa	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/pki	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/internal/provider	0.059s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/schema	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/testutil	0.024s [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/util	0.025s [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/vault	11.125s
```
