### PR TITLE
Add aws auth backend config identity

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/containerd/containerd v1.6.6 // indirect
 	github.com/coreos/go-oidc/v3 v3.4.0 // indirect
 	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
-	github.com/davecgh/go-spew v1.1.1
 	github.com/denisenkom/go-mssqldb v0.12.0
 	github.com/docker/distribution v2.8.1+incompatible // indirect
 	github.com/go-sql-driver/mysql v1.6.0

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -197,6 +197,10 @@ const (
 	FieldDeleteVersionAfter         = "delete_version_after"
 	FieldCustomMetadata             = "custom_metadata"
 	FieldCustomMetadataJSON         = "custom_metadata_json"
+	FieldIAMAlias                   = "iam_alias"
+	FieldIAMMetadata                = "iam_metadata"
+	FieldEC2Alias                   = "ec2_alias"
+	FieldEC2Metadata                = "ec2_metadata"
 
 	/*
 		common environment variables

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -390,6 +390,10 @@ var (
 			Resource:      UpdateSchemaResource(awsAuthBackendClientResource()),
 			PathInventory: []string{"/auth/aws/config/client"},
 		},
+		"vault_aws_auth_backend_config_identity": {
+			Resource:      awsAuthBackendConfigIdentityResource(),
+			PathInventory: []string{"/auth/aws/config/identity"},
+		},
 		"vault_aws_auth_backend_identity_whitelist": {
 			Resource:      UpdateSchemaResource(awsAuthBackendIdentityWhitelistResource()),
 			PathInventory: []string{"/auth/aws/config/tidy/identity-whitelist"},

--- a/vault/resource_aws_auth_backend_config_identity.go
+++ b/vault/resource_aws_auth_backend_config_identity.go
@@ -79,25 +79,25 @@ func awsAuthBackendConfigIdentityWrite(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(err)
 	}
 
-	backend := d.Get("backend").(string)
+	backend := d.Get(consts.FieldBackend).(string)
 
 	var iamMetadata, ec2Metadata []string
-	if iamMetadataConfig, ok := d.GetOk("iam_metadata"); ok {
+	if iamMetadataConfig, ok := d.GetOk(consts.FieldIAMMetadata); ok {
 		iamMetadata = util.TerraformSetToStringArray(iamMetadataConfig)
 	}
 
-	if ec2MetadataConfig, ok := d.GetOk("ec2_metadata"); ok {
+	if ec2MetadataConfig, ok := d.GetOk(consts.FieldEC2Metadata); ok {
 		ec2Metadata = util.TerraformSetToStringArray(ec2MetadataConfig)
 	}
 
 	data := map[string]interface{}{
-		"iam_metadata": iamMetadata,
-		"ec2_metadata": ec2Metadata,
+		consts.FieldIAMMetadata: iamMetadata,
+		consts.FieldEC2Metadata: ec2Metadata,
 	}
 
 	fields := []string{
-		"iam_alias",
-		"ec2_alias",
+		consts.FieldIAMAlias,
+		consts.FieldEC2Alias,
 	}
 	for _, k := range fields {
 		data[k] = d.Get(k)
@@ -143,17 +143,17 @@ func awsAuthBackendConfigIdentityRead(_ context.Context, d *schema.ResourceData,
 	}
 
 	fields := []string{
-		"iam_alias",
-		"iam_metadata",
-		"ec2_alias",
-		"ec2_metadata",
+		consts.FieldIAMAlias,
+		consts.FieldIAMMetadata,
+		consts.FieldEC2Alias,
+		consts.FieldEC2Metadata,
 	}
 	for _, k := range fields {
 		if err := d.Set(k, resp.Data[k]); err != nil {
 			return diag.FromErr(err)
 		}
 	}
-	if err := d.Set("backend", backend); err != nil {
+	if err := d.Set(consts.FieldBackend, backend); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/vault/resource_aws_auth_backend_config_identity.go
+++ b/vault/resource_aws_auth_backend_config_identity.go
@@ -1,0 +1,175 @@
+package vault
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-vault/util"
+	"github.com/hashicorp/vault/api"
+)
+
+var (
+	awsAuthBackendConfigIdentityBackendFromPathRegex = regexp.MustCompile("^auth/(.+)/config/identity$")
+)
+
+func awsAuthBackendConfigIdentityResource() *schema.Resource {
+	return &schema.Resource{
+		Create: awsAuthBackendConfigIdentityWrite,
+		Update: awsAuthBackendConfigIdentityWrite,
+		Read:   awsAuthBackendConfigIdentityRead,
+		Delete: awsAuthBackendConfigIdentityDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"iam_alias": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "role_id",
+				Description:  "How to generate the identity alias when using the iam auth method.",
+				ValidateFunc: validation.StringInSlice([]string{"role_id", "unique_id", "full_arn"}, false),
+			},
+			"iam_metadata": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "The metadata to include on the token returned by the login endpoint.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"ec2_alias": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Description:  "Configures how to generate the identity alias when using the ec2 auth method.",
+				Default:      "role_id",
+				ValidateFunc: validation.StringInSlice([]string{"role_id", "instance_id", "image_id"}, false),
+			},
+			"ec2_metadata": {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "The metadata to include on the token returned by the login endpoint.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"backend": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Unique name of the auth backend to configure.",
+				ForceNew:    true,
+				Default:     "aws",
+				// standardise on no beginning or trailing slashes
+				StateFunc: func(v interface{}) string {
+					return strings.Trim(v.(string), "/")
+				},
+			},
+		},
+	}
+}
+
+func awsAuthBackendConfigIdentityWrite(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	var iamMetadata, ec2Metadata []string
+	backend := d.Get("backend").(string)
+	iamAlias := d.Get("iam_alias").(string)
+	ec2Alias := d.Get("ec2_alias").(string)
+
+	if iamMetadataConfig, ok := d.GetOk("iam_metadata"); ok {
+		iamMetadata = util.TerraformSetToStringArray(iamMetadataConfig)
+	}
+
+	if ec2MetadataConfig, ok := d.GetOk("ec2_metadata"); ok {
+		ec2Metadata = util.TerraformSetToStringArray(ec2MetadataConfig)
+	}
+
+	path := awsAuthBackendConfigIdentityPath(backend)
+	data := map[string]interface{}{
+		"iam_alias":    iamAlias,
+		"iam_metadata": iamMetadata,
+		"ec2_alias":    ec2Alias,
+		"ec2_metadata": ec2Metadata,
+	}
+
+	log.Printf("[DEBUG] Writing AWS identity config to %q", path)
+	_, err := client.Logical().Write(path, data)
+
+	if err != nil {
+		return fmt.Errorf("error configuring AWS auth identity config %q: %s", path, err)
+	}
+	d.SetId(path)
+
+	log.Printf("[DEBUG] Wrote AWS identity config to %q", path)
+
+	return awsAuthBackendConfigIdentityRead(d, meta)
+}
+
+func awsAuthBackendConfigIdentityRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+
+	path := d.Id()
+
+	backend, err := awsAuthBackendConfigIdentityBackendFromPath(path)
+	if err != nil {
+		return fmt.Errorf("invalid path %q for AWS auth identity config:  %s", path, err)
+	}
+
+	log.Printf("[DEBUG] Reading identity config %q from AWS auth backend", path)
+	resp, err := client.Logical().Read(path)
+	if err != nil {
+		return fmt.Errorf("error reading AWS auth backend identity config %q: %s", path, err)
+	}
+	log.Printf("[DEBUG] Read identity config %q from AWS auth backend", path)
+	if resp == nil {
+		log.Printf("[WARN] AWS auth backend identity config %q not found, removing it from state", path)
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("iam_alias", resp.Data["iam_alias"])
+	d.Set("iam_metadata", resp.Data["iam_metadata"])
+	d.Set("ec2_alias", resp.Data["ec2_alias"])
+	d.Set("ec2_metadata", resp.Data["ec2_metadata"])
+	d.Set("backend", backend)
+
+	return nil
+}
+
+func awsAuthBackendConfigIdentityDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] Deleting AWS identity config from state file")
+	return nil
+}
+
+func awsAuthBackendConfigIdentityExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	client := meta.(*api.Client)
+
+	path := d.Id()
+
+	log.Printf("[DEBUG] Checking if identity config %q exists in AWS auth backend", path)
+	resp, err := client.Logical().Read(path)
+	if err != nil {
+		return true, fmt.Errorf("error checking for existence of AWS auth backend identity config %q: %s", path, err)
+	}
+	log.Printf("[DEBUG] Checked if identity config %q exists in AWS auth backend", path)
+	return resp != nil, nil
+}
+
+func awsAuthBackendConfigIdentityPath(backend string) string {
+	return "auth/" + strings.Trim(backend, "/") + "/config/identity"
+}
+
+func awsAuthBackendConfigIdentityBackendFromPath(path string) (string, error) {
+	if !awsAuthBackendConfigIdentityBackendFromPathRegex.MatchString(path) {
+		return "", fmt.Errorf("no backend found")
+	}
+	res := awsAuthBackendConfigIdentityBackendFromPathRegex.FindStringSubmatch(path)
+	if len(res) != 2 {
+		return "", fmt.Errorf("unexpected number of matches (%d) for backend", len(res))
+	}
+	return res[1], nil
+}

--- a/vault/resource_aws_auth_backend_config_identity_test.go
+++ b/vault/resource_aws_auth_backend_config_identity_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
@@ -22,26 +23,26 @@ func TestAccAwsAuthBackendConfigIdentity(t *testing.T) {
 			{
 				Config: testAccAwsAuthBackendConfigIdentity_basic(backend),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "backend", backend),
-					resource.TestCheckResourceAttr(resourceName, "iam_alias", "unique_id"),
-					resource.TestCheckResourceAttr(resourceName, "iam_metadata.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "iam_metadata.0", "client_arn"),
-					resource.TestCheckResourceAttr(resourceName, "iam_metadata.1", "inferred_aws_region"),
-					resource.TestCheckResourceAttr(resourceName, "ec2_alias", "role_id"),
-					resource.TestCheckResourceAttr(resourceName, "ec2_metadata.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "ec2_metadata.0", "account_id"),
-					resource.TestCheckResourceAttr(resourceName, "ec2_metadata.1", "auth_type"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldBackend, backend),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldIAMAlias, "unique_id"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldIAMMetadata+".#", "2"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldIAMMetadata+".0", "client_arn"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldIAMMetadata+".1", "inferred_aws_region"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldEC2Alias, "role_id"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldEC2Metadata+".#", "2"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldEC2Metadata+".0", "account_id"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldEC2Metadata+".1", "auth_type"),
 				),
 			},
 			{
 				Config: testAccAwsAuthBackendConfigIdentity_updated(backend),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "backend", backend),
-					resource.TestCheckResourceAttr(resourceName, "iam_alias", "full_arn"),
-					resource.TestCheckResourceAttr(resourceName, "iam_metadata.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "iam_metadata.0", "client_user_id"),
-					resource.TestCheckResourceAttr(resourceName, "ec2_alias", "role_id"),
-					resource.TestCheckResourceAttr(resourceName, "ec2_metadata.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldBackend, backend),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldIAMAlias, "full_arn"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldIAMMetadata+".#", "1"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldIAMMetadata+".0", "client_user_id"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldEC2Alias, "role_id"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldEC2Metadata+".#", "0"),
 				),
 			},
 			testutil.GetImportTestStep(resourceName, false, nil),

--- a/vault/resource_aws_auth_backend_config_identity_test.go
+++ b/vault/resource_aws_auth_backend_config_identity_test.go
@@ -1,0 +1,156 @@
+package vault
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/vault/api"
+)
+
+func TestAccAwsAuthBackendConfigIdentity_import(t *testing.T) {
+	backend := acctest.RandomWithPrefix("aws")
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccCheckAwsAuthBackendConfigIdentityDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsAuthBackendConfigIdentity_basic(backend),
+				Check:  testAccAwsAuthBackendConfigIdentityCheck_attrs(backend),
+			},
+			{
+				ResourceName:      "vault_aws_auth_backend_config_identity.config",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccAwsAuthBackendConfigIdentity_basic(t *testing.T) {
+	backend := acctest.RandomWithPrefix("aws")
+	resource.Test(t, resource.TestCase{
+		Providers:    testProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckAwsAuthBackendConfigIdentityDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsAuthBackendConfigIdentity_basic(backend),
+				Check:  testAccAwsAuthBackendConfigIdentityCheck_attrs(backend),
+			},
+			{
+				Config: testAccAwsAuthBackendConfigIdentity_updated(backend),
+				Check:  testAccAwsAuthBackendConfigIdentityCheck_attrs(backend),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsAuthBackendConfigIdentityDestroy(s *terraform.State) error {
+	config := testProvider.Meta().(*api.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "vault_aws_auth_backend_config_identity" {
+			continue
+		}
+		secret, err := config.Logical().Read(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error checking for AWS auth backend %q config: %s", rs.Primary.ID, err)
+		}
+		if secret != nil {
+			return fmt.Errorf("AWS auth backend %q still configured", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testAccAwsAuthBackendConfigIdentity_basic(backend string) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "aws" {
+  type = "aws"
+  path = "%s"
+  description = "Test auth backend for AWS backend config"
+}
+
+resource "vault_aws_auth_backend_config_identity" "config" {
+  backend = vault_auth_backend.aws.path
+  iam_alias = "unique_id"
+  iam_metadata = ["inferred_aws_region", "client_arn"]
+}
+`, backend)
+}
+
+func testAccAwsAuthBackendConfigIdentityCheck_attrs(backend string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourceState := s.Modules[0].Resources["vault_aws_auth_backend_config_identity.config"]
+		if resourceState == nil {
+			return fmt.Errorf("resource not found in state")
+		}
+
+		instanceState := resourceState.Primary
+		if instanceState == nil {
+			return fmt.Errorf("resource has no primary instance")
+		}
+
+		endpoint := instanceState.ID
+
+		if endpoint != "auth/"+backend+"/config/identity" {
+			return fmt.Errorf("expected ID to be %q, got %q", "auth/"+backend+"/config/identity", endpoint)
+		}
+
+		config := testProvider.Meta().(*api.Client)
+		resp, err := config.Logical().Read(endpoint)
+		if err != nil {
+			return fmt.Errorf("error reading back AWS auth identity config from %q: %s", endpoint, err)
+		}
+		if resp == nil {
+			return fmt.Errorf("AWS auth not configured at %q", endpoint)
+		}
+		attrs := map[string]string{
+			"iam_alias":    "iam_alias",
+			"iam_metadata": "iam_metadata",
+			"ec2_alias":    "ec2_alias",
+			"ec2_metadata": "ec2_metadata",
+		}
+		for stateAttr, apiAttr := range attrs {
+			if resp.Data[apiAttr] == nil && instanceState.Attributes[stateAttr] == "" {
+				continue
+			}
+
+			if stateStringVal, ok := instanceState.Attributes[stateAttr]; ok {
+				if resp.Data[apiAttr] != stateStringVal {
+					return fmt.Errorf("expected %s (%s) of %q to be %q, got %q", apiAttr, stateAttr, endpoint, stateStringVal, resp.Data[apiAttr])
+				}
+			} else if listLength, ok := instanceState.Attributes[stateAttr+".#"]; ok {
+				compLen, _ := strconv.Atoi(listLength)
+				for i := 0; i < compLen; i++ {
+					stateVal := instanceState.Attributes[fmt.Sprintf("%s.%d", stateAttr, i)]
+					respVal := resp.Data[apiAttr].([]interface{})[i]
+					if respVal != stateVal {
+						return fmt.Errorf("expected %s (%s) of %q to be %q, got %q", apiAttr, stateAttr, endpoint, stateVal, respVal)
+					}
+				}
+			}
+		}
+		return nil
+	}
+}
+
+func testAccAwsAuthBackendConfigIdentity_updated(backend string) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "aws" {
+  path = "%s"
+  type = "aws"
+  description = "Test auth backend for AWS backend config"
+}
+
+resource "vault_aws_auth_backend_config_identity" "config" {
+  backend = vault_auth_backend.aws.path
+  iam_alias = "full_arn"
+  iam_metadata = ["client_user_id"]
+}`, backend)
+}

--- a/website/docs/r/aws_auth_backend_config_identity.html.md
+++ b/website/docs/r/aws_auth_backend_config_identity.html.md
@@ -30,6 +30,11 @@ resource "vault_aws_auth_backend_config_identity" "example" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+   *Available only for Vault Enterprise*.
+
 * `iam_alias` - (Optional) How to generate the identity alias when using the iam auth method. Valid choices are
   `role_id`, `unique_id`, and `full_arn`. Defaults to `role_id`
 

--- a/website/docs/r/aws_auth_backend_config_identity.html.md
+++ b/website/docs/r/aws_auth_backend_config_identity.html.md
@@ -1,0 +1,55 @@
+---
+layout: "vault"
+page_title: "Vault: vault_aws_auth_backend_config_identity resource"
+sidebar_current: "docs-vault-resource-aws-auth-backend-config-identity"
+description: |-
+  Manages AWS auth backend identity configuration in Vault.
+---
+
+# vault\_aws\_auth\_backend\_config_identity
+
+Manages an AWS auth backend identity configuration in a Vault server. This configuration defines how Vault interacts
+with the identity store. See the [Vault documentation](https://www.vaultproject.io/docs/auth/aws.html) for more
+information.
+
+## Example Usage
+
+```hcl
+resource "vault_auth_backend" "aws" {
+  type = "aws"
+}
+
+resource "vault_aws_auth_backend_config_identity" "example" {
+  backend      = vault_auth_backend.aws.path
+  iam_alias    = "full_arn"
+  iam_metadata = ["canonical_arn", "account_id"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `iam_alias` - (Optional) How to generate the identity alias when using the iam auth method. Valid choices are
+  `role_id`, `unique_id`, and `full_arn`. Defaults to `role_id`
+
+* `iam_metadata` - (Optional) The metadata to include on the token returned by the `login` endpoint. This metadata will be
+  added to both audit logs, and on the `iam_alias`
+
+* `ec2_alias` - (Optional) How to generate the identity alias when using the ec2 auth method. Valid choices are
+  `role_id`, `instance_id`, and `image_id`. Defaults to `role_id`
+
+* `ec2_metadata` - (Optional) The metadata to include on the token returned by the `login` endpoint. This metadata will be
+  added to both audit logs, and on the `ec2_alias`
+
+## Attributes Reference
+
+No additional attributes are exported by this resource.
+
+## Import
+
+AWS auth backend identity config can be imported using `auth/`, the `backend` path, and `/config/identity` e.g.
+
+```
+$ terraform import vault_aws_auth_backend_role.example auth/aws/config/identity
+```

--- a/website/vault.erb
+++ b/website/vault.erb
@@ -142,6 +142,10 @@
                             <a href="/docs/providers/vault/r/aws_auth_backend_client.html">vault_aws_auth_backend_client</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-vault-resource-aws-auth-backend-config-identity") %>>
+                            <a href="/docs/providers/vault/r/aws_auth_backend_config_identity.html">vault_aws_auth_backend_config_identity</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-vault-resource-aws-auth-backend-identity-whitelist") %>>
                             <a href="/docs/providers/vault/r/aws_auth_backend_identity_whitelist.html">vault_aws_auth_backend_identity_whitelist</a>
                         </li>


### PR DESCRIPTION
This change introduces the aws_auth_backend_config_identity resource so that users can configure the way the AWS auth backend interacts with the Identity store. This is adapted from the community PR https://github.com/hashicorp/terraform-provider-vault/pull/1248


Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`resource/aws_auth_backend_config_identity`: Configure how Vault interacts with the Identity store for AWS authentication
```

Output from acceptance testing:

```
$ TESTARGS="--run TestAccAwsAuthBackendConfigIdentity" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test --run TestAccAwsAuthBackendConfigIdentity -timeout 30m ./...
?   	github.com/hashicorp/terraform-provider-vault	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/generate	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/codegen	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/generated	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode	1.501s [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode	2.873s [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet	1.318s [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role	2.225s [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template	3.068s [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation	1.360s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/helper	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/consts	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/internal/identity/entity	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/group	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/mfa	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/pki	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/internal/provider	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/schema	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/testutil	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/util	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/vault	4.715s
```
