### PR TITLE
Don't allow setting `path_fq` for `vault_namespace` resource

### DIFF
--- a/vault/resource_namespace.go
+++ b/vault/resource_namespace.go
@@ -26,7 +26,6 @@ const (
 func namespaceResource() *schema.Resource {
 	return &schema.Resource{
 		Create: namespaceCreate,
-		Update: namespaceCreate,
 		Delete: namespaceDelete,
 		Read:   ReadWrapper(namespaceRead),
 		Importer: &schema.ResourceImporter{
@@ -49,7 +48,6 @@ func namespaceResource() *schema.Resource {
 			consts.FieldPathFQ: {
 				Type:        schema.TypeString,
 				Computed:    true,
-				Optional:    true,
 				Description: "The fully qualified namespace path.",
 			},
 		},


### PR DESCRIPTION
The `path_fq` is computed attribute and not an argument, so don't allow users to set it.

Trying to set it to arbitrary value led into Terraform trying to re-create the namespace which failed.

<details>
<summary>Repro before the fix</summary>

With configuration:

```terraform
provider "vault" {
  namespace = "admin"
}

resource "vault_namespace" "foo" {
  path    = "foo"
  path_fq = "bar"
}
```

First apply:

```
$ terraform apply

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # vault_namespace.foo will be created
  + resource "vault_namespace" "foo" {
      + id           = (known after apply)
      + namespace_id = (known after apply)
      + path         = "foo"
      + path_fq      = "bar"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

vault_namespace.foo: Creating...
vault_namespace.foo: Creation complete after 0s [id=admin/foo/]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

$ terraform state show vault_namespace.foo
# vault_namespace.foo:
resource "vault_namespace" "foo" {
    id           = "admin/foo/"
    namespace_id = "VVquu"
    path         = "foo"
    path_fq      = "foo"
}
```

First apply:

```
$ terraform apply
vault_namespace.foo: Refreshing state... [id=admin/foo/]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # vault_namespace.foo will be updated in-place
  ~ resource "vault_namespace" "foo" {
        id           = "admin/foo/"
      ~ path_fq      = "foo" -> "bar"
        # (2 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

vault_namespace.foo: Modifying... [id=admin/foo/]
╷
│ Error: error writing to Vault: Error making API request.
│
│ Namespace: admin
│ URL: PUT https://<VAULT_ADDR>:8200/v1/sys/namespaces/foo
│ Code: 400. Errors:
│
│ * namespace "admin/foo/" already exists
│
│   with vault_namespace.foo,
│   on main.tf line 16, in resource "vault_namespace" "foo":
│   16: resource "vault_namespace" "foo" {
│
```

</details>

<details>
<summary>Output from acceptance testing</summary>

```
$ make testacc-ent TESTARGS='-run=TestAccNamespace'
make testacc TF_ACC_ENTERPRISE=1
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -run=TestAccNamespace -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/codegen   (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/mfa     [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/pki      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/provider (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
ok      github.com/hashicorp/terraform-provider-vault/testutil  (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/vault     29.235s
```

</details>

---

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request