### PR TITLE
Fix qr_size config for identity mfa TOTP

### DIFF
--- a/internal/identity/mfa/totp.go
+++ b/internal/identity/mfa/totp.go
@@ -45,7 +45,8 @@ var (
 		},
 		consts.FieldQRSize: {
 			Type:        schema.TypeInt,
-			Computed:    true,
+			Optional:    true,
+			Default:     200,
 			Description: `The pixel size of the generated square QR code.`,
 		},
 		consts.FieldAlgorithm: {

--- a/vault/resource_identity_mfa_totp_test.go
+++ b/vault/resource_identity_mfa_totp_test.go
@@ -43,7 +43,7 @@ resource "%s" "test" {
 						resource.TestCheckResourceAttr(resourceName, consts.FieldIssuer, "issuer1"),
 						resource.TestCheckResourceAttr(resourceName, consts.FieldPeriod, "30"),
 						resource.TestCheckResourceAttr(resourceName, consts.FieldKeySize, "20"),
-						resource.TestCheckResourceAttr(resourceName, consts.FieldQRSize, "0"),
+						resource.TestCheckResourceAttr(resourceName, consts.FieldQRSize, "200"),
 						resource.TestCheckResourceAttr(resourceName, consts.FieldAlgorithm, "SHA256"),
 						resource.TestCheckResourceAttr(resourceName, consts.FieldDigits, "6"),
 						resource.TestCheckResourceAttr(resourceName, consts.FieldSkew, "1"),
@@ -61,6 +61,7 @@ resource "%s" "test" {
   digits                  = 8
   skew                    = 0
   max_validation_attempts = 10
+  qr_size				  = 500
 }
 `, mfa.ResourceNameTOTP),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -68,7 +69,7 @@ resource "%s" "test" {
 						resource.TestCheckResourceAttr(resourceName, consts.FieldIssuer, "issuer2"),
 						resource.TestCheckResourceAttr(resourceName, consts.FieldPeriod, "60"),
 						resource.TestCheckResourceAttr(resourceName, consts.FieldKeySize, "30"),
-						resource.TestCheckResourceAttr(resourceName, consts.FieldQRSize, "0"),
+						resource.TestCheckResourceAttr(resourceName, consts.FieldQRSize, "500"),
 						resource.TestCheckResourceAttr(resourceName, consts.FieldAlgorithm, "SHA512"),
 						resource.TestCheckResourceAttr(resourceName, consts.FieldDigits, "8"),
 						resource.TestCheckResourceAttr(resourceName, consts.FieldSkew, "0"),


### PR DESCRIPTION
This PR fixes an issue where `qr_size` would be set to zero when attempting to create this resource using the provider. A user would also be unable to specify a `qr_size` in the tf code, and would instead need to log into Vault and manually configure this option. The test has also been modified accordingly to verify defaults as well as manual config setting is executed correctly against Vault.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fix qr_size config for identity mfa totp
```

Output from testing:

```
$ go test -timeout 30s -run ^TestIdentityMFATOTP$ github.com/hashicorp/terraform-provider-vault/vault -v
2023/02/07 13:18:18 [INFO] Using Vault token with the following policies: root
=== RUN   TestIdentityMFATOTP
=== PAUSE TestIdentityMFATOTP
=== CONT  TestIdentityMFATOTP
--- PASS: TestIdentityMFATOTP (3.67s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/vault	4.236s
```
