### PR TITLE
Docs: improve bound_audiences documentation for jwt role

### DIFF
--- a/website/docs/r/jwt_auth_backend_role.html.md
+++ b/website/docs/r/jwt_auth_backend_role.html.md
@@ -67,8 +67,9 @@ The following arguments are supported:
 
 * `role_type` - (Optional) Type of role, either "oidc" (default) or "jwt".
 
-* `bound_audiences` - (Required for roles of type `jwt`, optional for roles of
-  type `oidc`) List of `aud` claims to match against. Any match is sufficient.
+* `bound_audiences` - (For "jwt" roles, at least one of `bound_audiences`, `bound_subject`, `bound_claims`
+  or `token_bound_cidrs` is required. Optional for "oidc" roles.) List of `aud` claims to match against.
+  Any match is sufficient.
 
 * `user_claim` - (Required) The claim to use to uniquely identify
   the user; this will be used as the name for the Identity entity alias created


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates hashicorp/vault#18264

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Docs: improve bound_audiences documentation for jwt role
```

Please let me know if there's anything else I should change. I believe it's supposed to have the same wording as [vault's documentation](https://github.com/hashicorp/vault/pull/18265/files)
