### PR TITLE
deprecate ad secrets resources

### DIFF
--- a/vault/data_source_ad_credentials.go
+++ b/vault/data_source_ad_credentials.go
@@ -14,7 +14,8 @@ import (
 
 func adAccessCredentialsDataSource() *schema.Resource {
 	return &schema.Resource{
-		Read: ReadWrapper(readCredsResource),
+		DeprecationMessage: `This data source is replaced by "vault_ldap_static_credentials" and will be removed in the next major release.`,
+		Read:               ReadWrapper(readCredsResource),
 		Schema: map[string]*schema.Schema{
 			"backend": {
 				Type:        schema.TypeString,

--- a/vault/resource_ad_secret_backend.go
+++ b/vault/resource_ad_secret_backend.go
@@ -213,10 +213,11 @@ func adSecretBackendResource() *schema.Resource {
 		},
 	}
 	return provider.MustAddMountMigrationSchema(&schema.Resource{
-		Create: createConfigResource,
-		Update: updateConfigResource,
-		Read:   ReadWrapper(readConfigResource),
-		Delete: deleteConfigResource,
+		DeprecationMessage: `This resource is replaced by "vault_ldap_secret_backend" and will be removed in the next major release.`,
+		Create:             createConfigResource,
+		Update:             updateConfigResource,
+		Read:               ReadWrapper(readConfigResource),
+		Delete:             deleteConfigResource,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/vault/resource_ad_secret_library.go
+++ b/vault/resource_ad_secret_library.go
@@ -63,10 +63,11 @@ func adSecretBackendLibraryResource() *schema.Resource {
 		},
 	}
 	return &schema.Resource{
-		Create: createLibraryResource,
-		Update: updateLibraryResource,
-		Read:   ReadWrapper(readLibraryResource),
-		Delete: deleteLibraryResource,
+		DeprecationMessage: `This resource is replaced by "vault_ldap_secret_backend_library_set" and will be removed in the next major release.`,
+		Create:             createLibraryResource,
+		Update:             updateLibraryResource,
+		Read:               ReadWrapper(readLibraryResource),
+		Delete:             deleteLibraryResource,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/vault/resource_ad_secret_roles.go
+++ b/vault/resource_ad_secret_roles.go
@@ -59,10 +59,11 @@ func adSecretBackendRoleResource() *schema.Resource {
 		},
 	}
 	return &schema.Resource{
-		Create: createRoleResource,
-		Update: updateRoleResource,
-		Read:   ReadWrapper(readRoleResource),
-		Delete: deleteRoleResource,
+		DeprecationMessage: `This resource is replaced by "vault_ldap_secret_backend_static_role" and will be removed in the next major release.`,
+		Create:             createRoleResource,
+		Update:             updateRoleResource,
+		Read:               ReadWrapper(readRoleResource),
+		Delete:             deleteRoleResource,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},

--- a/website/docs/d/ad_access_credentials.html.md
+++ b/website/docs/d/ad_access_credentials.html.md
@@ -8,6 +8,9 @@ description: |-
 
 # vault\_ad\_access\_credentials
 
+~> **Note** This data source is replaced by "vault_ldap_static_credentials" and
+will be removed in the next major release.
+
 Reads Active Directory credentials from an AD secret backend in Vault.
 
 ~> **Important** All data retrieved from Vault will be

--- a/website/docs/r/ad_secret_backend.html.md
+++ b/website/docs/r/ad_secret_backend.html.md
@@ -8,6 +8,9 @@ description: |-
 
 # vault\_ad\_secret\_backend
 
+~> **Note** This resource is replaced by "vault_ldap_secret_backend" and will
+be removed in the next major release.
+
 Creates an Active Directory Secret Backend for Vault. Active Directory secret backend
 rotates existing Active Directory service account passwords based on the TTL of the role.
 

--- a/website/docs/r/ad_secret_backend_library.html.md
+++ b/website/docs/r/ad_secret_backend_library.html.md
@@ -8,6 +8,9 @@ description: |-
 
 # vault\_ad\_secret\_backend\_library
 
+~> **Note** This resource is replaced by "vault_ldap_secret_backend_library_set"
+and will be removed in the next major release.
+
 Creates a library on an Active Directory Secret Backend for Vault. Libraries create
 a pool of existing Active Directory service accounts which can be checked out
 by users.

--- a/website/docs/r/ad_secret_role.html.md
+++ b/website/docs/r/ad_secret_role.html.md
@@ -8,6 +8,9 @@ description: |-
 
 # vault\_ad\_secret\_role
 
+~> **Note** This resource is replaced by "vault_ldap_secret_backend_static_role"
+and will be removed in the next major release.
+
 Creates a role on an Active Directory Secret Backend for Vault. Roles are
 used to map credentials to existing Active Directory service accounts.
 


### PR DESCRIPTION
This PR marks the ad secret resources as deprecated. 

The Active Directory (AD) secrets engine has been deprecated as of the Vault 1.13 release. See the deprecation table: https://developer.hashicorp.com/vault/docs/deprecation

With the upcoming LDAP secrets resources we can mark these resources as deprecated and follow our deprecation process which broadly involves:
- Mark the resource/field as deprecated.
- Update the docs for the related resources/fields
- Provide guidance on how to migrate
- Eventually remove the feature all together. Normally we do that with a major version upgrade.

This PR supersedes https://github.com/hashicorp/terraform-provider-vault/pull/1837