### PR TITLE
add max_retries for AWS auth client resource

### DIFF
--- a/vault/resource_aws_auth_backend_client_test.go
+++ b/vault/resource_aws_auth_backend_client_test.go
@@ -4,6 +4,7 @@
 package vault
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"testing"
@@ -186,6 +187,15 @@ func testAccAWSAuthBackendClientCheck_attrs(backend string) resource.TestCheckFu
 				return fmt.Errorf("expected %s (%s) of %q to be %q, got %q", apiAttr, stateAttr, endpoint, instanceState.Attributes[stateAttr], resp.Data[apiAttr])
 			}
 		}
+
+		if v, ok := resp.Data["max_retries"]; ok {
+			got := v.(json.Number).String()
+			expected := instanceState.Attributes["max_retries"]
+			if got != expected {
+				return fmt.Errorf("expected max_retries to be %q, got %q", expected, got)
+			}
+		}
+
 		return nil
 	}
 }
@@ -207,6 +217,7 @@ resource "vault_aws_auth_backend_client" "client" {
   sts_endpoint = "http://vault.test/sts"
   sts_region = "vault-test"
   iam_server_id_header_value = "vault.test"
+  max_retries = 1
 }
 `, backend)
 }
@@ -228,6 +239,7 @@ resource "vault_aws_auth_backend_client" "client" {
   sts_endpoint = "http://updated.vault.test/sts"
   sts_region = "updated-vault-test"
   iam_server_id_header_value = "updated.vault.test"
+  max_retries = 2
 }`, backend)
 }
 

--- a/website/docs/r/aws_auth_backend_client.html.md
+++ b/website/docs/r/aws_auth_backend_client.html.md
@@ -72,6 +72,9 @@ The following arguments are supported:
 	`X-Vault-AWS-IAM-Server-ID` header as part of `GetCallerIdentity` requests
 	that are used in the IAM auth method.
 
+* `max_retries` - (Optional) Number of max retries the client should use for
+    recoverable errors.
+
 ## Attributes Reference
 
 No additional attributes are exported by this resource.


### PR DESCRIPTION
Add support for the AWS auth client max_retries field. ([API doc](https://developer.hashicorp.com/vault/api-docs/auth/aws#max_retries))

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
AWS Auth Client: add max_retries field
```

Output from acceptance testing:

```
TESTARGS="--run AWSAuthBackendClient" make testacc            
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test --run AWSAuthBackendClient -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/codegen   (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/mfa     [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/pki      [no test files]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    0.428s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    0.543s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    0.769s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        0.985s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    1.211s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      1.399s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/provider (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/testutil  (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/vault     7.912s
```
