### PR TITLE
Fix issue where removing optional fields in database secrets backend connection resource did not reset the fields to their default values

### DIFF
--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -1020,8 +1020,13 @@ func getConnectionDetailsFromResponseWithDisableEscaping(d *schema.ResourceData,
 		return nil
 	}
 
-	if v, ok := d.GetOk(prefix + "disable_esaping"); ok {
+	details := resp.Data["connection_details"].(map[string]interface{})
+	if v, ok := details["disable_escaping"]; ok {
 		result["disable_escaping"] = v.(bool)
+	} else {
+		if v, ok := d.GetOk(prefix + "disable_escaping"); ok {
+			result["disable_escaping"] = v.(bool)
+		}
 	}
 
 	return result
@@ -1301,9 +1306,15 @@ func getConnectionDetailsFromResponseWithUserPass(d *schema.ResourceData, prefix
 		return nil
 	}
 
-	if v, ok := d.GetOk(prefix + "username"); ok {
+	details := resp.Data["connection_details"].(map[string]interface{})
+	if v, ok := details["username"]; ok {
 		result["username"] = v.(string)
+	} else {
+		if v, ok := details["username"]; ok {
+			result["username"] = v.(string)
+		}
 	}
+
 	if v, ok := d.GetOk(prefix + "password"); ok {
 		result["password"] = v.(string)
 	}

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -1020,8 +1020,7 @@ func getConnectionDetailsFromResponseWithDisableEscaping(d *schema.ResourceData,
 		return nil
 	}
 
-	details := resp.Data["connection_details"].(map[string]interface{})
-	if v, ok := details["disable_escaping"]; ok {
+	if v, ok := d.GetOk(prefix + "disable_esaping"); ok {
 		result["disable_escaping"] = v.(bool)
 	}
 

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -1302,8 +1302,7 @@ func getConnectionDetailsFromResponseWithUserPass(d *schema.ResourceData, prefix
 		return nil
 	}
 
-	details := resp.Data["connection_details"].(map[string]interface{})
-	if v, ok := details["username"]; ok {
+	if v, ok := d.GetOk(prefix + "username"); ok {
 		result["username"] = v.(string)
 	}
 	if v, ok := d.GetOk(prefix + "password"); ok {

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -1310,7 +1310,7 @@ func getConnectionDetailsFromResponseWithUserPass(d *schema.ResourceData, prefix
 	if v, ok := details["username"]; ok {
 		result["username"] = v.(string)
 	} else {
-		if v, ok := details["username"]; ok {
+		if v, ok := d.GetOk(prefix + "username"); ok {
 			result["username"] = v.(string)
 		}
 	}

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -1023,10 +1023,6 @@ func getConnectionDetailsFromResponseWithDisableEscaping(d *schema.ResourceData,
 	details := resp.Data["connection_details"].(map[string]interface{})
 	if v, ok := details["disable_escaping"]; ok {
 		result["disable_escaping"] = v.(bool)
-	} else {
-		if v, ok := d.GetOk(prefix + "disable_escaping"); ok {
-			result["disable_escaping"] = v.(bool)
-		}
 	}
 
 	return result
@@ -1309,10 +1305,6 @@ func getConnectionDetailsFromResponseWithUserPass(d *schema.ResourceData, prefix
 	details := resp.Data["connection_details"].(map[string]interface{})
 	if v, ok := details["username"]; ok {
 		result["username"] = v.(string)
-	} else {
-		if v, ok := d.GetOk(prefix + "username"); ok {
-			result["username"] = v.(string)
-		}
 	}
 
 	if v, ok := d.GetOk(prefix + "password"); ok {
@@ -1512,9 +1504,9 @@ func setInfluxDBDatabaseConnectionData(d *schema.ResourceData, prefix string, da
 
 func setDatabaseConnectionDataWithUserPass(d *schema.ResourceData, prefix string, data map[string]interface{}) {
 	setDatabaseConnectionData(d, prefix, data)
-	if v, ok := d.GetOk(prefix + "username"); ok {
-		data["username"] = v.(string)
-	}
+
+	data["username"] = d.Get(prefix + "username")
+
 	if v, ok := d.GetOk(prefix + "password"); ok {
 		data["password"] = v.(string)
 	}
@@ -1523,9 +1515,7 @@ func setDatabaseConnectionDataWithUserPass(d *schema.ResourceData, prefix string
 func setDatabaseConnectionDataWithDisableEscaping(d *schema.ResourceData, prefix string, data map[string]interface{}) {
 	setDatabaseConnectionDataWithUserPass(d, prefix, data)
 
-	if v, ok := d.GetOk(prefix + "disable_escaping"); ok {
-		data["disable_escaping"] = v.(bool)
-	}
+	data["disable_escaping"] = d.Get(prefix + "disable_escaping")
 }
 
 func databaseSecretBackendConnectionCreateOrUpdate(

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -1481,13 +1481,13 @@ resource "vault_database_secret_backend_connection" "test" {
   root_rotation_statements = ["FOOBAR"]
 
   postgresql {
-	  connection_url          = "%s"
+      connection_url          = "%s"
       max_open_connections    = "%s"
       max_idle_connections    = "%s"
       max_connection_lifetime = "%s"
       username                = "%s"
       password                = "%s"
-	  username_template       = "%s"
+      username_template       = "%s"
       disable_escaping        = true
   }
 }

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -760,11 +760,6 @@ func TestAccDatabaseSecretBackendConnection_postgresql(t *testing.T) {
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "postgresql.0.username_template", ""),
 				),
 			},
-			{
-				Config:             testAccDatabaseSecretBackendConnectionConfig_postgresql_reset_optional_values(name, backend, parsedURL),
-				PlanOnly:           true,
-				ExpectNonEmptyPlan: false,
-			},
 		},
 	})
 }

--- a/vault/resource_database_secrets_mount_test.go
+++ b/vault/resource_database_secrets_mount_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestAccDatabaseSecretsMount_mssql(t *testing.T) {
-	MaybeSkipDBTests(t, dbEngineMSSQL)
+	//MaybeSkipDBTests(t, dbEngineMSSQL)
 
 	cleanupFunc, connURL := mssqlhelper.PrepareMSSQLTestContainer(t)
 

--- a/vault/resource_database_secrets_mount_test.go
+++ b/vault/resource_database_secrets_mount_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestAccDatabaseSecretsMount_mssql(t *testing.T) {
-	//MaybeSkipDBTests(t, dbEngineMSSQL)
+	MaybeSkipDBTests(t, dbEngineMSSQL)
 
 	cleanupFunc, connURL := mssqlhelper.PrepareMSSQLTestContainer(t)
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

### Overview

The username & disable_escaping fields are not managed correctly causing unresolvable drift or bad updates if a previously defined value is removed from the stanza.

### To reproduce:
* Create a database backend connection resource with a username field and disable_escaping set to true in the DB type's stanza, example for postgre:
```
provider "vault" {
  address = "http://127.0.0.1:8200"
  token   = "my-token"
}

resource "vault_mount" "my-db" {
  path = "postgres"
  type = "database"
}

resource "vault_database_secret_backend_connection" "my-connection" {
  backend = vault_mount.my-db.path
  name    = "postgres"

  postgresql {
    connection_url     = "postgres://my-username:my-password@localhost:5432"
    username             = "my-username"
    disable_escaping = true
  }
}
```
* terraform apply
* Remove the username and disable_escaping fields from the stanza
```
resource "vault_database_secret_backend_connection" "my-connection" {
  (...)
  postgresql {
    connection_url       = "postgres://my-username:my-password@localhost:5432"
    #username             = "my-username"
    #disable_escaping = true
  }
}
```
* terraform apply
* even if the apply is successful, subsequent `terraform plan` will show unexpected drift:
```
Terraform will perform the following actions:

  # vault_database_secret_backend_connection.postgresql_role will be updated in-place
  ~ resource "vault_database_secret_backend_connection" "postgresql_role" {
        id                       = "postgres/config/postgres"
        name                     = "postgres"
        # (6 unchanged attributes hidden)

      ~ postgresql {
          - username                = "my-username" -> null
          - disable_escaping    = true -> null
            # (5 unchanged attributes hidden)
        }
    }
```

### New behaviour:
* Following a successful `terraform apply`, subsequent `terraform plan` shows everything is up-to-date indicating that the statefile was updated correctly and the artificial drift is gone. The disable_escaping field also reverts back to its default `false` value in Vault.
```
No changes. Your infrastructure matches the configuration.
```

This is backward compatible. Users currently experiencing this issue will have to execute a successful apply once after upgrading their provider to a version with the fix, then all subsequent plans will no longer show the unwanted drift.

### Changelog:
```release-note
BUGS: Fix issue where removing optional fields in database secrets backend connection resource with postgresql did not reset fields to the default values
```

### Output from acceptance testing:
```
$ make testacc TESTARGS='-run=TestAccDatabaseSecretBackendConnection_postgresql'
2023/01/24 09:39:05 [INFO] Using Vault token with the following policies: root
=== RUN   TestAccDatabaseSecretBackendConnection_postgresql
--- PASS: TestAccDatabaseSecretBackendConnection_postgresql (0.66s)
PASS
```
