### PR TITLE
vault-ssh: add key_type and key_bits to the ssh ca generation call.

### DIFF
--- a/vault/resource_ssh_secret_backend_ca_test.go
+++ b/vault/resource_ssh_secret_backend_ca_test.go
@@ -31,6 +31,22 @@ func TestAccSSHSecretBackendCA_basic(t *testing.T) {
 	})
 }
 
+func TestAccSSHSecretBackendCA_generated(t *testing.T) {
+	backend := "ssh-" + acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testProviders,
+		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		CheckDestroy: testAccCheckSSHSecretBackendCADestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSSHSecretBackendCAConfigGeneratedWithParams(backend),
+				Check:  testAccSSHSecretBackendCACheck(backend),
+			},
+		},
+	})
+}
+
 func TestAccSSHSecretBackendCA_provided(t *testing.T) {
 	backend := "ssh-" + acctest.RandString(10)
 
@@ -101,6 +117,22 @@ resource "vault_mount" "test" {
 resource "vault_ssh_secret_backend_ca" "test" {
   backend              = vault_mount.test.path
   generate_signing_key = true
+}`, backend)
+}
+
+func testAccSSHSecretBackendCAConfigGeneratedWithParams(backend string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "test" {
+  type = "ssh"
+  path = "%s"
+  description = "SSH Secret backend"
+}
+
+resource "vault_ssh_secret_backend_ca" "test" {
+  backend              = vault_mount.test.path
+  generate_signing_key = true
+  key_type             = "ec"
+  key_bits             = 256
 }`, backend)
 }
 


### PR DESCRIPTION
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Closes #1700

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
```release-note
* Adds "key_bits" and "key_type" to the "vault_ssh_secret_backend_ca" resource. 
```

Output from acceptance testing:
```
$ make testacc TESTARGS='-run=TestAccXXX'
TESTARGS="--run TestAccSSHSecretBackendCA" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test --run TestAccSSHSecretBackendCA -timeout 30m ./...
?   	github.com/hashicorp/terraform-provider-vault	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/generate	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/codegen	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/generated	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/helper	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/consts	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/internal/identity/entity	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/group	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/mfa	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/pki	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/internal/provider	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/schema	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/testutil	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/util	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/vault	4.275s
```
