### PR TITLE
Fix KVV2 datasource upon retrieval of soft deleted secrets

### DIFF
--- a/vault/data_source_kv_secret_v2.go
+++ b/vault/data_source_kv_secret_v2.go
@@ -137,8 +137,10 @@ func kvSecretV2DataSourceRead(_ context.Context, d *schema.ResourceData, meta in
 		return diag.FromErr(err)
 	}
 
-	if err := d.Set(consts.FieldData, serializeDataMapToString(data.(map[string]interface{}))); err != nil {
-		return diag.FromErr(err)
+	if v, ok := data.(map[string]interface{}); ok {
+		if err := d.Set(consts.FieldData, serializeDataMapToString(v)); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	if v, ok := secret.Data["metadata"]; ok {

--- a/vault/data_source_kv_secret_v2_test.go
+++ b/vault/data_source_kv_secret_v2_test.go
@@ -9,8 +9,10 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/vault/api"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -54,6 +56,60 @@ func TestDataSourceKVV2Secret(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "data.baz", "{\"riff\":\"raff\"}"),
 					testutil.CheckJSONData(resourceName, consts.FieldDataJSON, expectedSubkeys),
 				),
+			},
+		},
+	})
+}
+
+func TestDataSourceKVV2Secret_deletedSecret(t *testing.T) {
+	mount := acctest.RandomWithPrefix("tf-kv")
+	name := acctest.RandomWithPrefix("foo")
+
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testutil.TestAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+
+					err := client.Sys().Mount(mount, &api.MountInput{
+						Type:        "kv-v2",
+						Description: "Mount for testing KV datasource",
+					})
+					if err != nil {
+						t.Fatalf(fmt.Sprintf("error mounting kvv2 engine; err=%s", err))
+					}
+
+					m := map[string]interface{}{
+						"foo": "bar",
+						"baz": "qux",
+					}
+
+					data := map[string]interface{}{
+						consts.FieldData: m,
+					}
+
+					// Write data at path
+					path := fmt.Sprintf("%s/data/%s", mount, name)
+					resp, err := client.Logical().Write(path, data)
+					if err != nil {
+						t.Fatalf(fmt.Sprintf("error writing to Vault; err=%s", err))
+					}
+
+					if resp == nil {
+						t.Fatalf("empty response")
+					}
+
+					// Soft Delete KV V2 secret at path
+					// Secret data returned from Vault is nil
+					// confirm that plan does not result in panic
+					_, err = client.Logical().Delete(path)
+					if err != nil {
+					}
+				},
+				Config:   kvV2DatasourceConfig(mount, name),
+				PlanOnly: true,
 			},
 		},
 	})
@@ -112,4 +168,13 @@ data "vault_kv_secret_v2" "test" {
   name  = vault_kv_secret_v2.test.name
   version = 1
 }`, kvV2MountConfig(mount), name)
+}
+
+func kvV2DatasourceConfig(mount, name string) string {
+	return fmt.Sprintf(`
+data "vault_kv_secret_v2" "test" {
+  mount = "%s"
+  name  = "%s"
+}
+`, mount, name)
 }


### PR DESCRIPTION
This PR adds a type cast check for the data returned on reading a KV V2 secret from Vault. The current implementation panics when trying to retrieve a secret that has been soft deleted (the secret still exists, but the `data` attribute is `nil`). The PR also adds a test for this use-case and confirms that the fix works as expected.

Fixes #1731 

```
$ make testacc TESTARGS='-v -run TestDataSourceKVV2Secret_deletedSecret'
=== RUN   TestDataSourceKVV2Secret_deletedSecret
--- PASS: TestDataSourceKVV2Secret_deletedSecret (0.98s)
PASS
```