### PR TITLE
fix tests: set github org ID to avoid rate limiting errors

### DIFF
--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -302,6 +302,8 @@ func (c *ghRESTClient) do(method, path string, v interface{}) error {
 		return fmt.Errorf("invalid response for req=%#v, resp=%#v", req, resp)
 	}
 
+	fmt.Println("x-ratelimit-limit")
+	fmt.Println(resp.Header["x-ratelimit-limit"])
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -302,8 +302,6 @@ func (c *ghRESTClient) do(method, path string, v interface{}) error {
 		return fmt.Errorf("invalid response for req=%#v, resp=%#v", req, resp)
 	}
 
-	fmt.Println("x-ratelimit-limit")
-	fmt.Println(resp.Header["x-ratelimit-limit"])
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err

--- a/testutil/testutil_test.go
+++ b/testutil/testutil_test.go
@@ -1,7 +1,6 @@
 package testutil
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -272,47 +271,6 @@ func Test_assertVaultState(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := assertVaultState(tt.resp, tt.tfs, tt.path, tt.tests...); (err != nil) != tt.wantErr {
 				t.Errorf("assertVaultState() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
-
-func TestGetGHOrgResponse(t *testing.T) {
-	tests := []struct {
-		name string
-		org  string
-		want *GHOrgResponse
-	}{
-		{
-			name: "hashicorp",
-			org:  "hashicorp",
-			want: &GHOrgResponse{
-				Login: "hashicorp",
-				ID:    761456,
-			},
-		},
-		{
-			name: "github",
-			org:  "github",
-			want: &GHOrgResponse{
-				Login: "github",
-				ID:    9919,
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := GetGHOrgResponse(t, tt.org); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetGHOrgResponse() = %v, want %v", got, tt.want)
-			}
-			v, ok := ghOrgResponseCache.Load(tt.org)
-			if !ok {
-				t.Fatalf("GetGHOrgResponse() result not cached for %s", tt.org)
-			}
-
-			got := v.(*GHOrgResponse)
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("GetGHOrgResponse() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/vault/resource_github_auth_backend_test.go
+++ b/vault/resource_github_auth_backend_test.go
@@ -17,13 +17,6 @@ import (
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
-// as of vault-1.10 github-auth acceptance tests should use a valid GitHub
-// organization where applicable.
-const (
-	testGHOrg   = "hashicorp"
-	testGHOrgID = 761456
-)
-
 func TestAccGithubAuthBackend_basic(t *testing.T) {
 	testutil.SkipTestAcc(t)
 
@@ -38,14 +31,14 @@ func TestAccGithubAuthBackend_basic(t *testing.T) {
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeGitHub, consts.FieldPath),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGithubAuthBackendConfig_basic(path, testGHOrg),
+				Config: testAccGithubAuthBackendConfig_basic(path, testutil.TestGHOrg),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAuthMountExists(resourceName, &resAuth),
 					resource.TestCheckResourceAttr(resourceName, "id", path),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
-					resource.TestCheckResourceAttr(resourceName, "organization", testGHOrg),
+					resource.TestCheckResourceAttr(resourceName, "organization", testutil.TestGHOrg),
 					// expect computed value for organization_id
-					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(testGHOrgID)),
+					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(testutil.TestGHOrgID)),
 					resource.TestCheckResourceAttr(resourceName, "token_ttl", "1200"),
 					resource.TestCheckResourceAttr(resourceName, "token_max_ttl", "3000"),
 					resource.TestCheckResourceAttrPtr(resourceName, "accessor", &resAuth.Accessor),
@@ -85,14 +78,14 @@ func TestAccGithubAuthBackend_ns(t *testing.T) {
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeGitHub, consts.FieldPath),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGithubAuthBackendConfig_ns(ns, path, testGHOrg),
+				Config: testAccGithubAuthBackendConfig_ns(ns, path),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAuthMountExists(resourceName, &resAuth),
 					resource.TestCheckResourceAttr(resourceName, "id", path),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
-					resource.TestCheckResourceAttr(resourceName, "organization", testGHOrg),
+					resource.TestCheckResourceAttr(resourceName, "organization", testutil.TestGHOrg),
 					// expect computed value for organization_id
-					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(testGHOrgID)),
+					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(testutil.TestGHOrgID)),
 					resource.TestCheckResourceAttr(resourceName, "token_ttl", "1200"),
 					resource.TestCheckResourceAttr(resourceName, "token_max_ttl", "3000"),
 					resource.TestCheckResourceAttrPtr(resourceName, "accessor", &resAuth.Accessor),
@@ -121,8 +114,8 @@ func TestAccGithubAuthBackend_tuning(t *testing.T) {
 					testAccCheckAuthMountExists(resourceName, &resAuth),
 					resource.TestCheckResourceAttr(resourceName, "id", backend),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, backend),
-					resource.TestCheckResourceAttr(resourceName, "organization", testGHOrg),
-					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(testGHOrgID)),
+					resource.TestCheckResourceAttr(resourceName, "organization", testutil.TestGHOrg),
+					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(testutil.TestGHOrgID)),
 					resource.TestCheckResourceAttr(resourceName, "tune.0.default_lease_ttl", "10m"),
 					resource.TestCheckResourceAttr(resourceName, "tune.0.max_lease_ttl", "20m"),
 					resource.TestCheckResourceAttr(resourceName, "tune.0.listing_visibility", "hidden"),
@@ -147,8 +140,8 @@ func TestAccGithubAuthBackend_tuning(t *testing.T) {
 					testAccCheckAuthMountExists(resourceName, &resAuth),
 					resource.TestCheckResourceAttr(resourceName, "id", backend),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, backend),
-					resource.TestCheckResourceAttr(resourceName, "organization", testGHOrg),
-					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(testGHOrgID)),
+					resource.TestCheckResourceAttr(resourceName, "organization", testutil.TestGHOrg),
+					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(testutil.TestGHOrgID)),
 					resource.TestCheckResourceAttr(resourceName, "tune.0.default_lease_ttl", "50m"),
 					resource.TestCheckResourceAttr(resourceName, "tune.0.max_lease_ttl", "1h10m"),
 					resource.TestCheckResourceAttr(resourceName, "tune.0.listing_visibility", "unauth"),
@@ -183,21 +176,21 @@ func TestAccGithubAuthBackend_description(t *testing.T) {
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeGitHub, consts.FieldPath),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGithubAuthBackendConfig_description(path, testGHOrg, "Github Auth Mount"),
+				Config: testAccGithubAuthBackendConfig_description(path, "Github Auth Mount"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAuthMountExists(resourceName, &resAuth),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
-					resource.TestCheckResourceAttr(resourceName, "organization", testGHOrg),
-					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(testGHOrgID)),
+					resource.TestCheckResourceAttr(resourceName, "organization", testutil.TestGHOrg),
+					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(testutil.TestGHOrgID)),
 					resource.TestCheckResourceAttr(resourceName, "description", "Github Auth Mount"),
 				),
 			},
 			{
-				Config: testAccGithubAuthBackendConfig_description(path, testGHOrg, "Github Auth Mount Updated"),
+				Config: testAccGithubAuthBackendConfig_description(path, "Github Auth Mount Updated"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAuthMountExists(resourceName, &resAuth),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
-					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(testGHOrgID)),
+					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(testutil.TestGHOrgID)),
 					resource.TestCheckResourceAttr(resourceName, "description", "Github Auth Mount Updated"),
 				),
 			},
