### PR TITLE
Fix and update documentation of the `vault_namespace` resource

### DIFF
--- a/website/docs/r/namespace.html.md
+++ b/website/docs/r/namespace.html.md
@@ -81,10 +81,14 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-* `namespace_id` - ID of the namespace.
+In addition to the above arguments, the following attributes are exported:
+
+* `id` - The fully qualified path to the namespace, including the provider `namespace` and a trailing slash.
 
 * `path_fq` - The fully qualified path to the namespace. Useful when provisioning resources in a child `namespace`.
   The path is relative to the provider's `namespace` argument.
+
+* `namespace_id` - Vault server's internal ID of the namespace.
 
 ## Import
 

--- a/website/docs/r/namespace.html.md
+++ b/website/docs/r/namespace.html.md
@@ -99,26 +99,29 @@ $ terraform import vault_namespace.example <name>
 
 If the declared resource is imported and intends to support namespaces using a provider alias, then the name is relative to the namespace path.
 
-```
-
+```hcl
 provider "vault" {
   # Configuration options
   namespace = "example"
   alias     = "example"
 }
 
-resource vault_namespace "example2" {
+resource "vault_namespace" "example2" {
   provider = vault.example
+  path     = "example2"
 }
+```
 
+```
 $ terraform import vault_namespace.example2 example2
 
 $ terraform state show vault_namespace.example2
-# vault_namespace.example2
+# vault_namespace.example2:
 resource "vault_namespace" "example2" {
     id           = "example/example2/"
     namespace_id = <known after import>
     path         = "example2"
+    path_fq      = "example2"
 }
 ```
 

--- a/website/docs/r/namespace.html.md
+++ b/website/docs/r/namespace.html.md
@@ -80,13 +80,14 @@ The following arguments are supported:
   The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
    *Available only for Vault Enterprise*.
 
-* `path` - (Required) The path of the namespace. Must not have a trailing `/`
+* `path` - (Required) The path of the namespace. Must not have a trailing `/`.
 
 ## Attributes Reference
 
 * `namespace_id` - ID of the namespace.
 
 * `path_fq` - The fully qualified path to the namespace. Useful when provisioning resources in a child `namespace`.
+  The path is relative to the provider's `namespace` argument.
 
 ## Import
 

--- a/website/docs/r/namespace.html.md
+++ b/website/docs/r/namespace.html.md
@@ -84,7 +84,7 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-* `id` - ID of the namespace.
+* `namespace_id` - ID of the namespace.
 
 * `path_fq` - The fully qualified path to the namespace. Useful when provisioning resources in a child `namespace`.
 


### PR DESCRIPTION
- Fix `namespace_id` attribute name in the `vault_namespace` resource docs.

    The `id` of the namespace resource was changed to be the full path in [#570](https://github.com/hashicorp/terraform-provider-vault/pull/570),
    and the ID of the namespace is now in the `namespace_id` attribute, but
    the documentation was not updated.

- Document that `path_fq` is relative to the provider's namespace.
- Add correct description for the `id` attribute.
- Fix and update the import example.
- Refactor the nested namespace example.

   Drop extraneous local variable, and iterate over previous resources.

---

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request