### PR TITLE
Fix bug where `vault_kv_secret_v2` resource's `cas` field had no effect

### DIFF
--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -194,6 +194,8 @@ const (
 	FieldUpgradeInfoJSON            = "upgrade_info_json"
 	FieldMaxVersions                = "max_versions"
 	FieldCASRequired                = "cas_required"
+	FieldCAS                        = "cas"
+	FieldOptions                    = "options"
 	FieldDeleteVersionAfter         = "delete_version_after"
 	FieldCustomMetadata             = "custom_metadata"
 	FieldCustomMetadataJSON         = "custom_metadata_json"

--- a/vault/resource_kv_secret_v2.go
+++ b/vault/resource_kv_secret_v2.go
@@ -184,13 +184,14 @@ func kvSecretV2Write(ctx context.Context, d *schema.ResourceData, meta interface
 		return diag.Errorf("data_json %#v syntax error: %s", d.Get(consts.FieldDataJSON), err)
 	}
 
-	data := map[string]interface{}{
-		"data": secretData,
+	options := d.Get(consts.FieldOptions).(map[string]interface{})
+	if _, isSet := options["cas"]; !isSet {
+		options["cas"] = d.Get(consts.FieldCAS)
 	}
 
-	kvFields := []string{"cas", "options"}
-	for _, k := range kvFields {
-		data[k] = d.Get(k)
+	data := map[string]interface{}{
+		"data":    secretData,
+		"options": options,
 	}
 
 	if _, err := client.Logical().Write(path, data); err != nil {

--- a/vault/resource_kv_secret_v2_test.go
+++ b/vault/resource_kv_secret_v2_test.go
@@ -30,6 +30,7 @@ func TestAccKVSecretV2(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "data.zip", "zap"),
 					resource.TestCheckResourceAttr(resourceName, "data.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "data.flag", "false"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.version", "1"),
 				),
 			},
 			{
@@ -48,6 +49,7 @@ func TestAccKVSecretV2(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "custom_metadata.0.data.pizza", "please"),
 					resource.TestCheckResourceAttr(resourceName, "custom_metadata.0.delete_version_after", "0"),
 					resource.TestCheckResourceAttr(resourceName, "custom_metadata.0.max_versions", "5"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.version", "2"),
 				),
 			},
 			{
@@ -71,10 +73,16 @@ func testKVSecretV2Config_initial(mount, name string) string {
 `, kvV2MountConfig(mount))
 
 	ret += fmt.Sprintf(`
+resource "vault_kv_secret_backend_v2" "test" {
+	mount        = vault_mount.kvv2.path
+	cas_required = true
+}
+
 resource "vault_kv_secret_v2" "test" {
-  mount               = vault_mount.kvv2.path
+  mount               = vault_kv_secret_backend_v2.test.mount
   name                = "%s"
   delete_all_versions = true
+  cas                 = 0
   data_json = jsonencode(
     {
       zip  = "zap",
@@ -94,10 +102,16 @@ func testKVSecretV2Config_updated(mount, name string) string {
 `, kvV2MountConfig(mount))
 
 	ret += fmt.Sprintf(`
+resource "vault_kv_secret_backend_v2" "test" {
+	mount        = vault_mount.kvv2.path
+	cas_required = true
+}
+
 resource "vault_kv_secret_v2" "test" {
-  mount               = vault_mount.kvv2.path
+  mount               =  vault_kv_secret_backend_v2.test.mount
   name                = "%s"
   delete_all_versions = true
+  cas                 = 1
   data_json = jsonencode(
     {
       zip  = "zoop",


### PR DESCRIPTION
This PR fixes a bug described in issue #1727. The `vault_kv_secret_v2` resource's `cas` field's value was misplaced in the payload sent to Vault, failing to create or update secrets in an engine that required the check-and-set parameter.

This PR also updates the resource's acceptance test by using the `cas` field. Running the test without the fix reproduces the error described in the issue.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1727

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix a bug where the `vault_kv_secret_v2` resource's `cas` field had no effect.
```

Output from acceptance testing:

```
export VAULT_ADDR="http://localhost:8200"
export VAULT_TOKEN="******"
$ make testacc TESTARGS='-run=TestAccKVSecretV2'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -run=TestAccKVSecretV2 -timeout 30m ./...
?   	github.com/hashicorp/terraform-provider-vault	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/generate	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/codegen	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/generated	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/helper	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/consts	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/internal/identity/entity	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/group	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/mfa	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/pki	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/internal/provider	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/schema	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/testutil	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/util	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/vault	2.198s
```
