### PR TITLE
Add 'allowed_uri_sans_template' option to PKI Backend Role

### DIFF
--- a/vault/resource_pki_secret_backend_role.go
+++ b/vault/resource_pki_secret_backend_role.go
@@ -132,6 +132,13 @@ func pkiSecretBackendRoleResource() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			"allowed_uri_sans_template": {
+				Type:        schema.TypeBool,
+				Required:    false,
+				Optional:    true,
+				Description: "When set, allowed_uri_sans may contain templates, as with ACL Path Templating.",
+				Default:     false,
+			},
 			"allowed_other_sans": {
 				Type:        schema.TypeList,
 				Required:    false,
@@ -405,6 +412,7 @@ func pkiSecretBackendRoleCreate(d *schema.ResourceData, meta interface{}) error 
 		"enforce_hostnames":                  d.Get("enforce_hostnames"),
 		"allow_ip_sans":                      d.Get("allow_ip_sans"),
 		"allowed_uri_sans":                   d.Get("allowed_uri_sans"),
+		"allowed_uri_sans_template":          d.Get("allowed_uri_sans_template"),
 		"allowed_other_sans":                 d.Get("allowed_other_sans"),
 		"server_flag":                        d.Get("server_flag"),
 		"client_flag":                        d.Get("client_flag"),
@@ -551,6 +559,7 @@ func pkiSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("enforce_hostnames", secret.Data["enforce_hostnames"])
 	d.Set("allow_ip_sans", secret.Data["allow_ip_sans"])
 	d.Set("allowed_uri_sans", secret.Data["allowed_uri_sans"])
+	d.Set("allowed_uri_sans_template", secret.Data["allowed_uri_sans_template"])
 	d.Set("allowed_other_sans", secret.Data["allowed_other_sans"])
 	d.Set("server_flag", secret.Data["server_flag"])
 	d.Set("client_flag", secret.Data["client_flag"])
@@ -629,6 +638,7 @@ func pkiSecretBackendRoleUpdate(d *schema.ResourceData, meta interface{}) error 
 		"enforce_hostnames":                  d.Get("enforce_hostnames"),
 		"allow_ip_sans":                      d.Get("allow_ip_sans"),
 		"allowed_uri_sans":                   d.Get("allowed_uri_sans"),
+		"allowed_uri_sans_template":          d.Get("allowed_uri_sans_template"),
 		"allowed_other_sans":                 d.Get("allowed_other_sans"),
 		"server_flag":                        d.Get("server_flag"),
 		"client_flag":                        d.Get("client_flag"),

--- a/vault/resource_pki_secret_backend_role_test.go
+++ b/vault/resource_pki_secret_backend_role_test.go
@@ -75,6 +75,7 @@ func TestPkiSecretBackendRole_policy_identifier(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceName, "require_cn", "true"),
 		resource.TestCheckResourceAttr(resourceName, "basic_constraints_valid_for_non_ca", "false"),
 		resource.TestCheckResourceAttr(resourceName, "not_before_duration", "45m"),
+		resource.TestCheckResourceAttr(resourceName, "allowed_uri_sans_template", "false"),
 	}
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
@@ -174,6 +175,7 @@ func TestPkiSecretBackendRole_basic(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceName, "not_before_duration", "45m"),
 		resource.TestCheckResourceAttr(resourceName, "policy_identifiers.#", "1"),
 		resource.TestCheckResourceAttr(resourceName, "policy_identifiers.0", "1.2.3.4"),
+		resource.TestCheckResourceAttr(resourceName, "allowed_uri_sans_template", "false"),
 	}
 	resource.Test(t, resource.TestCase{
 		Providers:    testProviders,
@@ -269,6 +271,7 @@ func TestPkiSecretBackendRole_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "policy_identifiers.0", "1.2.3.4"),
 					resource.TestCheckResourceAttr(resourceName, "basic_constraints_valid_for_non_ca", "false"),
 					resource.TestCheckResourceAttr(resourceName, "not_before_duration", "45m"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_uri_sans_template", "true"),
 				),
 			},
 			{
@@ -353,6 +356,7 @@ resource "vault_pki_secret_backend_role" "test" {
   enforce_hostnames = true
   allow_ip_sans = true
   allowed_uri_sans = ["uri.test.domain"]
+  allowed_uri_sans_template = true
   allowed_other_sans = ["1.2.3.4.5.5;UTF8:test"]
   server_flag = true
   client_flag = true

--- a/website/docs/r/pki_secret_backend_role.html.md
+++ b/website/docs/r/pki_secret_backend_role.html.md
@@ -69,6 +69,8 @@ The following arguments are supported:
 
 * `allowed_uri_sans` - (Optional) Defines allowed URI SANs
 
+* `allowed_uri_sans_template` - (Optional) When set, `allowed_uri_sans` may contain templates, as with ACL Path Templating. 
+
 * `allowed_other_sans` - (Optional) Defines allowed custom SANs
 
 * `server_flag` - (Optional) Flag to specify certificates for server use


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
FEATURES

- Support `allowed_uri_sans_template` on PKI Engine Role.

```

Output from acceptance testing:

```
terraform-provider-vault on  master [!] via 🐹 v1.20.2 
➜ VAULT_ADDR="http://localhost:8200" VAULT_TOKEN="..." TESTARGS="--run TestPkiSecretBackendRole" make testacc 
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test --run TestPkiSecretBackendRole -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
ok      github.com/hashicorp/terraform-provider-vault/codegen   (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    1.857s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    1.836s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    1.861s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/mfa     [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/pki      [no test files]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        1.403s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    1.557s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      1.603s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/provider (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/testutil  (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/vault     11.489s
```
