### PR TITLE
Add token_file argument to provider block

### DIFF
--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -515,6 +515,15 @@ func createChildToken(d *schema.ResourceData, c *api.Client, namespace string) (
 }
 
 func GetToken(d *schema.ResourceData) (string, error) {
+	if tokenFilePath := d.Get("token_file").(string); tokenFilePath != "" {
+		buf, err := os.ReadFile(tokenFilePath)
+		if err != nil {
+			return "", fmt.Errorf("error reading token file: %s", err)
+		}
+
+		return string(buf), nil
+	}
+
 	if token := d.Get("token").(string); token != "" {
 		return token, nil
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -80,9 +80,15 @@ func NewProvider(
 			},
 			"token": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc(api.EnvVaultToken, ""),
 				Description: "Token to use to authenticate to Vault.",
+			},
+			"token_file": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("TERRAFORM_VAULT_TOKEN_FILE", ""),
+				Description: "Path to a token to use to authenticate to Vault.",
 			},
 			"token_name": {
 				Type:        schema.TypeString,

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -114,8 +114,23 @@ variables in order to keep credential information out of the configuration.
   `skip_child_token` is set to `true` (see below). Note that
   the given token must have the update capability on the auth/token/create
   path in Vault in order to create child tokens.  A token is required for
-  the provider.  A token can explicitly set via token argument, alternatively 
-  a token can be dynamically set via an `auth_login*` block.
+  the provider. A token can explicitly set via the `token` or `token_file` 
+  arguments, with `token_file` taking precedence if both arguments are set. 
+  Alternatively, a token can be dynamically set via an `auth_login*` block.
+
+* `token_file` - (Optional) Path to a file on disk that contains a Vault 
+  token that will be used by Terraform to authenticate. May be set via the
+  `TERRAFORM_VAULT_TOKEN_FILE` environment variable. If none is otherwise 
+  supplied, Terraform will attempt to read it from `~/.vault-token` (where 
+  the vault command stores its current token). Terraform will issue itself 
+  a new token that is a child of the one given, with a short TTL to limit 
+  the exposure of any requested secrets, unless `skip_child_token` is set 
+  to `true` (see below). Note that the given token must have the update 
+  capability on the auth/token/create path in Vault in order to create child 
+  tokens. A token is required for the provider. A token can explicitly set
+  via the `token` or `token_file` arguments, with `token_file` taking precedence 
+  if both arguments are set. Alternatively, a token can be dynamically set 
+  via an `auth_login*` block.
 
 * `token_name` - (Optional) Token name, that will be used by Terraform when
   creating the child token (`display_name`). This is useful to provide a reference of the


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
`provider`: Add support for specifying Vault token via file path to token file using the `token_file` argument
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
