### PR TITLE
secret/pki: add issuer_ref field

### DIFF
--- a/vault/resource_pki_secret_backend_role_test.go
+++ b/vault/resource_pki_secret_backend_role_test.go
@@ -227,12 +227,8 @@ func TestPkiSecretBackendRole_basic(t *testing.T) {
 					meta := testProvider.Meta().(*provider.ProviderMeta)
 					return !meta.IsAPISupported(provider.VaultVersion111), nil
 				},
-				Config: testPkiSecretBackendRoleConfig_basic(name, backend, 3600, 7200, testLegacyPolicyIdentifiers),
-				Check: resource.ComposeTestCheckFunc(
-					append(checks,
-						resource.TestCheckResourceAttr(resourceName, "issuer_ref", "default"),
-					)...,
-				),
+				Config: testPkiSecretBackendRoleConfig_basic(name, backend, 3600, 7200, ""),
+				Check:  resource.TestCheckResourceAttr(resourceName, "issuer_ref", "default"),
 			},
 			{
 				ResourceName:      resourceName,
@@ -244,12 +240,8 @@ func TestPkiSecretBackendRole_basic(t *testing.T) {
 					meta := testProvider.Meta().(*provider.ProviderMeta)
 					return !meta.IsAPISupported(provider.VaultVersion111), nil
 				},
-				Config: testPkiSecretBackendRoleConfig_basic(name, backend, 3600, 7200, testLegacyPolicyIdentifiers+"\n"+`issuer_ref = "root-a"`),
-				Check: resource.ComposeTestCheckFunc(
-					append(checks,
-						resource.TestCheckResourceAttr(resourceName, "issuer_ref", "root-a"),
-					)...,
-				),
+				Config: testPkiSecretBackendRoleConfig_basic(name, backend, 3600, 7200, `issuer_ref = "root-a"`),
+				Check:  resource.TestCheckResourceAttr(resourceName, "issuer_ref", "root-a"),
 			},
 			{
 				ResourceName:      resourceName,

--- a/vault/resource_pki_secret_backend_role_test.go
+++ b/vault/resource_pki_secret_backend_role_test.go
@@ -223,6 +223,40 @@ func TestPkiSecretBackendRole_basic(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
+				SkipFunc: func() (bool, error) {
+					meta := testProvider.Meta().(*provider.ProviderMeta)
+					return !meta.IsAPISupported(provider.VaultVersion111), nil
+				},
+				Config: testPkiSecretBackendRoleConfig_basic(name, backend, 3600, 7200, testLegacyPolicyIdentifiers),
+				Check: resource.ComposeTestCheckFunc(
+					append(checks,
+						resource.TestCheckResourceAttr(resourceName, "issuer_ref", "default"),
+					)...,
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				SkipFunc: func() (bool, error) {
+					meta := testProvider.Meta().(*provider.ProviderMeta)
+					return !meta.IsAPISupported(provider.VaultVersion111), nil
+				},
+				Config: testPkiSecretBackendRoleConfig_basic(name, backend, 3600, 7200, testLegacyPolicyIdentifiers+"\n"+`issuer_ref = "root-a"`),
+				Check: resource.ComposeTestCheckFunc(
+					append(checks,
+						resource.TestCheckResourceAttr(resourceName, "issuer_ref", "root-a"),
+					)...,
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testPkiSecretBackendRoleConfig_updated(name, backend, testLegacyPolicyIdentifiers),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
@@ -280,7 +314,7 @@ func TestPkiSecretBackendRole_basic(t *testing.T) {
 	})
 }
 
-func testPkiSecretBackendRoleConfig_basic(name, path string, roleTTL, maxTTL int, policyIdentifiers string) string {
+func testPkiSecretBackendRoleConfig_basic(name, path string, roleTTL, maxTTL int, extraConfig string) string {
 	return fmt.Sprintf(`
 resource "vault_mount" "pki" {
   path = "%s"
@@ -327,7 +361,7 @@ resource "vault_pki_secret_backend_role" "test" {
   not_before_duration                = "45m"
   allowed_serial_numbers             = ["*"]
 }
-`, path, name, roleTTL, maxTTL, policyIdentifiers)
+`, path, name, roleTTL, maxTTL, extraConfig)
 }
 
 func testPkiSecretBackendRoleConfig_updated(name, path string, policyIdentifiers string) string {

--- a/website/docs/r/pki_secret_backend_role.html.md
+++ b/website/docs/r/pki_secret_backend_role.html.md
@@ -45,6 +45,11 @@ The following arguments are supported:
 
 * `name` - (Required) The name to identify this role within the backend. Must be unique within the backend.
 
+* `issuer_ref` - (Optional) Specifies the default issuer of this request. May
+  be the value `default`, a name, or an issuer ID. Use ACLs to prevent access to
+  the `/pki/issuer/:issuer_ref/{issue,sign}/:name` paths to prevent users
+  overriding the role's `issuer_ref` value.
+
 * `ttl` - (Optional, integer) The TTL, in seconds, for any certificate issued against this role.
 
 * `max_ttl` - (Optional, integer) The maximum lease TTL, in seconds, for the role.


### PR DESCRIPTION
This PR adds the [issuer_ref](https://developer.hashicorp.com/vault/api-docs/secret/pki#issuer_ref-9) field to the `vault_pki_secret_backend_role` resource. This field will be managed for all Vault versions greater than 1.11.