### PR TITLE
Refactor test case for deprecated `use_microsoft_graph_api` field

### DIFF
--- a/vault/resource_azure_secret_backend_test.go
+++ b/vault/resource_azure_secret_backend_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
@@ -16,44 +17,9 @@ func TestAzureSecretBackend(t *testing.T) {
 	testutil.SkipTestAcc(t)
 
 	path := acctest.RandomWithPrefix("tf-test-azure")
+	updatedPath := acctest.RandomWithPrefix("tf-test-azure-updated")
 	resourceType := "vault_azure_secret_backend"
 	resourceName := resourceType + ".test"
-	azureInitialCheckFuncs := []resource.TestCheckFunc{
-		resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
-		resource.TestCheckResourceAttr(resourceName, "subscription_id", "11111111-2222-3333-4444-111111111111"),
-		resource.TestCheckResourceAttr(resourceName, "tenant_id", "11111111-2222-3333-4444-222222222222"),
-		resource.TestCheckResourceAttr(resourceName, "client_id", "11111111-2222-3333-4444-333333333333"),
-		resource.TestCheckResourceAttr(resourceName, "client_secret", "12345678901234567890"),
-		resource.TestCheckResourceAttr(resourceName, "environment", "AzurePublicCloud"),
-	}
-
-	azureUpdatedCheckFuncs := []resource.TestCheckFunc{
-		resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
-		resource.TestCheckResourceAttr(resourceName, "subscription_id", "11111111-2222-3333-4444-111111111111"),
-		resource.TestCheckResourceAttr(resourceName, "tenant_id", "22222222-3333-4444-5555-333333333333"),
-		resource.TestCheckResourceAttr(resourceName, "client_id", "22222222-3333-4444-5555-444444444444"),
-		resource.TestCheckResourceAttr(resourceName, "client_secret", "098765432109876543214"),
-		resource.TestCheckResourceAttr(resourceName, "environment", "AzurePublicCloud"),
-	}
-
-	azureUpdatedSubscriptionIDCheckFuncs := []resource.TestCheckFunc{
-		resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
-		resource.TestCheckResourceAttr(resourceName, "subscription_id", "11111112-2221-3332-4443-111111111110"),
-		resource.TestCheckResourceAttr(resourceName, "tenant_id", "22222222-3333-4444-5555-333333333333"),
-		resource.TestCheckResourceAttr(resourceName, "client_id", "22222222-3333-4444-5555-444444444444"),
-		resource.TestCheckResourceAttr(resourceName, "client_secret", "098765432109876543214"),
-		resource.TestCheckResourceAttr(resourceName, "environment", "AzurePublicCloud"),
-	}
-
-	skipMSGraphCheck := provider.IsAPISupported(testProvider.Meta(), provider.VaultVersion112)
-	if !skipMSGraphCheck {
-		azureInitialCheckFuncs = append(azureInitialCheckFuncs,
-			resource.TestCheckResourceAttr(resourceName, "use_microsoft_graph_api", "false"))
-		azureUpdatedCheckFuncs = append(azureUpdatedCheckFuncs,
-			resource.TestCheckResourceAttr(resourceName, "use_microsoft_graph_api", "true"))
-		azureUpdatedSubscriptionIDCheckFuncs = append(azureUpdatedSubscriptionIDCheckFuncs,
-			resource.TestCheckResourceAttr(resourceName, "use_microsoft_graph_api", "true"))
-	}
 
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
@@ -64,18 +30,73 @@ func TestAzureSecretBackend(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAzureSecretBackend_initialConfig(path),
-				Check:  resource.ComposeTestCheckFunc(azureInitialCheckFuncs...),
+				Check:  getAzureBackendChecks(resourceName, path, false),
 			},
 			{
 				Config: testAzureSecretBackend_updated(path),
-				Check:  resource.ComposeTestCheckFunc(azureUpdatedCheckFuncs...),
+				Check:  getAzureBackendChecks(resourceName, path, true),
 			},
+			// Clear out previous test step that uses use_microsoft_graph_api
+			// allows for a cleaner import test
 			{
-				Config: testAzureSecretBackend_updateSubscriptionID(path),
-				Check:  resource.ComposeTestCheckFunc(azureUpdatedSubscriptionIDCheckFuncs...),
+				Config: testAzureSecretBackend_initialConfig(updatedPath),
+				Check:  getAzureBackendChecks(resourceName, updatedPath, false),
 			},
+			testutil.GetImportTestStep(resourceName, false, nil,
+				"client_secret", "disable_remount"),
 		},
 	})
