### PR TITLE
Add nil check for `IsEnterpriseSupported` util

### DIFF
--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -113,6 +113,9 @@ func (p *ProviderMeta) IsAPISupported(minVersion *version.Version) bool {
 // features.
 func (p *ProviderMeta) IsEnterpriseSupported() bool {
 	ver := p.GetVaultVersion()
+	if ver == nil {
+		return false
+	}
 	return strings.Contains(ver.Metadata(), enterpriseMetadata)
 }
 

--- a/internal/provider/meta_test.go
+++ b/internal/provider/meta_test.go
@@ -498,6 +498,14 @@ func TestIsEnterpriseSupported(t *testing.T) {
 				vaultVersion: VaultVersion12,
 			},
 		},
+		{
+			name:     "unsupported unset",
+			expected: false,
+			meta: &ProviderMeta{
+				client:       rootClient,
+				vaultVersion: nil,
+			},
+		},
 	}
 
 	for _, tt := range testCases {


### PR DESCRIPTION
This PR adds a `nil` check that was missed while adding the `IsEnterpriseSupported` util function. The Vault Version can be `nil` if `skip_get_vault_version` is set as `true` in the provider block.

This PR also adds a test case that tests this use-case.