### PR TITLE
pki/secrets: add missing fields to role resource

### DIFF
--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -230,6 +230,7 @@ const (
 	FieldEnforceHostnames              = "enforce_hostnames"
 	FieldAllowIPSans                   = "allow_ip_sans"
 	FieldAllowedURISans                = "allowed_uri_sans"
+	FieldAllowedURISansTemplate        = "allowed_uri_sans_template"
 	FieldAllowedOtherSans              = "allowed_other_sans"
 	FieldServerFlag                    = "server_flag"
 	FieldClientFlag                    = "client_flag"

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -231,6 +231,7 @@ const (
 	FieldAllowIPSans                   = "allow_ip_sans"
 	FieldAllowedURISans                = "allowed_uri_sans"
 	FieldAllowedURISansTemplate        = "allowed_uri_sans_template"
+	FieldAllowedWildcardCertificates   = "allow_wildcard_certificates"
 	FieldAllowedOtherSans              = "allowed_other_sans"
 	FieldServerFlag                    = "server_flag"
 	FieldClientFlag                    = "client_flag"

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -231,7 +231,7 @@ const (
 	FieldAllowIPSans                   = "allow_ip_sans"
 	FieldAllowedURISans                = "allowed_uri_sans"
 	FieldAllowedURISansTemplate        = "allowed_uri_sans_template"
-	FieldAllowedWildcardCertificates   = "allow_wildcard_certificates"
+	FieldAllowWildcardCertificates     = "allow_wildcard_certificates"
 	FieldAllowedOtherSans              = "allowed_other_sans"
 	FieldServerFlag                    = "server_flag"
 	FieldClientFlag                    = "client_flag"

--- a/vault/resource_pki_secret_backend_role.go
+++ b/vault/resource_pki_secret_backend_role.go
@@ -64,7 +64,7 @@ var pkiSecretBooleanFields = []string{
 	consts.FieldAllowLocalhost,
 	consts.FieldAllowSubdomains,
 	consts.FieldAllowedURISansTemplate,
-	consts.FieldAllowedWildcardCertificates,
+	consts.FieldAllowWildcardCertificates,
 	consts.FieldBasicConstraintsValidForNonCA,
 	consts.FieldEnforceHostnames,
 	consts.FieldGenerateLease,
@@ -204,7 +204,7 @@ func pkiSecretBackendRoleResource() *schema.Resource {
 				Computed:    true,
 				Description: "Flag to indicate that `allowed_uri_sans` specifies a template expression (e.g. {{identity.entity.aliases.<mount accessor>.name}})",
 			},
-			consts.FieldAllowedWildcardCertificates: {
+			consts.FieldAllowWildcardCertificates: {
 				Type:        schema.TypeBool,
 				Required:    false,
 				Optional:    true,

--- a/vault/resource_pki_secret_backend_role.go
+++ b/vault/resource_pki_secret_backend_role.go
@@ -28,48 +28,49 @@ var (
 // Any new fields should probably not be added to these lists. Instead handle
 // them separately within a provider.IsAPISupported guard
 var pkiSecretFields = []string{
-	consts.FieldTTL,
-	consts.FieldMaxTTL,
 	consts.FieldAllowedDomainsTemplate,
-	consts.FieldAllowedURISans,
 	consts.FieldAllowedOtherSans,
-	consts.FieldServerFlag,
+	consts.FieldAllowedURISans,
 	consts.FieldClientFlag,
 	consts.FieldCodeSigningFlag,
+	consts.FieldCountry,
 	consts.FieldEmailProtectionFlag,
-	consts.FieldKeyType,
 	consts.FieldKeyBits,
+	consts.FieldKeyType,
+	consts.FieldLocality,
+	consts.FieldMaxTTL,
+	consts.FieldNotBeforeDuration,
 	consts.FieldOU,
 	consts.FieldOrganization,
-	consts.FieldCountry,
-	consts.FieldLocality,
-	consts.FieldProvince,
-	consts.FieldStreetAddress,
 	consts.FieldPostalCode,
-	consts.FieldNotBeforeDuration,
+	consts.FieldProvince,
+	consts.FieldServerFlag,
+	consts.FieldStreetAddress,
+	consts.FieldTTL,
 }
 
 var pkiSecretListFields = []string{
 	consts.FieldAllowedDomains,
-	consts.FieldKeyUsage,
-	consts.FieldExtKeyUsage,
 	consts.FieldAllowedSerialNumbers,
+	consts.FieldExtKeyUsage,
+	consts.FieldKeyUsage,
 }
 
 var pkiSecretBooleanFields = []string{
-	consts.FieldAllowLocalhost,
-	consts.FieldAllowBareDomains,
-	consts.FieldAllowSubdomains,
-	consts.FieldAllowGlobDomains,
 	consts.FieldAllowAnyName,
-	consts.FieldEnforceHostnames,
+	consts.FieldAllowBareDomains,
+	consts.FieldAllowGlobDomains,
 	consts.FieldAllowIPSans,
-	consts.FieldUseCSRCommonName,
-	consts.FieldUseCSRSans,
+	consts.FieldAllowLocalhost,
+	consts.FieldAllowSubdomains,
+	consts.FieldAllowedURISansTemplate,
+	consts.FieldBasicConstraintsValidForNonCA,
+	consts.FieldEnforceHostnames,
 	consts.FieldGenerateLease,
 	consts.FieldNoStore,
 	consts.FieldRequireCN,
-	consts.FieldBasicConstraintsValidForNonCA,
+	consts.FieldUseCSRCommonName,
+	consts.FieldUseCSRSans,
 }
 
 func pkiSecretBackendRoleResource() *schema.Resource {
@@ -195,6 +196,12 @@ func pkiSecretBackendRoleResource() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
+			},
+			consts.FieldAllowedURISansTemplate: {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: "Flag to indicate that `allowed_uri_sans` specifies a template expression (e.g. {{identity.entity.aliases.<mount accessor>.name}})",
 			},
 			consts.FieldServerFlag: {
 				Type:        schema.TypeBool,

--- a/vault/resource_pki_secret_backend_role.go
+++ b/vault/resource_pki_secret_backend_role.go
@@ -64,6 +64,7 @@ var pkiSecretBooleanFields = []string{
 	consts.FieldAllowLocalhost,
 	consts.FieldAllowSubdomains,
 	consts.FieldAllowedURISansTemplate,
+	consts.FieldAllowedWildcardCertificates,
 	consts.FieldBasicConstraintsValidForNonCA,
 	consts.FieldEnforceHostnames,
 	consts.FieldGenerateLease,
@@ -202,6 +203,13 @@ func pkiSecretBackendRoleResource() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				Description: "Flag to indicate that `allowed_uri_sans` specifies a template expression (e.g. {{identity.entity.aliases.<mount accessor>.name}})",
+			},
+			consts.FieldAllowedWildcardCertificates: {
+				Type:        schema.TypeBool,
+				Required:    false,
+				Optional:    true,
+				Description: "Flag to allow wildcard certificates",
+				Default:     true,
 			},
 			consts.FieldServerFlag: {
 				Type:        schema.TypeBool,

--- a/vault/resource_pki_secret_backend_role_test.go
+++ b/vault/resource_pki_secret_backend_role_test.go
@@ -144,6 +144,7 @@ func TestPkiSecretBackendRole_basic(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceName, "enforce_hostnames", "true"),
 		resource.TestCheckResourceAttr(resourceName, "allow_ip_sans", "true"),
 		resource.TestCheckResourceAttr(resourceName, "allowed_uri_sans.0", "uri.test.domain"),
+		resource.TestCheckResourceAttr(resourceName, "allowed_uri_sans_template", "false"),
 		resource.TestCheckResourceAttr(resourceName, "allowed_other_sans.0", "1.2.3.4.5.5;UTF8:test"),
 		resource.TestCheckResourceAttr(resourceName, "server_flag", "true"),
 		resource.TestCheckResourceAttr(resourceName, "client_flag", "true"),
@@ -266,7 +267,10 @@ func TestPkiSecretBackendRole_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "allow_any_name", "false"),
 					resource.TestCheckResourceAttr(resourceName, "enforce_hostnames", "true"),
 					resource.TestCheckResourceAttr(resourceName, "allow_ip_sans", "true"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_uri_sans.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "allowed_uri_sans.0", "uri.test.domain"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_uri_sans.1", "spiffe://{{identity.entity.name}}"),
+					resource.TestCheckResourceAttr(resourceName, "allowed_uri_sans_template", "true"),
 					resource.TestCheckResourceAttr(resourceName, "allowed_other_sans.0", "1.2.3.4.5.5;UTF8:test"),
 					resource.TestCheckResourceAttr(resourceName, "server_flag", "true"),
 					resource.TestCheckResourceAttr(resourceName, "client_flag", "true"),
@@ -378,7 +382,8 @@ resource "vault_pki_secret_backend_role" "test" {
   allow_any_name = false
   enforce_hostnames = true
   allow_ip_sans = true
-  allowed_uri_sans = ["uri.test.domain"]
+  allowed_uri_sans = ["uri.test.domain", "spiffe://{{identity.entity.name}}"]
+  allowed_uri_sans_template = true
   allowed_other_sans = ["1.2.3.4.5.5;UTF8:test"]
   server_flag = true
   client_flag = true

--- a/vault/resource_pki_secret_backend_role_test.go
+++ b/vault/resource_pki_secret_backend_role_test.go
@@ -146,6 +146,7 @@ func TestPkiSecretBackendRole_basic(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceName, "allowed_uri_sans.0", "uri.test.domain"),
 		resource.TestCheckResourceAttr(resourceName, "allowed_uri_sans_template", "false"),
 		resource.TestCheckResourceAttr(resourceName, "allowed_other_sans.0", "1.2.3.4.5.5;UTF8:test"),
+		resource.TestCheckResourceAttr(resourceName, "allow_wildcard_certificates", "true"),
 		resource.TestCheckResourceAttr(resourceName, "server_flag", "true"),
 		resource.TestCheckResourceAttr(resourceName, "client_flag", "true"),
 		resource.TestCheckResourceAttr(resourceName, "code_signing_flag", "false"),
@@ -272,6 +273,7 @@ func TestPkiSecretBackendRole_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "allowed_uri_sans.1", "spiffe://{{identity.entity.name}}"),
 					resource.TestCheckResourceAttr(resourceName, "allowed_uri_sans_template", "true"),
 					resource.TestCheckResourceAttr(resourceName, "allowed_other_sans.0", "1.2.3.4.5.5;UTF8:test"),
+					resource.TestCheckResourceAttr(resourceName, "allow_wildcard_certificates", "false"),
 					resource.TestCheckResourceAttr(resourceName, "server_flag", "true"),
 					resource.TestCheckResourceAttr(resourceName, "client_flag", "true"),
 					resource.TestCheckResourceAttr(resourceName, "code_signing_flag", "false"),
@@ -385,6 +387,7 @@ resource "vault_pki_secret_backend_role" "test" {
   allowed_uri_sans = ["uri.test.domain", "spiffe://{{identity.entity.name}}"]
   allowed_uri_sans_template = true
   allowed_other_sans = ["1.2.3.4.5.5;UTF8:test"]
+  allow_wildcard_certificates = false
   server_flag = true
   client_flag = true
   code_signing_flag = false

--- a/website/docs/r/pki_secret_backend_role.html.md
+++ b/website/docs/r/pki_secret_backend_role.html.md
@@ -74,6 +74,8 @@ The following arguments are supported:
 
 * `allowed_uri_sans` - (Optional) Defines allowed URI SANs
 
+* `allowed_uri_sans_template` - (Optional) Flag, if set, `allowed_uri_sans` can be specified using identity template expressions such as `{{identity.entity.aliases.<mount accessor>.name}}`.
+
 * `allowed_other_sans` - (Optional) Defines allowed custom SANs
 
 * `server_flag` - (Optional) Flag to specify certificates for server use
@@ -84,7 +86,7 @@ The following arguments are supported:
 
 * `email_protection_flag` - (Optional) Flag to specify certificates for email protection use
 
-* `key_type` - (Optional) The generated key type, choices: `rsa`, `ec`, `ed25519`, `any`  
+* `key_type` - (Optional) The generated key type, choices: `rsa`, `ec`, `ed25519`, `any`
   Defaults to `rsa`
 
 * `key_bits` - (Optional) The number of bits of generated keys

--- a/website/docs/r/pki_secret_backend_role.html.md
+++ b/website/docs/r/pki_secret_backend_role.html.md
@@ -78,6 +78,8 @@ The following arguments are supported:
 
 * `allowed_other_sans` - (Optional) Defines allowed custom SANs
 
+* `allow_wildcard_certificates` - (Optional) Flag to allow wildcard certificates.
+
 * `server_flag` - (Optional) Flag to specify certificates for server use
 
 * `client_flag` - (Optional) Flag to specify certificates for client use


### PR DESCRIPTION
This PR adds the following fields to the `vault_pki_secret_backend_role` resource:

- [allowed_uri_sans_template](https://developer.hashicorp.com/vault/api-docs/secret/pki#allowed_uri_sans_template)
  - Addresses 
    - https://github.com/hashicorp/terraform-provider-vault/issues/1486
    - https://github.com/hashicorp/terraform-provider-vault/pull/1182
    - https://github.com/hashicorp/terraform-provider-vault/pull/1855
- [allow_wildcard_certificates](https://developer.hashicorp.com/vault/api-docs/secret/pki#allow_wildcard_certificates)
  - Addresses
    - https://github.com/hashicorp/terraform-provider-vault/issues/1853
    - https://github.com/hashicorp/terraform-provider-vault/issues/1419

