### PR TITLE
fix KVv2 data source when specifying a version

### DIFF
--- a/vault/data_source_kv_secret_v2_test.go
+++ b/vault/data_source_kv_secret_v2_test.go
@@ -37,6 +37,21 @@ func TestDataSourceKVV2Secret(t *testing.T) {
 					testutil.CheckJSONData(resourceName, consts.FieldDataJSON, expectedSubkeys),
 				),
 			},
+			{
+				Config: testDataSourceKVV2SecretWithVersionConfig(mount, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldMount, mount),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldName, name),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, fmt.Sprintf("%s/data/%s", mount, name)),
+					resource.TestCheckResourceAttr(resourceName, "destroyed", "false"),
+					resource.TestCheckResourceAttr(resourceName, "data.%", "4"),
+					resource.TestCheckResourceAttr(resourceName, "data.zip", "zap"),
+					resource.TestCheckResourceAttr(resourceName, "data.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "data.test", "false"),
+					resource.TestCheckResourceAttr(resourceName, "data.baz", "{\"riff\":\"raff\"}"),
+					testutil.CheckJSONData(resourceName, consts.FieldDataJSON, expectedSubkeys),
+				),
+			},
 		},
 	})
 }
@@ -65,5 +80,33 @@ resource "vault_kv_secret_v2" "test" {
 data "vault_kv_secret_v2" "test" {
   mount = vault_mount.kvv2.path
   name  = vault_kv_secret_v2.test.name
+}`, kvV2MountConfig(mount), name)
+}
+
+func testDataSourceKVV2SecretWithVersionConfig(mount, name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "vault_kv_secret_v2" "test" {
+  mount                      = vault_mount.kvv2.path
+  name                       = "%s"
+  cas                        = 1
+  delete_all_versions        = true
+  data_json                  = jsonencode(
+  {
+      zip  = "zap",
+      foo  = "bar",
+      test = false
+      baz = {
+          riff = "raff"
+        }
+  }
+  )
+}
+
+data "vault_kv_secret_v2" "test" {
+  mount = vault_mount.kvv2.path
+  name  = vault_kv_secret_v2.test.name
+  version = 1
 }`, kvV2MountConfig(mount), name)
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-vault/issues/1612 by using ReadWithData instead of using `?version=` in path with Read leading to a bad URL encoding when request is submitted to Vault.