@@ -238,28 +231,28 @@ func TestGithubAuthBackend_remount(t *testing.T) {
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeGitHub, consts.FieldPath),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGithubAuthBackendConfig_basic(path, testGHOrg),
+				Config: testAccGithubAuthBackendConfig_basic(path, testutil.TestGHOrg),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAuthMountExists(resourceName, &resAuth),
 					resource.TestCheckResourceAttr(resourceName, "id", path),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
-					resource.TestCheckResourceAttr(resourceName, "organization", testGHOrg),
+					resource.TestCheckResourceAttr(resourceName, "organization", testutil.TestGHOrg),
 					// expect computed value for organization_id
-					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(testGHOrgID)),
+					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(testutil.TestGHOrgID)),
 					resource.TestCheckResourceAttr(resourceName, "token_ttl", "1200"),
 					resource.TestCheckResourceAttr(resourceName, "token_max_ttl", "3000"),
 					resource.TestCheckResourceAttrPtr(resourceName, "accessor", &resAuth.Accessor),
 				),
 			},
 			{
-				Config: testAccGithubAuthBackendConfig_basic(updatedPath, testGHOrg),
+				Config: testAccGithubAuthBackendConfig_basic(updatedPath, testutil.TestGHOrg),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAuthMountExists(resourceName, &resAuth),
 					resource.TestCheckResourceAttr(resourceName, "id", updatedPath),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, updatedPath),
