### PR TITLE
Merge Vault 1.13 features to `main` 

### DIFF
--- a/vault/provider.go
+++ b/vault/provider.go
@@ -490,6 +490,10 @@ var (
 			Resource:      UpdateSchemaResource(gcpSecretBackendResource("vault_gcp_secret_backend")),
 			PathInventory: []string{"/gcp/config"},
 		},
+		"vault_gcp_secret_impersonated_account": {
+			Resource:      UpdateSchemaResource(gcpSecretImpersonatedAccountResource()),
+			PathInventory: []string{"/gcp/impersonated-account/{name}"},
+		},
 		"vault_gcp_secret_roleset": {
 			Resource:      UpdateSchemaResource(gcpSecretRolesetResource()),
 			PathInventory: []string{"/gcp/roleset/{name}"},

--- a/vault/resource_gcp_secret_impersonated_account.go
+++ b/vault/resource_gcp_secret_impersonated_account.go
@@ -1,0 +1,225 @@
+package vault
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+)
+
+var (
+	gcpSecretImpersonatedAccountBackendFromPathRegex = regexp.MustCompile("^(.+)/impersonated-account/.+$")
+	gcpSecretImpersonatedAccountNameFromPathRegex    = regexp.MustCompile("^.+/impersonated-account/(.+)$")
+)
+
+func gcpSecretImpersonatedAccountResource() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: gcpSecretImpersonatedAccountCreate,
+		ReadContext:   ReadContextWrapper(gcpSecretImpersonatedAccountRead),
+		UpdateContext: gcpSecretImpersonatedAccountUpdate,
+		DeleteContext: gcpSecretImpersonatedAccountDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			consts.FieldBackend: {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Path where the GCP secrets engine is mounted.",
+				ForceNew:    true,
+				// standardise on no beginning or trailing slashes
+				StateFunc: func(v interface{}) string {
+					return strings.Trim(v.(string), "/")
+				},
+			},
+			"impersonated_account": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Name of the Impersonated Account to create",
+				ForceNew:    true,
+			},
+			"service_account_email": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Email of the GCP service account.",
+			},
+			"token_scopes": {
+				Type: schema.TypeSet,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Optional:    true,
+				Description: "List of OAuth scopes to assign to `access_token` secrets generated under this impersonated account (`access_token` impersonated accounts only) ",
+			},
+			"service_account_project": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Project of the GCP Service Account managed by this impersonated account",
+			},
+		},
+	}
+}
+
+func gcpSecretImpersonatedAccountCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := provider.GetClient(d, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	backend := d.Get(consts.FieldBackend).(string)
+	impersonatedAccount := d.Get("impersonated_account").(string)
+
+	path := gcpSecretImpersonatedAccountPath(backend, impersonatedAccount)
+
+	log.Printf("[DEBUG] Writing GCP Secrets backend impersonated account %q", path)
+
+	data := map[string]interface{}{}
+	gcpSecretImpersonatedAccountUpdateFields(d, data)
+	_, err = client.Logical().Write(path, data)
+	if err != nil {
+		d.SetId("")
+		return diag.Errorf("error writing GCP Secrets backend impersonated account %q: %s", path, err)
+	}
+	d.SetId(path)
+	log.Printf("[DEBUG] Wrote GCP Secrets backend impersonated account %q", path)
+
+	return gcpSecretImpersonatedAccountRead(ctx, d, meta)
+}
+
+func gcpSecretImpersonatedAccountRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := provider.GetClient(d, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	path := d.Id()
+
+	backend, err := gcpSecretImpersonatedAccountBackendFromPath(path)
+	if err != nil {
+		return diag.Errorf("invalid path %q for GCP secrets backend impersonated account: %s", path, err)
+	}
+
+	impersonatedAccount, err := gcpSecretImpersonatedAccountNameFromPath(path)
+	if err != nil {
+		return diag.Errorf("invalid path %q for GCP Secrets backend impersonated account: %s", path, err)
+	}
+
+	log.Printf("[DEBUG] Reading GCP Secrets backend impersonated account %q", path)
+	resp, err := client.Logical().Read(path)
+	if err != nil {
+		return diag.Errorf("error reading GCP Secrets backend impersonated account %q: %s", path, err)
+	}
+
+	log.Printf("[DEBUG] Read GCP Secrets backend impersonated account %q", path)
+	if resp == nil {
+		log.Printf("[WARN] GCP Secrets backend impersonated account %q not found, removing from state", path)
+		d.SetId("")
+		return nil
+	}
+
+	if err := d.Set(consts.FieldBackend, backend); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("impersonated_account", impersonatedAccount); err != nil {
+		return diag.FromErr(err)
+	}
+
+	for _, k := range []string{"token_scopes", "service_account_email", "service_account_project"} {
+		v, ok := resp.Data[k]
+		if ok {
+			if err := d.Set(k, v); err != nil {
+				return diag.Errorf("error reading %s for GCP Secrets backend impersonated account %q: %q", k, path, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func gcpSecretImpersonatedAccountUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := provider.GetClient(d, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	path := d.Id()
+
+	data := map[string]interface{}{}
+	gcpSecretImpersonatedAccountUpdateFields(d, data)
+
+	log.Printf("[DEBUG] Updating GCP Secrets backend impersonated account %q", path)
+
+	_, err = client.Logical().Write(path, data)
+	if err != nil {
+		return diag.Errorf("error updating GCP Secrets backend impersonated account %q: %s", path, err)
+	}
+	log.Printf("[DEBUG] Updated GCP Secrets backend impersonated account %q", path)
+
+	return gcpSecretImpersonatedAccountRead(ctx, d, meta)
+}
+
+func gcpSecretImpersonatedAccountDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := provider.GetClient(d, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	path := d.Id()
+
+	log.Printf("[DEBUG] Deleting GCP secrets backend impersonated account %q", path)
+	_, err = client.Logical().Delete(path)
+	if err != nil {
+		return diag.Errorf("error deleting GCP secrets backend impersonated account %q", path)
+	}
+	log.Printf("[DEBUG] Deleted GCP secrets backend impersonated account %q", path)
+
+	return nil
+}
+
+func gcpSecretImpersonatedAccountUpdateFields(d *schema.ResourceData, data map[string]interface{}) {
+	if v, ok := d.GetOk("service_account_email"); ok {
+		data["service_account_email"] = v.(string)
+	}
+
+	if v, ok := d.GetOk("service_account_project"); ok {
+		data["service_account_project"] = v.(string)
+	}
+
+	if v, ok := d.GetOk("token_scopes"); ok {
+		data["token_scopes"] = v.(*schema.Set).List()
+	}
+}
+
+func gcpSecretImpersonatedAccountPath(backend, impersonatedAccount string) string {
+	return strings.Trim(backend, "/") + "/impersonated-account/" + strings.Trim(impersonatedAccount, "/")
+}
+
+func gcpSecretImpersonatedAccountBackendFromPath(path string) (string, error) {
+	if !gcpSecretImpersonatedAccountBackendFromPathRegex.MatchString(path) {
+		return "", fmt.Errorf("no backend found")
+	}
+	res := gcpSecretImpersonatedAccountBackendFromPathRegex.FindStringSubmatch(path)
+	if len(res) != 2 {
+		return "", fmt.Errorf("unexpected number of matches (%d) for backend", len(res))
+	}
+	return res[1], nil
+}
+
+func gcpSecretImpersonatedAccountNameFromPath(path string) (string, error) {
+	if !gcpSecretImpersonatedAccountNameFromPathRegex.MatchString(path) {
+		return "", fmt.Errorf("no impersonated account found")
+	}
+	res := gcpSecretImpersonatedAccountNameFromPathRegex.FindStringSubmatch(path)
+	if len(res) != 2 {
+		return "", fmt.Errorf("unexpected number of matches (%d) for role", len(res))
+	}
+	return res[1], nil
+}

--- a/vault/resource_gcp_secret_impersonated_account_test.go
+++ b/vault/resource_gcp_secret_impersonated_account_test.go
@@ -1,0 +1,122 @@
+package vault
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+	"github.com/hashicorp/terraform-provider-vault/testutil"
+	"golang.org/x/oauth2/google"
+)
+
+// This test requires that you pass credentials for a user or service account having the IAM rights
+// listed at https://www.vaultproject.io/docs/secrets/gcp/index.html for the project you are testing
+// on. The credentials must also allow setting IAM permissions on the project being tested.
+func TestGCPSecretImpersonatedAccount(t *testing.T) {
+	testutil.SkipTestEnvSet(t, testutil.EnvVarSkipVaultNext)
+
+	backend := acctest.RandomWithPrefix("tf-test-gcp")
+	impersonatedAccount := acctest.RandomWithPrefix("tf-test")
+	credentials, project := testutil.GetTestGCPCreds(t)
+
+	// We will use the provided key as the impersonated account
+	conf, err := google.JWTConfigFromJSON([]byte(credentials), "https://www.googleapis.com/auth/cloud-platform")
+	if err != nil {
+		t.Fatalf("error decoding GCP Credentials: %v", err)
+	}
+	serviceAccountEmail := conf.Email
+
+	resourceName := "vault_gcp_secret_impersonated_account.test"
+	resource.Test(t, resource.TestCase{
+		Providers:    testProviders,
+		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		CheckDestroy: testGCPSecretImpersonatedAccountDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testGCPSecretImpersonatedAccount_initial(backend, impersonatedAccount, credentials, serviceAccountEmail),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldBackend, backend),
+					resource.TestCheckResourceAttr(resourceName, "impersonated_account", impersonatedAccount),
+					resource.TestCheckResourceAttr(resourceName, "service_account_email", serviceAccountEmail),
+					resource.TestCheckResourceAttr(resourceName, "service_account_project", project),
+					resource.TestCheckResourceAttr(resourceName, "token_scopes.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "token_scopes.0", "https://www.googleapis.com/auth/cloud-platform"),
+				),
+			},
+			{
+				Config: testGCPSecretImpersonatedAccount_updated(backend, impersonatedAccount, credentials, serviceAccountEmail),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldBackend, backend),
+					resource.TestCheckResourceAttr(resourceName, "impersonated_account", impersonatedAccount),
+					resource.TestCheckResourceAttr(resourceName, "service_account_email", serviceAccountEmail),
+					resource.TestCheckResourceAttr(resourceName, "service_account_project", project),
+					resource.TestCheckResourceAttr(resourceName, "token_scopes.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "token_scopes.0", "https://www.googleapis.com/auth/cloud-platform"),
+					resource.TestCheckResourceAttr(resourceName, "token_scopes.1", "https://www.googleapis.com/auth/cloud-platform.read-only"),
+				),
+			},
+			testutil.GetImportTestStep(resourceName, false, nil),
+		},
+	})
+}
+
+func testGCPSecretImpersonatedAccountDestroy(s *terraform.State) error {
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "vault_gcp_secret_impersonated_account" {
+			continue
+		}
+		secret, err := client.Logical().Read(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error checking for GCP Secrets ImpersonatedAccount %q: %s", rs.Primary.ID, err)
+		}
+		if secret != nil {
+			return fmt.Errorf("GCP Secrets ImpersonatedAccount %q still exists", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testGCPSecretImpersonatedAccount_initial(backend, impersonatedAccount, credentials, serviceAccountEmail string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "vault_gcp_secret_impersonated_account" "test" {
+	backend = vault_gcp_secret_backend.test.path
+	impersonated_account = "%s"
+	token_scopes   = ["https://www.googleapis.com/auth/cloud-platform"]
+	service_account_email = "%s"
+}
+`, testGCPSecretImpersonatedAccount_backend(backend, credentials), impersonatedAccount, serviceAccountEmail)
+}
+
+func testGCPSecretImpersonatedAccount_updated(backend, impersonatedAccount, credentials, serviceAccountEmail string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "vault_gcp_secret_impersonated_account" "test" {
+	backend = vault_gcp_secret_backend.test.path
+	impersonated_account = "%s"
+	token_scopes   = [
+        "https://www.googleapis.com/auth/cloud-platform.read-only",
+        "https://www.googleapis.com/auth/cloud-platform",
+    ]
+	service_account_email = "%s"
+}
+`, testGCPSecretImpersonatedAccount_backend(backend, credentials), impersonatedAccount, serviceAccountEmail)
+}
+
+func testGCPSecretImpersonatedAccount_backend(path, credentials string) string {
+	return fmt.Sprintf(`
+resource "vault_gcp_secret_backend" "test" {
+	path = "%s"
+	credentials = <<CREDS
+%s
+CREDS
+}`, path, credentials)
+}

--- a/website/docs/r/gcp_secret_impersonated_account.html.md
+++ b/website/docs/r/gcp_secret_impersonated_account.html.md
@@ -1,0 +1,61 @@
+---
+layout: "vault"
+page_title: "Vault: vault_gcp_secret_impersonated_account resource"
+sidebar_current: "docs-vault-resource-gcp-secret-impersonated-account"
+description: |-
+  Creates a Impersonated Account for the GCP Secret Backend for Vault.
+---
+
+# vault\_gcp\_secret\_impersonated\_account
+
+Creates a Impersonated Account in the [GCP Secrets Engine](https://www.vaultproject.io/docs/secrets/gcp/index.html) for Vault.
+
+Each [impersonated account](https://www.vaultproject.io/docs/secrets/gcp/index.html#impersonated-accounts) is tied to a separately managed
+Service Account.
+
+## Example Usage
+
+```hcl
+resource "google_service_account" "this" {
+  account_id = "my-awesome-account"
+}
+
+resource "vault_gcp_secret_backend" "gcp" {
+  path        = "gcp"
+  credentials = "${file("credentials.json")}"
+}
+
+resource "vault_gcp_secret_impersonated_account" "impersonated_account" {
+  backend        = vault_gcp_secret_backend.gcp.path
+
+  impersonated_account  = "this"
+  service_account_email = google_service_account.this.email
+  token_scopes          = ["https://www.googleapis.com/auth/cloud-platform"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `backend` - (Required, Forces new resource) Path where the GCP Secrets Engine is mounted
+
+* `impersonated_account` - (Required, Forces new resource) Name of the Impersonated Account to create
+
+* `service_account_email` - (Required, Forces new resource) Email of the GCP service account to impersonate.
+
+* `token_scopes` - (Required) List of OAuth scopes to assign to access tokens generated under this impersonated account.
+
+## Attributes Reference
+
+In addition to the fields above, the following attributes are also exposed:
+
+* `service_account_project` - Project the service account belongs to.
+
+## Import
+
+A impersonated account can be imported using its Vault Path. For example, referencing the example above,
+
+```
+$ terraform import vault_gcp_secret_impersonated_account.impersonated_account gcp/impersonated-account/project_viewer
+```


### PR DESCRIPTION
This PR merges features that are targeted for Vault 1.13. Now that the 1.13 release is out and we are running tests against it in CI, we can merge this code into the main branch and release this feature in the upcoming TFVP minor release.

Features being merged with this PR:
- Add resource for GCP impersonated account endpoints (#1745)