### PR TITLE
Add parameters to resource vault_pki_secret_backend_crl_config

### DIFF
--- a/vault/resource_pki_secret_backend_crl_config.go
+++ b/vault/resource_pki_secret_backend_crl_config.go
@@ -38,6 +38,39 @@ func pkiSecretBackendCrlConfigResource() *schema.Resource {
 				Optional:    true,
 				Description: "Disables or enables CRL building",
 			},
+			"ocsp_disable": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Disables or enables the OCSP responder in Vault.",
+			},
+			"ocsp_expiry": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The amount of time an OCSP response can be cached for, (controls the NextUpdate field), useful for OCSP stapling refresh durations.",
+				Default:     "12h",
+			},
+			"auto_rebuild": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Enables or disables periodic rebuilding of the CRL upon expiry.",
+			},
+			"auto_rebuild_grace_period": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Grace period before CRL expiry to attempt rebuild of CRL.",
+				Default:     "12h",
+			},
+			"enable_delta": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Enables or disables building of delta CRLs with up-to-date revocation information, augmenting the last complete CRL.",
+			},
+			"delta_rebuild_interval": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Interval to check for new revocations on, to regenerate the delta CRL.",
+				Default:     "15m",
+			},
 		},
 	}
 }
@@ -57,6 +90,24 @@ func pkiSecretBackendCrlConfigCreate(d *schema.ResourceData, meta interface{}) e
 	}
 	if disable, ok := d.GetOk("disable"); ok {
 		data["disable"] = disable
+	}
+	if ocsp_disable, ok := d.GetOk("ocsp_disable"); ok {
+		data["ocsp_disable"] = ocsp_disable
+	}
+	if ocsp_expiry, ok := d.GetOk("ocsp_expiry"); ok {
+		data["ocsp_expiry"] = ocsp_expiry
+	}
+	if auto_rebuild, ok := d.GetOk("auto_rebuild"); ok {
+		data["auto_rebuild"] = auto_rebuild
+	}
+	if auto_rebuild_grace_period, ok := d.GetOk("auto_rebuild_grace_period"); ok {
+		data["auto_rebuild_grace_period"] = auto_rebuild_grace_period
+	}
+	if enable_delta, ok := d.GetOk("enable_delta"); ok {
+		data["enable_delta"] = enable_delta
+	}
+	if delta_rebuild_interval, ok := d.GetOk("delta_rebuild_interval"); ok {
+		data["delta_rebuild_interval"] = delta_rebuild_interval
 	}
 
 	log.Printf("[DEBUG] Creating CRL config on PKI secret backend %q", backend)
@@ -94,6 +145,12 @@ func pkiSecretBackendCrlConfigRead(d *schema.ResourceData, meta interface{}) err
 
 	d.Set("expiry", config.Data["expiry"])
 	d.Set("disable", config.Data["disable"])
+	d.Set("ocsp_disable", config.Data["ocsp_disable"])
+	d.Set("ocsp_expiry", config.Data["ocsp_expiry"])
+	d.Set("auto_rebuild", config.Data["auto_rebuild"])
+	d.Set("auto_rebuild_grace_period", config.Data["auto_rebuild_grace_period"])
+	d.Set("enable_delta", config.Data["enable_delta"])
+	d.Set("delta_rebuild_interval", config.Data["delta_rebuild_interval"])
 
 	return nil
 }
@@ -113,6 +170,24 @@ func pkiSecretBackendCrlConfigUpdate(d *schema.ResourceData, meta interface{}) e
 	}
 	if disable, ok := d.GetOk("disable"); ok {
 		data["disable"] = disable
+	}
+	if ocsp_disable, ok := d.GetOk("ocsp_disable"); ok {
+		data["ocsp_disable"] = ocsp_disable
+	}
+	if ocsp_expiry, ok := d.GetOk("ocsp_expiry"); ok {
+		data["ocsp_expiry"] = ocsp_expiry
+	}
+	if auto_rebuild, ok := d.GetOk("auto_rebuild"); ok {
+		data["auto_rebuild"] = auto_rebuild
+	}
+	if auto_rebuild_grace_period, ok := d.GetOk("auto_rebuild_grace_period"); ok {
+		data["auto_rebuild_grace_period"] = auto_rebuild_grace_period
+	}
+	if enable_delta, ok := d.GetOk("enable_delta"); ok {
+		data["enable_delta"] = enable_delta
+	}
+	if delta_rebuild_interval, ok := d.GetOk("delta_rebuild_interval"); ok {
+		data["delta_rebuild_interval"] = delta_rebuild_interval
 	}
 
 	log.Printf("[DEBUG] Updating CRL config on PKI secret backend %q", backend)