-					resource.TestCheckResourceAttr(resourceName, "organization", testGHOrg),
+					resource.TestCheckResourceAttr(resourceName, "organization", testutil.TestGHOrg),
 					// expect computed value for organization_id
-					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(testGHOrgID)),
+					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(testutil.TestGHOrgID)),
 					resource.TestCheckResourceAttr(resourceName, "token_ttl", "1200"),
 					resource.TestCheckResourceAttr(resourceName, "token_max_ttl", "3000"),
 					resource.TestCheckResourceAttrPtr(resourceName, "accessor", &resAuth.Accessor),
@@ -317,7 +310,7 @@ resource "vault_github_auth_backend" "test" {
 `, path, org)
 }
 
-func testAccGithubAuthBackendConfig_ns(ns, path, org string) string {
+func testAccGithubAuthBackendConfig_ns(ns, path string) string {
 	config := fmt.Sprintf(`
 resource "vault_namespace" "test" {
   path = "%s"
@@ -331,7 +324,7 @@ resource "vault_github_auth_backend" "test" {
   token_ttl     = 1200
   token_max_ttl = 3000
 }
-`, ns, path, org, testGHOrgID)
+`, ns, path, testutil.TestGHOrg, testutil.TestGHOrgID)
 
 	return config
 }
@@ -366,7 +359,7 @@ resource "vault_github_auth_backend" "test" {
 		token_type = "batch"
 	}
 }
-`, path, testGHOrg, testGHOrgID)
+`, path, testutil.TestGHOrg, testutil.TestGHOrgID)
 }
 
 func testAccGithubAuthBackendConfig_tuningUpdated(path string) string {
@@ -386,10 +379,10 @@ resource "vault_github_auth_backend" "test" {
 		token_type = "default-batch"
 	}
 }
-`, path, testGHOrg, testGHOrgID)
+`, path, testutil.TestGHOrg, testutil.TestGHOrgID)
 }
 
