### PR TITLE
Avoid writing empty strings to Vault when creating managed keys

### DIFF
--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -196,6 +196,11 @@ func GetTestNomadCreds(t *testing.T) (string, string) {
 	return v[0], v[1]
 }
 
+func GetTestPKCSCreds(t *testing.T) (string, string, string) {
+	v := SkipTestEnvUnset(t, "PKCS_KEY_LIBRARY", "PKCS_KEY_SLOT", "PKCS_KEY_PIN")
+	return v[0], v[1], v[2]
+}
+
 func TestCheckResourceAttrJSON(name, key, expectedValue string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		resourceState, ok := s.RootModule().Resources[name]

--- a/vault/resource_managed_keys.go
+++ b/vault/resource_managed_keys.go
@@ -611,7 +611,7 @@ func readAndSetManagedKeys(d *schema.ResourceData, client *api.Client, providerT
 }
 
 func readAWSManagedKeys(d *schema.ResourceData, client *api.Client) error {
-	redacted := []string{"access_key", "secret_key"}
+	redacted := []string{consts.FieldAccessKey, consts.FieldSecretKey}
 	if err := readAndSetManagedKeys(d, client, consts.FieldAWS,
 		map[string]string{consts.FieldUUID: "UUID"}, redacted); err != nil {
 		return err
@@ -631,7 +631,7 @@ func readAzureManagedKeys(d *schema.ResourceData, client *api.Client) error {
 }
 
 func readPKCSManagedKeys(d *schema.ResourceData, client *api.Client) error {
-	redacted := []string{"pin"}
+	redacted := []string{consts.FieldPin, consts.FieldKeyID}
 	if err := readAndSetManagedKeys(d, client, consts.FieldPKCS,
 		map[string]string{consts.FieldUUID: "UUID"}, redacted); err != nil {
 		return err

--- a/vault/resource_managed_keys.go
+++ b/vault/resource_managed_keys.go
@@ -371,6 +371,12 @@ func getManagedKeysConfigData(config map[string]interface{}, sm schemaMap) (stri
 
 	for blockKey := range sm {
 		if v, ok := config[blockKey]; ok {
+			// ensure empty strings are not written
+			// to vault as part of the data
+			if s, ok := v.(string); ok && s == "" {
+				continue
+			}
+
 			data[blockKey] = v
 
 			if blockKey == consts.FieldName {


### PR DESCRIPTION
This PR adds a fix where empty strings were being written to Vault. We should make it so that only fields provided by the user are written along with the data to Vault; if a field is not provided, empty string values should not be written. This was causing PKCS key creation to fail, since two mutually exclusive fields `slot` and `token_label` were both being sent to Vault. The PR also adds a test that is meant to be run locally since it requires a lot of prior setup (including its own Vault server config)

Fixes #1772 

Output from acceptance testing:
```
=== RUN   TestManagedKeysPKCS
--- PASS: TestManagedKeysPKCS (1.69s)
PASS
```