### PR TITLE
remove deprecated function oktaAuthBackendExists

### DIFF
--- a/vault/resource_okta_auth_backend.go
+++ b/vault/resource_okta_auth_backend.go
@@ -28,7 +28,6 @@ func oktaAuthBackendResource() *schema.Resource {
 		Delete: oktaAuthBackendDelete,
 		Read:   ReadWrapper(oktaAuthBackendRead),
 		Update: oktaAuthBackendUpdate,
-		Exists: oktaAuthBackendExists,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -288,10 +287,6 @@ func oktaAuthBackendDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	return nil
-}
-
-func oktaAuthBackendExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	return isOktaAuthBackendPresent(meta.(*provider.ProviderMeta).GetClient(), d.Id())
 }
 
 func oktaAuthBackendRead(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->
Without this, terraform always tries to create `vault_okta_auth_backend` resources that use the `namespace` attribute (and fails because they already exist) because it searches in the provider namespace for auths instead of in the appropriate namespace.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fixed resource vault_okta_auth_backend not honoring namespace attribute correctly
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
