### PR TITLE
docs: use the right attribute to import 'vault_jwt_auth_backend'

### DIFF
--- a/website/docs/r/jwt_auth_backend.html.md
+++ b/website/docs/r/jwt_auth_backend.html.md
@@ -145,7 +145,7 @@ In addition to the fields above, the following attributes are exported:
 
 ## Import
 
-JWT auth backend can be imported using the `type`, e.g.
+JWT auth backend can be imported using the `path`, e.g.
 
 ```
 $ terraform import vault_jwt_auth_backend.oidc oidc


### PR DESCRIPTION
- jwt auth backend only accepts in the type attribute `jwt` or `oidc`
- the path attribute is the one used by this provider as a resource identifier

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```
