### PR TITLE
add debug setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,10 @@ dev: fmtcheck
 	go build -o terraform-provider-vault
 	mv terraform-provider-vault ~/.terraform.d/plugins/
 
+debug: fmtcheck
+	go build -gcflags "all=-N -l" -o terraform-provider-vault
+	mv terraform-provider-vault ~/.terraform.d/plugins/
+
 generate:
 	result=$(cd generated && find . -type f -not -name '*_test.go' | grep -v 'registry.go' | xargs rm && cd - )
 	go run cmd/generate/main.go -openapi-doc=testdata/openapi.json

--- a/README.md
+++ b/README.md
@@ -122,3 +122,51 @@ make dev
 ```
 Now Terraform is set up to use the `dev` provider build instead of the provider 
 from the HashiCorp registry.
+
+Debugging the Provider
+---------------------------
+
+The following is adapted from [Debugging Providers](https://developer.hashicorp.com/terraform/plugin/debugging).
+
+### Starting A Provider In Debug Mode
+
+You can enable debbuging with the `make debug` target:
+
+```shell
+make debug
+```
+
+This target will build a binary with compiler optimizations disabled and copy
+the provider binary to the `~/.terraform.d/plugins` directory. Next run Delve
+on the host machine:
+
+```shell
+dlv exec --accept-multiclient --continue --headless --listen=:2345 \
+  ~/.terraform.d/plugins/terraform-provider-vault -- -debug
+```
+
+The above command enables the debugger to run the process for you.
+`terraform-provider-vault` is the name of the executable that was built with
+the `make debug` target. The above command will also output the
+`TF_REATTACH_PROVIDERS` information:
+
+```shell
+TF_REATTACH_PROVIDERS='{"hashicorp/vault":{"Protocol":"grpc","ProtocolVersion":5,"Pid":52780,"Test":true,"Addr":{"Network":"unix","String":"/var/folders/g1/9xn1l6mx0x1dry5wqm78fjpw0000gq/T/plugin2557833286"}}}'
+```
+
+Connect your debugger, such as your editor or the Delve CLI, to the debug
+server. The following command will connect with the Delve CLI:
+
+```shell
+dlv connect :2345
+```
+
+At this point you may set breakpoint in your code.
+
+### Running Terraform With A Provider In Debug Mode
+
+Copy the line starting with `TF_REATTACH_PROVIDERS` from your provider's output.
+Either export it, or prefix every Terraform command with it.
+
+Run Terraform as usual. Any breakpoints you have set will halt execution and
+show you the current variable values.

--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"flag"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 
 	"github.com/hashicorp/terraform-provider-vault/generated"
@@ -16,7 +18,19 @@ func main() {
 	for name, resource := range generated.ResourceRegistry {
 		p.RegisterResource(name, vault.UpdateSchemaResource(resource))
 	}
-	plugin.Serve(&plugin.ServeOpts{
+
+	serveOpts := &plugin.ServeOpts{
 		ProviderFunc: p.SchemaProvider,
-	})
+	}
+
+	var debug bool
+	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
+	if debug {
+		serveOpts.Debug = debug
+		serveOpts.ProviderAddr = "hashicorp/vault"
+	}
+
+	plugin.Serve(serveOpts)
 }


### PR DESCRIPTION
We make the following updates:
- include a debug make target that will compile the TFVP with optimizations disabled to enable debugging
- include a debug flag for the terraform-plugin-sdk [ServeOpts](https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2/plugin#ServeOpts) field in the provider's main.go file to start a debug server and control it's lifecycle
- add a how-to section on debugging in the README

