### PR TITLE
Enable GCP impersonated account test for Vault 1.13

### DIFF
--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -204,6 +204,10 @@ const (
 	FieldIAMMetadata                = "iam_metadata"
 	FieldEC2Alias                   = "ec2_alias"
 	FieldEC2Metadata                = "ec2_metadata"
+	FieldImpersonatedAccount        = "impersonated_account"
+	FieldServiceAccountEmail        = "service_account_email"
+	FieldTokenScopes                = "token_scopes"
+	FieldServiceAccountProject      = "service_account_project"
 
 	/*
 		common environment variables

--- a/vault/resource_gcp_secret_impersonated_account.go
+++ b/vault/resource_gcp_secret_impersonated_account.go
@@ -39,19 +39,19 @@ func gcpSecretImpersonatedAccountResource() *schema.Resource {
 					return strings.Trim(v.(string), "/")
 				},
 			},
-			"impersonated_account": {
+			consts.FieldImpersonatedAccount: {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "Name of the Impersonated Account to create",
 				ForceNew:    true,
 			},
-			"service_account_email": {
+			consts.FieldServiceAccountEmail: {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
 				Description: "Email of the GCP service account.",
 			},
-			"token_scopes": {
+			consts.FieldTokenScopes: {
 				Type: schema.TypeSet,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -59,7 +59,7 @@ func gcpSecretImpersonatedAccountResource() *schema.Resource {
 				Optional:    true,
 				Description: "List of OAuth scopes to assign to `access_token` secrets generated under this impersonated account (`access_token` impersonated accounts only) ",
 			},
-			"service_account_project": {
+			consts.FieldServiceAccountProject: {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Project of the GCP Service Account managed by this impersonated account",
@@ -75,7 +75,7 @@ func gcpSecretImpersonatedAccountCreate(ctx context.Context, d *schema.ResourceD
 	}
 
 	backend := d.Get(consts.FieldBackend).(string)
-	impersonatedAccount := d.Get("impersonated_account").(string)
+	impersonatedAccount := d.Get(consts.FieldImpersonatedAccount).(string)
 
 	path := gcpSecretImpersonatedAccountPath(backend, impersonatedAccount)
 
@@ -128,11 +128,11 @@ func gcpSecretImpersonatedAccountRead(ctx context.Context, d *schema.ResourceDat
 	if err := d.Set(consts.FieldBackend, backend); err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set("impersonated_account", impersonatedAccount); err != nil {
+	if err := d.Set(consts.FieldImpersonatedAccount, impersonatedAccount); err != nil {
 		return diag.FromErr(err)
 	}
 
-	for _, k := range []string{"token_scopes", "service_account_email", "service_account_project"} {
+	for _, k := range []string{consts.FieldTokenScopes, consts.FieldServiceAccountEmail, consts.FieldServiceAccountProject} {
 		v, ok := resp.Data[k]
 		if ok {
 			if err := d.Set(k, v); err != nil {
@@ -185,16 +185,16 @@ func gcpSecretImpersonatedAccountDelete(ctx context.Context, d *schema.ResourceD
 }
 
 func gcpSecretImpersonatedAccountUpdateFields(d *schema.ResourceData, data map[string]interface{}) {
-	if v, ok := d.GetOk("service_account_email"); ok {
-		data["service_account_email"] = v.(string)
+	if v, ok := d.GetOk(consts.FieldServiceAccountEmail); ok {
+		data[consts.FieldServiceAccountEmail] = v.(string)
 	}
 
-	if v, ok := d.GetOk("service_account_project"); ok {
-		data["service_account_project"] = v.(string)
+	if v, ok := d.GetOk(consts.FieldServiceAccountProject); ok {
+		data[consts.FieldServiceAccountProject] = v.(string)
 	}
 
-	if v, ok := d.GetOk("token_scopes"); ok {
-		data["token_scopes"] = v.(*schema.Set).List()
+	if v, ok := d.GetOk(consts.FieldTokenScopes); ok {
+		data[consts.FieldTokenScopes] = v.(*schema.Set).List()
 	}
 }
 

--- a/vault/resource_gcp_secret_impersonated_account_test.go
+++ b/vault/resource_gcp_secret_impersonated_account_test.go
@@ -7,18 +7,17 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"golang.org/x/oauth2/google"
+
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
-	"golang.org/x/oauth2/google"
 )
 
 // This test requires that you pass credentials for a user or service account having the IAM rights
 // listed at https://www.vaultproject.io/docs/secrets/gcp/index.html for the project you are testing
 // on. The credentials must also allow setting IAM permissions on the project being tested.
 func TestGCPSecretImpersonatedAccount(t *testing.T) {
-	testutil.SkipTestEnvSet(t, testutil.EnvVarSkipVaultNext)
-
 	backend := acctest.RandomWithPrefix("tf-test-gcp")
 	impersonatedAccount := acctest.RandomWithPrefix("tf-test")
 	credentials, project := testutil.GetTestGCPCreds(t)
@@ -32,8 +31,11 @@ func TestGCPSecretImpersonatedAccount(t *testing.T) {
 
 	resourceName := "vault_gcp_secret_impersonated_account.test"
 	resource.Test(t, resource.TestCase{
-		Providers:    testProviders,
-		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		Providers: testProviders,
+		PreCheck: func() {
+			testutil.TestAccPreCheck(t)
+			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion113)
+		},
 		CheckDestroy: testGCPSecretImpersonatedAccountDestroy,
 		Steps: []resource.TestStep{
 			{


### PR DESCRIPTION
Now that Vault 1.13 has been enabled in TFVP CI, we can run the GCP Impersonated accounts test against the 1.13 instance