### PR TITLE
Add cn_validations property to pki_secret_backend_role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ FEATURES:
 * Update `vault_database_secret_backend_connection`to support `password_authentication` for PostgreSQL, allowing to encrypt password before being passed to PostgreSQL ([#2371](https://github.com/hashicorp/terraform-provider-vault/pull/2371))
 * Add support for `external_id` field for the `vault_aws_auth_backend_sts_role` resource ([#2370](https://github.com/hashicorp/terraform-provider-vault/pull/2370))
 * Add support for ACME configuration with the `vault_pki_secret_backend_config_acme` resource. Requires Vault 1.14+ ([#2157](https://github.com/hashicorp/terraform-provider-vault/pull/2157)).
+* Update `vault_pki_secret_backend_role` to support the `cn_validations` role field ([#1820](https://github.com/hashicorp/terraform-provider-vault/pull/1820)).
 
 ## 4.5.0 (Nov 19, 2024)
 

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -444,7 +444,7 @@ const (
 	FieldDefaultDirectoryPolicy        = "default_directory_policy"
 	FieldDnsResolver                   = "dns_resolver"
 	FieldEabPolicy                     = "eab_policy"
-
+	FieldCnValidations                 = "cn_validations"
 	/*
 		common environment variables
 	*/

--- a/vault/resource_pki_secret_backend_role.go
+++ b/vault/resource_pki_secret_backend_role.go
@@ -50,6 +50,7 @@ var pkiSecretListFields = []string{
 	consts.FieldAllowedSerialNumbers,
 	consts.FieldExtKeyUsage,
 	consts.FieldExtKeyUsageOIDs,
+	consts.FieldCnValidations,
 }
 
 var pkiSecretBooleanFields = []string{
@@ -423,9 +424,15 @@ func pkiSecretBackendRoleResource() *schema.Resource {
 				Required:    false,
 				Optional:    true,
 				Description: "Defines allowed Subject serial numbers.",
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			consts.FieldCnValidations: {
+				Type:        schema.TypeList,
+				Required:    false,
+				Optional:    true,
+				Computed:    true,
+				Description: "Specify validations to run on the Common Name field of the certificate.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			consts.FieldAllowedUserIds: {
 				Type:        schema.TypeList,

--- a/vault/resource_pki_secret_backend_role_test.go
+++ b/vault/resource_pki_secret_backend_role_test.go
@@ -180,6 +180,9 @@ func TestPkiSecretBackendRole_basic(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceName, "not_before_duration", "45m"),
 		resource.TestCheckResourceAttr(resourceName, "policy_identifiers.#", "1"),
 		resource.TestCheckResourceAttr(resourceName, "policy_identifiers.0", "1.2.3.4"),
+		resource.TestCheckResourceAttr(resourceName, "cn_validations.#", "2"),
+		resource.TestCheckTypeSetElemAttr(resourceName, "cn_validations.*", "email"),
+		resource.TestCheckTypeSetElemAttr(resourceName, "cn_validations.*", "hostname"),
 	}
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
@@ -320,6 +323,8 @@ func TestPkiSecretBackendRole_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "policy_identifiers.0", "1.2.3.4"),
 					resource.TestCheckResourceAttr(resourceName, "basic_constraints_valid_for_non_ca", "false"),
 					resource.TestCheckResourceAttr(resourceName, "not_before_duration", "45m"),
+					resource.TestCheckResourceAttr(resourceName, "cn_validations.#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "cn_validations.*", "disabled"),
 				),
 			},
 			{
@@ -391,6 +396,7 @@ resource "vault_pki_secret_backend_role" "test" {
   basic_constraints_valid_for_non_ca = false
   not_before_duration                = "45m"
   allowed_serial_numbers             = ["*"]
+  cn_validations					 = ["email", "hostname"]
 }
 `, path, name, roleTTL, maxTTL, extraConfig)
 }
@@ -446,6 +452,7 @@ resource "vault_pki_secret_backend_role" "test" {
   basic_constraints_valid_for_non_ca = false
   not_before_duration = "45m"
   allowed_serial_numbers = ["*"]
+  cn_validations = ["disabled"]
 }`, path, name, policyIdentifiers)
 }
 

--- a/website/docs/r/pki_secret_backend_role.html.md
+++ b/website/docs/r/pki_secret_backend_role.html.md
@@ -86,6 +86,8 @@ The following arguments are supported:
 
 * `client_flag` - (Optional) Flag to specify certificates for client use
 
+* `cn_validations` - (Optional) Validations to run on the Common Name field of the certificate, choices: `email`, `hostname`, `disabled`
+
 * `code_signing_flag` - (Optional) Flag to specify certificates for code signing use
 
 * `email_protection_flag` - (Optional) Flag to specify certificates for email protection use


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--

-->

```release-note
- Add cn_validations property to pki_secret_backend_role
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
