### PR TITLE
fix: check if tokenInfo is nil

### DIFF
--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -406,6 +406,11 @@ func setChildToken(d *schema.ResourceData, c *api.Client) error {
 	if err != nil {
 		return err
 	}
+
+	if tokenInfo == nil {
+		return fmt.Errorf("failed to lookup self token")
+	}
+
 	if tokenNamespaceRaw, ok := tokenInfo.Data["namespace_path"]; ok {
 		tokenNamespace := tokenNamespaceRaw.(string)
 		if tokenNamespace != "" {


### PR DESCRIPTION
prevents nil dereference as err and tokenInfo can be nil at same time

It fixes this crash
```
Stack trace from the terraform-provider-vault_v3.12.0_x5 plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0xfc8ec0]

goroutine 67 [running]:
github.com/hashicorp/terraform-provider-vault/internal/provider.setChildToken(0xc000f52140?, 0xc000f52140)
	github.com/hashicorp/terraform-provider-vault/internal/provider/meta.go:382 +0xe0
github.com/hashicorp/terraform-provider-vault/internal/provider.NewProviderMeta(0xc000efc480)
	github.com/hashicorp/terraform-provider-vault/internal/provider/meta.go:230 +0xa34
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Provider).Configure(0xc0002802a0, {0x181d2d0, 0xc00063ac60}, 0xd?)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.16.0/helper/schema/provider.go:287 +0x18f
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ConfigureProvider(0xc0009a25e8, {0x181d228?, 0xc0006be3c0?}, 0xc000a003d8)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.16.0/helper/schema/grpc_provider.go:557 +0x345
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).Configure(0xc000931cc0, {0x181d2d0?, 0xc0009e8150?}, 0xc0006be140)
	github.com/hashicorp/terraform-plugin-go@v0.9.0/tfprotov5/tf5server/server.go:555 +0x2ef
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_Configure_Handler({0x13cbea0?, 0xc000931cc0}, {0x181d2d0, 0xc0009e8150}, 0xc000f56000, 0x0)
	github.com/hashicorp/terraform-plugin-go@v0.9.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:331 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0000b41e0, {0x1822120, 0xc0004fc680}, 0xc000510d80, 0xc0009a1560, 0x2104fd8, 0x0)
	google.golang.org/grpc@v1.50.0/server.go:1318 +0xb2b
google.golang.org/grpc.(*Server).handleStream(0xc0000b41e0, {0x1822120, 0xc0004fc680}, 0xc000510d80, 0x0)
	google.golang.org/grpc@v1.50.0/server.go:1659 +0xa2f
google.golang.org/grpc.(*Server).serveStreams.func1.2()
	google.golang.org/grpc@v1.50.0/server.go:955 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
	google.golang.org/grpc@v1.50.0/server.go:953 +0x28a

Error: The terraform-provider-vault_v3.12.0_x5 plugin crashed!
```
happened to us, when there were multiple redirects...
[ParseSecret](https://github.com/hashicorp/vault/blob/c5d0528d27569ed8c146e721586f9399d7457809/api/secret.go#L320) can `return nil, nil`

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix panic during lookup of self token
```

