### PR TITLE
set VAULT_AUTH_CONFIG_GITHUB_TOKEN on vault container to avoid GH rate limit when running acceptance tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
         env:
           VAULT_DEV_ROOT_TOKEN_ID: root
           VAULT_LICENSE: ${{ secrets.VAULT_LICENSE }}
-          VAULT_AUTH_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VAULT_AUTH_CONFIG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         options: >-
           --health-cmd "VAULT_ADDR=http://127.0.0.1:8200 vault status"
           --health-interval 1s

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,7 @@ jobs:
         env:
           VAULT_DEV_ROOT_TOKEN_ID: root
           VAULT_LICENSE: ${{ secrets.VAULT_LICENSE }}
+          VAULT_AUTH_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         options: >-
           --health-cmd "VAULT_ADDR=http://127.0.0.1:8200 vault status"
           --health-interval 1s


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -run=TestAccXXX -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
ok      github.com/hashicorp/terraform-provider-vault/codegen   0.677s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    0.385s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    0.578s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    0.788s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        1.217s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/pki      [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/mfa     [no test files]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    0.910s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      0.401s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  0.510s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/provider 0.728s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/testutil  0.804s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util      0.906s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/vault     0.616s [no tests to run]

```