-func testAccGithubAuthBackendConfig_description(path, org, description string) string {
+func testAccGithubAuthBackendConfig_description(path, description string) string {
 	return fmt.Sprintf(`
 resource "vault_github_auth_backend" "test" {
 	path = "%s"
@@ -397,5 +390,5 @@ resource "vault_github_auth_backend" "test" {
 	organization_id = %d
 	description = "%s"
 }
-`, path, org, testGHOrgID, description)
+`, path, testutil.TestGHOrg, testutil.TestGHOrgID, description)
 }

--- a/vault/resource_github_auth_backend_test.go
+++ b/vault/resource_github_auth_backend_test.go
@@ -78,8 +78,11 @@ func TestAccGithubAuthBackend_ns(t *testing.T) {
 	var resAuth api.AuthMount
 
 	resource.Test(t, resource.TestCase{
-		Providers:    testProviders,
-		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		Providers: testProviders,
+		PreCheck: func() {
+			testutil.TestAccPreCheck(t)
+			testutil.TestEntPreCheck(t)
+		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeGitHub, consts.FieldPath),
 		Steps: []resource.TestStep{
 			{
@@ -325,10 +328,11 @@ resource "vault_github_auth_backend" "test" {
   namespace     = vault_namespace.test.path
   path          = "%s"
   organization  = "%s"
+  organization_id = %d
   token_ttl     = 1200
   token_max_ttl = 3000
 }
-`, ns, path, org)
+`, ns, path, org, testGHOrgID)
 
 	return config
 }
@@ -350,7 +354,8 @@ func testAccGithubAuthBackendConfig_tuning(path string) string {
 resource "vault_github_auth_backend" "test" {
   	path = "%s"
   	organization = "%s"
-  
+    organization_id = %d
+
   	tune {
 		default_lease_ttl = "10m"
 		max_lease_ttl = "20m"
@@ -362,7 +367,7 @@ resource "vault_github_auth_backend" "test" {
 		token_type = "batch"
 	}
 }
-`, path, testGHOrg)
+`, path, testGHOrg, testGHOrgID)
 }
 
 func testAccGithubAuthBackendConfig_tuningUpdated(path string) string {
@@ -370,7 +375,8 @@ func testAccGithubAuthBackendConfig_tuningUpdated(path string) string {
 resource "vault_github_auth_backend" "test" {
   	path = "%s"
 	organization = "%s"
-  
+    organization_id = %d
+
   	tune {
 		default_lease_ttl = "50m"
 		max_lease_ttl = "1h10m"
@@ -381,7 +387,7 @@ resource "vault_github_auth_backend" "test" {
 		token_type = "default-batch"
 	}
 }
-`, path, testGHOrg)
+`, path, testGHOrg, testGHOrgID)
 }
 
 func testAccGithubAuthBackendConfig_description(path, org, description string) string {
@@ -389,7 +395,8 @@ func testAccGithubAuthBackendConfig_description(path, org, description string) s
 resource "vault_github_auth_backend" "test" {
 	path = "%s"
 	organization = "%s"
-	description = "%s"  
+	organization_id = %d
+	description = "%s"
 }
-`, path, org, description)
+`, path, org, testGHOrgID, description)
 }

--- a/vault/resource_github_auth_backend_test.go
+++ b/vault/resource_github_auth_backend_test.go
@@ -19,12 +19,13 @@ import (
 
 // as of vault-1.10 github-auth acceptance tests should use a valid GitHub
 // organization where applicable.
-const testGHOrg = "hashicorp"
+const (
+	testGHOrg   = "hashicorp"
+	testGHOrgID = 761456
+)
 
 func TestAccGithubAuthBackend_basic(t *testing.T) {
 	testutil.SkipTestAcc(t)
-
-	orgMeta := testutil.GetGHOrgResponse(t, testGHOrg)
 
 	path := acctest.RandomWithPrefix("github")
 	resourceType := "vault_github_auth_backend"
@@ -44,7 +45,7 @@ func TestAccGithubAuthBackend_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
 					resource.TestCheckResourceAttr(resourceName, "organization", testGHOrg),
 					// expect computed value for organization_id
-					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(orgMeta.ID)),
+					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(testGHOrgID)),
 					resource.TestCheckResourceAttr(resourceName, "token_ttl", "1200"),
 					resource.TestCheckResourceAttr(resourceName, "token_max_ttl", "3000"),
 					resource.TestCheckResourceAttrPtr(resourceName, "accessor", &resAuth.Accessor),
@@ -70,8 +71,6 @@ func TestAccGithubAuthBackend_basic(t *testing.T) {
 func TestAccGithubAuthBackend_ns(t *testing.T) {
 	testutil.SkipTestAcc(t)
 
-	orgMeta := testutil.GetGHOrgResponse(t, testGHOrg)
-
 	path := acctest.RandomWithPrefix("github")
 	ns := acctest.RandomWithPrefix("ns")
 	resourceType := "vault_github_auth_backend"
@@ -91,7 +90,7 @@ func TestAccGithubAuthBackend_ns(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
 					resource.TestCheckResourceAttr(resourceName, "organization", testGHOrg),
 					// expect computed value for organization_id
-					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(orgMeta.ID)),
+					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(testGHOrgID)),
 					resource.TestCheckResourceAttr(resourceName, "token_ttl", "1200"),
 					resource.TestCheckResourceAttr(resourceName, "token_max_ttl", "3000"),
 					resource.TestCheckResourceAttrPtr(resourceName, "accessor", &resAuth.Accessor),
@@ -103,8 +102,6 @@ func TestAccGithubAuthBackend_ns(t *testing.T) {
 
 func TestAccGithubAuthBackend_tuning(t *testing.T) {
 	testutil.SkipTestAcc(t)
-
-	orgMeta := testutil.GetGHOrgResponse(t, testGHOrg)
 
 	backend := acctest.RandomWithPrefix("github")
 	resourceType := "vault_github_auth_backend"
@@ -123,7 +120,7 @@ func TestAccGithubAuthBackend_tuning(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "id", backend),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, backend),
 					resource.TestCheckResourceAttr(resourceName, "organization", testGHOrg),
-					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(orgMeta.ID)),
+					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(testGHOrgID)),
 					resource.TestCheckResourceAttr(resourceName, "tune.0.default_lease_ttl", "10m"),
 					resource.TestCheckResourceAttr(resourceName, "tune.0.max_lease_ttl", "20m"),
 					resource.TestCheckResourceAttr(resourceName, "tune.0.listing_visibility", "hidden"),
@@ -149,7 +146,7 @@ func TestAccGithubAuthBackend_tuning(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "id", backend),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, backend),
 					resource.TestCheckResourceAttr(resourceName, "organization", testGHOrg),
-					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(orgMeta.ID)),
+					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(testGHOrgID)),
 					resource.TestCheckResourceAttr(resourceName, "tune.0.default_lease_ttl", "50m"),
 					resource.TestCheckResourceAttr(resourceName, "tune.0.max_lease_ttl", "1h10m"),
 					resource.TestCheckResourceAttr(resourceName, "tune.0.listing_visibility", "unauth"),
@@ -174,8 +171,6 @@ func TestAccGithubAuthBackend_tuning(t *testing.T) {
 func TestAccGithubAuthBackend_description(t *testing.T) {
 	testutil.SkipTestAcc(t)
 
-	orgMeta := testutil.GetGHOrgResponse(t, testGHOrg)
-
 	path := acctest.RandomWithPrefix("github")
 	resourceType := "vault_github_auth_backend"
 	resourceName := resourceType + ".test"
@@ -191,7 +186,7 @@ func TestAccGithubAuthBackend_description(t *testing.T) {
 					testAccCheckAuthMountExists(resourceName, &resAuth),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
 					resource.TestCheckResourceAttr(resourceName, "organization", testGHOrg),
-					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(orgMeta.ID)),
+					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(testGHOrgID)),
 					resource.TestCheckResourceAttr(resourceName, "description", "Github Auth Mount"),
 				),
 			},
@@ -200,8 +195,7 @@ func TestAccGithubAuthBackend_description(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAuthMountExists(resourceName, &resAuth),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
-					resource.TestCheckResourceAttr(resourceName, "organization", orgMeta.Login),
-					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(orgMeta.ID)),
+					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(testGHOrgID)),
 					resource.TestCheckResourceAttr(resourceName, "description", "Github Auth Mount Updated"),
 				),
 			},
@@ -232,8 +226,6 @@ func TestGithubAuthBackend_remount(t *testing.T) {
 	path := acctest.RandomWithPrefix("tf-test-gh")
 	updatedPath := acctest.RandomWithPrefix("tf-test-gh-updated")
 
-	orgMeta := testutil.GetGHOrgResponse(t, testGHOrg)
-
 	resourceType := "vault_github_auth_backend"
 	resourceName := resourceType + ".test"
 	var resAuth api.AuthMount
@@ -251,7 +243,7 @@ func TestGithubAuthBackend_remount(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
 					resource.TestCheckResourceAttr(resourceName, "organization", testGHOrg),
 					// expect computed value for organization_id
-					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(orgMeta.ID)),
+					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(testGHOrgID)),
 					resource.TestCheckResourceAttr(resourceName, "token_ttl", "1200"),
 					resource.TestCheckResourceAttr(resourceName, "token_max_ttl", "3000"),
 					resource.TestCheckResourceAttrPtr(resourceName, "accessor", &resAuth.Accessor),
@@ -265,7 +257,7 @@ func TestGithubAuthBackend_remount(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, updatedPath),
 					resource.TestCheckResourceAttr(resourceName, "organization", testGHOrg),
 					// expect computed value for organization_id
-					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(orgMeta.ID)),
+					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(testGHOrgID)),
 					resource.TestCheckResourceAttr(resourceName, "token_ttl", "1200"),
 					resource.TestCheckResourceAttr(resourceName, "token_max_ttl", "3000"),
 					resource.TestCheckResourceAttrPtr(resourceName, "accessor", &resAuth.Accessor),

--- a/vault/resource_github_auth_backend_test.go
+++ b/vault/resource_github_auth_backend_test.go
@@ -80,7 +80,6 @@ func TestAccGithubAuthBackend_ns(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
 		PreCheck: func() {
-			testutil.TestAccPreCheck(t)
 			testutil.TestEntPreCheck(t)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeGitHub, consts.FieldPath),

--- a/vault/resource_github_team_test.go
+++ b/vault/resource_github_team_test.go
@@ -21,16 +21,13 @@ func TestAccGithubTeam_basic(t *testing.T) {
 	resName := "vault_github_team.team"
 	team := "my-team-slugified"
 
-	orgMeta := testutil.GetGHOrgResponse(t, testGHOrg)
-	orgID := strconv.Itoa(orgMeta.ID)
-
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		CheckDestroy: testAccGithubTeamCheckDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGithubTeamConfig_basic(backend, team, orgID, []string{"admin", "security"}),
+				Config: testAccGithubTeamConfig_basic(backend, team, []string{"admin", "security"}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resName, "id", "auth/"+backend+"/map/teams/"+team),
 					resource.TestCheckResourceAttr(resName, "backend", backend),
@@ -41,7 +38,7 @@ func TestAccGithubTeam_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccGithubTeamConfig_basic(backend, team, orgID, []string{}),
+				Config: testAccGithubTeamConfig_basic(backend, team, []string{}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resName, "id", "auth/"+backend+"/map/teams/"+team),
 					resource.TestCheckResourceAttr(resName, "backend", backend),
@@ -57,16 +54,13 @@ func TestAccGithubTeam_teamConfigError(t *testing.T) {
 	backend := acctest.RandomWithPrefix("github")
 	team := "Team With Spaces"
 
-	orgMeta := testutil.GetGHOrgResponse(t, testGHOrg)
-	orgID := strconv.Itoa(orgMeta.ID)
-
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		CheckDestroy: testAccGithubTeamCheckDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccGithubTeamConfig_basic(backend, team, orgID, []string{}),
+				Config:      testAccGithubTeamConfig_basic(backend, team, []string{}),
 				ExpectError: regexp.MustCompile(`\: expected team to be a slugified value*`),
 			},
 		},
@@ -78,15 +72,12 @@ func TestAccGithubTeam_importBasic(t *testing.T) {
 	resName := "vault_github_team.team"
 	team := "import-team"
 
-	orgMeta := testutil.GetGHOrgResponse(t, testGHOrg)
-	orgID := strconv.Itoa(orgMeta.ID)
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testutil.TestAccPreCheck(t) },
 		Providers: testProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGithubTeamConfig_basic(backend, team, orgID, []string{"admin", "developer"}),
+				Config: testAccGithubTeamConfig_basic(backend, team, []string{"admin", "developer"}),
 			},
 			{
 				ResourceName:      resName,
@@ -132,7 +123,7 @@ func testAccGithubTeamCheckDestroy(s *terraform.State) error {
 	return fmt.Errorf("Github Team resource still exists")
 }
 
-func testAccGithubTeamConfig_basic(backend, team, orgID string, policies []string) string {
+func testAccGithubTeamConfig_basic(backend string, team string, policies []string) string {
 	p, _ := json.Marshal(policies)
 	return fmt.Sprintf(`
 resource "vault_github_auth_backend" "gh" {
@@ -146,5 +137,5 @@ resource "vault_github_team" "team" {
 	team = "%s"
 	policies = %s
 }
-`, backend, orgID, team, p)
+`, backend, strconv.Itoa(testGHOrgID), team, p)
 }

