### PR TITLE
Add parameter allowed_metadata_extensions to resource vault_cert_auth

### DIFF
--- a/vault/resource_cert_auth_backend_role.go
+++ b/vault/resource_cert_auth_backend_role.go
@@ -94,6 +94,14 @@ func certAuthBackendRoleResource() *schema.Resource {
 			Optional: true,
 			Computed: true,
 		},
+		"allowed_metadata_extensions": {
+			Type:        schema.TypeSet,
+			Optional:    true,
+			Description: "A array of oid extensions. Upon successful authentication, these extensions will be added as metadata if they are present in the certificate.",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
 		"backend": {
 			Type:     schema.TypeString,
 			Optional: true,
@@ -150,6 +158,10 @@ func certAuthResourceWrite(ctx context.Context, d *schema.ResourceData, meta int
 		data["allowed_dns_sans"] = v.(*schema.Set).List()
 	}
 
+	if v, ok := d.GetOk("allowed_metadata_extensions"); ok {
+		data["allowed_metadata_extensions"] = v.(*schema.Set).List()
+	}
+
 	if v, ok := d.GetOk("allowed_uri_sans"); ok {
 		data["allowed_uri_sans"] = v.(*schema.Set).List()
 	}
@@ -204,6 +216,10 @@ func certAuthResourceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 
 	if v, ok := d.GetOk("allowed_uri_sans"); ok {
 		data["allowed_uri_sans"] = v.(*schema.Set).List()
+	}
+
+	if d.HasChange("allowed_metadata_extensions") {
+		data["allowed_metadata_extensions"] = d.Get("allowed_metadata_extensions").(*schema.Set).List()
 	}
 
 	if d.HasChange("allowed_organizational_units") {
@@ -306,6 +322,17 @@ func certAuthResourceRead(_ context.Context, d *schema.ResourceData, meta interf
 				schema.HashString, resp.Data["required_extensions"].([]interface{})))
 	} else {
 		d.Set("required_extensions",
+			schema.NewSet(
+				schema.HashString, []interface{}{}))
+	}
+
+	// Vault sometimes returns these as null instead of an empty list.
+	if resp.Data["allowed_metadata_extensions"] != nil {
+		d.Set("allowed_metadata_extensions",
+			schema.NewSet(
+				schema.HashString, resp.Data["allowed_metadata_extensions"].([]interface{})))
+	} else {
+		d.Set("allowed_metadata_extensions",
 			schema.NewSet(
 				schema.HashString, []interface{}{}))
 	}

--- a/vault/resource_cert_auth_backend_role_test.go
+++ b/vault/resource_cert_auth_backend_role_test.go
@@ -77,6 +77,11 @@ func TestCertAuthBackend(t *testing.T) {
 
 	allowedOrgUnits := []string{"foo", "baz"}
 
+	allowedMetadataExtensions := []string{
+		"1.3.6.1.4.1.34380.1.2.1",
+		"1.3.6.1.4.1.34380.1.2.2",
+	}
+
 	resourceName := "vault_cert_auth_backend_role.test"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
@@ -84,7 +89,7 @@ func TestCertAuthBackend(t *testing.T) {
 		CheckDestroy: testCertAuthBackendDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testCertAuthBackendConfig_basic(backend, name, testCertificate, allowedNames, allowedOrgUnits),
+				Config: testCertAuthBackendConfig_basic(backend, name, testCertificate, allowedNames, allowedOrgUnits, allowedMetadataExtensions),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "backend", backend),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
@@ -95,6 +100,9 @@ func TestCertAuthBackend(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "allowed_organizational_units.#", "2"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "allowed_organizational_units.*", "foo"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "allowed_organizational_units.*", "baz"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_organizational_units.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_metadata_extensions.0", "1.3.6.1.4.1.34380.1.2.1"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_metadata_extensions.1", "1.3.6.1.4.1.34380.1.2.2"),
 					testCertAuthBackendCheck_attrs(resourceName, backend, name),
 				),
 			},
@@ -108,6 +116,7 @@ func TestCertAuthBackend(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "token_max_ttl", "0"),
 					resource.TestCheckResourceAttr(resourceName, "allowed_names.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "allowed_organizational_units.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_metadata_extensions.#", "0"),
 					testCertAuthBackendCheck_attrs(resourceName, backend, name),
 				),
 			},
@@ -177,6 +186,7 @@ func testCertAuthBackendCheck_attrs(resourceName, backend, name string) resource
 			"allowed_email_sans":           "allowed_email_sans",
 			"allowed_uri_sans":             "allowed_uri_sans",
 			"allowed_organizational_units": "allowed_organizational_units",
+			"allowed_metadata_extensions":  "allowed_metadata_extensions",
 			"required_extensions":          "required_extensions",
 			"certificate":                  "certificate",
 		}
@@ -193,7 +203,7 @@ func testCertAuthBackendCheck_attrs(resourceName, backend, name string) resource
 				VaultAttr:    v,
 			}
 			switch k {
-			case TokenFieldPolicies, "allowed_names", "allowed_organizational_units":
+			case TokenFieldPolicies, "allowed_names", "allowed_organizational_units", "allowed_metadata_extensions":
 				ta.AsSet = true
 			}
 
@@ -204,7 +214,7 @@ func testCertAuthBackendCheck_attrs(resourceName, backend, name string) resource
 	}
 }
 
-func testCertAuthBackendConfig_basic(backend, name, certificate string, allowedNames, allowedOrgUnits []string) string {
+func testCertAuthBackendConfig_basic(backend, name, certificate string, allowedNames, allowedOrgUnits []string, allowedMetadataExtensions []string) string {
 	config := fmt.Sprintf(`
 
 resource "vault_auth_backend" "cert" {
@@ -223,8 +233,9 @@ EOF
     token_max_ttl                = 600
     token_policies               = ["test_policy_1", "test_policy_2"]
     allowed_organizational_units = %s
+    allowed_metadata_extensions  = %s
 }
-`, backend, name, certificate, util.ArrayToTerraformList(allowedNames), util.ArrayToTerraformList(allowedOrgUnits))
+`, backend, name, certificate, util.ArrayToTerraformList(allowedNames), util.ArrayToTerraformList(allowedOrgUnits), util.ArrayToTerraformList(allowedMetadataExtensions))
 
 	return config
 }


### PR DESCRIPTION
…_backend_role

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes https://github.com/hashicorp/terraform-provider-vault/issues/1696

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
- Add parameter "allowed_metadata_extensions" to resource "vault_cert_auth_backend_role"
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestCertAuthBackendConfig'
ok  	github.com/hashicorp/terraform-provider-vault/vault	3.344s
...
```
