### PR TITLE
Quota rate limit role

### DIFF
--- a/vault/resource_quota_rate_limit.go
+++ b/vault/resource_quota_rate_limit.go
@@ -60,6 +60,11 @@ func quotaRateLimitResource() *schema.Resource {
 				Description:  "If set, when a client reaches a rate limit threshold, the client will be prohibited from any further requests until after the 'block_interval' in seconds has elapsed.",
 				ValidateFunc: validation.IntAtLeast(0),
 			},
+			"role": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "If set on a quota where path is set to an auth mount with a concept of roles (such as '/auth/approle/'), this will make the quota restrict login requests to that mount that are made with the specified role. The request will fail if the auth mount does not have a concept of roles, or path is not an auth mount.",
+			},
 		},
 	}
 }
@@ -79,6 +84,7 @@ func quotaRateLimitCreate(ctx context.Context, d *schema.ResourceData, meta inte
 	data := map[string]interface{}{}
 	data["path"] = d.Get("path").(string)
 	data["rate"] = d.Get("rate").(float64)
+	data["role"] = d.Get("role").(string)
 
 	if v, ok := d.GetOk("interval"); ok {
 		data["interval"] = v
@@ -119,7 +125,7 @@ func quotaRateLimitRead(ctx context.Context, d *schema.ResourceData, meta interf
 		return nil
 	}
 
-	for _, k := range []string{"path", "rate", "interval", "block_interval"} {
+	for _, k := range []string{"path", "rate", "interval", "block_interval", "role"} {
 		v, ok := resp.Data[k]
 		if ok {
 			if err := d.Set(k, v); err != nil {
@@ -145,6 +151,7 @@ func quotaRateLimitUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	data := map[string]interface{}{}
 	data["path"] = d.Get("path").(string)
 	data["rate"] = d.Get("rate").(float64)
+	data["role"] = d.Get("role").(string)
 
 	if v, ok := d.GetOk("interval"); ok {
 		data["interval"] = v

--- a/website/docs/r/quota_rate_limit.md
+++ b/website/docs/r/quota_rate_limit.md
@@ -51,6 +51,11 @@ The following arguments are supported:
 * `block_interval` - (Optional) If set, when a client reaches a rate limit threshold, the client will
   be prohibited from any further requests until after the 'block_interval' in seconds has elapsed.
 
+* `role` - (Optional) If set on a quota where path is set to an auth mount with a concept of roles 
+  (such as `/auth/approle/`), this will make the quota restrict login requests to that mount that are 
+  made with the specified role. The request will fail if the auth mount does not have a concept of
+  roles, or path is not an auth mount.
+
 ## Attributes Reference
 
 No additional attributes are exported by this resource.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
<!--- Relates OR Closes #0000 --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add resource_quota_rate_limit support for `role`
```

Output from acceptance testing:

```
$ TESTARGS="--run TestQuotaRateLimit" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test --run TestQuotaRateLimit -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/codegen   (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/mfa     [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/pki      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/provider (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
ok      github.com/hashicorp/terraform-provider-vault/testutil  (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/vault     3.356s
```
