### PR TITLE
Fix KV incorrect metadata path for prefixed mounts

### DIFF
--- a/vault/resource_kv_secret_backend_v2_test.go
+++ b/vault/resource_kv_secret_backend_v2_test.go
@@ -49,6 +49,87 @@ func TestAccKVSecretBackendV2(t *testing.T) {
 	})
 }
 
+func TestKVV2SecretNameFromPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		want      string
+		expectErr bool
+	}{
+		{
+			name:      "non-prefixed secret name",
+			path:      "cloud/data/dev-token",
+			want:      "dev-token",
+			expectErr: false,
+		},
+		{
+			name:      "prefixed secret name",
+			path:      "cloud/data/engineering/admin/token",
+			want:      "engineering/admin/token",
+			expectErr: false,
+		},
+		{
+			name:      "invalid path",
+			path:      "secret/random/value",
+			want:      "",
+			expectErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, err := getKVV2SecretNameFromPath(tt.path)
+			if err == nil && tt.expectErr {
+				t.Fatalf("expected error but got nil")
+			}
+
+			if name != tt.want {
+				t.Fatalf("expected name %s, but got %s", tt.want, name)
+			}
+		})
+	}
+}
+
+func TestKVV2SecretMountFromPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		want      string
+		expectErr bool
+	}{
+		{
+			name:      "non-prefixed mount name",
+			path:      "cloud-metadata/data/token",
+			want:      "cloud-metadata",
+			expectErr: false,
+		},
+		{
+			name:      "prefixed secret name",
+			path:      "cloud-metadata/vault/kv/data/token",
+			want:      "cloud-metadata/vault/kv",
+			expectErr: false,
+		},
+		{
+			name:      "invalid path",
+			path:      "secret/random/value",
+			want:      "",
+			expectErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mount, err := getKVV2SecretMountFromPath(tt.path)
+
+			if err == nil && tt.expectErr {
+				t.Fatalf("expected error but got nil")
+			}
+
+			if mount != tt.want {
+				t.Fatalf("expected name %s, but got %s", tt.want, mount)
+			}
+		})
+	}
+}
+
 func testKVSecretBackendV2Config(path string, isUpdate bool) string {
 	ret := fmt.Sprintf(`
 %s

--- a/vault/resource_kv_secret_v2.go
+++ b/vault/resource_kv_secret_v2.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"strings"
+	"regexp"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -19,12 +19,17 @@ import (
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
-var kvMetadataFields = map[string]string{
-	consts.FieldMaxVersions:        consts.FieldMaxVersions,
-	consts.FieldCASRequired:        consts.FieldCASRequired,
-	consts.FieldDeleteVersionAfter: consts.FieldDeleteVersionAfter,
-	consts.FieldCustomMetadata:     consts.FieldData,
-}
+var (
+	kvV2SecretMountFromPathRegex = regexp.MustCompile("^(.+)/data/.+$")
+	kvV2SecretNameFromPathRegex  = regexp.MustCompile("^.+/data/(.+)$")
+
+	kvMetadataFields = map[string]string{
+		consts.FieldMaxVersions:        consts.FieldMaxVersions,
+		consts.FieldCASRequired:        consts.FieldCASRequired,
+		consts.FieldDeleteVersionAfter: consts.FieldDeleteVersionAfter,
+		consts.FieldCustomMetadata:     consts.FieldData,
+	}
+)
 
 func kvSecretV2Resource(name string) *schema.Resource {
 	return &schema.Resource{
@@ -231,15 +236,33 @@ func kvSecretV2Read(_ context.Context, d *schema.ResourceData, meta interface{})
 	// id should be of the form "mount/data/name"
 	// limit substrings to 3 in case name has '/'
 	// in it or if it's a nested secret
-	parsedPath := strings.SplitN(path, "/", 3)
-	if len(parsedPath) != 3 {
-		return diag.Errorf("invalid format for KV secret path %s", path)
+	//parsedPath := strings.SplitN(path, "/", 3)
+	//if len(parsedPath) != 3 {
+	//	return diag.Errorf("invalid format for KV secret path %s", path)
+	//}
+	//
+	//mount := parsedPath[0]
+	//name := parsedPath[2]
+	//
+	//// Set mount and name fields
+	//if err := d.Set(consts.FieldMount, mount); err != nil {
+	//	return diag.FromErr(err)
+	//}
+	//
+	//if err := d.Set(consts.FieldName, name); err != nil {
+	//	return diag.FromErr(err)
+	//}
+
+	mount, err := getKVV2SecretMountFromPath(path)
+	if err != nil {
+		return diag.Errorf("unable to read mount from ID %s, err=%s", path, err)
 	}
 
-	mount := parsedPath[0]
-	name := parsedPath[2]
+	name, err := getKVV2SecretNameFromPath(path)
+	if err != nil {
+		return diag.Errorf("unable to read name from ID %s, err=%s", path, err)
+	}
 
-	// Set mount and name fields
 	if err := d.Set(consts.FieldMount, mount); err != nil {
 		return diag.FromErr(err)
 	}
@@ -285,8 +308,7 @@ func kvSecretV2Read(_ context.Context, d *schema.ResourceData, meta interface{})
 				// Read & Set custom metadata
 				if _, ok := v[consts.FieldCustomMetadata]; ok {
 					// construct metadata path
-					parsedPath[1] = "metadata"
-					metadataPath := strings.Join(parsedPath, "/")
+					metadataPath := getKVV2Path(mount, name, consts.FieldMetadata)
 					cm, err := readKVV2Metadata(client, metadataPath)
 					if err != nil {
 						return diag.FromErr(err)
@@ -363,4 +385,26 @@ func kvSecretV2Delete(_ context.Context, d *schema.ResourceData, meta interface{
 	}
 
 	return nil
+}
+
+func getKVV2SecretNameFromPath(path string) (string, error) {
+	if !kvV2SecretNameFromPathRegex.MatchString(path) {
+		return "", fmt.Errorf("no name found")
+	}
+	res := kvV2SecretNameFromPathRegex.FindStringSubmatch(path)
+	if len(res) != 2 {
+		return "", fmt.Errorf("unexpected number of matches (%d) for name", len(res))
+	}
+	return res[1], nil
+}
+
+func getKVV2SecretMountFromPath(path string) (string, error) {
+	if !kvV2SecretMountFromPathRegex.MatchString(path) {
+		return "", fmt.Errorf("no mount found")
+	}
+	res := kvV2SecretMountFromPathRegex.FindStringSubmatch(path)
+	if len(res) != 2 {
+		return "", fmt.Errorf("unexpected number of matches (%d) for mount", len(res))
+	}
+	return res[1], nil
 }

--- a/vault/resource_kv_secret_v2.go
+++ b/vault/resource_kv_secret_v2.go
@@ -233,26 +233,6 @@ func kvSecretV2Read(_ context.Context, d *schema.ResourceData, meta interface{})
 		return diag.FromErr(err)
 	}
 
-	// id should be of the form "mount/data/name"
-	// limit substrings to 3 in case name has '/'
-	// in it or if it's a nested secret
-	//parsedPath := strings.SplitN(path, "/", 3)
-	//if len(parsedPath) != 3 {
-	//	return diag.Errorf("invalid format for KV secret path %s", path)
-	//}
-	//
-	//mount := parsedPath[0]
-	//name := parsedPath[2]
-	//
-	//// Set mount and name fields
-	//if err := d.Set(consts.FieldMount, mount); err != nil {
-	//	return diag.FromErr(err)
-	//}
-	//
-	//if err := d.Set(consts.FieldName, name); err != nil {
-	//	return diag.FromErr(err)
-	//}
-
 	mount, err := getKVV2SecretMountFromPath(path)
 	if err != nil {
 		return diag.Errorf("unable to read mount from ID %s, err=%s", path, err)

--- a/vault/resource_kv_secret_v2_test.go
+++ b/vault/resource_kv_secret_v2_test.go
@@ -19,7 +19,7 @@ func TestAccKVSecretV2(t *testing.T) {
 	mount := acctest.RandomWithPrefix("tf-kvv2")
 	name := acctest.RandomWithPrefix("tf-secret")
 
-	updatedMount := acctest.RandomWithPrefix("tf-cloud-metadata")
+	updatedMount := acctest.RandomWithPrefix("random-prefix/tf-cloud-metadata")
 	updatedName := acctest.RandomWithPrefix("tf-database-creds")
 
 	customMetadata := `{"extra":"cheese","pizza":"please"}`


### PR DESCRIPTION
In v3.13.0, we aimed to incorporate a fix for the construction of the metadata path for KV V2 secrets (#1722). Unfortunately, this introduced a regression for customers that had prefixed mounts (mounts that were prefixed with a string and contained a `/`, for example `cloud-metadata/kvv2-mount`).  This PR includes a fix that correctly parses mount and secret names from the ID path using regexes.

A test has been modified to also test for prefixed mounts. This test fails without the addition of the fixes in this PR.

Fixes #1770 #1780 

```
$ make testacc TESTARGS='-v -run TestAccKVSecretV2'
=== RUN   TestAccKVSecretV2
--- PASS: TestAccKVSecretV2 (5.46s)
PASS

```

