### PR TITLE
update gha workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       version: ${{ steps.go-version.outputs.version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - id: go-version
         run: echo "version=$(cat .go-version)" >> $GITHUB_OUTPUT
   build:
@@ -26,7 +26,7 @@ jobs:
     container:
       image: "docker.mirror.hashicorp.services/golang:${{ needs.go-version.outputs.version }}"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: Build
         run: |
           make build
@@ -113,7 +113,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: Acceptance Tests
         env:
           VAULT_TOKEN: "root"

--- a/.github/workflows/issue-comment-created.yml
+++ b/.github/workflows/issue-comment-created.yml
@@ -8,7 +8,7 @@ jobs:
   issue_comment_triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-ecosystem/action-remove-labels@v1
+      - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1.3.0
         with:
           labels: |
             stale

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -8,8 +8,8 @@ jobs:
   issue_triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: github/issue-labeler@v2.4
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+    - uses: github/issue-labeler@e24a3eb6b2e28c8904d086302a2b760647f5f45c # v3.1
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/labeler-issue-triage.yml

--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -1,3 +1,4 @@
+name: Jira Sync
 on:
   issues:
     types: [opened, closed, deleted, reopened]
@@ -5,68 +6,14 @@ on:
     types: [opened, closed, reopened]
   issue_comment: # Also triggers when commenting on a PR from the conversation view
     types: [created]
-
-name: Jira Sync
-
 jobs:
   sync:
-    runs-on: ubuntu-latest
-    name: Jira sync
-    steps:
-    - name: Login
-      uses: atlassian/gajira-login@v2.0.0
-      env:
-        JIRA_BASE_URL: ${{ secrets.JIRA_SYNC_BASE_URL }}
-        JIRA_USER_EMAIL: ${{ secrets.JIRA_SYNC_USER_EMAIL }}
-        JIRA_API_TOKEN: ${{ secrets.JIRA_SYNC_API_TOKEN }}
-
-    - name: Preprocess
-      if: github.event.action == 'opened' || github.event.action == 'created'
-      id: preprocess
-      run: |
-        if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
-          echo "::set-output name=type::PR"
-        else
-          echo "::set-output name=type::ISS"
-        fi
-
-    - name: Create ticket
-      if: github.event.action == 'opened'
-      uses: tomhjp/gh-action-jira-create@v0.2.0
-      with:
-        project: VAULT
-        issuetype: "GH Issue"
-        summary: "${{ github.event.repository.name }} [${{ steps.preprocess.outputs.type }} #${{ github.event.issue.number || github.event.pull_request.number }}]: ${{ github.event.issue.title || github.event.pull_request.title }}"
-        description: "${{ github.event.issue.body || github.event.pull_request.body }}\n\n_Created from GitHub Action for ${{ github.event.issue.html_url || github.event.pull_request.html_url }} from ${{ github.actor }}_"
-        # customfield_10089 is Issue Link custom field
-        # customfield_10091 is team custom field
-        extraFields: '{"fixVersions": [{"name": "TBD"}], "customfield_10091": ["ecosystem", "tfvp"], "customfield_10089": "${{ github.event.issue.html_url || github.event.pull_request.html_url }}"}'
-
-    - name: Search
-      if: github.event.action != 'opened'
-      id: search
-      uses: tomhjp/gh-action-jira-search@v0.2.1
-      with:
-        # cf[10089] is Issue Link custom field
-        jql: 'project = "VAULT" and cf[10089]="${{ github.event.issue.html_url || github.event.pull_request.html_url }}"'
-
-    - name: Sync comment
-      if: github.event.action == 'created' && steps.search.outputs.issue
-      uses: tomhjp/gh-action-jira-comment@v0.2.0
-      with:
-        issue: ${{ steps.search.outputs.issue }}
-        comment: "${{ github.actor }} ${{ github.event.review.state || 'commented' }}:\n\n${{ github.event.comment.body || github.event.review.body }}\n\n${{ github.event.comment.html_url || github.event.review.html_url }}"
-
-    - name: Close ticket
-      if: (github.event.action == 'closed' || github.event.action == 'deleted') && steps.search.outputs.issue
-      uses: atlassian/gajira-transition@v2.0.1
-      with:
-        issue: ${{ steps.search.outputs.issue }}
-        transition: Closed
-
-    - name: Reopen ticket
-      if: github.event.action == 'reopened' && steps.search.outputs.issue
-      uses: atlassian/gajira-transition@v2.0.1
-      with:
-        issue: ${{ steps.search.outputs.issue }}
-        transition: "Re-Triage"
+    uses: hashicorp/vault-workflows-common/.github/workflows/jira.yaml@main
+    # assuming you use Vault to get secrets
+    # if you use GitHub secrets, use secrets.XYZ instead of steps.secrets.outputs.XYZ
+    secrets:
+      JIRA_SYNC_BASE_URL: ${{ secrets.JIRA_SYNC_BASE_URL }}
+      JIRA_SYNC_USER_EMAIL: ${{ secrets.JIRA_SYNC_USER_EMAIL }}
+      JIRA_SYNC_API_TOKEN: ${{ secrets.JIRA_SYNC_API_TOKEN }}
+    with:
+      teams-array: '["ecosystem", "applications-eco"]'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,7 +6,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v3
+    - uses: actions/labeler@ba790c862c380240c6d5e7427be5ace9a05c754b # v4.0.3
       with:
         configuration-path: .github/labeler-pull-request-triage.yml
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,18 +14,18 @@ jobs:
     outputs:
       version: ${{ steps.go-version.outputs.version }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - id: go-version
-        run: echo "::set-output name=version::$(cat ./.go-version)"
+        run: echo "version=$(cat .go-version)" >> $GITHUB_OUTPUT
   release-notes:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           fetch-depth: 0
       - name: Generate Release Notes
         run: sed -n -e "1{/# /d;}" -e "2{/^$/d;}" -e "/# $(git describe --abbrev=0 --exclude="$(git describe --abbrev=0 --match='v*.*.*' --tags)" --match='v*.*.*' --tags | tr -d v)/q;p" CHANGELOG.md > release-notes.txt
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: release-notes
           path: release-notes.txt


### PR DESCRIPTION
Use the common Jira sync workflow, remove deprecated command usage and pin the GH action shas.

Closes https://github.com/hashicorp/terraform-provider-vault/issues/1861, https://github.com/hashicorp/terraform-provider-vault/pull/1826