+}
+
+func getAzureBackendChecks(resourceName, path string, isUpdate bool) resource.TestCheckFunc {
+	baseChecks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
+	}
+
+	commonInitialChecks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(resourceName, "subscription_id", "11111111-2222-3333-4444-111111111111"),
+		resource.TestCheckResourceAttr(resourceName, "tenant_id", "11111111-2222-3333-4444-222222222222"),
+		resource.TestCheckResourceAttr(resourceName, "client_id", "11111111-2222-3333-4444-333333333333"),
+		resource.TestCheckResourceAttr(resourceName, "client_secret", "12345678901234567890"),
+		resource.TestCheckResourceAttr(resourceName, "environment", "AzurePublicCloud"),
+	}
+
+	commonUpdateChecks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(resourceName, "subscription_id", "11111111-2222-3333-4444-111111111111"),
+		resource.TestCheckResourceAttr(resourceName, "tenant_id", "22222222-3333-4444-5555-333333333333"),
+		resource.TestCheckResourceAttr(resourceName, "client_id", "22222222-3333-4444-5555-444444444444"),
+		resource.TestCheckResourceAttr(resourceName, "client_secret", "098765432109876543214"),
+		resource.TestCheckResourceAttr(resourceName, "environment", "AzurePublicCloud"),
+	}
+
+	if !isUpdate {
+		baseChecks = append(baseChecks, commonInitialChecks...)
+	} else {
+		baseChecks = append(baseChecks, commonUpdateChecks...)
+	}
+
+	return func(state *terraform.State) error {
+		var checks []resource.TestCheckFunc
+		meta := testProvider.Meta().(*provider.ProviderMeta)
+		var extras []resource.TestCheckFunc
+		// only check use_microsoft_graph_api if Vault version is
+		// < 1.12.0
+		if !meta.IsAPISupported(provider.VaultVersion112) {
+			if !isUpdate {
+				extras = []resource.TestCheckFunc{
+					resource.TestCheckResourceAttr(resourceName, "use_microsoft_graph_api", "false"),
+				}
+			} else {
+				extras = []resource.TestCheckFunc{
+					resource.TestCheckResourceAttr(resourceName, "use_microsoft_graph_api", "true"),
+				}
+			}
+			checks = append(baseChecks, extras...)
+		} else {
+			checks = baseChecks
+		}
+		return resource.ComposeAggregateTestCheckFunc(checks...)(state)
+	}
 }
 
 func TestAzureSecretBackend_remount(t *testing.T) {
@@ -104,15 +125,6 @@ func TestAzureSecretBackend_remount(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceName, "environment", "AzurePublicCloud"),
 	}
 
