### PR TITLE
fix vault_jwt_auth_backend import guidance to specify "path"

### DIFF
--- a/website/docs/r/jwt_auth_backend.html.md
+++ b/website/docs/r/jwt_auth_backend.html.md
@@ -145,7 +145,7 @@ In addition to the fields above, the following attributes are exported:
 
 ## Import
 
-JWT auth backend can be imported using the `type`, e.g.
+JWT auth backend can be imported using the `path`, e.g.
 
 ```
 $ terraform import vault_jwt_auth_backend.oidc oidc


### PR DESCRIPTION

Documentation currently indicates that the import parameter is `type` when it should actually be `path`

```release-note
Fix vault_jwt_auth_backend import guidance to specify "path" value
```

Testing output:
```
# Create auth mount:
vault auth enable -path=my/jwt jwt

# Configure mount (import will fail if there is no config)
curl -sk -H x-vault-token:$VAULT_TOKEN http://127.0.0.1:8200/v1/auth/my/jwt/config -XPOST -d '{"jwt_validation_pubkeys": "-----BEGIN PUBLIC KEY-----\n..."}'

# Attempt to import with "type":
terraform import -var-file=vars.tfvars vault_jwt_auth_backend.this jwt
│ Error: Cannot import non-existent remote object
│
│ While attempting to import an existing object to "vault_jwt_auth_backend.this", the provider detected that no object exists with the given id. Only pre-existing objects can be imported; check that the id is correct and that it is
│ associated with the provider's configured region or endpoint, or use "terraform apply" to create a new remote object for this resource.

# With path:
terraform import -var-file=vars.tfvars vault_jwt_auth_backend.this my/jwt
vault_jwt_auth_backend.this: Importing from ID "my/jwt"...
vault_jwt_auth_backend.this: Import prepared!
  Prepared vault_jwt_auth_backend for import
vault_jwt_auth_backend.this: Refreshing state... [id=my/jwt]

Import successful!

The resources that were imported are shown above. These resources are now in
your Terraform state and will henceforth be managed by Terraform.
```