### PR TITLE
Ensure that vault_kv_secret_backend_v2's mount is correctly imported

### DIFF
--- a/vault/resource_kv_secret_backend_v2.go
+++ b/vault/resource_kv_secret_backend_v2.go
@@ -3,6 +3,7 @@ package vault
 import (
 	"context"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -101,6 +102,13 @@ func kvSecretBackendV2Read(_ context.Context, d *schema.ResourceData, meta inter
 	configFields := []string{"max_versions", "cas_required"}
 	for _, k := range configFields {
 		if err := d.Set(k, config.Data[k]); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if _, ok := d.GetOk(consts.FieldMount); !ok {
+		// ensure that mount is set on import
+		if err := d.Set(consts.FieldMount, strings.TrimRight(path, "/config")); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/vault/resource_kv_secret_backend_v2_test.go
+++ b/vault/resource_kv_secret_backend_v2_test.go
@@ -38,10 +38,9 @@ func TestAccKVSecretBackendV2(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"mount"},
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/website/docs/d/kv_secret_v2.html.md
+++ b/website/docs/d/kv_secret_v2.html.md
@@ -31,22 +31,22 @@ resource "vault_mount" "kvv2" {
   description = "KV Version 2 secret engine mount"
 }
 
-resource "vault_kv_secret_v2" "secret" {
-  mount                      = vault_mount.kvv2.path
-  name                       = "secret"
-  cas                        = 1
-  delete_all_versions        = true
-  data_json                  = jsonencode(
-  {
-    zip       = "zap",
-    foo       = "bar"
-  }
+resource "vault_kv_secret_v2" "example" {
+  mount               = vault_mount.kvv2.path
+  name                = "secret"
+  cas                 = 1
+  delete_all_versions = true
+  data_json = jsonencode(
+    {
+      zip = "zap",
+      foo = "bar"
+    }
   )
 }
 
-data "vault_kv_secret_v2" "secret_data" {
+data "vault_kv_secret_v2" "example" {
   mount = vault_mount.kvv2.path
-  name  = vault_kv_secret_v2.test.name
+  name  = vault_kv_secret_v2.example.name
 }
 ```
 

--- a/website/docs/r/kv_secret_backend_v2.html.md
+++ b/website/docs/r/kv_secret_backend_v2.html.md
@@ -7,7 +7,7 @@ description: |-
   every key in the key-value store.
 ---
 
-# vault\_kv\_secret\_v2
+# vault\_kv\_secret\_backend\_v2
 
 Configures KV-V2 backend level settings that are applied to
 every key in the key-value store.


### PR DESCRIPTION
When importing a`vault_kv_secret_backend_v2` the `mount` field was not being set. The value for the `mount` can be derived from the provided `path`. This PR should resolve that issue.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1698 #1691

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->
