### PR TITLE
Enable Vault 1.13 in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,8 @@ jobs:
         image:
         - "vault-enterprise:1.10.6-ent"
         - "vault-enterprise:1.11.4-ent"
-        - "vault-enterprise:1.12.0-ent"
+        - "vault-enterprise:1.12.4-ent"
+        - "vault-enterprise:1.13.0-ent"
     container:
       image: "docker.mirror.hashicorp.services/golang:${{ needs.go-version.outputs.version }}"
     services:


### PR DESCRIPTION
This PR upgrades the build matrix so we are also running tests against Vault 1.13.