### PR TITLE
Add vault_gcp_auth_backend_role resource role_id attribute

### DIFF
--- a/vault/resource_gcp_auth_backend_role.go
+++ b/vault/resource_gcp_auth_backend_role.go
@@ -96,6 +96,11 @@ func gcpAuthBackendRoleResource() *schema.Resource {
 			Optional: true,
 			Computed: true,
 		},
+		"role_id": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The Vault generated role ID.",
+		},
 		"backend": {
 			Type:     schema.TypeString,
 			Optional: true,
@@ -270,6 +275,8 @@ func gcpAuthResourceRead(_ context.Context, d *schema.ResourceData, meta interfa
 			return diag.Errorf("error setting bound_labels for GCP auth backend role: %q", err)
 		}
 	}
+
+	d.Set("role_id", resp.Data["role_id"])
 
 	// These checks are done for backwards compatibility. The 'type' key used to be
 	// 'role_type' and was changed to 'role' errorneously before being corrected

--- a/vault/resource_gcp_auth_backend_role_test.go
+++ b/vault/resource_gcp_auth_backend_role_test.go
@@ -193,6 +193,7 @@ func testGCPAuthBackendRoleCheck_attrs(resourceName, backend, name string) resou
 			"bound_zones":            "bound_zones",
 			"bound_labels":           "bound_labels",
 			"add_group_aliases":      "add_group_aliases",
+			"role_id":                "role_id",
 		}
 
 		for _, v := range commonTokenFields {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1202

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add `vault_gcp_auth_backend_role` resource `role_id` attribute
```

Output from acceptance testing:

```
$ GOOGLE_CREDENTIALS_FILE=... \
  VAULT_TOKEN=... \
  VAULT_ADDR=... \
  TESTARGS="--run GCPAuthBackendRole" \
  make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test --run GCPAuthBackendRole -timeout 30m ./...
?   	github.com/hashicorp/terraform-provider-vault	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/generate	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/generated	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/codegen	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/helper	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/consts	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/group	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/pki	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/mfa	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/schema	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/internal/identity/entity	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/internal/provider	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/testutil	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/util	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/vault	6.668s
```