--- a/vault/resource_github_team_test.go
+++ b/vault/resource_github_team_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -129,7 +128,7 @@ func testAccGithubTeamConfig_basic(backend string, team string, policies []strin
 resource "vault_github_auth_backend" "gh" {
 	path = "%s"
 	organization = "hashicorp"
-	organization_id = "%s"
+	organization_id = %d
 }
 
 resource "vault_github_team" "team" {
@@ -137,5 +136,5 @@ resource "vault_github_team" "team" {
 	team = "%s"
 	policies = %s
 }
-`, backend, strconv.Itoa(testGHOrgID), team, p)
+`, backend, testGHOrgID, team, p)
 }

--- a/vault/resource_github_team_test.go
+++ b/vault/resource_github_team_test.go
@@ -136,5 +136,5 @@ resource "vault_github_team" "team" {
 	team = "%s"
 	policies = %s
 }
-`, backend, testGHOrgID, team, p)
+`, backend, testutil.TestGHOrgID, team, p)
 }

--- a/vault/resource_github_user_test.go
+++ b/vault/resource_github_user_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -111,7 +110,7 @@ func testAccGithubUserConfig_basic(backend string, user string, policies []strin
 resource "vault_github_auth_backend" "gh" {
 	path = "%s"
 	organization = "hashicorp"
-	organization_id = "%s"
+	organization_id = %d
 }
 
 resource "vault_github_user" "user" {
@@ -119,5 +118,5 @@ resource "vault_github_user" "user" {
 	user = "%s"
 	policies = %s
 }
-`, backend, strconv.Itoa(testGHOrgID), user, p)
+`, backend, testGHOrgID, user, p)
 }

