### PR TITLE
Update aws_access_credentials documentation link to credential_type

### DIFF
--- a/website/docs/d/aws_access_credentials.html.md
+++ b/website/docs/d/aws_access_credentials.html.md
@@ -88,7 +88,7 @@ not need to be specified.
 
 * `ttl` - (Optional) Specifies the TTL for the use of the STS token. This
 is specified as a string with a duration suffix. Valid only when
-`credential_type` of the connected `vault_aws_secret_backend_role` is `assumed_role` or `federation_token`
+`credential_type` of the connected `vault_aws_secret_backend_role` resource is `assumed_role` or `federation_token`
 
 ## Attributes Reference
 

--- a/website/docs/d/aws_access_credentials.html.md
+++ b/website/docs/d/aws_access_credentials.html.md
@@ -88,7 +88,7 @@ not need to be specified.
 
 * `ttl` - (Optional) Specifies the TTL for the use of the STS token. This
 is specified as a string with a duration suffix. Valid only when
-`credential_type` is `assumed_role` or `federation_token`
+`credential_type` of the connected `vault_aws_secret_backend_role` is `assumed_role` or `federation_token`
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1636

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Update aws_access_credentials documentation link to credential_type
```