### PR TITLE
Ensure that the qr_size can be properly configured.

### DIFF
--- a/internal/identity/mfa/duo.go
+++ b/internal/identity/mfa/duo.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
 const (
@@ -50,11 +51,14 @@ var duoSchemaMap = map[string]*schema.Schema{
 	},
 }
 
+// GetDuoSchemaResource returns the resource needed to provision an identity/mfa/duo resource.
 func GetDuoSchemaResource() (*schema.Resource, error) {
 	config, _ := NewContextFuncConfig(MethodTypeDuo, PathTypeMethodID, nil, nil, map[string]string{
 		// API is inconsistent between create/update and read.
 		"pushinfo": consts.FieldPushInfo,
 	})
+
+	config.setAPIValueGetter(consts.FieldUsernameFormat, util.GetAPIRequestValue)
 
 	return getMethodSchemaResource(duoSchemaMap, config), nil
 }

--- a/internal/identity/mfa/login_enforcement.go
+++ b/internal/identity/mfa/login_enforcement.go
@@ -62,6 +62,8 @@ var loginEnforcementSchemaMap = map[string]*schema.Schema{
 	},
 }
 
+// GetLoginEnforcementSchemaResource returns the resource needed to provision an identity/mfa/login-enforcement
+// resource.
 func GetLoginEnforcementSchemaResource() (*schema.Resource, error) {
 	config, err := NewContextFuncConfig(MethodTypeLoginEnforcement, PathTypeName, nil, nil, nil)
 	if err != nil {

--- a/internal/identity/mfa/mfa.go
+++ b/internal/identity/mfa/mfa.go
@@ -255,7 +255,7 @@ func (c *contextFuncConfig) GetSecretFields() []string {
 func (c *contextFuncConfig) GetRequestData(d *schema.ResourceData) map[string]interface{} {
 	result := make(map[string]interface{})
 	for _, k := range c.GetWriteFields() {
-		getter := c.getAPIValueGetterFunc(k)
+		getter := c.getAPIValueGetter(k)
 		if getter == nil {
 			getter = c.getDefaultAPIValueGetterFunc()
 		}
@@ -267,19 +267,6 @@ func (c *contextFuncConfig) GetRequestData(d *schema.ResourceData) map[string]in
 }
 
 func (c *contextFuncConfig) getDefaultAPIValueGetterFunc() util.VaultAPIValueGetter {
-	if c.defaultAPIValueGetter == nil {
-		return util.GetAPIRequestValueOk
-	} else {
-		return c.defaultAPIValueGetter
-	}
-}
-
-func (c *contextFuncConfig) getAPIValueGetterFunc(k string) util.VaultAPIValueGetter {
-	if c.apiValueGetters != nil {
-		if f, ok := c.apiValueGetters[k]; ok {
-			return f
-		}
-	}
 	if c.defaultAPIValueGetter == nil {
 		return util.GetAPIRequestValueOk
 	} else {

--- a/internal/identity/mfa/mfa.go
+++ b/internal/identity/mfa/mfa.go
@@ -257,7 +257,7 @@ func (c *contextFuncConfig) GetRequestData(d *schema.ResourceData) map[string]in
 	for _, k := range c.GetWriteFields() {
 		getter := c.getAPIValueGetter(k)
 		if getter == nil {
-			getter = c.getDefaultAPIValueGetterFunc()
+			getter = c.getDefaultAPIValueGetter()
 		}
 		if v, ok := getter(d, k); ok {
 			result[k] = v
@@ -266,7 +266,7 @@ func (c *contextFuncConfig) GetRequestData(d *schema.ResourceData) map[string]in
 	return result
 }
 
-func (c *contextFuncConfig) getDefaultAPIValueGetterFunc() util.VaultAPIValueGetter {
+func (c *contextFuncConfig) getDefaultAPIValueGetter() util.VaultAPIValueGetter {
 	if c.defaultAPIValueGetter == nil {
 		return util.GetAPIRequestValueOk
 	} else {

--- a/internal/identity/mfa/okta.go
+++ b/internal/identity/mfa/okta.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
 const (
@@ -44,6 +45,7 @@ var oktaSchemaMap = map[string]*schema.Schema{
 	},
 }
 
+// GetOKTASchemaResource returns the resource needed to provision an identity/mfa/okta resource.
 func GetOKTASchemaResource() (*schema.Resource, error) {
 	config, err := NewContextFuncConfig(MethodTypeOKTA, PathTypeMethodID, nil, nil, nil)
 	// TODO: the primary_email field is not included in the response
@@ -53,6 +55,8 @@ func GetOKTASchemaResource() (*schema.Resource, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	config.setAPIValueGetter(consts.FieldUsernameFormat, util.GetAPIRequestValue)
 
 	return getMethodSchemaResource(oktaSchemaMap, config), nil
 }

--- a/internal/identity/mfa/ping_id.go
+++ b/internal/identity/mfa/ping_id.go
@@ -65,6 +65,7 @@ var pingIDSchemaMap = map[string]*schema.Schema{
 	},
 }
 
+// GetPingIDSchemaResource returns the resource needed to provision an identity/mfa/pingid resource.
 func GetPingIDSchemaResource() (*schema.Resource, error) {
 	config, err := NewContextFuncConfig(MethodTypePingID, PathTypeMethodID, nil, []string{
 		consts.FieldType,

--- a/internal/identity/mfa/totp.go
+++ b/internal/identity/mfa/totp.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
 const (
@@ -85,6 +86,9 @@ func GetTOTPSchemaResource() (*schema.Resource, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// ensure that the qr_size field can be set to 0
+	config.setAPIValueGetter(consts.FieldQRSize, util.GetAPIRequestValueOkExists)
 
 	return getMethodSchemaResource(totpSchemaMap, config), nil
 }

--- a/internal/identity/mfa/totp.go
+++ b/internal/identity/mfa/totp.go
@@ -46,6 +46,7 @@ var (
 		consts.FieldQRSize: {
 			Type:        schema.TypeInt,
 			Computed:    true,
+			Optional:    true,
 			Description: `The pixel size of the generated square QR code.`,
 		},
 		consts.FieldAlgorithm: {
@@ -78,6 +79,7 @@ var (
 	}
 )
 
+// GetTOTPSchemaResource returns the resource needed to provision an identity/mfa/totp resource.
 func GetTOTPSchemaResource() (*schema.Resource, error) {
 	config, err := NewContextFuncConfig(MethodTypeTOTP, PathTypeMethodID, nil, nil, nil)
 	if err != nil {

--- a/util/util.go
+++ b/util/util.go
@@ -21,7 +21,13 @@ import (
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 )
 
-func JsonDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+type (
+	// VaultAPIValueGetter returns the value from the *schema.ResourceData for a key,
+	// along with a boolean that denotes the key's existence.
+	VaultAPIValueGetter func(*schema.ResourceData, string) (interface{}, bool)
+)
+
+func JsonDiffSuppress(k, old, new string, _ *schema.ResourceData) bool {
 	var oldJSON, newJSON interface{}
 	err := json.Unmarshal([]byte(old), &oldJSON)
 	if err != nil {
@@ -193,7 +199,7 @@ func ParsePath(userSuppliedPath, endpoint string, d *schema.ResourceData) string
 		if !ok {
 			continue
 		}
-		// All path parameters must be strings so it's safe to
+		// All path parameters must be strings, so it's safe to
 		// assume here.
 		val := valRaw.(string)
 		recomprised = strings.Replace(recomprised, fmt.Sprintf("{%s}", field), val, -1)
@@ -366,9 +372,19 @@ func GetAPIRequestDataWithSlice(d *schema.ResourceData, fields []string) map[str
 // GetAPIRequestDataWithSliceOk to pass to Vault from schema.ResourceData.
 // Only field values that are set in schema.ResourceData will be returned
 func GetAPIRequestDataWithSliceOk(d *schema.ResourceData, fields []string) map[string]interface{} {
+	return getAPIRequestDataWithSlice(d, GetAPIRequestValueOk, fields)
+}
+
+// GetAPIRequestDataWithSliceOkExists to pass to Vault from schema.ResourceData.
+// Only field values that are set in schema.ResourceData will be returned
+func GetAPIRequestDataWithSliceOkExists(d *schema.ResourceData, fields []string) map[string]interface{} {
+	return getAPIRequestDataWithSlice(d, GetAPIRequestValueOkExists, fields)
+}
+
+func getAPIRequestDataWithSlice(d *schema.ResourceData, f VaultAPIValueGetter, fields []string) map[string]interface{} {
 	data := make(map[string]interface{})
 	for _, k := range fields {
-		if v, ok := getAPIRequestValueOk(d, k); ok {
+		if v, ok := f(d, k); ok {
 			data[k] = v
 		}
 	}
@@ -389,13 +405,28 @@ func getAPIValue(i interface{}) interface{} {
 	}
 }
 
-func getAPIRequestValueOk(d *schema.ResourceData, k string) (interface{}, bool) {
+// GetAPIRequestValueOk returns the Vault API compatible value from *schema.ResourceData for provided key,
+// along with boolean representing keys existence in the resource data.
+// This is equivalent to calling the schema.ResourceData's GetOk() method.
+func GetAPIRequestValueOk(d *schema.ResourceData, k string) (interface{}, bool) {
 	sv, ok := d.GetOk(k)
-	if !ok {
-		return nil, ok
-	}
-
 	return getAPIValue(sv), ok
+}
+
+// GetAPIRequestValueOkExists returns the Vault API compatible value from *schema.ResourceData for provided key,
+// along with boolean representing keys existence in the resource data.
+// This is equivalent to calling the schema.ResourceData's deprecated GetOkExists() method.
+func GetAPIRequestValueOkExists(d *schema.ResourceData, k string) (interface{}, bool) {
+	sv, ok := d.GetOkExists(k)
+	return getAPIValue(sv), ok
+}
+
+// GetAPIRequestValue returns the value from *schema.ResourceData for provide key.
+// The existence boolean is always true, so it should be ignored,
+// this is done  in order to satisfy the VaultAPIValueGetter type.
+// This is equivalent to calling the schema.ResourceData's Get() method.
+func GetAPIRequestValue(d *schema.ResourceData, k string) (interface{}, bool) {
+	return getAPIValue(d.Get(k)), true
 }
 
 func Remount(d *schema.ResourceData, client *api.Client, mountField string, isAuthMount bool) (string, error) {
@@ -407,7 +438,6 @@ func Remount(d *schema.ResourceData, client *api.Client, mountField string, isAu
 		o, n := d.GetChange(mountField)
 		oldPath := o.(string)
 		newPath := n.(string)
-
 		if isAuthMount {
 			oldPath = "auth/" + oldPath
 			newPath = "auth/" + newPath

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -433,6 +433,215 @@ func TestGetAPIRequestDataWithSlice(t *testing.T) {
 	}
 }
 
+func TestGetAPIRequestDataWithSliceOk(t *testing.T) {
+	tests := []struct {
+		name string
+		d    map[string]*schema.Schema
+		s    []string
+		sm   map[string]interface{}
+		want map[string]interface{}
+	}{
+		{
+			name: "basic-default",
+			d: map[string]*schema.Schema{
+				"name": {
+					Type: schema.TypeString,
+				},
+			},
+			s: []string{"name"},
+			sm: map[string]interface{}{
+				"name": "bob",
+			},
+			want: map[string]interface{}{
+				"name": "bob",
+			},
+		},
+		{
+			name: "set",
+			d: map[string]*schema.Schema{
+				"name": {
+					Type: schema.TypeString,
+				},
+				"parts": {
+					Type: schema.TypeSet,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+			},
+			s: []string{
+				"name",
+				"parts",
+			},
+			sm: map[string]interface{}{
+				"name": "alice",
+				"parts": []interface{}{
+					"bolt",
+				},
+			},
+			want: map[string]interface{}{
+				"name": "alice",
+				"parts": []interface{}{
+					"bolt",
+				},
+			},
+		},
+		{
+			name: "parts-field-not-configured",
+			d: map[string]*schema.Schema{
+				"name": {
+					Type: schema.TypeString,
+				},
+			},
+			s: []string{
+				"name",
+				"parts",
+			},
+			sm: map[string]interface{}{
+				"name": "alice",
+			},
+			want: map[string]interface{}{
+				"name": "alice",
+			},
+		},
+		{
+			name: "zero-value-int-field",
+			d: map[string]*schema.Schema{
+				"name": {
+					Type: schema.TypeString,
+				},
+				"enabled": {
+					Type: schema.TypeInt,
+				},
+			},
+			s: []string{
+				"name",
+				"enabled",
+			},
+			sm: map[string]interface{}{
+				"name":    "alice",
+				"enabled": 0,
+			},
+			want: map[string]interface{}{
+				"name": "alice",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := schema.TestResourceDataRaw(t, tt.d, tt.sm)
+			if got := GetAPIRequestDataWithSliceOk(r, tt.s); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetAPIRequestDataWithSliceOk() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetAPIRequestDataWithSliceOkExists(t *testing.T) {
+	tests := []struct {
+		name string
+		d    map[string]*schema.Schema
+		s    []string
+		sm   map[string]interface{}
+		want map[string]interface{}
+	}{
+		{
+			name: "basic-default",
+			d: map[string]*schema.Schema{
+				"name": {
+					Type: schema.TypeString,
+				},
+			},
+			s: []string{"name"},
+			sm: map[string]interface{}{
+				"name": "bob",
+			},
+			want: map[string]interface{}{
+				"name": "bob",
+			},
+		},
+		{
+			name: "set",
+			d: map[string]*schema.Schema{
+				"name": {
+					Type: schema.TypeString,
+				},
+				"parts": {
+					Type: schema.TypeSet,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+					},
+				},
+			},
+			s: []string{
+				"name",
+				"parts",
+			},
+			sm: map[string]interface{}{
+				"name": "alice",
+				"parts": []interface{}{
+					"bolt",
+				},
+			},
+			want: map[string]interface{}{
+				"name": "alice",
+				"parts": []interface{}{
+					"bolt",
+				},
+			},
+		},
+		{
+			name: "parts-field-not-configured",
+			d: map[string]*schema.Schema{
+				"name": {
+					Type: schema.TypeString,
+				},
+			},
+			s: []string{
+				"name",
+				"parts",
+			},
+			sm: map[string]interface{}{
+				"name": "alice",
+			},
+			want: map[string]interface{}{
+				"name": "alice",
+			},
+		},
+		{
+			name: "zero-value-int-field",
+			d: map[string]*schema.Schema{
+				"name": {
+					Type: schema.TypeString,
+				},
+				"enabled": {
+					Type: schema.TypeInt,
+				},
+			},
+			s: []string{
+				"name",
+				"enabled",
+			},
+			sm: map[string]interface{}{
+				"name":    "alice",
+				"enabled": 0,
+			},
+			want: map[string]interface{}{
+				"name":    "alice",
+				"enabled": 0,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := schema.TestResourceDataRaw(t, tt.d, tt.sm)
+			if got := GetAPIRequestDataWithSliceOkExists(r, tt.s); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetAPIRequestDataWithSliceOkExists() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCalculateConflictsWith(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/vault/resource_identity_mfa_duo_test.go
+++ b/vault/resource_identity_mfa_duo_test.go
@@ -61,6 +61,7 @@ resource "%s" "test" {
   integration_key = "int-key-2"
   api_hostname    = "foo.baz"
   push_info       = "push-info-2"
+  username_format = ""
 }
 `, mfa.ResourceNameDuo),
 				Check: resource.ComposeAggregateTestCheckFunc(

--- a/vault/resource_identity_mfa_login_enforcement_test.go
+++ b/vault/resource_identity_mfa_login_enforcement_test.go
@@ -24,6 +24,8 @@ func TestIdentityMFALoginEnforcement(t *testing.T) {
 		resource.TestCheckResourceAttrSet(resourceName, consts.FieldUUID),
 		resource.TestCheckResourceAttr(resourceName, consts.FieldNamespaceID, "root"),
 		resource.TestCheckResourceAttr(resourceName, consts.FieldName, name),
+		resource.TestCheckResourceAttr(resourceName, consts.FieldAuthMethodTypes+".#", "1"),
+		resource.TestCheckResourceAttr(resourceName, consts.FieldAuthMethodTypes+".0", "token"),
 	}
 
 	importTestStep := testutil.GetImportTestStep(resourceName, false, nil, consts.FieldIntegrationKey, consts.FieldSecretKey)
@@ -34,7 +36,7 @@ func TestIdentityMFALoginEnforcement(t *testing.T) {
 			{
 				Config: getTestMFAEnforcementConfig(name),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					append(checksCommon)...,
+					checksCommon...,
 				),
 			},
 			importTestStep,
@@ -56,6 +58,9 @@ resource "vault_identity_mfa_login_enforcement" "test" {
   name = "%s"
   mfa_method_ids = [
     vault_identity_mfa_duo.test.method_id,
+  ]
+  auth_method_types = [
+    "token"
   ]
 }
 `, name)

--- a/vault/resource_identity_mfa_totp_test.go
+++ b/vault/resource_identity_mfa_totp_test.go
@@ -61,7 +61,7 @@ resource "%s" "test" {
   digits                  = 8
   skew                    = 0
   max_validation_attempts = 10
-  qr_size = 300
+  qr_size                 = 300
 }
 `, mfa.ResourceNameTOTP),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -86,7 +86,7 @@ resource "%s" "test" {
   digits                  = 8
   skew                    = 0
   max_validation_attempts = 10
-  qr_size                 = 300
+  qr_size                 = 0
 }
 `, mfa.ResourceNameTOTP),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -94,7 +94,7 @@ resource "%s" "test" {
 						resource.TestCheckResourceAttr(resourceName, consts.FieldIssuer, "issuer2"),
 						resource.TestCheckResourceAttr(resourceName, consts.FieldPeriod, "60"),
 						resource.TestCheckResourceAttr(resourceName, consts.FieldKeySize, "30"),
-						resource.TestCheckResourceAttr(resourceName, consts.FieldQRSize, "300"),
+						resource.TestCheckResourceAttr(resourceName, consts.FieldQRSize, "0"),
 						resource.TestCheckResourceAttr(resourceName, consts.FieldAlgorithm, "SHA512"),
 						resource.TestCheckResourceAttr(resourceName, consts.FieldDigits, "8"),
 						resource.TestCheckResourceAttr(resourceName, consts.FieldSkew, "0"),

--- a/vault/resource_identity_mfa_totp_test.go
+++ b/vault/resource_identity_mfa_totp_test.go
@@ -35,7 +35,7 @@ func TestIdentityMFATOTP(t *testing.T) {
 			{
 				Config: fmt.Sprintf(`
 resource "%s" "test" {
-  issuer = "issuer1"
+  issuer  = "issuer1"
 }
 `, mfa.ResourceNameTOTP),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -43,7 +43,7 @@ resource "%s" "test" {
 						resource.TestCheckResourceAttr(resourceName, consts.FieldIssuer, "issuer1"),
 						resource.TestCheckResourceAttr(resourceName, consts.FieldPeriod, "30"),
 						resource.TestCheckResourceAttr(resourceName, consts.FieldKeySize, "20"),
-						resource.TestCheckResourceAttr(resourceName, consts.FieldQRSize, "0"),
+						resource.TestCheckResourceAttr(resourceName, consts.FieldQRSize, "200"),
 						resource.TestCheckResourceAttr(resourceName, consts.FieldAlgorithm, "SHA256"),
 						resource.TestCheckResourceAttr(resourceName, consts.FieldDigits, "6"),
 						resource.TestCheckResourceAttr(resourceName, consts.FieldSkew, "1"),
@@ -61,6 +61,7 @@ resource "%s" "test" {
   digits                  = 8
   skew                    = 0
   max_validation_attempts = 10
+  qr_size = 300
 }
 `, mfa.ResourceNameTOTP),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -68,7 +69,32 @@ resource "%s" "test" {
 						resource.TestCheckResourceAttr(resourceName, consts.FieldIssuer, "issuer2"),
 						resource.TestCheckResourceAttr(resourceName, consts.FieldPeriod, "60"),
 						resource.TestCheckResourceAttr(resourceName, consts.FieldKeySize, "30"),
-						resource.TestCheckResourceAttr(resourceName, consts.FieldQRSize, "0"),
+						resource.TestCheckResourceAttr(resourceName, consts.FieldQRSize, "300"),
+						resource.TestCheckResourceAttr(resourceName, consts.FieldAlgorithm, "SHA512"),
+						resource.TestCheckResourceAttr(resourceName, consts.FieldDigits, "8"),
+						resource.TestCheckResourceAttr(resourceName, consts.FieldSkew, "0"),
+						resource.TestCheckResourceAttr(resourceName, consts.FieldMaxValidationAttempts, "10"),
+					)...),
+			},
+			{
+				Config: fmt.Sprintf(`
+resource "%s" "test" {
+  issuer                  = "issuer2"
+  period                  = 60
+  key_size                = 30
+  algorithm               = "SHA512"
+  digits                  = 8
+  skew                    = 0
+  max_validation_attempts = 10
+  qr_size                 = 300
+}
+`, mfa.ResourceNameTOTP),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					append(checksCommon,
+						resource.TestCheckResourceAttr(resourceName, consts.FieldIssuer, "issuer2"),
+						resource.TestCheckResourceAttr(resourceName, consts.FieldPeriod, "60"),
+						resource.TestCheckResourceAttr(resourceName, consts.FieldKeySize, "30"),
+						resource.TestCheckResourceAttr(resourceName, consts.FieldQRSize, "300"),
 						resource.TestCheckResourceAttr(resourceName, consts.FieldAlgorithm, "SHA512"),
 						resource.TestCheckResourceAttr(resourceName, consts.FieldDigits, "8"),
 						resource.TestCheckResourceAttr(resourceName, consts.FieldSkew, "0"),


### PR DESCRIPTION
Previously, the `identity_mfa_totp` resource's schema did not allow the `qr_size` field to be configured by the user. It was set as Computed, but not Optional. After resolving this issue we discovered that Create/Update functions would always include this param in the vault API request, which negated the benefits of the field being Computed.

In order to resolve the above issue above, and other similar ones, it is now possible to set the `VaultAPIGetterFunc` by field on the `contextFuncConfig`. Which means it is possible to use any of the
following `schema.ResourceData` methods: `GetOk()`, `Get()`, `GetOkExists()`

Relates #1746 

