### PR TITLE
Add `custom_metadata` argument to the `vault_namespace` resource

### DIFF
--- a/vault/resource_namespace.go
+++ b/vault/resource_namespace.go
@@ -4,6 +4,7 @@
 package vault
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -26,7 +27,7 @@ const (
 func namespaceResource() *schema.Resource {
 	return &schema.Resource{
 		Create: namespaceCreate,
-		Update: namespaceCreate,
+		Update: namespaceUpdate,
 		Delete: namespaceDelete,
 		Read:   ReadWrapper(namespaceRead),
 		Importer: &schema.ResourceImporter{
@@ -52,6 +53,14 @@ func namespaceResource() *schema.Resource {
 				Optional:    true,
 				Description: "The fully qualified namespace path.",
 			},
+			consts.FieldCustomMetadata: {
+				Type:        schema.TypeMap,
+				Optional:    true,
+				Description: "Metadata associated with this namespace.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 		},
 	}
 }
@@ -64,9 +73,49 @@ func namespaceCreate(d *schema.ResourceData, meta interface{}) error {
 
 	path := d.Get(consts.FieldPath).(string)
 
+	var data map[string]interface{}
+
+	if provider.IsAPISupported(meta, provider.VaultVersion112) {
+		data = map[string]interface{}{}
+		if v, ok := d.GetOk(consts.FieldCustomMetadata); ok {
+			data["custom_metadata"] = v
+		}
+	}
+
 	log.Printf("[DEBUG] Creating namespace %s in Vault", path)
-	_, err := client.Logical().Write(SysNamespaceRoot+path, nil)
-	if err != nil {
+	if _, err := client.Logical().Write(SysNamespaceRoot+path, data); err != nil {
+		return fmt.Errorf("error writing to Vault: %s", err)
+	}
+
+	return namespaceRead(d, meta)
+}
+
+func namespaceUpdate(d *schema.ResourceData, meta interface{}) error {
+	if !provider.IsAPISupported(meta, provider.VaultVersion112) {
+		currentVersion := meta.(*provider.ProviderMeta).GetVaultVersion()
+
+		log.Printf("[WARN] Updating namespace not supported on current Vault version (%s), "+
+			"%s required", currentVersion, provider.VaultVersion112)
+
+		return namespaceRead(d, meta)
+	}
+
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
+	path := d.Get(consts.FieldPath).(string)
+
+	data := map[string]interface{}{}
+
+	if d.HasChange(consts.FieldCustomMetadata) {
+		o, n := d.GetChange(consts.FieldCustomMetadata)
+		data["custom_metadata"] = buildMergePatch(o, n)
+	}
+
+	log.Printf("[DEBUG] Updating namespace %s in Vault", path)
+	if _, err := client.Logical().JSONMergePatch(context.Background(), SysNamespaceRoot+path, data); err != nil {
 		return fmt.Errorf("error writing to Vault: %s", err)
 	}
 
@@ -156,6 +205,12 @@ func namespaceRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	toSet[consts.FieldPathFQ] = pathFQ
 
+	if provider.IsAPISupported(meta, provider.VaultVersion112) {
+		if v, ok := resp.Data["custom_metadata"]; ok {
+			toSet[consts.FieldCustomMetadata] = v
+		}
+	}
+
 	if err := util.SetResourceData(d, toSet); err != nil {
 		return err
 	}
@@ -174,4 +229,18 @@ func upgradeNonPathdNamespaceID(d *schema.ResourceData) {
 		log.Printf("[DEBUG] Setting namespace_id to old ID - %s", oldID)
 		d.Set(consts.FieldNamespaceID, oldID)
 	}
+}
+
+func buildMergePatch(old interface{}, new interface{}) interface{} {
+	// Take all the values from the new configuration
+	patch := new.(map[string]interface{})
+
+	// Delete existing keys which are not configured any more
+	for k := range old.(map[string]interface{}) {
+		if _, found := patch[k]; !found {
+			patch[k] = nil
+		}
+	}
+
+	return patch
 }

--- a/vault/resource_namespace.go
+++ b/vault/resource_namespace.go
@@ -205,10 +205,8 @@ func namespaceRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	toSet[consts.FieldPathFQ] = pathFQ
 
-	if provider.IsAPISupported(meta, provider.VaultVersion112) {
-		if v, ok := resp.Data["custom_metadata"]; ok {
-			toSet[consts.FieldCustomMetadata] = v
-		}
+	if v, ok := resp.Data["custom_metadata"]; ok {
+		toSet[consts.FieldCustomMetadata] = v
 	}
 
 	if err := util.SetResourceData(d, toSet); err != nil {

--- a/website/docs/r/namespace.html.md
+++ b/website/docs/r/namespace.html.md
@@ -19,6 +19,10 @@ Provides a resource to manage [Namespaces](https://www.vaultproject.io/docs/ente
 ```hcl
 resource "vault_namespace" "ns1" {
   path = "ns1"
+
+  custom_metadata = {
+    foo = "abc"
+  }
 }
 ```
 
@@ -81,6 +85,9 @@ The following arguments are supported:
    *Available only for Vault Enterprise*.
 
 * `path` - (Required) The path of the namespace. Must not have a trailing `/`
+
+* `custom_metadata` - (Optional) A map of strings containing arbitrary metadata for the namespace.
+  *Requires Vault 1.12+.*
 
 ## Attributes Reference
 


### PR DESCRIPTION
Vault 1.12 added support for specifying custom metadata for the namespaces as `map(string)`. The [API docs](https://developer.hashicorp.com/vault/api-docs/system/namespaces).

(Conflicts slightly with #1765, but the fix is trivial.)

<details>
<summary>Output from acceptance testing</summary>

```
$ make testacc-ent TESTARGS='-run=TestAccNamespace'
make testacc TF_ACC_ENTERPRISE=1
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -run=TestAccNamespace -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/codegen   (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    0.920s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    0.723s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    0.357s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        0.512s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    1.326s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      1.120s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/mfa     [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/pki      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/provider (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
ok      github.com/hashicorp/terraform-provider-vault/testutil  (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/vault     36.732s
```

</details>

---

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request