### PR TITLE
Fix parameters for user created within vault_okta_auth_backend resource

### DIFF
--- a/website/docs/r/okta_auth_backend.html.md
+++ b/website/docs/r/okta_auth_backend.html.md
@@ -76,9 +76,9 @@ If this is not supplied only locally configured groups will be enabled.
 
 ### Okta User
 
-* `username` - (Required Optional) Name of the user within Okta
+* `username` - (Required) Name of the user within Okta
 
-* `groups` - (Optional) List of Okta groups to associate with this user
+* `groups` - (Required) List of Okta groups to associate with this user
 
 * `policies` - (Optional) List of Vault policies to associate with this user
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->
### Community Note
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

Defining an Okta User within the `vault_okta_auth_backend` resource block (as opposed to as a separate resource okta_auth_backend_user) requires a `groups` parameter (even if it's an empty array). Also the username parameter is required (currently reads as `Required Optional`.

Example:
```
resource "vault_okta_auth_backend" "example1" {
  # namespace = "max"
  base_url = "okta.com"
  organization = $OKTA_ORG
  token = $VAULT_TOKEN

    user {
        username = "test@testing.com"
        policies   = ["admin"]
    }
}

➜  vault-provider tf apply
╷
│ Error: Missing required argument
│
│   with vault_okta_auth_backend.example1,
│   on main.tf line 13, in resource "vault_okta_auth_backend" "example1":
│   13: resource "vault_okta_auth_backend" "example1" {
│
│ The argument "user.0.groups" is required, but no definition was found.
```