### PR TITLE
build: use setup-terraform action workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,6 +123,7 @@ jobs:
         with:
           terraform_version: '1.4.*'
           terraform_wrapper: false
+      - name: Check Terraform CLI version
         run: terraform --version
       - name: Acceptance Tests
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,25 +15,24 @@ jobs:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - id: go-version
         run: echo "version=$(cat .go-version)" >> $GITHUB_OUTPUT
-  # build:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-  #     - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
-  #       with:
-  #         go-version-file: .go-version
-  #     - name: Build
-  #       run: |
-  #         make build
-  #     - name: Run unit tests
-  #       # here to short-circuit the acceptance tests, in the case of a failure.
-  #       env:
-  #         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-  #       run: |
-  #         make test
+  build:
+    needs: [go-version]
+    runs-on: ubuntu-latest
+    container:
+      image: "docker.mirror.hashicorp.services/golang:${{ needs.go-version.outputs.version }}"
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - name: Build
+        run: |
+          make build
+      - name: Run unit tests
+        # here to short-circuit the acceptance tests, in the case of a failure.
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make test
   acceptance:
-    # needs: [go-version, build]
-    needs: go-version
+    needs: [go-version, build]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -118,12 +117,13 @@ jobs:
           LDAP_PASSWORDS: "password1,password2,password3"
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - name: Install terrform dependencies
+      - name: Install setup-terraform dependencies
         run: apt-get -y update && apt-get install unzip
       - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: '1.4.*'
           terraform_wrapper: false
+        run: terraform --version
       - name: Acceptance Tests
         env:
           VAULT_TOKEN: "root"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,21 +16,13 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/rate_limit
-  go-version:
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.go-version.outputs.version }}
-    steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - id: go-version
-        run: echo "version=$(cat .go-version)" >> $GITHUB_OUTPUT
   build:
-    needs: [go-version]
     runs-on: ubuntu-latest
-    container:
-      image: "docker.mirror.hashicorp.services/golang:${{ needs.go-version.outputs.version }}"
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+        with:
+          go-version-file: .go-version
       - name: Build
         run: |
           make build
@@ -41,7 +33,7 @@ jobs:
         run: |
           make test
   acceptance:
-    needs: [go-version, build]
+    needs: build
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -50,8 +42,6 @@ jobs:
         - "vault-enterprise:1.11.9-ent"
         - "vault-enterprise:1.12.5-ent"
         - "vault-enterprise:1.13.1-ent"
-    container:
-      image: "docker.mirror.hashicorp.services/golang:${{ needs.go-version.outputs.version }}"
     services:
       vault:
         image: hashicorp/${{ matrix.image }}
@@ -126,6 +116,9 @@ jobs:
           LDAP_PASSWORDS: "password1,password2,password3"
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+        with:
+          go-version-file: .go-version
       - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: '1.4.*'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,6 +118,8 @@ jobs:
           LDAP_PASSWORDS: "password1,password2,password3"
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - name: Install terrform dependencies
+        run: apt-get -y update && apt-get install unzip
       - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: '1.4.*'
@@ -142,8 +144,6 @@ jobs:
           LDAP_BINDPASS: "adminpassword"
           LDAP_URL: "ldap://openldap:1389"
         run: |
-          docker ps -a
-          exit
           make testacc-ent TESTARGS='-test.v -test.parallel=10' SKIP_MSSQL_MULTI_CI=true SKIP_RAFT_TESTS=true SKIP_VAULT_NEXT_TESTS=true
       - name: "Generate Vault API Path Coverage Report"
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,6 @@
 name: Build
 
-on:
-  push:
-    paths:
-      - '.github/workflows/build.yaml'
-      - '**.go'
+on: push
 
 permissions:
   # Permission for checking out code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,33 +7,32 @@ permissions:
   contents: read
 
 jobs:
-  gh-api-quota-check:
+  go-version:
     runs-on: ubuntu-latest
