### PR TITLE
Set AWS credentials sensitive

### DIFF
--- a/vault/data_source_aws_access_credentials.go
+++ b/vault/data_source_aws_access_credentials.go
@@ -80,12 +80,14 @@ func awsAccessCredentialsDataSource() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "AWS access key ID read from Vault.",
+				Sensitive:   true,
 			},
 
 			"secret_key": {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "AWS secret key read from Vault.",
+				Sensitive:   true,
 			},
 
 			"security_token": {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Set AWS credentials as `sensitive`
```

This will mark AWS Credentials as `sensitive` such that Terraform tools like `Atlantis` will not reveal new AWS credentials in github conversations. It has been raised in [issue1537](https://github.com/hashicorp/terraform-provider-vault/issues/1537). 

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
