### PR TITLE
Add resource for new GCP impersonated account endpoints

### DIFF
--- a/vault/provider.go
+++ b/vault/provider.go
@@ -482,6 +482,10 @@ var (
 			Resource:      UpdateSchemaResource(gcpSecretBackendResource("vault_gcp_secret_backend")),
 			PathInventory: []string{"/gcp/config"},
 		},
+		"vault_gcp_secret_impersonated_account": {
+			Resource:      UpdateSchemaResource(gcpSecretImpersonatedAccountResource()),
+			PathInventory: []string{"/gcp/impersonated-account/{name}"},
+		},
 		"vault_gcp_secret_roleset": {
 			Resource:      UpdateSchemaResource(gcpSecretRolesetResource()),
 			PathInventory: []string{"/gcp/roleset/{name}"},

--- a/vault/resource_gcp_secret_impersonated_account.go
+++ b/vault/resource_gcp_secret_impersonated_account.go
@@ -1,0 +1,235 @@
+package vault
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+)
+
+var (
+	gcpSecretImpersonatedAccountBackendFromPathRegex = regexp.MustCompile("^(.+)/impersonated-account/.+$")
+	gcpSecretImpersonatedAccountNameFromPathRegex    = regexp.MustCompile("^.+/impersonated-account/(.+)$")
+)
+
+func gcpSecretImpersonatedAccountResource() *schema.Resource {
+	return &schema.Resource{
+		Create: gcpSecretImpersonatedAccountCreate,
+		Read:   gcpSecretImpersonatedAccountRead,
+		Update: gcpSecretImpersonatedAccountUpdate,
+		Delete: gcpSecretImpersonatedAccountDelete,
+		Exists: gcpSecretImpersonatedAccountExists,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"backend": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Path where the GCP secrets engine is mounted.",
+				ForceNew:    true,
+				// standardise on no beginning or trailing slashes
+				StateFunc: func(v interface{}) string {
+					return strings.Trim(v.(string), "/")
+				},
+			},
+			"impersonated_account": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the Impersonated Account to create",
+				ForceNew:    true,
+			},
+			"service_account_email": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Email of the GCP service account.",
+			},
+			"token_scopes": {
+				Type: schema.TypeSet,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Optional:    true,
+				Description: "List of OAuth scopes to assign to `access_token` secrets generated under this impersonated account (`access_token` impersonated accounts only) ",
+			},
+			"service_account_project": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Project of the GCP Service Account managed by this impersonated account",
+			},
+		},
+	}
+}
+
+func gcpSecretImpersonatedAccountCreate(d *schema.ResourceData, meta interface{}) error {
+	client, err := provider.GetClient(d, meta)
+	if err != nil {
+		return err
+	}
+
+	backend := d.Get("backend").(string)
+	impersonatedAccount := d.Get("impersonated_account").(string)
+
+	path := gcpSecretImpersonatedAccountPath(backend, impersonatedAccount)
+
+	log.Printf("[DEBUG] Writing GCP Secrets backend impersonated account %q", path)
+
+	data := map[string]interface{}{}
+	gcpSecretImpersonatedAccountUpdateFields(d, data)
+	d.SetId(path)
+	_, err = client.Logical().Write(path, data)
+	if err != nil {
+		d.SetId("")
+		return fmt.Errorf("error writing GCP Secrets backend impersonated account %q: %s", path, err)
+	}
+	log.Printf("[DEBUG] Wrote GCP Secrets backend impersonated account %q", path)
+
+	return gcpSecretImpersonatedAccountRead(d, meta)
+}
+
+func gcpSecretImpersonatedAccountRead(d *schema.ResourceData, meta interface{}) error {
+	client, err := provider.GetClient(d, meta)
+	if err != nil {
+		return err
+	}
+
+	path := d.Id()
+
+	backend, err := gcpSecretImpersonatedAccountBackendFromPath(path)
+	if err != nil {
+		return fmt.Errorf("invalid path %q for GCP secrets backend impersonated account: %s", path, err)
+	}
+
+	impersonatedAccount, err := gcpSecretImpersonatedAccountNameFromPath(path)
+	if err != nil {
+		return fmt.Errorf("invalid path %q for GCP Secrets backend impersonated account: %s", path, err)
+	}
+
+	log.Printf("[DEBUG] Reading GCP Secrets backend impersonated account %q", path)
+	resp, err := client.Logical().Read(path)
+	if err != nil {
+		return fmt.Errorf("error reading GCP Secrets backend impersonated account %q: %s", path, err)
+	}
+
+	log.Printf("[DEBUG] Read GCP Secrets backend impersonated account %q", path)
+	if resp == nil {
+		log.Printf("[WARN] GCP Secrets backend impersonated account %q not found, removing from state", path)
+		d.SetId("")
+		return nil
+	}
+
+	if err := d.Set("backend", backend); err != nil {
+		return err
+	}
+	if err := d.Set("impersonated_account", impersonatedAccount); err != nil {
+		return err
+	}
+
+	for _, k := range []string{"token_scopes", "service_account_email", "service_account_project"} {
+		v, ok := resp.Data[k]
+		if ok {
+			if err := d.Set(k, v); err != nil {
+				return fmt.Errorf("error reading %s for GCP Secrets backend impersonated account %q: %q", k, path, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func gcpSecretImpersonatedAccountUpdate(d *schema.ResourceData, meta interface{}) error {
+	client, err := provider.GetClient(d, meta)
+	if err != nil {
+		return err
+	}
+
+	path := d.Id()
+
+	data := map[string]interface{}{}
+	gcpSecretImpersonatedAccountUpdateFields(d, data)
+
+	log.Printf("[DEBUG] Updating GCP Secrets backend impersonated account %q", path)
+
+	_, err = client.Logical().Write(path, data)
+	if err != nil {
+		return fmt.Errorf("error updating GCP Secrets backend impersonated account %q: %s", path, err)
+	}
+	log.Printf("[DEBUG] Updated GCP Secrets backend impersonated account %q", path)
+
+	return gcpSecretImpersonatedAccountRead(d, meta)
+}
+
+func gcpSecretImpersonatedAccountDelete(d *schema.ResourceData, meta interface{}) error {
+	client, err := provider.GetClient(d, meta)
+	if err != nil {
+		return err
+	}
+
+	path := d.Id()
+
+	log.Printf("[DEBUG] Deleting GCP secrets backend impersonated account %q", path)
+	_, err = client.Logical().Delete(path)
+	if err != nil {
+		return fmt.Errorf("error deleting GCP secrets backend impersonated account %q", path)
+	}
+	log.Printf("[DEBUG] Deleted GCP secrets backend impersonated account %q", path)
+
+	return nil
+}
+
+func gcpSecretImpersonatedAccountUpdateFields(d *schema.ResourceData, data map[string]interface{}) {
+	if v, ok := d.GetOk("service_account_email"); ok {
+		data["service_account_email"] = v.(string)
+	}
+
+	if v, ok := d.GetOk("token_scopes"); ok {
+		data["token_scopes"] = v.(*schema.Set).List()
+	}
+}
+
+func gcpSecretImpersonatedAccountExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	client, err := provider.GetClient(d, meta)
+	if err != nil {
+		return false, err
+	}
+
+	path := d.Id()
+	log.Printf("[DEBUG] Checking if %q exists", path)
+	secret, err := client.Logical().Read(path)
+	if err != nil {
+		return true, fmt.Errorf("error checking if %q exists: %s", path, err)
+	}
+	log.Printf("[DEBUG] Checked if %q exists", path)
+	return secret != nil, nil
+}
+
+func gcpSecretImpersonatedAccountPath(backend, impersonatedAccount string) string {
+	return strings.Trim(backend, "/") + "/impersonated-account/" + strings.Trim(impersonatedAccount, "/")
+}
+
+func gcpSecretImpersonatedAccountBackendFromPath(path string) (string, error) {
+	if !gcpSecretImpersonatedAccountBackendFromPathRegex.MatchString(path) {
+		return "", fmt.Errorf("no backend found")
+	}
+	res := gcpSecretImpersonatedAccountBackendFromPathRegex.FindStringSubmatch(path)
+	if len(res) != 2 {
+		return "", fmt.Errorf("unexpected number of matches (%d) for backend", len(res))
+	}
+	return res[1], nil
+}
+
+func gcpSecretImpersonatedAccountNameFromPath(path string) (string, error) {
+	if !gcpSecretImpersonatedAccountNameFromPathRegex.MatchString(path) {
+		return "", fmt.Errorf("no impersonated account found")
+	}
+	res := gcpSecretImpersonatedAccountNameFromPathRegex.FindStringSubmatch(path)
+	if len(res) != 2 {
+		return "", fmt.Errorf("unexpected number of matches (%d) for role", len(res))
+	}
+	return res[1], nil
+}

--- a/vault/resource_gcp_secret_impersonated_account_test.go
+++ b/vault/resource_gcp_secret_impersonated_account_test.go
@@ -1,0 +1,189 @@
+package vault
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+	"github.com/hashicorp/terraform-provider-vault/testutil"
+	"golang.org/x/oauth2/google"
+)
+
+// This test requires that you pass credentials for a user or service account having the IAM rights
+// listed at https://www.vaultproject.io/docs/secrets/gcp/index.html for the project you are testing
+// on. The credentials must also allow setting IAM permissions on the project being tested.
+func TestGCPSecretImpersonatedAccount(t *testing.T) {
+	backend := "gcp"
+	impersonatedAccount := acctest.RandomWithPrefix("tf-test")
+	credentials, project := testutil.GetTestGCPCreds(t)
+
+	// We will use the provided key as the impersonated account
+	conf, err := google.JWTConfigFromJSON([]byte(credentials), "https://www.googleapis.com/auth/cloud-platform")
+	if err != nil {
+		t.Fatalf("error decoding GCP Credentials: %v", err)
+	}
+	serviceAccountEmail := conf.Email
+
+	noBindings := testGCPSecretImpersonatedAccount_accessToken(backend, impersonatedAccount, credentials, serviceAccountEmail)
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testProviders,
+		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		CheckDestroy: testGCPSecretImpersonatedAccountDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: noBindings,
+				Check: resource.ComposeTestCheckFunc(
+					testGCPSecretImpersonatedAccount_attrs(backend, impersonatedAccount),
+					resource.TestCheckResourceAttr("vault_gcp_secret_impersonated_account.test", "backend", backend),
+					resource.TestCheckResourceAttr("vault_gcp_secret_impersonated_account.test", "impersonated_account", impersonatedAccount),
+					resource.TestCheckResourceAttr("vault_gcp_secret_impersonated_account.test", "service_account_email", serviceAccountEmail),
+					resource.TestCheckResourceAttr("vault_gcp_secret_impersonated_account.test", "service_account_project", project),
+					resource.TestCheckResourceAttr("vault_gcp_secret_impersonated_account.test", "token_scopes.#", "1"),
+					resource.TestCheckResourceAttr("vault_gcp_secret_impersonated_account.test", "token_scopes.0", "https://www.googleapis.com/auth/cloud-platform"),
+				),
+			},
+			{
+				ResourceName:            "vault_gcp_secret_impersonated_account.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+func testGCPSecretImpersonatedAccount_attrs(backend, impersonatedAccount string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourceState := s.Modules[0].Resources["vault_gcp_secret_impersonated_account.test"]
+		if resourceState == nil {
+			return fmt.Errorf("resource not found in state")
+		}
+
+		instanceState := resourceState.Primary
+		if instanceState == nil {
+			return fmt.Errorf("resource not found in state")
+		}
+
+		endpoint := instanceState.ID
+
+		if endpoint != backend+"/impersonated-account/"+impersonatedAccount {
+			return fmt.Errorf("expected ID to be %q, got %q instead", backend+"/impersonated-account/"+impersonatedAccount, endpoint)
+		}
+
+		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+		resp, err := client.Logical().Read(endpoint)
+		if err != nil {
+			return fmt.Errorf("%q doesn't exist", endpoint)
+		}
+
+		attrs := map[string]string{
+			"service_account_project": "service_account_project",
+			"token_scopes":            "token_scopes",
+			"service_account_email":   "service_account_email",
+		}
+		for stateAttr, apiAttr := range attrs {
+			if resp.Data[apiAttr] == nil && instanceState.Attributes[stateAttr] == "" {
+				continue
+			}
+			var match bool
+			switch resp.Data[apiAttr].(type) {
+			case json.Number:
+				apiData, err := resp.Data[apiAttr].(json.Number).Int64()
+				if err != nil {
+					return fmt.Errorf("expected API field %s to be an int, was %q", apiAttr, resp.Data[apiAttr])
+				}
+				stateData, err := strconv.ParseInt(instanceState.Attributes[stateAttr], 10, 64)
+				if err != nil {
+					return fmt.Errorf("expected state field %s to be an int, was %q", stateAttr, instanceState.Attributes[stateAttr])
+				}
+				match = apiData == stateData
+			case bool:
+				if _, ok := resp.Data[apiAttr]; !ok && instanceState.Attributes[stateAttr] == "" {
+					match = true
+				} else {
+					stateData, err := strconv.ParseBool(instanceState.Attributes[stateAttr])
+					if err != nil {
+						return fmt.Errorf("expected state field %s to be a bool, was %q", stateAttr, instanceState.Attributes[stateAttr])
+					}
+					match = resp.Data[apiAttr] == stateData
+				}
+			case []interface{}:
+				apiData := resp.Data[apiAttr].([]interface{})
+				length := instanceState.Attributes[stateAttr+".#"]
+				if length == "" {
+					if len(resp.Data[apiAttr].([]interface{})) != 0 {
+						return fmt.Errorf("expected state field %s to have %d entries, had 0", stateAttr, len(apiData))
+					}
+					match = true
+				} else {
+					count, err := strconv.Atoi(length)
+					if err != nil {
+						return fmt.Errorf("expected %s.# to be a number, got %q", stateAttr, instanceState.Attributes[stateAttr+".#"])
+					}
+					if count != len(apiData) {
+						return fmt.Errorf("expected %s to have %d entries in state, has %d", stateAttr, len(apiData), count)
+					}
+
+					for i := 0; i < count; i++ {
+						found := false
+						for stateKey, stateValue := range instanceState.Attributes {
+							if strings.HasPrefix(stateKey, stateAttr) {
+								if apiData[i] == stateValue {
+									found = true
+								}
+							}
+						}
+						if !found {
+							return fmt.Errorf("Expected item %d of %s (%s in state) of %q to be in state but wasn't", i, apiAttr, stateAttr, apiData[i])
+						}
+					}
+					match = true
+				}
+			default:
+				match = resp.Data[apiAttr] == instanceState.Attributes[stateAttr]
+			}
+			if !match {
+				return fmt.Errorf("expected %s (%s in state) of %q to be %q, got %q", apiAttr, stateAttr, endpoint, instanceState.Attributes[stateAttr], resp.Data[apiAttr])
+			}
+		}
+
+		return nil
+	}
+}
+
+func testGCPSecretImpersonatedAccountDestroy(s *terraform.State) error {
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "vault_gcp_secret_impersonated_account" {
+			continue
+		}
+		secret, err := client.Logical().Read(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error checking for GCP Secrets ImpersonatedAccount %q: %s", rs.Primary.ID, err)
+		}
+		if secret != nil {
+			return fmt.Errorf("GCP Secrets ImpersonatedAccount %q still exists", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testGCPSecretImpersonatedAccount_accessToken(backend, impersonatedAccount, credentials, serviceAccountEmail string) string {
+	return fmt.Sprintf(`
+
+resource "vault_gcp_secret_impersonated_account" "test" {
+	backend = "gcp" # vault_gcp_secret_backend.test.path
+	impersonated_account = "%s"
+	token_scopes   = ["https://www.googleapis.com/auth/cloud-platform"]
+	service_account_email = "%s"
+}
+`, impersonatedAccount, serviceAccountEmail)
+}

--- a/vault/resource_gcp_secret_impersonated_account_test.go
+++ b/vault/resource_gcp_secret_impersonated_account_test.go
@@ -1,10 +1,7 @@
 package vault
 
 import (
-	"encoding/json"
 	"fmt"
-	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -20,7 +17,9 @@ import (
 // listed at https://www.vaultproject.io/docs/secrets/gcp/index.html for the project you are testing
 // on. The credentials must also allow setting IAM permissions on the project being tested.
 func TestGCPSecretImpersonatedAccount(t *testing.T) {
-	backend := "gcp"
+	testutil.SkipTestEnvSet(t, testutil.EnvVarSkipVaultNext)
+
+	backend := acctest.RandomWithPrefix("tf-test-gcp")
 	impersonatedAccount := acctest.RandomWithPrefix("tf-test")
 	credentials, project := testutil.GetTestGCPCreds(t)
 
@@ -31,8 +30,6 @@ func TestGCPSecretImpersonatedAccount(t *testing.T) {
 	}
 	serviceAccountEmail := conf.Email
 
-	noBindings := testGCPSecretImpersonatedAccount_accessToken(backend, impersonatedAccount, credentials, serviceAccountEmail)
-
 	resourceName := "vault_gcp_secret_impersonated_account.test"
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
@@ -40,9 +37,8 @@ func TestGCPSecretImpersonatedAccount(t *testing.T) {
 		CheckDestroy: testGCPSecretImpersonatedAccountDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: noBindings,
+				Config: testGCPSecretImpersonatedAccount_initial(backend, impersonatedAccount, credentials, serviceAccountEmail),
 				Check: resource.ComposeTestCheckFunc(
-					testGCPSecretImpersonatedAccount_attrs(backend, impersonatedAccount),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldBackend, backend),
 					resource.TestCheckResourceAttr(resourceName, "impersonated_account", impersonatedAccount),
 					resource.TestCheckResourceAttr(resourceName, "service_account_email", serviceAccountEmail),
@@ -52,112 +48,20 @@ func TestGCPSecretImpersonatedAccount(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:            "vault_gcp_secret_impersonated_account.test",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{},
+				Config: testGCPSecretImpersonatedAccount_updated(backend, impersonatedAccount, credentials, serviceAccountEmail),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldBackend, backend),
+					resource.TestCheckResourceAttr(resourceName, "impersonated_account", impersonatedAccount),
+					resource.TestCheckResourceAttr(resourceName, "service_account_email", serviceAccountEmail),
+					resource.TestCheckResourceAttr(resourceName, "service_account_project", project),
+					resource.TestCheckResourceAttr(resourceName, "token_scopes.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "token_scopes.0", "https://www.googleapis.com/auth/cloud-platform"),
+					resource.TestCheckResourceAttr(resourceName, "token_scopes.1", "https://www.googleapis.com/auth/cloud-platform.read-only"),
+				),
 			},
+			testutil.GetImportTestStep(resourceName, false, nil),
 		},
 	})
-}
-
-func testGCPSecretImpersonatedAccount_attrs(backend, impersonatedAccount string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		resourceState := s.Modules[0].Resources["vault_gcp_secret_impersonated_account.test"]
-		if resourceState == nil {
-			return fmt.Errorf("resource not found in state")
-		}
-
-		instanceState := resourceState.Primary
-		if instanceState == nil {
-			return fmt.Errorf("resource not found in state")
-		}
-
-		endpoint := instanceState.ID
-
-		if endpoint != backend+"/impersonated-account/"+impersonatedAccount {
-			return fmt.Errorf("expected ID to be %q, got %q instead", backend+"/impersonated-account/"+impersonatedAccount, endpoint)
-		}
-
-		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
-		resp, err := client.Logical().Read(endpoint)
-		if err != nil {
-			return fmt.Errorf("%q doesn't exist", endpoint)
-		}
-
-		attrs := map[string]string{
-			"service_account_project": "service_account_project",
-			"token_scopes":            "token_scopes",
-			"service_account_email":   "service_account_email",
-		}
-		for stateAttr, apiAttr := range attrs {
-			if resp.Data[apiAttr] == nil && instanceState.Attributes[stateAttr] == "" {
-				continue
-			}
-			var match bool
-			switch resp.Data[apiAttr].(type) {
-			case json.Number:
-				apiData, err := resp.Data[apiAttr].(json.Number).Int64()
-				if err != nil {
-					return fmt.Errorf("expected API field %s to be an int, was %q", apiAttr, resp.Data[apiAttr])
-				}
-				stateData, err := strconv.ParseInt(instanceState.Attributes[stateAttr], 10, 64)
-				if err != nil {
-					return fmt.Errorf("expected state field %s to be an int, was %q", stateAttr, instanceState.Attributes[stateAttr])
-				}
-				match = apiData == stateData
-			case bool:
-				if _, ok := resp.Data[apiAttr]; !ok && instanceState.Attributes[stateAttr] == "" {
-					match = true
-				} else {
-					stateData, err := strconv.ParseBool(instanceState.Attributes[stateAttr])
-					if err != nil {
-						return fmt.Errorf("expected state field %s to be a bool, was %q", stateAttr, instanceState.Attributes[stateAttr])
-					}
-					match = resp.Data[apiAttr] == stateData
-				}
-			case []interface{}:
-				apiData := resp.Data[apiAttr].([]interface{})
-				length := instanceState.Attributes[stateAttr+".#"]
-				if length == "" {
-					if len(resp.Data[apiAttr].([]interface{})) != 0 {
-						return fmt.Errorf("expected state field %s to have %d entries, had 0", stateAttr, len(apiData))
-					}
-					match = true
-				} else {
-					count, err := strconv.Atoi(length)
-					if err != nil {
-						return fmt.Errorf("expected %s.# to be a number, got %q", stateAttr, instanceState.Attributes[stateAttr+".#"])
-					}
-					if count != len(apiData) {
-						return fmt.Errorf("expected %s to have %d entries in state, has %d", stateAttr, len(apiData), count)
-					}
-
-					for i := 0; i < count; i++ {
-						found := false
-						for stateKey, stateValue := range instanceState.Attributes {
-							if strings.HasPrefix(stateKey, stateAttr) {
-								if apiData[i] == stateValue {
-									found = true
-								}
-							}
-						}
-						if !found {
-							return fmt.Errorf("Expected item %d of %s (%s in state) of %q to be in state but wasn't", i, apiAttr, stateAttr, apiData[i])
-						}
-					}
-					match = true
-				}
-			default:
-				match = resp.Data[apiAttr] == instanceState.Attributes[stateAttr]
-			}
-			if !match {
-				return fmt.Errorf("expected %s (%s in state) of %q to be %q, got %q", apiAttr, stateAttr, endpoint, instanceState.Attributes[stateAttr], resp.Data[apiAttr])
-			}
-		}
-
-		return nil
-	}
 }
 
 func testGCPSecretImpersonatedAccountDestroy(s *terraform.State) error {
@@ -178,14 +82,41 @@ func testGCPSecretImpersonatedAccountDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testGCPSecretImpersonatedAccount_accessToken(backend, impersonatedAccount, credentials, serviceAccountEmail string) string {
+func testGCPSecretImpersonatedAccount_initial(backend, impersonatedAccount, credentials, serviceAccountEmail string) string {
 	return fmt.Sprintf(`
+%s
 
 resource "vault_gcp_secret_impersonated_account" "test" {
-	backend = "gcp" # vault_gcp_secret_backend.test.path
+	backend = vault_gcp_secret_backend.test.path
 	impersonated_account = "%s"
 	token_scopes   = ["https://www.googleapis.com/auth/cloud-platform"]
 	service_account_email = "%s"
 }
-`, impersonatedAccount, serviceAccountEmail)
+`, testGCPSecretImpersonatedAccount_backend(backend, credentials), impersonatedAccount, serviceAccountEmail)
+}
+
+func testGCPSecretImpersonatedAccount_updated(backend, impersonatedAccount, credentials, serviceAccountEmail string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "vault_gcp_secret_impersonated_account" "test" {
+	backend = vault_gcp_secret_backend.test.path
+	impersonated_account = "%s"
+	token_scopes   = [
+        "https://www.googleapis.com/auth/cloud-platform.read-only",
+        "https://www.googleapis.com/auth/cloud-platform",
+    ]
+	service_account_email = "%s"
+}
+`, testGCPSecretImpersonatedAccount_backend(backend, credentials), impersonatedAccount, serviceAccountEmail)
+}
+
+func testGCPSecretImpersonatedAccount_backend(path, credentials string) string {
+	return fmt.Sprintf(`
+resource "vault_gcp_secret_backend" "test" {
+	path = "%s"
+	credentials = <<CREDS
+%s
+CREDS
+}`, path, credentials)
 }

--- a/vault/resource_gcp_secret_impersonated_account_test.go
+++ b/vault/resource_gcp_secret_impersonated_account_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 	"golang.org/x/oauth2/google"
@@ -32,6 +33,7 @@ func TestGCPSecretImpersonatedAccount(t *testing.T) {
 
 	noBindings := testGCPSecretImpersonatedAccount_accessToken(backend, impersonatedAccount, credentials, serviceAccountEmail)
 
+	resourceName := "vault_gcp_secret_impersonated_account.test"
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
@@ -41,12 +43,12 @@ func TestGCPSecretImpersonatedAccount(t *testing.T) {
 				Config: noBindings,
 				Check: resource.ComposeTestCheckFunc(
 					testGCPSecretImpersonatedAccount_attrs(backend, impersonatedAccount),
-					resource.TestCheckResourceAttr("vault_gcp_secret_impersonated_account.test", "backend", backend),
-					resource.TestCheckResourceAttr("vault_gcp_secret_impersonated_account.test", "impersonated_account", impersonatedAccount),
-					resource.TestCheckResourceAttr("vault_gcp_secret_impersonated_account.test", "service_account_email", serviceAccountEmail),
-					resource.TestCheckResourceAttr("vault_gcp_secret_impersonated_account.test", "service_account_project", project),
-					resource.TestCheckResourceAttr("vault_gcp_secret_impersonated_account.test", "token_scopes.#", "1"),
-					resource.TestCheckResourceAttr("vault_gcp_secret_impersonated_account.test", "token_scopes.0", "https://www.googleapis.com/auth/cloud-platform"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldBackend, backend),
+					resource.TestCheckResourceAttr(resourceName, "impersonated_account", impersonatedAccount),
+					resource.TestCheckResourceAttr(resourceName, "service_account_email", serviceAccountEmail),
+					resource.TestCheckResourceAttr(resourceName, "service_account_project", project),
+					resource.TestCheckResourceAttr(resourceName, "token_scopes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "token_scopes.0", "https://www.googleapis.com/auth/cloud-platform"),
 				),
 			},
 			{

--- a/website/docs/r/gcp_secret_impersonated_account.html.md
+++ b/website/docs/r/gcp_secret_impersonated_account.html.md
@@ -42,7 +42,7 @@ The following arguments are supported:
 
 * `impersonated_account` - (Required, Forces new resource) Name of the Impersonated Account to create
 
-* `service_account_email` - (Required, Forces new resource) Email of the GCP service account to manage.
+* `service_account_email` - (Required, Forces new resource) Email of the GCP service account to impersonate.
 
 * `token_scopes` - (Required) List of OAuth scopes to assign to access tokens generated under this impersonated account.
 

--- a/website/docs/r/gcp_secret_impersonated_account.html.md
+++ b/website/docs/r/gcp_secret_impersonated_account.html.md
@@ -1,0 +1,61 @@
+---
+layout: "vault"
+page_title: "Vault: vault_gcp_secret_impersonated_account resource"
+sidebar_current: "docs-vault-resource-gcp-secret-impersonated-account"
+description: |-
+  Creates a Impersonated Account for the GCP Secret Backend for Vault.
+---
+
+# vault\_gcp\_secret\_impersonated\_account
+
+Creates a Impersonated Account in the [GCP Secrets Engine](https://www.vaultproject.io/docs/secrets/gcp/index.html) for Vault.
+
+Each [impersonated account](https://www.vaultproject.io/docs/secrets/gcp/index.html#impersonated-accounts) is tied to a separately managed
+Service Account.
+
+## Example Usage
+
+```hcl
+resource "google_service_account" "this" {
+  account_id = "my-awesome-account"
+}
+
+resource "vault_gcp_secret_backend" "gcp" {
+  path        = "gcp"
+  credentials = "${file("credentials.json")}"
+}
+
+resource "vault_gcp_secret_impersonated_account" "impersonated_account" {
+  backend        = vault_gcp_secret_backend.gcp.path
+
+  impersonated_account  = "this"
+  service_account_email = google_service_account.this.email
+  token_scopes          = ["https://www.googleapis.com/auth/cloud-platform"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `backend` - (Required, Forces new resource) Path where the GCP Secrets Engine is mounted
+
+* `impersonated_account` - (Required, Forces new resource) Name of the Impersonated Account to create
+
+* `service_account_email` - (Required, Forces new resource) Email of the GCP service account to manage.
+
+* `token_scopes` - (Required) List of OAuth scopes to assign to access tokens generated under this impersonated account.
+
+## Attributes Reference
+
+In addition to the fields above, the following attributes are also exposed:
+
+* `service_account_project` - Project the service account belongs to.
+
+## Import
+
+A impersonated account can be imported using its Vault Path. For example, referencing the example above,
+
+```
+$ terraform import vault_gcp_secret_impersonated_account.impersonated_account gcp/impersonated-account/project_viewer
+```


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates To: https://github.com/hashicorp/vault-plugin-secrets-gcp/pull/129

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Adds `vault_gcp_secret_impersonated_account` resource
```

Output from acceptance testing:

Note, included the `-v` with `go test`.
```
$ TESTARGS="--run GCPSecretImpersonatedAccount" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test --run GCPSecretImpersonatedAccount -v -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/codegen   (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/mfa     [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/pki      [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/internal/provider (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/testutil  (cached) [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
2022/12/29 17:00:18 [INFO] Using Vault token with the following policies: root
=== RUN   TestGCPSecretImpersonatedAccount
--- PASS: TestGCPSecretImpersonatedAccount (1.62s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     2.105s
```
