### PR TITLE
Add support for PKI Key resource

### DIFF
--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -217,6 +217,8 @@ const (
 	FieldIPAddresses                = "ip_addresses"
 	FieldCIDRBlocks                 = "cidr_blocks"
 	FieldProjectRoles               = "project_roles"
+	FieldManagedKeyName             = "managed_key_name"
+	FieldManagedKeyID               = "managed_key_id"
 
 	/*
 		common environment variables

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -731,6 +731,10 @@ var (
 			Resource:      UpdateSchemaResource(pkiSecretBackendSignResource()),
 			PathInventory: []string{"/pki/sign/{role}"},
 		},
+		"vault_pki_secret_backend_key": {
+			Resource:      UpdateSchemaResource(pkiSecretBackendKeyResource()),
+			PathInventory: []string{"/pki/key/{key_id}"},
+		},
 		"vault_quota_lease_count": {
 			Resource:      UpdateSchemaResource(quotaLeaseCountResource()),
 			PathInventory: []string{"/sys/quotas/lease-count/{name}"},

--- a/vault/resource_pki_secret_backend_key.go
+++ b/vault/resource_pki_secret_backend_key.go
@@ -1,0 +1,204 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package vault
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+)
+
+var (
+	kmsType = "kms"
+
+	pkiSecretMountFromPathRegex = regexp.MustCompile("^(.+)/key/.+$")
+)
+
+func pkiSecretBackendKeyResource() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: MountCreateContextWrapper(pkiSecretBackendKeyWrite, provider.VaultVersion111),
+		UpdateContext: pkiSecretBackendKeyWrite,
+		DeleteContext: pkiSecretBackendKeyDelete,
+		ReadContext:   ReadContextWrapper(ReadContextWrapper(pkiSecretBackendKeyRead)),
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			consts.FieldMount: {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "Full path where PKI engine is mounted.",
+			},
+			consts.FieldType: {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Specifies the type of the key to create.",
+			},
+			consts.FieldKeyName: {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "When a new key is created with this request, optionally specifies the name for this.",
+			},
+			consts.FieldKeyType: {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Specifies the desired key type; must be 'rsa', 'ed25519' or 'ec'.",
+			},
+			consts.FieldKeyBits: {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Specifies the number of bits to use for the generated keys.",
+			},
+			consts.FieldManagedKeyName: {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The managed key's configured name.",
+			},
+			consts.FieldManagedKeyID: {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The managed key's UUID.",
+			},
+		},
+	}
+}
+
+func getPKIGenerateKeysPath(mount, keyType string) string {
+	return fmt.Sprintf("%s/keys/generate/%s", mount, keyType)
+}
+
+func getPKIKeysIDPath(mount, keyID string) string {
+	return fmt.Sprintf("%s/key/%s", mount, keyID)
+}
+
+func pkiSecretBackendKeyWrite(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
+
+	mount := d.Get(consts.FieldMount).(string)
+	keyType := d.Get(consts.FieldType).(string)
+	keyPath := getPKIGenerateKeysPath(mount, keyType)
+
+	fields := []string{
+		consts.FieldKeyName,
+		consts.FieldKeyType,
+		consts.FieldKeyBits,
+	}
+
+	if keyType == kmsType {
+		fields = append(fields, consts.FieldManagedKeyName, consts.FieldManagedKeyID)
+	}
+
+	data := map[string]interface{}{}
+	for _, k := range fields {
+		data[k] = d.Get(k)
+	}
+
+	resp, err := client.Logical().Write(keyPath, data)
+	if err != nil {
+		return diag.Errorf("error writing data to %q, err=%s", keyPath, err)
+	}
+
+	keyID := resp.Data[consts.FieldKeyID].(string)
+
+	// set key ID path
+	// this makes both mount and key ID info available
+	rid := getPKIKeysIDPath(mount, keyID)
+	d.SetId(rid)
+
+	return pkiSecretBackendKeyRead(ctx, d, meta)
+}
+
+func pkiSecretBackendKeyRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
+
+	keyPath := d.Id()
+
+	// get mount from full path
+	mount, err := pkiSecretMountFromPath(keyPath)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// set mount
+	if err := d.Set(consts.FieldMount, mount); err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[DEBUG] Reading %s from Vault", keyPath)
+	resp, err := client.Logical().Read(keyPath)
+	if err != nil {
+		return diag.Errorf("error reading from Vault: %s", err)
+	}
+	if resp == nil {
+		log.Printf("[WARN] key data (%s) not found, removing from state", keyPath)
+		d.SetId("")
+		return nil
+	}
+
+	fields := []string{
+		consts.FieldKeyName,
+		consts.FieldKeyType,
+		consts.FieldManagedKeyName,
+		consts.FieldManagedKeyID,
+	}
+
+	for _, k := range fields {
+		if err := d.Set(k, resp.Data[k]); err != nil {
+			return diag.Errorf("error setting state key %q for PKI Secret Key, err=%s",
+				k, err)
+		}
+	}
+
+	// key_bits not returned from Vault
+	// set from config
+	if err := d.Set(consts.FieldKeyBits, d.Get(consts.FieldKeyBits)); err != nil {
+		return diag.Errorf("error setting state key %q for PKI Secret Key, err=%s",
+			consts.FieldKeyBits, err)
+	}
+
+	return nil
+}
+
+func pkiSecretBackendKeyDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
+
+	keyPath := d.Id()
+
+	log.Printf("[DEBUG] Deleting PKI Key at %q", keyPath)
+	_, err := client.Logical().Delete(keyPath)
+	if err != nil {
+		return diag.Errorf("error deleting %q from Vault: %q", keyPath, err)
+	}
+
+	return nil
+}
+
+func pkiSecretMountFromPath(path string) (string, error) {
+	if !pkiSecretMountFromPathRegex.MatchString(path) {
+		return "", fmt.Errorf("no mount found")
+	}
+	res := pkiSecretMountFromPathRegex.FindStringSubmatch(path)
+	if len(res) != 2 {
+		return "", fmt.Errorf("unexpected number of matches (%d) for mount", len(res))
+	}
+	return res[1], nil
+}

--- a/vault/resource_pki_secret_backend_key.go
+++ b/vault/resource_pki_secret_backend_key.go
@@ -54,12 +54,14 @@ func pkiSecretBackendKeyResource() *schema.Resource {
 			consts.FieldKeyType: {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				ForceNew:    true,
 				Description: "Specifies the desired key type; must be 'rsa', 'ed25519' or 'ec'.",
 			},
 			consts.FieldKeyBits: {
 				Type:        schema.TypeInt,
 				Optional:    true,
+				Computed:    true,
 				ForceNew:    true,
 				Description: "Specifies the number of bits to use for the generated keys.",
 			},
@@ -112,7 +114,9 @@ func pkiSecretBackendKeyCreate(ctx context.Context, d *schema.ResourceData, meta
 
 	data := map[string]interface{}{}
 	for _, k := range fields {
-		data[k] = d.Get(k)
+		if v, ok := d.GetOk(k); ok {
+			data[k] = v
+		}
 	}
 
 	resp, err := client.Logical().WriteWithContext(ctx, keyPath, data)

--- a/vault/resource_pki_secret_backend_key.go
+++ b/vault/resource_pki_secret_backend_key.go
@@ -28,7 +28,7 @@ func pkiSecretBackendKeyResource() *schema.Resource {
 		CreateContext: MountCreateContextWrapper(pkiSecretBackendKeyCreate, provider.VaultVersion111),
 		UpdateContext: pkiSecretBackendKeyUpdate,
 		DeleteContext: pkiSecretBackendKeyDelete,
-		ReadContext:   ReadContextWrapper(ReadContextWrapper(pkiSecretBackendKeyRead)),
+		ReadContext:   ReadContextWrapper(pkiSecretBackendKeyRead),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -124,7 +124,10 @@ func pkiSecretBackendKeyCreate(ctx context.Context, d *schema.ResourceData, meta
 		return diag.Errorf("error writing data to %q, err=%s", keyPath, err)
 	}
 
-	keyID := resp.Data[consts.FieldKeyID].(string)
+	keyID, ok := resp.Data[consts.FieldKeyID].(string)
+	if !ok {
+		return diag.Errorf("did not receive a key ID from Vault response; key ID required")
+	}
 
 	// set key ID path
 	// this makes both mount and key ID info available

--- a/vault/resource_pki_secret_backend_key_test.go
+++ b/vault/resource_pki_secret_backend_key_test.go
@@ -134,8 +134,8 @@ func testPKIKeyUpdate(resourceName string, store *testPKIKeyStore, expectedEqual
 			return fmt.Errorf("key_id not found in state")
 		}
 
-		if (store.id == id) && !expectedEqual {
-			return fmt.Errorf("expected key ID to be updated, but got unchanged ID %s", id)
+		if (store.id == id) != expectedEqual {
+			return fmt.Errorf("expectedEqual=%v, got IDs %s and %s", expectedEqual, id, store.id)
 		}
 
 		return nil

--- a/vault/resource_pki_secret_backend_key_test.go
+++ b/vault/resource_pki_secret_backend_key_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package vault
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/testutil"
+)
+
+func TestAccPKISecretBackendKey_basic(t *testing.T) {
+	mount := acctest.RandomWithPrefix("tf-test-pki")
+	resourceType := "vault_pki_secret_backend_key"
+	resourceName := resourceType + ".test"
+
+	keyName := acctest.RandomWithPrefix("tf-pki-key")
+	updatedKeyName := acctest.RandomWithPrefix("tf-pki-key-updated")
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		PreCheck:          func() { testutil.TestAccPreCheck(t) },
+		CheckDestroy:      testCheckMountDestroyed(resourceType, consts.MountTypePKI, consts.FieldMount),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPKISecretBackendKey_basic(mount, keyName, "rsa", "2048"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldMount, mount),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldKeyName, keyName),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldKeyType, "rsa"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldKeyBits, "2048"),
+				),
+			},
+			{
+				Config: testAccPKISecretBackendKey_basic(mount, updatedKeyName, "rsa", "2048"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldMount, mount),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldKeyName, updatedKeyName),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldKeyType, "rsa"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldKeyBits, "2048"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{consts.FieldType, consts.FieldKeyBits},
+			},
+		},
+	})
+}
+
+func testAccPKISecretBackendKey_basic(path, keyName, keyType, keyBits string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "pki" {
+	path        = "%s"
+	type        = "pki"
+    description = "PKI secret engine mount"
+}
+
+resource "vault_pki_secret_backend_key" "test" {
+  mount    = vault_mount.pki.path
+  type     = "exported"
+  key_name = "%s"
+  key_type = "%s"
+  key_bits = "%s"
+}`, path, keyName, keyType, keyBits)
+}

--- a/vault/resource_pki_secret_backend_key_test.go
+++ b/vault/resource_pki_secret_backend_key_test.go
@@ -9,10 +9,16 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
+
+type testPKIKeyStore struct {
+	id string
+}
 
 func TestAccPKISecretBackendKey_basic(t *testing.T) {
 	mount := acctest.RandomWithPrefix("tf-test-pki")
@@ -22,10 +28,15 @@ func TestAccPKISecretBackendKey_basic(t *testing.T) {
 	keyName := acctest.RandomWithPrefix("tf-pki-key")
 	updatedKeyName := acctest.RandomWithPrefix("tf-pki-key-updated")
 
+	store := &testPKIKeyStore{}
+
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
-		PreCheck:          func() { testutil.TestAccPreCheck(t) },
-		CheckDestroy:      testCheckMountDestroyed(resourceType, consts.MountTypePKI, consts.FieldMount),
+		PreCheck: func() {
+			testutil.TestAccPreCheck(t)
+			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion111)
+		},
+		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypePKI, consts.FieldMount),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPKISecretBackendKey_basic(mount, keyName, "rsa", "2048"),
@@ -34,8 +45,11 @@ func TestAccPKISecretBackendKey_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, consts.FieldKeyName, keyName),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldKeyType, "rsa"),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldKeyBits, "2048"),
+					testCapturePKIKeyID(resourceName, store),
 				),
 			},
+			// key name can be updated
+			// test that updating name ensures the key ID is unchanged
 			{
 				Config: testAccPKISecretBackendKey_basic(mount, updatedKeyName, "rsa", "2048"),
 				Check: resource.ComposeTestCheckFunc(
@@ -43,6 +57,21 @@ func TestAccPKISecretBackendKey_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, consts.FieldKeyName, updatedKeyName),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldKeyType, "rsa"),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldKeyBits, "2048"),
+					// ensure that the Key ID is unchanged
+					testPKIKeyUpdate(resourceName, store, true),
+					testCapturePKIKeyID(resourceName, store),
+				),
+			},
+			// any other updates trigger a force new
+			// test that key ID is different (new key created)
+			{
+				Config: testAccPKISecretBackendKey_basic(mount, updatedKeyName, "ec", "224"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldMount, mount),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldKeyName, updatedKeyName),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldKeyType, "ec"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldKeyBits, "224"),
+					testPKIKeyUpdate(resourceName, store, false),
 				),
 			},
 			{
@@ -70,4 +99,45 @@ resource "vault_pki_secret_backend_key" "test" {
   key_type = "%s"
   key_bits = "%s"
 }`, path, keyName, keyType, keyBits)
+}
+
+func testCapturePKIKeyID(resourceName string, store *testPKIKeyStore) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, err := testutil.GetResourceFromRootModule(s, resourceName)
+		if err != nil {
+			return err
+		}
+
+		id, ok := rs.Primary.Attributes["key_id"]
+		if !ok {
+			return fmt.Errorf("key_id not found in state")
+		}
+		store.id = id
+
+		return nil
+	}
+}
+
+func testPKIKeyUpdate(resourceName string, store *testPKIKeyStore, expectedEqual bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if store.id == "" {
+			return fmt.Errorf("id in %#v is empty", store)
+		}
+
+		rs, err := testutil.GetResourceFromRootModule(s, resourceName)
+		if err != nil {
+			return err
+		}
+
+		id, ok := rs.Primary.Attributes["key_id"]
+		if !ok {
+			return fmt.Errorf("key_id not found in state")
+		}
+
+		if (store.id == id) && !expectedEqual {
+			return fmt.Errorf("expected key ID to be updated, but got unchanged ID %s", id)
+		}
+
+		return nil
+	}
 }

--- a/website/docs/r/pki_secret_backend_key.html.md
+++ b/website/docs/r/pki_secret_backend_key.html.md
@@ -1,0 +1,70 @@
+---
+layout: "vault"
+page_title: "Vault: vault_pki_secret_backend_key resource"
+sidebar_current: "docs-vault-resource-pki-secret-backend-key"
+description: |-
+  Creates a key on a PKI Secret Backend for Vault.
+---
+
+# vault\_pki\_secret\_backend\_key
+
+Creates a key on a PKI Secret Backend for Vault.
+
+## Example Usage
+
+```hcl
+resource "vault_mount" "pki" {
+  path                      = "pki"
+  type                      = "pki"
+  default_lease_ttl_seconds = 3600
+  max_lease_ttl_seconds     = 86400
+}
+
+resource "vault_pki_secret_backend_key" "key" {
+  mount    = vault_mount.pki.path
+  type     = "exported"
+  key_name = "example-key"
+  key_type = "rsa"
+  key_bits = "2048"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  *Available only for Vault Enterprise*.
+
+* `mount` - (Required) The path the PKI secret backend is mounted at, with no leading or trailing `/`s.
+
+* `type` - (Required) Specifies the type of the key to create. Can be `exported`,`internal` or `kms`.
+
+* `key_name` - (Optional) When a new key is created with this request, optionally specifies the name for this. 
+  The global ref `default` may not be used as a name.
+
+* `key_type` - (Optional) Specifies the desired key type; must be `rsa`, `ed25519` or `ec`.
+
+* `key_bits` - (Optional) Specifies the number of bits to use for the generated keys. 
+  Allowed values are 0 (universal default); with `key_type=rsa`, allowed values are:
+  2048 (default), 3072, or 4096; with `key_type=ec`, allowed values are: 224, 256 (default), 
+  384, or 521; ignored with `key_type=ed25519`.
+
+* `managed_key_name` - (Optional) The managed key's configured name.
+
+* `managed_key_name` - (Optional) The managed key's UUID.
+
+
+## Attributes Reference
+
+No additional attributes are exported by this resource.
+
+## Import
+
+PKI secret backend roles can be imported using the `id`, e.g.
+
+```
+$ terraform import vault_pki_secret_backend_key.key pki/key/bf9b0d48-d0dd-652c-30be-77d04fc7e94d
+```

--- a/website/docs/r/pki_secret_backend_key.html.md
+++ b/website/docs/r/pki_secret_backend_key.html.md
@@ -54,7 +54,7 @@ The following arguments are supported:
 
 * `managed_key_name` - (Optional) The managed key's configured name.
 
-* `managed_key_name` - (Optional) The managed key's UUID.
+* `managed_key_id` - (Optional) The managed key's UUID.
 
 
 ## Attributes Reference

--- a/website/docs/r/pki_secret_backend_key.html.md
+++ b/website/docs/r/pki_secret_backend_key.html.md
@@ -59,7 +59,9 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-No additional attributes are exported by this resource.
+The following attributes are exported:
+
+* `key_id` - ID of the generated key.
 
 ## Import
 

--- a/website/vault.erb
+++ b/website/vault.erb
@@ -509,6 +509,10 @@
                             <a href="/docs/providers/vault/r/pki_secret_backend_sign.html">vault_pki_secret_backend_sign</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-vault-resource-pki-secret-backend-key") %>>
+                            <a href="/docs/providers/vault/r/pki_secret_backend_key.html">vault_pki_secret_backend_key</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-vault-resource-policy") %>>
                             <a href="/docs/providers/vault/r/policy.html">vault_policy</a>
                         </li>


### PR DESCRIPTION
This PR adds a new PKI Key resource. This helps us move closer to enabling multi-issuer support in the PKI Secret engine.

The PR contains relevant tests and documentation