### PR TITLE
Fix panic while importing namespaces in TFVP

### DIFF
--- a/vault/provider.go
+++ b/vault/provider.go
@@ -883,7 +883,18 @@ func MountCreateContextWrapper(f schema.CreateContextFunc, minVersion *version.V
 func importNamespace(d *schema.ResourceData) error {
 	if ns := os.Getenv(consts.EnvVarVaultNamespaceImport); ns != "" {
 		s := d.State()
-		if _, ok := s.Attributes[consts.FieldNamespace]; !ok {
+		var attemptNamespaceImport bool
+		if s == nil {
+			// state does not yet exist
+			// import is acceptable
+			attemptNamespaceImport = true
+		} else {
+			// only import if namespace
+			// is not already set in state
+			_, ok := s.Attributes[consts.FieldNamespace]
+			attemptNamespaceImport = !ok
+		}
+		if attemptNamespaceImport {
 			log.Printf(`[INFO] Environment variable %s set, `+
 				`attempting TF state import "%s=%s"`,
 				consts.EnvVarVaultNamespaceImport, consts.FieldNamespace, ns)


### PR DESCRIPTION
This PR adds a nil check in the code that performs namespace imports. The code checks the TF state to ensure a namespace is not already set to state, however it does not account for the case where the state attributes are nil. This case occurs when a user would like to perform a `terraform import` command before any `plan` or `apply` runs (`terraform.tfstate` file does not necessarily exist)