--- a/vault/resource_pki_secret_backend_crl_config.go
+++ b/vault/resource_pki_secret_backend_crl_config.go
@@ -35,22 +35,26 @@ func pkiSecretBackendCrlConfigResource() *schema.Resource {
 			},
 			"disable": {
 				Type:        schema.TypeBool,
+				Default:     false,
 				Optional:    true,
 				Description: "Disables or enables CRL building",
 			},
 			"ocsp_disable": {
 				Type:        schema.TypeBool,
+				Default:     false,
 				Optional:    true,
 				Description: "Disables or enables the OCSP responder in Vault.",
 			},
 			"ocsp_expiry": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "The amount of time an OCSP response can be cached for, (controls the NextUpdate field), useful for OCSP stapling refresh durations.",
-				Default:     "12h",
+				Type:     schema.TypeString,
+				Optional: true,
+				Description: "The amount of time an OCSP response can be cached for, " +
+					"useful for OCSP stapling refresh durations.",
+				Computed: true,
 			},
 			"auto_rebuild": {
 				Type:        schema.TypeBool,
+				Default:     false,
 				Optional:    true,
 				Description: "Enables or disables periodic rebuilding of the CRL upon expiry.",
 			},
@@ -58,18 +62,20 @@ func pkiSecretBackendCrlConfigResource() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Grace period before CRL expiry to attempt rebuild of CRL.",
-				Default:     "12h",
+				Computed:    true,
 			},
 			"enable_delta": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: "Enables or disables building of delta CRLs with up-to-date revocation information, augmenting the last complete CRL.",
+				Type:     schema.TypeBool,
+				Default:  false,
+				Optional: true,
+				Description: "Enables or disables building of delta CRLs with up-to-date revocation " +
+					"information, augmenting the last complete CRL.",
 			},
 			"delta_rebuild_interval": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Interval to check for new revocations on, to regenerate the delta CRL.",
-				Default:     "15m",
+				Computed:    true,
 			},
 		},
 	}
@@ -91,23 +97,23 @@ func pkiSecretBackendCrlConfigCreate(d *schema.ResourceData, meta interface{}) e
 	if disable, ok := d.GetOk("disable"); ok {
 		data["disable"] = disable
 	}