-	skipMSGraphCheck := provider.IsAPISupported(testProvider.Meta(), provider.VaultVersion112)
-	if !skipMSGraphCheck {
-		azureInitialCheckFuncs = append(azureInitialCheckFuncs,
-			resource.TestCheckResourceAttr(resourceName, "use_microsoft_graph_api", "false"))
-
-		azureUpdatedCheckFuncs = append(azureUpdatedCheckFuncs,
-			resource.TestCheckResourceAttr(resourceName, "use_microsoft_graph_api", "false"))
-	}
-
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
 		PreCheck: func() {
@@ -121,11 +133,11 @@ func TestAzureSecretBackend_remount(t *testing.T) {
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeAzure, consts.FieldPath),
 		Steps: []resource.TestStep{
 			{
-				Config: testAzureSecretBackend_initialConfig(path),
+				Config: testAzureSecretBackend_remount(path),
 				Check:  resource.ComposeTestCheckFunc(azureInitialCheckFuncs...),
 			},
 			{
-				Config: testAzureSecretBackend_initialConfig(updatedPath),
+				Config: testAzureSecretBackend_remount(updatedPath),
 				Check:  resource.ComposeTestCheckFunc(azureUpdatedCheckFuncs...),
 			},
 			testutil.GetImportTestStep(resourceName, false, nil, "client_secret", "disable_remount"),
@@ -133,40 +145,41 @@ func TestAzureSecretBackend_remount(t *testing.T) {
 	})
 }
 
-func testAzureSecretBackend_initialConfig(updatedPath string) string {
+func testAzureSecretBackend_initialConfig(path string) string {
 	return fmt.Sprintf(`
-	resource "vault_azure_secret_backend" "test" {
-	 path = "%s"
-	 subscription_id = "11111111-2222-3333-4444-111111111111"
-	 tenant_id = "11111111-2222-3333-4444-222222222222"
-	 client_id = "11111111-2222-3333-4444-333333333333"
-	 client_secret = "12345678901234567890"
-	 environment = "AzurePublicCloud"
-	}`, updatedPath)
+resource "vault_azure_secret_backend" "test" {
+  path            = "%s"
+  subscription_id = "11111111-2222-3333-4444-111111111111"
+  tenant_id       = "11111111-2222-3333-4444-222222222222"
+  client_id       = "11111111-2222-3333-4444-333333333333"
+  client_secret   = "12345678901234567890"
+  environment     = "AzurePublicCloud"
+  disable_remount = true
+}`, path)
 }
 
 func testAzureSecretBackend_updated(path string) string {
 	return fmt.Sprintf(`
-	resource "vault_azure_secret_backend" "test" {
-	 path = "%s"
-	 subscription_id = "11111111-2222-3333-4444-111111111111"
-	 tenant_id = "22222222-3333-4444-5555-333333333333"
-	 client_id = "22222222-3333-4444-5555-444444444444"
-	 client_secret = "098765432109876543214"
-	 environment = "AzurePublicCloud"
-	 use_microsoft_graph_api = true
-	}`, path)
+resource "vault_azure_secret_backend" "test" {
+  path                    = "%s"
+  subscription_id         = "11111111-2222-3333-4444-111111111111"
+  tenant_id               = "22222222-3333-4444-5555-333333333333"
+  client_id               = "22222222-3333-4444-5555-444444444444"
+  client_secret           = "098765432109876543214"
+  environment             = "AzurePublicCloud"
+  disable_remount         = true
+  use_microsoft_graph_api = true
+}`, path)
 }
 
-func testAzureSecretBackend_updateSubscriptionID(path string) string {
+func testAzureSecretBackend_remount(path string) string {
 	return fmt.Sprintf(`
-	resource "vault_azure_secret_backend" "test" {
-	 path = "%s"
-	 subscription_id = "11111112-2221-3332-4443-111111111110"
-	 tenant_id = "22222222-3333-4444-5555-333333333333"
-	 client_id = "22222222-3333-4444-5555-444444444444"
-	 client_secret = "098765432109876543214"
-	 environment = "AzurePublicCloud"
-	 use_microsoft_graph_api = true
-	}`, path)
+resource "vault_azure_secret_backend" "test" {
+  path            = "%s"
+  subscription_id = "11111111-2222-3333-4444-111111111111"
+  tenant_id       = "11111111-2222-3333-4444-222222222222"
+  client_id       = "11111111-2222-3333-4444-333333333333"
+  client_secret   = "12345678901234567890"
+  environment     = "AzurePublicCloud"
+}`, path)
 }


### PR DESCRIPTION
This PR refactors the Azure Secret Backend test cases to match the correct format to test the deprecation of a field