--- a/vault/resource_github_user_test.go
+++ b/vault/resource_github_user_test.go
@@ -118,5 +118,5 @@ resource "vault_github_user" "user" {
 	user = "%s"
 	policies = %s
 }
-`, backend, testGHOrgID, user, p)
+`, backend, testutil.TestGHOrgID, user, p)
 }

--- a/vault/resource_github_user_test.go
+++ b/vault/resource_github_user_test.go
@@ -20,16 +20,13 @@ func TestAccGithubUser_basic(t *testing.T) {
 	resName := "vault_github_user.user"
 	user := "john_doe"
 
-	orgMeta := testutil.GetGHOrgResponse(t, testGHOrg)
-	orgID := strconv.Itoa(orgMeta.ID)
-
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
 		CheckDestroy: testAccGithubUserCheckDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGithubUserConfig_basic(backend, user, orgID, []string{"admin", "security"}),
+				Config: testAccGithubUserConfig_basic(backend, user, []string{"admin", "security"}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resName, "id", "auth/"+backend+"/map/users/"+user),
 					resource.TestCheckResourceAttr(resName, "backend", backend),
@@ -40,7 +37,7 @@ func TestAccGithubUser_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccGithubUserConfig_basic(backend, user, orgID, []string{}),
+				Config: testAccGithubUserConfig_basic(backend, user, []string{}),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resName, "id", "auth/"+backend+"/map/users/"+user),
 					resource.TestCheckResourceAttr(resName, "backend", backend),