-	if ocsp_disable, ok := d.GetOk("ocsp_disable"); ok {
-		data["ocsp_disable"] = ocsp_disable
+	if ocspDisable, ok := d.GetOk("ocsp_disable"); ok {
+		data["ocsp_disable"] = ocspDisable
 	}
-	if ocsp_expiry, ok := d.GetOk("ocsp_expiry"); ok {
-		data["ocsp_expiry"] = ocsp_expiry
+	if ocspExpiry, ok := d.GetOk("ocsp_expiry"); ok {
+		data["ocsp_expiry"] = ocspExpiry
 	}
-	if auto_rebuild, ok := d.GetOk("auto_rebuild"); ok {
-		data["auto_rebuild"] = auto_rebuild
+	if autoRebuild, ok := d.GetOk("auto_rebuild"); ok {
+		data["auto_rebuild"] = autoRebuild
 	}
-	if auto_rebuild_grace_period, ok := d.GetOk("auto_rebuild_grace_period"); ok {
-		data["auto_rebuild_grace_period"] = auto_rebuild_grace_period
+	if autoRebuildGracePeriod, ok := d.GetOk("auto_rebuild_grace_period"); ok {
+		data["auto_rebuild_grace_period"] = autoRebuildGracePeriod
 	}
-	if enable_delta, ok := d.GetOk("enable_delta"); ok {
-		data["enable_delta"] = enable_delta
+	if enableDelta, ok := d.GetOk("enable_delta"); ok {
+		data["enable_delta"] = enableDelta
 	}
-	if delta_rebuild_interval, ok := d.GetOk("delta_rebuild_interval"); ok {
-		data["delta_rebuild_interval"] = delta_rebuild_interval
+	if deltaRebuildInterval, ok := d.GetOk("delta_rebuild_interval"); ok {
+		data["delta_rebuild_interval"] = deltaRebuildInterval
 	}
 
 	log.Printf("[DEBUG] Creating CRL config on PKI secret backend %q", backend)
@@ -171,23 +177,23 @@ func pkiSecretBackendCrlConfigUpdate(d *schema.ResourceData, meta interface{}) e
 	if disable, ok := d.GetOk("disable"); ok {
 		data["disable"] = disable
 	}
-	if ocsp_disable, ok := d.GetOk("ocsp_disable"); ok {
-		data["ocsp_disable"] = ocsp_disable
+	if ocspDisable, ok := d.GetOk("ocsp_disable"); ok {
+		data["ocsp_disable"] = ocspDisable
 	}
-	if ocsp_expiry, ok := d.GetOk("ocsp_expiry"); ok {
-		data["ocsp_expiry"] = ocsp_expiry
+	if ocspExpiry, ok := d.GetOk("ocsp_expiry"); ok {
+		data["ocsp_expiry"] = ocspExpiry
 	}
-	if auto_rebuild, ok := d.GetOk("auto_rebuild"); ok {
-		data["auto_rebuild"] = auto_rebuild
+	if autoRebuild, ok := d.GetOk("auto_rebuild"); ok {
+		data["auto_rebuild"] = autoRebuild
 	}
-	if auto_rebuild_grace_period, ok := d.GetOk("auto_rebuild_grace_period"); ok {
-		data["auto_rebuild_grace_period"] = auto_rebuild_grace_period
+	if autoRebuildGracePeriod, ok := d.GetOk("auto_rebuild_grace_period"); ok {
+		data["auto_rebuild_grace_period"] = autoRebuildGracePeriod
 	}
-	if enable_delta, ok := d.GetOk("enable_delta"); ok {
-		data["enable_delta"] = enable_delta
+	if enableDelta, ok := d.GetOk("enable_delta"); ok {
+		data["enable_delta"] = enableDelta
 	}
-	if delta_rebuild_interval, ok := d.GetOk("delta_rebuild_interval"); ok {
-		data["delta_rebuild_interval"] = delta_rebuild_interval
+	if deltaRebuildInterval, ok := d.GetOk("delta_rebuild_interval"); ok {
+		data["delta_rebuild_interval"] = deltaRebuildInterval
 	}
 
 	log.Printf("[DEBUG] Updating CRL config on PKI secret backend %q", backend)

--- a/vault/resource_pki_secret_backend_crl_config_test.go
+++ b/vault/resource_pki_secret_backend_crl_config_test.go
@@ -25,6 +25,12 @@ func TestPkiSecretBackendCrlConfig_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_crl_config.test", "expiry", "72h"),
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_crl_config.test", "disable", "true"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_crl_config.test", "ocsp_disable", "false"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_crl_config.test", "ocsp_expiry", "13h"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_crl_config.test", "auto_rebuild", "true"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_crl_config.test", "auto_rebuild_grace_period", "12h"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_crl_config.test", "enable_delta", "true"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_crl_config.test", "delta_rebuild_interval", "15m"),
 				),
 			},
 		},
@@ -63,6 +69,12 @@ resource "vault_pki_secret_backend_crl_config" "test" {
 
   expiry = "72h"
   disable = true
+  ocsp_disable = false
+  ocsp_expiry = "13h"
+  auto_rebuild = true
+  auto_rebuild_grace_period = "12h"
+  enable_delta = true
+  delta_rebuild_interval = "15m"
 } 
 
 `, rootPath)

--- a/vault/resource_pki_secret_backend_crl_config_test.go
+++ b/vault/resource_pki_secret_backend_crl_config_test.go
@@ -33,18 +33,6 @@ func TestPkiSecretBackendCrlConfig_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_crl_config.test", "delta_rebuild_interval", "15m"),
 				),
 			},
-		},
-	})
-}
-
-func TestPkiSecretBackendCrlConfig_updated(t *testing.T) {
-	rootPath := "pki-root-" + strconv.Itoa(acctest.RandInt())
-
-	resource.Test(t, resource.TestCase{
-		Providers:    testProviders,
-		PreCheck:     func() { testutil.TestAccPreCheck(t) },
-		CheckDestroy: testCheckMountDestroyed("vault_mount", consts.MountTypePKI, consts.FieldPath),
-		Steps: []resource.TestStep{
 			{
 				Config: testPkiSecretBackendCrlConfigConfig_updated(rootPath),
 				Check: resource.ComposeTestCheckFunc(

--- a/vault/resource_pki_secret_backend_crl_config_test.go
+++ b/vault/resource_pki_secret_backend_crl_config_test.go
@@ -26,11 +26,36 @@ func TestPkiSecretBackendCrlConfig_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_crl_config.test", "expiry", "72h"),
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_crl_config.test", "disable", "true"),
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_crl_config.test", "ocsp_disable", "false"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_crl_config.test", "ocsp_expiry", "12h"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_crl_config.test", "auto_rebuild", "false"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_crl_config.test", "auto_rebuild_grace_period", "12h"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_crl_config.test", "enable_delta", "false"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_crl_config.test", "delta_rebuild_interval", "15m"),
+				),
+			},
+		},
+	})
+}
+
+func TestPkiSecretBackendCrlConfig_updated(t *testing.T) {
+	rootPath := "pki-root-" + strconv.Itoa(acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testProviders,
+		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		CheckDestroy: testCheckMountDestroyed("vault_mount", consts.MountTypePKI, consts.FieldPath),
+		Steps: []resource.TestStep{
+			{
+				Config: testPkiSecretBackendCrlConfigConfig_updated(rootPath),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_crl_config.test", "expiry", "72h"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_crl_config.test", "disable", "true"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_crl_config.test", "ocsp_disable", "true"),
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_crl_config.test", "ocsp_expiry", "13h"),
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_crl_config.test", "auto_rebuild", "true"),
-					resource.TestCheckResourceAttr("vault_pki_secret_backend_crl_config.test", "auto_rebuild_grace_period", "12h"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_crl_config.test", "auto_rebuild_grace_period", "14h"),
 					resource.TestCheckResourceAttr("vault_pki_secret_backend_crl_config.test", "enable_delta", "true"),
-					resource.TestCheckResourceAttr("vault_pki_secret_backend_crl_config.test", "delta_rebuild_interval", "15m"),
+					resource.TestCheckResourceAttr("vault_pki_secret_backend_crl_config.test", "delta_rebuild_interval", "30m"),
 				),
 			},
 		},
@@ -69,12 +94,49 @@ resource "vault_pki_secret_backend_crl_config" "test" {
 
   expiry = "72h"
   disable = true
-  ocsp_disable = false
+} 
+
+`, rootPath)
+}
+
+func testPkiSecretBackendCrlConfigConfig_updated(rootPath string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "test-root" {
+  path = "%s"
+  type = "pki"
+  description = "test root"
+  default_lease_ttl_seconds = "8640000"
+  max_lease_ttl_seconds = "8640000"
+}
+
+resource "vault_pki_secret_backend_root_cert" "test-ca" {
+	backend    = vault_mount.test-root.path
+	depends_on = ["vault_mount.test-root"]
+
+	type                 = "internal"
+	common_name          = "test-ca.example.com"
+	ttl                  = "8640000"
+	format               = "pem"
+	private_key_format   = "der"
+	key_type             = "rsa"
+	key_bits             = 4096
+	ou                   = "Test OU"
+	organization         = "ACME Ltd"
+}
+
+resource "vault_pki_secret_backend_crl_config" "test" {
+  depends_on = ["vault_mount.test-root","vault_pki_secret_backend_root_cert.test-ca"]
+
+  backend = vault_mount.test-root.path
+
+  expiry = "72h"
+  disable = true
+  ocsp_disable = true
   ocsp_expiry = "13h"
   auto_rebuild = true
-  auto_rebuild_grace_period = "12h"
+  auto_rebuild_grace_period = "14h"
   enable_delta = true
-  delta_rebuild_interval = "15m"
+  delta_rebuild_interval = "30m"
 } 
 
 `, rootPath)

--- a/website/docs/r/pki_secret_backend_crl_config.html.md
+++ b/website/docs/r/pki_secret_backend_crl_config.html.md
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 * `ocsp_expiry` - (Optional) The amount of time an OCSP response can be cached for, useful for OCSP stapling refresh durations.
 
-* `auto_rebuild` - (Optional) Enables or disables periodic rebuilding of the CRL upon expiry.
+* `auto_rebuild` - (Optional) Enables periodic rebuilding of the CRL upon expiry.
 
 * `auto_rebuild_grace_period` - (Optional) Grace period before CRL expiry to attempt rebuild of CRL.
 

--- a/website/docs/r/pki_secret_backend_crl_config.html.md
+++ b/website/docs/r/pki_secret_backend_crl_config.html.md
@@ -54,7 +54,6 @@ The following arguments are supported:
 
 * `delta_rebuild_interval` - (Optional) Interval to check for new revocations on, to regenerate the delta CRL.
 
-
 ## Attributes Reference
 
 No additional attributes are exported by this resource.

--- a/website/docs/r/pki_secret_backend_crl_config.html.md
+++ b/website/docs/r/pki_secret_backend_crl_config.html.md
@@ -50,7 +50,7 @@ The following arguments are supported:
 
 * `auto_rebuild_grace_period` - (Optional) Grace period before CRL expiry to attempt rebuild of CRL.
 
-* `enable_delta` - (Optional) Enables or disables building of delta CRLs with up-to-date revocation information, augmenting the last complete CRL.
+* `enable_delta` - (Optional) Enables building of delta CRLs with up-to-date revocation information, augmenting the last complete CRL.
 
 * `delta_rebuild_interval` - (Optional) Interval to check for new revocations on, to regenerate the delta CRL.
 

--- a/website/docs/r/pki_secret_backend_crl_config.html.md
+++ b/website/docs/r/pki_secret_backend_crl_config.html.md
@@ -42,6 +42,19 @@ The following arguments are supported:
 
 * `disable` - (Optional) Disables or enables CRL building.
 
+* `ocsp_disable` - (Optional) Disables or enables the OCSP responder in Vault.
+
+* `ocsp_expiry` - (Optional) The amount of time an OCSP response can be cached for, useful for OCSP stapling refresh durations.
+
+* `auto_rebuild` - (Optional) Enables or disables periodic rebuilding of the CRL upon expiry.
+
+* `auto_rebuild_grace_period` - (Optional) Grace period before CRL expiry to attempt rebuild of CRL.
+
+* `enable_delta` - (Optional) Enables or disables building of delta CRLs with up-to-date revocation information, augmenting the last complete CRL.
+
+* `delta_rebuild_interval` - (Optional) Interval to check for new revocations on, to regenerate the delta CRL.
+
+
 ## Attributes Reference
 
 No additional attributes are exported by this resource.

--- a/website/docs/r/pki_secret_backend_crl_config.html.md
+++ b/website/docs/r/pki_secret_backend_crl_config.html.md
@@ -42,7 +42,7 @@ The following arguments are supported:
 
 * `disable` - (Optional) Disables or enables CRL building.
 
-* `ocsp_disable` - (Optional) Disables or enables the OCSP responder in Vault.
+* `ocsp_disable` - (Optional) Disables the OCSP responder in Vault.
 
 * `ocsp_expiry` - (Optional) The amount of time an OCSP response can be cached for, useful for OCSP stapling refresh durations.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes https://github.com/hashicorp/terraform-provider-vault/issues/1696

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
- Add following parameters to resource "vault_pki_secret_backend_crl_config": ocsp_disable, ocsp_expiry, auto_rebuild, auto_rebuild_grace_period, enable_delta, delta_rebuild_interval

```

Output from acceptance testing:

```
make testacc TESTARGS='-run=TestPkiSecretBackendCrlConfig_basic'
ok  	github.com/hashicorp/terraform-provider-vault/vault	4.079s
...
```
