### PR TITLE
Add PKI Unified CRL parameters

### DIFF
--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -268,6 +268,7 @@ const (
 	VaultVersion110 = "1.10.0"
 	VaultVersion111 = "1.11.0"
 	VaultVersion112 = "1.12.0"
+	VaultVersion113 = "1.13.0"
 
 	/*
 		Vault auth methods

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -37,6 +37,7 @@ var (
 	VaultVersion110 = version.Must(version.NewSemver(consts.VaultVersion110))
 	VaultVersion111 = version.Must(version.NewSemver(consts.VaultVersion111))
 	VaultVersion112 = version.Must(version.NewSemver(consts.VaultVersion112))
+	VaultVersion113 = version.Must(version.NewSemver(consts.VaultVersion113))
 )
 
 // ProviderMeta provides resources with access to the Vault client and

--- a/vault/resource_pki_secret_backend_crl_config.go
+++ b/vault/resource_pki_secret_backend_crl_config.go
@@ -88,6 +88,25 @@ func pkiSecretBackendCrlConfigResource() *schema.Resource {
 				Description: "Interval to check for new revocations on, to regenerate the delta CRL.",
 				Computed:    true,
 			},
+			"cross_cluster_revocation": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Enable cross-cluster revocation request queues.",
+				Computed:    true,
+			},
+			"unified_crl": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Enables unified CRL and OCSP building.",
+				Computed:    true,
+			},
+			"unified_crl_on_existing_paths": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Description: "Enables serving the unified CRL and OCSP on the existing, previously " +
+					"cluster-local paths.",
+				Computed: true,
+			},
 		},
 	}
 }
@@ -114,6 +133,14 @@ func pkiSecretBackendCrlConfigCreate(d *schema.ResourceData, meta interface{}) e
 			"auto_rebuild_grace_period",
 			"enable_delta",
 			"delta_rebuild_interval",
+		}...)
+	}
+
+	if provider.IsAPISupported(meta, provider.VaultVersion113) {
+		fields = append(fields, []string{
+			"cross_cluster_revocation",
+			"unified_crl",
+			"unified_crl_on_existing_paths",
 		}...)
 	}
 

--- a/vault/resource_pki_secret_backend_crl_config.go
+++ b/vault/resource_pki_secret_backend_crl_config.go
@@ -213,6 +213,14 @@ func pkiSecretBackendCrlConfigUpdate(d *schema.ResourceData, meta interface{}) e
 		}...)
 	}
 
+	if provider.IsAPISupported(meta, provider.VaultVersion113) {
+		fields = append(fields, []string{
+			"cross_cluster_revocation",
+			"unified_crl",
+			"unified_crl_on_existing_paths",
+		}...)
+	}
+
 	data := util.GetAPIRequestDataWithSliceOk(d, fields)
 	log.Printf("[DEBUG] Updating CRL config on PKI secret path %q", path)
 	_, err := client.Logical().Write(path, data)

--- a/vault/resource_pki_secret_backend_crl_config_test.go
+++ b/vault/resource_pki_secret_backend_crl_config_test.go
@@ -48,9 +48,9 @@ func getCRLConfigChecks(resourceName string, isUpdate bool) resource.TestCheckFu
 	}
 
 	v113UpdateChecks := []resource.TestCheckFunc{
-		resource.TestCheckResourceAttr(resourceName, "cross_cluster_revocation", "false"),
-		resource.TestCheckResourceAttr(resourceName, "unified_crl", "false"),
-		resource.TestCheckResourceAttr(resourceName, "unified_crl_on_existing_paths", "false"),
+		resource.TestCheckResourceAttr(resourceName, "cross_cluster_revocation", "true"),
+		resource.TestCheckResourceAttr(resourceName, "unified_crl", "true"),
+		resource.TestCheckResourceAttr(resourceName, "unified_crl_on_existing_paths", "true"),
 	}
 
 	return func(state *terraform.State) error {
@@ -177,15 +177,18 @@ func testPkiSecretBackendCrlConfigConfig_explicit(rootPath string) string {
 %s
 
 resource "vault_pki_secret_backend_crl_config" "test" {
-  backend                   = vault_pki_secret_backend_root_cert.test-ca.backend
-  expiry                    = "72h"
-  disable                   = true
-  ocsp_disable              = false
-  ocsp_expiry               = "23h"
-  auto_rebuild              = true
-  auto_rebuild_grace_period = "24h"
-  enable_delta              = true
-  delta_rebuild_interval    = "18m"
+  backend                   	= vault_pki_secret_backend_root_cert.test-ca.backend
+  expiry                    	= "72h"
+  disable                   	= true
+  ocsp_disable              	= false
+  ocsp_expiry               	= "23h"
+  auto_rebuild              	= true
+  auto_rebuild_grace_period 	= "24h"
+  enable_delta              	= true
+  delta_rebuild_interval   		= "18m"
+  cross_cluster_revocation  	= true
+  unified_crl					= true
+  unified_crl_on_existing_paths = true
 }
 `, testPkiSecretBackendCrlConfigConfig_base(rootPath))
 }

--- a/vault/resource_pki_secret_backend_crl_config_test.go
+++ b/vault/resource_pki_secret_backend_crl_config_test.go
@@ -22,32 +22,58 @@ func getCRLConfigChecks(resourceName string, isUpdate bool) resource.TestCheckFu
 		resource.TestCheckResourceAttr(resourceName, "expiry", "72h"),
 		resource.TestCheckResourceAttr(resourceName, "disable", "true"),
 	}
+
+	v112BaseChecks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(resourceName, "ocsp_disable", "false"),
+		resource.TestCheckResourceAttr(resourceName, "ocsp_expiry", "12h"),
+		resource.TestCheckResourceAttr(resourceName, "auto_rebuild", "true"),
+		resource.TestCheckResourceAttr(resourceName, "auto_rebuild_grace_period", "12h"),
+		resource.TestCheckResourceAttr(resourceName, "enable_delta", "true"),
+		resource.TestCheckResourceAttr(resourceName, "delta_rebuild_interval", "15m"),
+	}
+
+	v112UpdateChecks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(resourceName, "ocsp_disable", "false"),
+		resource.TestCheckResourceAttr(resourceName, "ocsp_expiry", "23h"),
+		resource.TestCheckResourceAttr(resourceName, "auto_rebuild", "true"),
+		resource.TestCheckResourceAttr(resourceName, "auto_rebuild_grace_period", "24h"),
+		resource.TestCheckResourceAttr(resourceName, "enable_delta", "true"),
+		resource.TestCheckResourceAttr(resourceName, "delta_rebuild_interval", "18m"),
+	}
+
+	v113BaseChecks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(resourceName, "cross_cluster_revocation", "false"),
+		resource.TestCheckResourceAttr(resourceName, "unified_crl", "false"),
+		resource.TestCheckResourceAttr(resourceName, "unified_crl_on_existing_paths", "false"),
+	}
+
+	v113UpdateChecks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(resourceName, "cross_cluster_revocation", "false"),
+		resource.TestCheckResourceAttr(resourceName, "unified_crl", "false"),
+		resource.TestCheckResourceAttr(resourceName, "unified_crl_on_existing_paths", "false"),
+	}
+
 	return func(state *terraform.State) error {
 		var checks []resource.TestCheckFunc
 		meta := testProvider.Meta().(*provider.ProviderMeta)
-		if meta.IsAPISupported(provider.VaultVersion112) {
-			var extras []resource.TestCheckFunc
+		isVaultVersion113 := meta.IsAPISupported(provider.VaultVersion113)
+		isVaultVersion112 := meta.IsAPISupported(provider.VaultVersion112)
+		switch {
+		case isVaultVersion113:
 			if !isUpdate {
-				extras = []resource.TestCheckFunc{
-					resource.TestCheckResourceAttr(resourceName, "ocsp_disable", "false"),
-					resource.TestCheckResourceAttr(resourceName, "ocsp_expiry", "12h"),
-					resource.TestCheckResourceAttr(resourceName, "auto_rebuild", "true"),
-					resource.TestCheckResourceAttr(resourceName, "auto_rebuild_grace_period", "12h"),
-					resource.TestCheckResourceAttr(resourceName, "enable_delta", "true"),
-					resource.TestCheckResourceAttr(resourceName, "delta_rebuild_interval", "15m"),
-				}
+				checks = append(checks, v113BaseChecks...)
+				checks = append(checks, v112BaseChecks...)
 			} else {
-				extras = []resource.TestCheckFunc{
-					resource.TestCheckResourceAttr(resourceName, "ocsp_disable", "false"),
-					resource.TestCheckResourceAttr(resourceName, "ocsp_expiry", "23h"),
-					resource.TestCheckResourceAttr(resourceName, "auto_rebuild", "true"),
-					resource.TestCheckResourceAttr(resourceName, "auto_rebuild_grace_period", "24h"),
-					resource.TestCheckResourceAttr(resourceName, "enable_delta", "true"),
-					resource.TestCheckResourceAttr(resourceName, "delta_rebuild_interval", "18m"),
-				}
+				checks = append(checks, v113UpdateChecks...)
+				checks = append(checks, v112UpdateChecks...)
 			}
-			checks = append(checks, extras...)
-		} else {
+		case isVaultVersion112:
+			if !isUpdate {
+				checks = append(checks, v112BaseChecks...)
+			} else {
+				checks = append(checks, v112UpdateChecks...)
+			}
+		default:
 			checks = baseChecks
 		}
 		return resource.ComposeAggregateTestCheckFunc(checks...)(state)
@@ -67,6 +93,9 @@ func TestPkiSecretBackendCrlConfig(t *testing.T) {
 			"auto_rebuild_grace_period",
 			"enable_delta",
 			"delta_rebuild_interval",
+			"cross_cluster_revocation",
+			"unified_crl",
+			"unified_crl_on_existing_paths",
 		)
 	})
 
@@ -83,7 +112,7 @@ func TestPkiSecretBackendCrlConfig(t *testing.T) {
 func setupCRLConfigTest(t *testing.T, preCheck func(), ignoreImportFields ...string) {
 	rootPath := "pki-root-" + strconv.Itoa(acctest.RandInt())
 	resourceName := "vault_pki_secret_backend_crl_config.test"
-	steps := append([]resource.TestStep{
+	steps := []resource.TestStep{
 		{
 			Config: testPkiSecretBackendCrlConfigConfig_defaults(rootPath),
 			Check:  getCRLConfigChecks(resourceName, false),
@@ -93,7 +122,7 @@ func setupCRLConfigTest(t *testing.T, preCheck func(), ignoreImportFields ...str
 			Check:  getCRLConfigChecks(resourceName, true),
 		},
 		testutil.GetImportTestStep(resourceName, false, nil, ignoreImportFields...),
-	})
+	}
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
 		PreCheck:     preCheck,
@@ -136,7 +165,7 @@ resource "vault_pki_secret_backend_crl_config" "test" {
   expiry       = "72h"
   disable      = true
   ocsp_disable = false
-  #ocsp_expiry = "13h"
+  ocsp_expiry = "12h"
   auto_rebuild = true
   enable_delta = true
 }

--- a/website/docs/r/pki_secret_backend_crl_config.html.md
+++ b/website/docs/r/pki_secret_backend_crl_config.html.md
@@ -56,6 +56,13 @@ The following arguments are supported:
 
 * `delta_rebuild_interval` - (Optional) Interval to check for new revocations on, to regenerate the delta CRL.
 
+* `cross_cluster_revocation` - (Optional) Enable cross-cluster revocation request queues. **Vault 1.13**
+
+* `unified_crl` - (Optional) Enables unified CRL and OCSP building. **Vault 1.13**
+
+* `unified_crl_on_existing_paths` - (Optional) Enables serving the unified CRL and OCSP on the existing, previously
+ cluster-local paths. **Vault 1.13**
+
 ## Attributes Reference
 
 No additional attributes are exported by this resource.


### PR DESCRIPTION
This PR adds the newly introduced parameters for CRL cross revocation that was introduced in Vault 1.13.0 Enterprise. This solves issues with maintaining or creating new PKI CRL configurations using the provider against Vault 1.13.0.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1788

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
update PKI Backend CRL Config resource with new parameters introduced in 1.13.0
```

Output from testing:

```
❯ TF_ACC=1 go test -timeout 30s -v -run ^TestPkiSecretBackendCrlConfig$ github.com/hashicorp/terraform-provider-vault/vault
2023/03/07 12:34:35 [INFO] Using Vault token with the following policies: root
=== RUN   TestPkiSecretBackendCrlConfig
=== RUN   TestPkiSecretBackendCrlConfig/vault-1.11-and-below
    resource_pki_secret_backend_crl_config_test.go:88: Vault server version "1.13.0+ent"
    resource_pki_secret_backend_crl_config_test.go:88: Vault version >= "1.12.0"
=== RUN   TestPkiSecretBackendCrlConfig/vault-1.12-and-above
    resource_pki_secret_backend_crl_config_test.go:106: Vault server version "1.13.0+ent"
--- PASS: TestPkiSecretBackendCrlConfig (3.93s)
    --- SKIP: TestPkiSecretBackendCrlConfig/vault-1.11-and-below (0.00s)
    --- PASS: TestPkiSecretBackendCrlConfig/vault-1.12-and-above (3.93s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     4.431s
```