@@ -57,15 +54,12 @@ func TestAccGithubUser_importBasic(t *testing.T) {
 	resName := "vault_github_user.user"
 	user := "import"
 
-	orgMeta := testutil.GetGHOrgResponse(t, testGHOrg)
-	orgID := strconv.Itoa(orgMeta.ID)
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testutil.TestAccPreCheck(t) },
 		Providers: testProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGithubUserConfig_basic(backend, user, orgID, []string{"security", "admin"}),
+				Config: testAccGithubUserConfig_basic(backend, user, []string{"security", "admin"}),
 			},
 			{
 				ResourceName:      resName,
@@ -111,7 +105,7 @@ func testAccGithubUserCheckDestroy(s *terraform.State) error {
 	return fmt.Errorf("Github user resource still exists")
 }
 
-func testAccGithubUserConfig_basic(backend, user, orgID string, policies []string) string {
+func testAccGithubUserConfig_basic(backend string, user string, policies []string) string {
 	p, _ := json.Marshal(policies)
 	return fmt.Sprintf(`
 resource "vault_github_auth_backend" "gh" {
@@ -125,5 +119,5 @@ resource "vault_github_user" "user" {
 	user = "%s"
 	policies = %s
 }
-`, backend, orgID, user, p)
+`, backend, strconv.Itoa(testGHOrgID), user, p)
 }


### PR DESCRIPTION
We are hitting github rate limit quotas for Github auth. This is because the github auth method will fetch the GH organization ID if one is not provided in the config. The `TestAccGithubAuthBackend_basic` test is already testing a config with and without setting the `organization_id` and checking the computed value. So we set the `organization_id` for all other tests to avoid rate limiting.