### PR TITLE
Add enterprise check for new Raft Autopilot parameter

### DIFF
--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	DefaultMaxHTTPRetries = 2
-	enterpriseSuffix      = "+ent"
+	enterpriseMetadata    = "ent"
 )
 
 var (
@@ -104,18 +104,13 @@ func (p *ProviderMeta) IsAPISupported(minVersion *version.Version) bool {
 	return ver.GreaterThanOrEqual(minVersion)
 }
 
-// IsEntAPISupported receives a minimum version
-// of type *version.Version.
-//
-// It returns a boolean describing whether the
-// ProviderMeta vaultVersion is above the
-// minimum version and supports enterprise
+// IsEnterpriseSupported returns a boolean
+// describing whether the ProviderMeta
+// vaultVersion supports enterprise
 // features.
-func (p *ProviderMeta) IsEntAPISupported(minVersion *version.Version) bool {
+func (p *ProviderMeta) IsEnterpriseSupported() bool {
 	ver := p.GetVaultVersion()
-
-	return p.IsAPISupported(minVersion) &&
-		strings.HasSuffix(ver.String(), enterpriseSuffix)
+	return strings.Contains(ver.Metadata(), enterpriseMetadata)
 }
 
 // GetVaultVersion returns the providerMeta
@@ -354,11 +349,10 @@ func IsAPISupported(meta interface{}, minVersion *version.Version) bool {
 	return p.IsAPISupported(minVersion)
 }
 
-// IsEntAPISupported works the same as
-// IsAPISupported, but also confirms that
+// IsEnterpriseSupported confirms that
 // the providerMeta API supports enterprise
 // features.
-func IsEntAPISupported(meta interface{}, minVersion *version.Version) bool {
+func IsEnterpriseSupported(meta interface{}) bool {
 	var p *ProviderMeta
 	switch v := meta.(type) {
 	case *ProviderMeta:
@@ -367,7 +361,7 @@ func IsEntAPISupported(meta interface{}, minVersion *version.Version) bool {
 		panic(fmt.Sprintf("meta argument must be a %T, not %T", p, meta))
 	}
 
-	return p.IsEntAPISupported(minVersion)
+	return p.IsEnterpriseSupported()
 }
 
 func getVaultVersion(client *api.Client) (*version.Version, error) {

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -22,7 +22,10 @@ import (
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 )
 
-const DefaultMaxHTTPRetries = 2
+const (
+	DefaultMaxHTTPRetries = 2
+	enterpriseSuffix      = "+ent"
+)
 
 var (
 	MaxHTTPRetriesCCC int
@@ -99,6 +102,20 @@ func (p *ProviderMeta) IsAPISupported(minVersion *version.Version) bool {
 		return false
 	}
 	return ver.GreaterThanOrEqual(minVersion)
+}
+
+// IsEntAPISupported receives a minimum version
+// of type *version.Version.
+//
+// It returns a boolean describing whether the
+// ProviderMeta vaultVersion is above the
+// minimum version and supports enterprise
+// features.
+func (p *ProviderMeta) IsEntAPISupported(minVersion *version.Version) bool {
+	ver := p.GetVaultVersion()
+
+	return p.IsAPISupported(minVersion) &&
+		strings.HasSuffix(ver.String(), enterpriseSuffix)
 }
 
 // GetVaultVersion returns the providerMeta
@@ -335,6 +352,22 @@ func IsAPISupported(meta interface{}, minVersion *version.Version) bool {
 	}
 
 	return p.IsAPISupported(minVersion)
+}
+
+// IsEntAPISupported works the same as
+// IsAPISupported, but also confirms that
+// the providerMeta API supports enterprise
+// features.
+func IsEntAPISupported(meta interface{}, minVersion *version.Version) bool {
+	var p *ProviderMeta
+	switch v := meta.(type) {
+	case *ProviderMeta:
+		p = v
+	default:
+		panic(fmt.Sprintf("meta argument must be a %T, not %T", p, meta))
+	}
+
+	return p.IsEntAPISupported(minVersion)
 }
 
 func getVaultVersion(client *api.Client) (*version.Version, error) {

--- a/internal/provider/meta_test.go
+++ b/internal/provider/meta_test.go
@@ -445,7 +445,7 @@ func TestIsAPISupported(t *testing.T) {
 	}
 }
 
-func TestIsENTAPISupported(t *testing.T) {
+func TestIsEnterpriseSupported(t *testing.T) {
 	rootClient, err := api.NewClient(api.DefaultConfig())
 	if err != nil {
 		t.Fatalf("error initializing root client, err=%s", err)
@@ -456,7 +456,7 @@ func TestIsENTAPISupported(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	VaultVersion11, err := version.NewVersion("1.11.0+entrandom")
+	VaultVersion11HSM, err := version.NewVersion("1.11.0+ent.hsm")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -467,33 +467,29 @@ func TestIsENTAPISupported(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name       string
-		minVersion *version.Version
-		expected   bool
-		meta       interface{}
+		name     string
+		expected bool
+		meta     interface{}
 	}{
 		{
-			name:       "not-enterprise",
-			minVersion: version.Must(version.NewSemver("1.8.0")),
-			expected:   false,
+			name:     "not-enterprise",
+			expected: false,
 			meta: &ProviderMeta{
 				client:       rootClient,
 				vaultVersion: VaultVersion10,
 			},
 		},
 		{
-			name:       "wrong-suffix",
-			minVersion: version.Must(version.NewSemver("1.11.0")),
-			expected:   false,
+			name:     "enterprise-hsm",
+			expected: true,
 			meta: &ProviderMeta{
 				client:       rootClient,
-				vaultVersion: VaultVersion11,
+				vaultVersion: VaultVersion11HSM,
 			},
 		},
 		{
-			name:       "enterprise-supported",
-			minVersion: version.Must(version.NewSemver("1.12.0")),
-			expected:   true,
+			name:     "enterprise",
+			expected: true,
 			meta: &ProviderMeta{
 				client:       rootClient,
 				vaultVersion: VaultVersion12,
@@ -517,10 +513,10 @@ func TestIsENTAPISupported(t *testing.T) {
 				tt.meta = m
 			}
 
-			isTFVersionGreater := tt.meta.(*ProviderMeta).IsEntAPISupported(tt.minVersion)
+			isEnterprise := tt.meta.(*ProviderMeta).IsEnterpriseSupported()
 
-			if isTFVersionGreater != tt.expected {
-				t.Errorf("IsAPISupported() got = %v, want %v", isTFVersionGreater, tt.expected)
+			if isEnterprise != tt.expected {
+				t.Errorf("IsEnterpriseSupported() got = %v, want %v", isEnterprise, tt.expected)
 			}
 		})
 	}

--- a/vault/resource_raft_autopilot_test.go
+++ b/vault/resource_raft_autopilot_test.go
@@ -16,7 +16,7 @@ func TestAccRaftAutopilotConfig_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
 		PreCheck: func() {
-			testutil.TestAccPreCheck(t)
+			testutil.TestEntPreCheck(t)
 			testutil.SkipTestEnvSet(t, "SKIP_RAFT_TESTS")
 		},
 		CheckDestroy: testAccRaftAutopilotConfigCheckDestroy,

--- a/vault/resource_raft_autopilot_test.go
+++ b/vault/resource_raft_autopilot_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestAccRaftAutopilotConfig_basic(t *testing.T) {
+	resourceName := "vault_raft_autopilot.test"
+
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
 		PreCheck: func() {
@@ -24,27 +26,28 @@ func TestAccRaftAutopilotConfig_basic(t *testing.T) {
 			{
 				Config: testAccRaftAutopilotConfig_basic(true, "12h0m0s", 3),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_raft_autopilot.test", "cleanup_dead_servers", "true"),
-					resource.TestCheckResourceAttr("vault_raft_autopilot.test", "dead_server_last_contact_threshold", "12h0m0s"),
-					resource.TestCheckResourceAttr("vault_raft_autopilot.test", "last_contact_threshold", autopilotDefaults["last_contact_threshold"].(string)),
-					resource.TestCheckResourceAttr("vault_raft_autopilot.test", "max_trailing_logs", strconv.Itoa(autopilotDefaults["max_trailing_logs"].(int))),
-					resource.TestCheckResourceAttr("vault_raft_autopilot.test", "min_quorum", strconv.Itoa(autopilotDefaults["min_quorum"].(int))),
-					resource.TestCheckResourceAttr("vault_raft_autopilot.test", "server_stabilization_time", autopilotDefaults["server_stabilization_time"].(string)),
-					resource.TestCheckResourceAttr("vault_raft_autopilot.test", "disable_upgrade_migration", "false"),
+					resource.TestCheckResourceAttr(resourceName, "cleanup_dead_servers", "true"),
+					resource.TestCheckResourceAttr(resourceName, "dead_server_last_contact_threshold", "12h0m0s"),
+					resource.TestCheckResourceAttr(resourceName, "last_contact_threshold", autopilotDefaults["last_contact_threshold"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "max_trailing_logs", strconv.Itoa(autopilotDefaults["max_trailing_logs"].(int))),
+					resource.TestCheckResourceAttr(resourceName, "min_quorum", strconv.Itoa(autopilotDefaults["min_quorum"].(int))),
+					resource.TestCheckResourceAttr(resourceName, "server_stabilization_time", autopilotDefaults["server_stabilization_time"].(string)),
+					resource.TestCheckResourceAttr(resourceName, "disable_upgrade_migration", "false"),
 				),
 			},
 			{
 				Config: testAccRaftAutopilotConfig_updated(true, true, "30s", "20s", "50s", 100, 5),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_raft_autopilot.test", "cleanup_dead_servers", "true"),
-					resource.TestCheckResourceAttr("vault_raft_autopilot.test", "dead_server_last_contact_threshold", "30s"),
-					resource.TestCheckResourceAttr("vault_raft_autopilot.test", "last_contact_threshold", "20s"),
-					resource.TestCheckResourceAttr("vault_raft_autopilot.test", "max_trailing_logs", "100"),
-					resource.TestCheckResourceAttr("vault_raft_autopilot.test", "min_quorum", "5"),
-					resource.TestCheckResourceAttr("vault_raft_autopilot.test", "server_stabilization_time", "50s"),
-					resource.TestCheckResourceAttr("vault_raft_autopilot.test", "disable_upgrade_migration", "true"),
+					resource.TestCheckResourceAttr(resourceName, "cleanup_dead_servers", "true"),
+					resource.TestCheckResourceAttr(resourceName, "dead_server_last_contact_threshold", "30s"),
+					resource.TestCheckResourceAttr(resourceName, "last_contact_threshold", "20s"),
+					resource.TestCheckResourceAttr(resourceName, "max_trailing_logs", "100"),
+					resource.TestCheckResourceAttr(resourceName, "min_quorum", "5"),
+					resource.TestCheckResourceAttr(resourceName, "server_stabilization_time", "50s"),
+					resource.TestCheckResourceAttr(resourceName, "disable_upgrade_migration", "true"),
 				),
 			},
+			testutil.GetImportTestStep(resourceName, false, nil),
 		},
 	})
 }

--- a/website/docs/r/raft_autopilot.html.md
+++ b/website/docs/r/raft_autopilot.html.md
@@ -60,3 +60,11 @@ stable in the 'healthy' state before being added to the cluster.
 ## Attributes Reference
 
 No additional attributes are exported by this resource.
+
+## Import
+
+Raft Autopilot config can be imported using the ID, e.g.
+
+```
+$ terraform import vault_raft_autopilot.autopilot sys/storage/raft/autopilot/configuration
+```


### PR DESCRIPTION
In v3.12.0 we added a new parameter to the Raft Autopilot resource `disable_upgrade_migration`. There was a bug introduced due to the field having a default value of `false` written to Vault, and since this is an enterprise field this was breaking the TF config s for non-enterprise users. The improvements made in this PR fix the bug and also add some utils to the `provider` package to check for enterprise servers.

Fixes #1718 

Output from acceptance testing:

```
=== RUN   TestAccRaftAutopilotConfig_basic
--- PASS: TestAccRaftAutopilotConfig_basic (2.59s)
PASS

=== RUN   TestIsEnterpriseSupported
=== RUN   TestIsEnterpriseSupported/not-enterprise
=== RUN   TestIsEnterpriseSupported/enterprise-hsm
=== RUN   TestIsEnterpriseSupported/enterprise
--- PASS: TestIsEnterpriseSupported (0.00s)
    --- PASS: TestIsEnterpriseSupported/not-enterprise (0.00s)
    --- PASS: TestIsEnterpriseSupported/enterprise-hsm (0.00s)
    --- PASS: TestIsEnterpriseSupported/enterprise (0.00s)
PASS
```