-    steps:
-      - name: get GH rate-limit config
-        run: |
-          curl -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/rate_limit
-  build:
-    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.go-version.outputs.version }}
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
-        with:
-          go-version-file: .go-version
-      - name: Build
-        run: |
-          make build
-      - name: Run unit tests
-        # here to short-circuit the acceptance tests, in the case of a failure.
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        run: |
-          make test
+      - id: go-version
+        run: echo "version=$(cat .go-version)" >> $GITHUB_OUTPUT
+  # build:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+  #     - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
+  #       with:
+  #         go-version-file: .go-version
+  #     - name: Build
+  #       run: |
+  #         make build
+  #     - name: Run unit tests
+  #       # here to short-circuit the acceptance tests, in the case of a failure.
+  #       env:
+  #         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+  #       run: |
+  #         make test
   acceptance:
-    needs: build
+    needs: [go-version, build]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -42,6 +41,8 @@ jobs:
         - "vault-enterprise:1.11.9-ent"
         - "vault-enterprise:1.12.5-ent"
         - "vault-enterprise:1.13.1-ent"
+    container:
+      image: "docker.mirror.hashicorp.services/golang:${{ needs.go-version.outputs.version }}"
     services:
       vault:
         image: hashicorp/${{ matrix.image }}
@@ -116,9 +117,6 @@ jobs:
           LDAP_PASSWORDS: "password1,password2,password3"
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
-        with:
-          go-version-file: .go-version
       - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: '1.4.*'
@@ -143,6 +141,8 @@ jobs:
           LDAP_BINDPASS: "adminpassword"
           LDAP_URL: "ldap://openldap:1389"
         run: |
+          docker ps -a
+          exit
           make testacc-ent TESTARGS='-test.v -test.parallel=10' SKIP_MSSQL_MULTI_CI=true SKIP_RAFT_TESTS=true SKIP_VAULT_NEXT_TESTS=true
       - name: "Generate Vault API Path Coverage Report"
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,14 @@
 name: Build
 
-on: push
+on:
+  push:
+    paths:
+      - '.github/workflows/build.yaml'
+      - '**.go'
+
+permissions:
+  # Permission for checking out code
+  contents: read
 
 jobs:
   gh-api-quota-check:
@@ -122,6 +130,10 @@ jobs:
           LDAP_PASSWORDS: "password1,password2,password3"
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: '1.4.*'
+          terraform_wrapper: false
       - name: Acceptance Tests
         env:
           VAULT_TOKEN: "root"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,8 @@ jobs:
   #       run: |
   #         make test
   acceptance:
-    needs: [go-version, build]
+    # needs: [go-version, build]
+    needs: go-version
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,14 @@ jobs:
       image: "docker.mirror.hashicorp.services/golang:${{ needs.go-version.outputs.version }}"
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - name: Install setup-terraform dependencies
+        run: apt-get -y update && apt-get install unzip
+      # setup-terraform is used to install the Terraform CLI. If we don't do
+      # this then the terraform-plugin-sdk will attempt to download it for each test!
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: '1.4.*'
+          terraform_wrapper: false
       - name: Build
         run: |
           make build
@@ -117,8 +125,11 @@ jobs:
           LDAP_PASSWORDS: "password1,password2,password3"
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      # setup-terraform expects unzip to be available but we are running in a docker container that doesn't have it pre-installed
       - name: Install setup-terraform dependencies
         run: apt-get -y update && apt-get install unzip
+      # setup-terraform is used to install the Terraform CLI. If we don't do
+      # this then the terraform-plugin-sdk will attempt to download it for each test!
       - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: '1.4.*'

--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,10 @@ build: fmtcheck
 	go install
 
 test: fmtcheck
-	TF_ACC= go test $(TESTARGS) -timeout 10m -parallel=4 $(TEST_PATH)
+	TF_ACC= go test $(TESTARGS) -timeout 10m -parallel=20 $(TEST_PATH)
 
 testacc: fmtcheck
-	TF_ACC=1 go test $(TESTARGS) -timeout 30m $(TEST_PATH)
+	TF_ACC=1 go test $(TESTARGS) -timeout 30m -parallel=20 $(TEST_PATH)
 
 testacc-ent:
 	make testacc TF_ACC_ENTERPRISE=1


### PR DESCRIPTION
We will use the https://github.com/hashicorp/setup-terraform/ action to setup the Terraform CLI. This should prevent the intermittent CI failures we have been seeing where the terraform-plugin-sdk sees upstream (502) errors from release.hashicorp.com when attempting to download the Terraform CLI.