### PR TITLE
secrets/ldap: fix bindpass getting overwritten

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,7 +138,7 @@ jobs:
           SAMBA_DC_DNS_BACKEND: "SAMBA_INTERNAL"
     steps:
       - name: Check containers
-        run: docker ps -a
+        run: /usr/bin/docker ps -a -f 'name=ad'
 
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       # setup-terraform expects unzip to be available but we are running in a docker container that doesn't have it pre-installed
@@ -173,7 +173,11 @@ jobs:
           LDAP_URL: "ldap://openldap:1389"
           AD_URL: "ldaps://ad:636"
         run: |
+          echo "debug docker"
+          /usr/bin/docker ps -a -f 'name=ad'
           make testacc-ent TESTARGS='--run TestLDAPSecretBackend_SchemaAD -v' SKIP_MSSQL_MULTI_CI=true SKIP_RAFT_TESTS=true SKIP_VAULT_NEXT_TESTS=true
+          echo "debug docker"
+          /usr/bin/docker ps -a -f 'name=ad'
       - name: "Generate Vault API Path Coverage Report"
         run: |
           go run cmd/coverage/main.go -openapi-doc=./testdata/openapi.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,33 +15,32 @@ jobs:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - id: go-version
         run: echo "version=$(cat .go-version)" >> $GITHUB_OUTPUT
-  # build:
-  #   needs: [go-version]
-  #   runs-on: ubuntu-latest
-  #   container:
-  #     image: "docker.mirror.hashicorp.services/golang:${{ needs.go-version.outputs.version }}"
-  #   steps:
-  #     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-  #     - name: Install setup-terraform dependencies
-  #       run: apt-get -y update && apt-get install unzip
-  #     # setup-terraform is used to install the Terraform CLI. If we don't do
-  #     # this then the terraform-plugin-sdk will attempt to download it for each test!
-  #     - uses: hashicorp/setup-terraform@v2
-  #       with:
-  #         terraform_version: '1.4.*'
-  #         terraform_wrapper: false
-  #     - name: Build
-  #       run: |
-  #         make build
-  #     - name: Run unit tests
-  #       # here to short-circuit the acceptance tests, in the case of a failure.
-  #       env:
-  #         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-  #       run: |
-  #         make test
-  acceptance:
-    # needs: [go-version, build]
+  build:
     needs: [go-version]
+    runs-on: ubuntu-latest
+    container:
+      image: "docker.mirror.hashicorp.services/golang:${{ needs.go-version.outputs.version }}"
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - name: Install setup-terraform dependencies
+        run: apt-get -y update && apt-get install unzip
+      # setup-terraform is used to install the Terraform CLI. If we don't do
+      # this then the terraform-plugin-sdk will attempt to download it for each test!
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: '1.4.*'
+          terraform_wrapper: false
+      - name: Build
+        run: |
+          make build
+      - name: Run unit tests
+        # here to short-circuit the acceptance tests, in the case of a failure.
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          make test
+  acceptance:
+    needs: [go-version, build]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -124,22 +123,7 @@ jobs:
           LDAP_ADMIN_PASSWORD: "adminpassword"
           LDAP_USERS: "alice,bob,foo"
           LDAP_PASSWORDS: "password1,password2,password3"
-      ad:
-        image: laslabs/alpine-samba-dc:0.1.0
-        ports:
-        - '389:389'
-        - '636:636'
-        options: >-
-          --cap-add "SYS_ADMIN"
-        env:
-          SAMBA_DC_REALM: "corp.example.net"
-          SAMBA_DC_DOMAIN: "EXAMPLE"
-          SAMBA_DC_ADMIN_PASSWD: "SuperSecretPassw0rd"
-          SAMBA_DC_DNS_BACKEND: "SAMBA_INTERNAL"
     steps:
-      - name: Check containers
-        run: /usr/bin/docker ps -a -f 'name=ad'
-
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       # setup-terraform expects unzip to be available but we are running in a docker container that doesn't have it pre-installed
       - name: Install setup-terraform dependencies
@@ -171,13 +155,8 @@ jobs:
           LDAP_BINDDN: "cn=admin,dc=example,dc=org"
           LDAP_BINDPASS: "adminpassword"
           LDAP_URL: "ldap://openldap:1389"
-          AD_URL: "ldaps://ad:636"
         run: |
-          echo "debug docker"
-          /usr/bin/docker ps -a -f 'name=ad'
-          make testacc-ent TESTARGS='--run TestLDAPSecretBackend_SchemaAD -v' SKIP_MSSQL_MULTI_CI=true SKIP_RAFT_TESTS=true SKIP_VAULT_NEXT_TESTS=true
-          echo "debug docker"
-          /usr/bin/docker ps -a -f 'name=ad'
+          make testacc-ent TESTARGS='-test.v -test.parallel=10' SKIP_MSSQL_MULTI_CI=true SKIP_RAFT_TESTS=true SKIP_VAULT_NEXT_TESTS=true
       - name: "Generate Vault API Path Coverage Report"
         run: |
           go run cmd/coverage/main.go -openapi-doc=./testdata/openapi.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,6 @@ jobs:
           LDAP_PASSWORDS: "password1,password2,password3"
       ad:
         image: laslabs/alpine-samba-dc:0.1.0
-        privileged: true
         ports:
         - '2389:389'
         - '2636:636'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,6 +123,17 @@ jobs:
           LDAP_ADMIN_PASSWORD: "adminpassword"
           LDAP_USERS: "alice,bob,foo"
           LDAP_PASSWORDS: "password1,password2,password3"
+      ad:
+        image: laslabs/alpine-samba-dc:0.1.0
+        privileged: true
+        ports:
+        - '2389:389'
+        - '2636:636'
+        environment:
+          - SAMBA_DC_REALM=corp.example.net
+          - SAMBA_DC_DOMAIN=EXAMPLE
+          - SAMBA_DC_ADMIN_PASSWD=SuperSecretPassw0rd
+          - SAMBA_DC_DNS_BACKEND=SAMBA_INTERNAL
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       # setup-terraform expects unzip to be available but we are running in a docker container that doesn't have it pre-installed

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,10 +130,6 @@ jobs:
         - '2636:636'
         options: >-
           --cap-add "SYS_ADMIN"
-          --health-cmd "LDAPTLS_REQCERT=never ldapsearch -x -b 'CN=Users,DC=corp,DC=example,DC=net' -h 127.0.0.1 -p 2389 -Z -D 'CN=Administrator,CN=Users,DC=corp,DC=example,DC=net' -w 'SuperSecretPassw0rd' CN=Administrator"
-          --health-interval 20s
-          --health-timeout 20s
-          --health-retries 2
         env:
           SAMBA_DC_REALM: "corp.example.net"
           SAMBA_DC_DOMAIN: "EXAMPLE"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,10 +129,10 @@ jobs:
         - '2389:389'
         - '2636:636'
         env:
-          - SAMBA_DC_REALM=corp.example.net
-          - SAMBA_DC_DOMAIN=EXAMPLE
-          - SAMBA_DC_ADMIN_PASSWD=SuperSecretPassw0rd
-          - SAMBA_DC_DNS_BACKEND=SAMBA_INTERNAL
+          SAMBA_DC_REALM: "corp.example.net"
+          SAMBA_DC_DOMAIN: "EXAMPLE"
+          SAMBA_DC_ADMIN_PASSWD: "SuperSecretPassw0rd"
+          SAMBA_DC_DNS_BACKEND: "SAMBA_INTERNAL"
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       # setup-terraform expects unzip to be available but we are running in a docker container that doesn't have it pre-installed

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,8 +126,8 @@ jobs:
       ad:
         image: laslabs/alpine-samba-dc:0.1.0
         ports:
-        - '2389:389'
-        - '2636:636'
+        - '389:389'
+        - '636:636'
         options: >-
           --cap-add "SYS_ADMIN"
         env:
@@ -136,6 +136,9 @@ jobs:
           SAMBA_DC_ADMIN_PASSWD: "SuperSecretPassw0rd"
           SAMBA_DC_DNS_BACKEND: "SAMBA_INTERNAL"
     steps:
+      - name: Check containers
+        run: docker ps -a
+
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       # setup-terraform expects unzip to be available but we are running in a docker container that doesn't have it pre-installed
       - name: Install setup-terraform dependencies
@@ -167,7 +170,7 @@ jobs:
           LDAP_BINDDN: "cn=admin,dc=example,dc=org"
           LDAP_BINDPASS: "adminpassword"
           LDAP_URL: "ldap://openldap:1389"
-          AD_URL: "ldaps://ad:2636"
+          AD_URL: "ldaps://ad:636"
         run: |
           make testacc-ent TESTARGS='-test.v -test.parallel=10' SKIP_MSSQL_MULTI_CI=true SKIP_RAFT_TESTS=true SKIP_VAULT_NEXT_TESTS=true
       - name: "Generate Vault API Path Coverage Report"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,7 @@ jobs:
         ports:
         - '2389:389'
         - '2636:636'
-        environment:
+        env:
           - SAMBA_DC_REALM=corp.example.net
           - SAMBA_DC_DOMAIN=EXAMPLE
           - SAMBA_DC_ADMIN_PASSWD=SuperSecretPassw0rd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,30 +15,30 @@ jobs:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - id: go-version
         run: echo "version=$(cat .go-version)" >> $GITHUB_OUTPUT
-  build:
-    needs: [go-version]
-    runs-on: ubuntu-latest
-    container:
-      image: "docker.mirror.hashicorp.services/golang:${{ needs.go-version.outputs.version }}"
-    steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - name: Install setup-terraform dependencies
-        run: apt-get -y update && apt-get install unzip
-      # setup-terraform is used to install the Terraform CLI. If we don't do
-      # this then the terraform-plugin-sdk will attempt to download it for each test!
-      - uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: '1.4.*'
-          terraform_wrapper: false
-      - name: Build
-        run: |
-          make build
-      - name: Run unit tests
-        # here to short-circuit the acceptance tests, in the case of a failure.
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        run: |
-          make test
+  # build:
+  #   needs: [go-version]
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: "docker.mirror.hashicorp.services/golang:${{ needs.go-version.outputs.version }}"
+  #   steps:
+  #     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+  #     - name: Install setup-terraform dependencies
+  #       run: apt-get -y update && apt-get install unzip
+  #     # setup-terraform is used to install the Terraform CLI. If we don't do
+  #     # this then the terraform-plugin-sdk will attempt to download it for each test!
+  #     - uses: hashicorp/setup-terraform@v2
+  #       with:
+  #         terraform_version: '1.4.*'
+  #         terraform_wrapper: false
+  #     - name: Build
+  #       run: |
+  #         make build
+  #     - name: Run unit tests
+  #       # here to short-circuit the acceptance tests, in the case of a failure.
+  #       env:
+  #         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+  #       run: |
+  #         make test
   acceptance:
     needs: [go-version, build]
     runs-on: ubuntu-latest
@@ -172,7 +172,7 @@ jobs:
           LDAP_URL: "ldap://openldap:1389"
           AD_URL: "ldaps://ad:636"
         run: |
-          make testacc-ent TESTARGS='-test.v -test.parallel=10' SKIP_MSSQL_MULTI_CI=true SKIP_RAFT_TESTS=true SKIP_VAULT_NEXT_TESTS=true
+          make testacc-ent TESTARGS='--run TestLDAPSecretBackend_SchemaAD -v' SKIP_MSSQL_MULTI_CI=true SKIP_RAFT_TESTS=true SKIP_VAULT_NEXT_TESTS=true
       - name: "Generate Vault API Path Coverage Report"
         run: |
           go run cmd/coverage/main.go -openapi-doc=./testdata/openapi.json

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,8 @@ jobs:
   #       run: |
   #         make test
   acceptance:
-    needs: [go-version, build]
+    # needs: [go-version, build]
+    needs: [go-version]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,6 +128,8 @@ jobs:
         ports:
         - '2389:389'
         - '2636:636'
+        options: >-
+          --cap-add "SYS_ADMIN"
         env:
           SAMBA_DC_REALM: "corp.example.net"
           SAMBA_DC_DOMAIN: "EXAMPLE"
@@ -165,6 +167,7 @@ jobs:
           LDAP_BINDDN: "cn=admin,dc=example,dc=org"
           LDAP_BINDPASS: "adminpassword"
           LDAP_URL: "ldap://openldap:1389"
+          AD_URL: "ldaps://ad:2636"
         run: |
           make testacc-ent TESTARGS='-test.v -test.parallel=10' SKIP_MSSQL_MULTI_CI=true SKIP_RAFT_TESTS=true SKIP_VAULT_NEXT_TESTS=true
       - name: "Generate Vault API Path Coverage Report"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,6 +130,10 @@ jobs:
         - '2636:636'
         options: >-
           --cap-add "SYS_ADMIN"
+          --health-cmd "LDAPTLS_REQCERT=never ldapsearch -x -b 'CN=Users,DC=corp,DC=example,DC=net' -h 127.0.0.1 -p 2389 -Z -D 'CN=Administrator,CN=Users,DC=corp,DC=example,DC=net' -w 'SuperSecretPassw0rd' CN=Administrator"
+          --health-interval 1s
+          --health-timeout 5s
+          --health-retries 5
         env:
           SAMBA_DC_REALM: "corp.example.net"
           SAMBA_DC_DOMAIN: "EXAMPLE"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,9 +131,9 @@ jobs:
         options: >-
           --cap-add "SYS_ADMIN"
           --health-cmd "LDAPTLS_REQCERT=never ldapsearch -x -b 'CN=Users,DC=corp,DC=example,DC=net' -h 127.0.0.1 -p 2389 -Z -D 'CN=Administrator,CN=Users,DC=corp,DC=example,DC=net' -w 'SuperSecretPassw0rd' CN=Administrator"
-          --health-interval 1s
-          --health-timeout 5s
-          --health-retries 5
+          --health-interval 20s
+          --health-timeout 20s
+          --health-retries 2
         env:
           SAMBA_DC_REALM: "corp.example.net"
           SAMBA_DC_DOMAIN: "EXAMPLE"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -61,7 +61,6 @@ services:
   # available so manual test runs should take this into account
   ad:
     image: laslabs/alpine-samba-dc:0.1.0
-    privileged: true
     ports:
       - '2389:389'
       - '2636:636'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -56,3 +56,19 @@ services:
       - LDAP_ADMIN_PASSWORD=adminpassword
       - LDAP_USERS=alice,bob,foo
       - LDAP_PASSWORDS=password1,password2,password3
+
+  # this container will take at least 20 seconds for the ad service to be
+  # available so manual test runs should take this into account
+  ad:
+    image: laslabs/alpine-samba-dc:0.1.0
+    privileged: true
+    ports:
+      - '2389:389'
+      - '2636:636'
+    environment:
+      - SAMBA_DC_REALM=corp.example.net
+      - SAMBA_DC_DOMAIN=EXAMPLE
+      - SAMBA_DC_ADMIN_PASSWD=SuperSecretPassw0rd
+      - SAMBA_DC_DNS_BACKEND=SAMBA_INTERNAL
+
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -61,6 +61,8 @@ services:
   # available so manual test runs should take this into account
   ad:
     image: laslabs/alpine-samba-dc:0.1.0
+    cap_add:
+    - "SYS_ADMIN"
     ports:
       - '2389:389'
       - '2636:636'

--- a/vault/resource_ldap_secret_backend.go
+++ b/vault/resource_ldap_secret_backend.go
@@ -187,6 +187,13 @@ func createUpdateLDAPConfigResource(ctx context.Context, d *schema.ResourceData,
 	}
 
 	for _, field := range fields {
+		// don't update bindpass unless it was changed in the config so that we
+		// don't overwrite it in the event a rotate-root operation was
+		// performed in Vault
+		if field == consts.FieldBindPass && !d.HasChange(field) {
+			continue
+		}
+
 		if v, ok := d.GetOk(field); ok {
 			data[field] = v
 		}

--- a/vault/resource_ldap_secret_backend_test.go
+++ b/vault/resource_ldap_secret_backend_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
@@ -34,7 +35,6 @@ func TestLDAPSecretBackend(t *testing.T) {
 		resourceName          = resourceType + ".test"
 		description           = "test description"
 		updatedDescription    = "new test description"
-		userDN                = "CN=Users,DC=corp,DC=example,DC=net"
 		updatedUserDN         = "CN=Users,DC=corp,DC=hashicorp,DC=com"
 	)
 	resource.Test(t, resource.TestCase{
@@ -46,10 +46,10 @@ func TestLDAPSecretBackend(t *testing.T) {
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeLDAP, consts.FieldPath),
 		Steps: []resource.TestStep{
 			{
-				Config: testLDAPSecretBackendConfig_defaults(bindDN, bindPass),
+				Config: testLDAPSecretBackendConfig_defaults(path, bindDN, bindPass),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, consts.FieldSchema, "openldap"),
-					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, "ldap"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldDescription, description),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldDefaultLeaseTTL, "0"),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldMaxLeaseTTL, "0"),
@@ -62,26 +62,10 @@ func TestLDAPSecretBackend(t *testing.T) {
 				),
 			},
 			{
-				Config: testLDAPSecretBackendConfig(path, description, bindDN, bindPass, url, userDN, "ad", true),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, consts.FieldSchema, "ad"),
-					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
-					resource.TestCheckResourceAttr(resourceName, consts.FieldDescription, description),
-					resource.TestCheckResourceAttr(resourceName, consts.FieldDefaultLeaseTTL, "3600"),
-					resource.TestCheckResourceAttr(resourceName, consts.FieldMaxLeaseTTL, "7200"),
-					resource.TestCheckResourceAttr(resourceName, consts.FieldBindDN, bindDN),
-					resource.TestCheckResourceAttr(resourceName, consts.FieldBindPass, bindPass),
-					resource.TestCheckResourceAttr(resourceName, consts.FieldURL, url),
-					resource.TestCheckResourceAttr(resourceName, consts.FieldUserDN, userDN),
-					resource.TestCheckResourceAttr(resourceName, consts.FieldInsecureTLS, "true"),
-					resource.TestCheckResourceAttr(resourceName, consts.FieldConnectionTimeout, "99"),
-				),
-			},
-			{
-				Config: testLDAPSecretBackendConfig(path, updatedDescription, bindDN, bindPass, url, updatedUserDN, "ad", false),
+				Config: testLDAPSecretBackendConfig(path, updatedDescription, bindDN, bindPass, url, updatedUserDN, "openldap", false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
-					resource.TestCheckResourceAttr(resourceName, consts.FieldSchema, "ad"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldSchema, "openldap"),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldDescription, updatedDescription),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldDefaultLeaseTTL, "3600"),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldMaxLeaseTTL, "7200"),
@@ -99,14 +83,102 @@ func TestLDAPSecretBackend(t *testing.T) {
 	})
 }
 
+// TestLDAPSecretBackend_SchemaAD tests vault_ldap_secret_backend for the AD
+// schema and tests that the bindpass is not overwritten unless it is
+// explicitly changed in the TF config so that we don't clobber a bindpass that
+// was changed via a rotate-root operation in Vault.
+func TestLDAPSecretBackend_SchemaAD(t *testing.T) {
+	var (
+		path         = acctest.RandomWithPrefix("tf-test-ldap")
+		resourceType = "vault_ldap_secret_backend"
+		resourceName = resourceType + ".test"
+		userDN       = "CN=Users,DC=corp,DC=example,DC=net"
+		bindPass     = "SuperSecretPassw0rd"
+		bindDN       = "CN=Administrator,CN=Users,DC=corp,DC=example,DC=net"
+		url          = "ldaps://localhost:2636"
+	)
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		PreCheck: func() {
+			testutil.TestAccPreCheck(t)
+			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion112)
+		},
+		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeLDAP, consts.FieldPath),
+		Steps: []resource.TestStep{
+			{
+				Config: testLDAPSecretBackendConfig_ad(path, ""),
+				Check: resource.ComposeTestCheckFunc(
+					func(*terraform.State) error {
+						client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+						if _, err := client.Logical().Write(path+"/rotate-root", nil); err != nil {
+							return err
+						}
+						return nil
+					},
+					resource.TestCheckResourceAttr(resourceName, consts.FieldSchema, "ad"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldDescription, ""),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldDefaultLeaseTTL, "0"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldMaxLeaseTTL, "0"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldBindDN, bindDN),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldBindPass, bindPass),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldURL, url),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldUserDN, userDN),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldInsecureTLS, "true"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldConnectionTimeout, "30"),
+				),
+			},
+			{
+				Config: testLDAPSecretBackendConfig_ad(path, `description = "new description"`),
+				Check: resource.ComposeTestCheckFunc(
+					func(*terraform.State) error {
+						client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+						if _, err := client.Logical().Write(path+"/rotate-root", nil); err != nil {
+							return err
+						}
+						return nil
+					},
+					resource.TestCheckResourceAttr(resourceName, consts.FieldSchema, "ad"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldDescription, "new description"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldDefaultLeaseTTL, "0"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldMaxLeaseTTL, "0"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldBindDN, bindDN),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldURL, url),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldUserDN, userDN),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldInsecureTLS, "true"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldConnectionTimeout, "30"),
+
+					// Even though we did a rotate-root, we expect the TF state
+					// to have no change for bindpass because we did not
+					// explicitly change it in the config and it is not
+					// returned by the Vault API.
+					resource.TestCheckResourceAttr(resourceName, consts.FieldBindPass, bindPass),
+				),
+			},
+			{
+				Config: testLDAPSecretBackendConfig_ad_updated(path, `description = "new description"`),
+				Check: resource.ComposeTestCheckFunc(
+					// We explicitly updated the bindpass in the TF config so
+					// we expect the state to contain the new value.
+					resource.TestCheckResourceAttr(resourceName, consts.FieldBindPass, "NEW-SuperSecretPassw0rd"),
+				),
+			},
+			testutil.GetImportTestStep(resourceName, false, nil,
+				consts.FieldBindPass, consts.FieldConnectionTimeout, consts.FieldDisableRemount),
+		},
+	})
+}
+
 // testLDAPSecretBackendConfig_defaults is used to setup the backend defaults.
-func testLDAPSecretBackendConfig_defaults(bindDN, bindPass string) string {
+func testLDAPSecretBackendConfig_defaults(path, bindDN, bindPass string) string {
 	return fmt.Sprintf(`
 resource "vault_ldap_secret_backend" "test" {
+  path                      = "%s"
   description               = "test description"
   binddn                    = "%s"
   bindpass                  = "%s"
-}`, bindDN, bindPass)
+}`, path, bindDN, bindPass)
 }
 
 func testLDAPSecretBackendConfig(mount, description, bindDN, bindPass, url, userDN, schema string, insecureTLS bool) string {
@@ -125,4 +197,34 @@ resource "vault_ldap_secret_backend" "test" {
   schema                    = "%s"
 }
 `, mount, description, bindDN, bindPass, url, userDN, insecureTLS, schema)
+}
+
+func testLDAPSecretBackendConfig_ad(path, extraConfig string) string {
+	return fmt.Sprintf(`
+resource "vault_ldap_secret_backend" "test" {
+  path         = "%s"
+  binddn       = "CN=Administrator,CN=Users,DC=corp,DC=example,DC=net"
+  bindpass     = "SuperSecretPassw0rd"
+  url          = "ldaps://localhost:2636"
+  insecure_tls = "true"
+  userdn       = "CN=Users,DC=corp,DC=example,DC=net"
+  schema       = "ad"
+  %s
+}
+`, path, extraConfig)
+}
+
+func testLDAPSecretBackendConfig_ad_updated(path, extraConfig string) string {
+	return fmt.Sprintf(`
+resource "vault_ldap_secret_backend" "test" {
+  path         = "%s"
+  binddn       = "CN=Administrator,CN=Users,DC=corp,DC=example,DC=net"
+  bindpass     = "NEW-SuperSecretPassw0rd"
+  url          = "ldaps://localhost:2636"
+  insecure_tls = "true"
+  userdn       = "CN=Users,DC=corp,DC=example,DC=net"
+  schema       = "ad"
+  %s
+}
+`, path, extraConfig)
 }

--- a/vault/resource_ldap_secret_backend_test.go
+++ b/vault/resource_ldap_secret_backend_test.go
@@ -6,6 +6,7 @@ package vault
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -90,6 +91,10 @@ func TestLDAPSecretBackend(t *testing.T) {
 //
 // use "docker compose up -d ad" to test this locally
 func TestLDAPSecretBackend_SchemaAD(t *testing.T) {
+	// unfortunately it is necessary to sleep here to wait for the AD container
+	// service to become available
+	time.Sleep(20 * time.Second)
+
 	var (
 		path         = acctest.RandomWithPrefix("tf-test-ldap")
 		resourceType = "vault_ldap_secret_backend"

--- a/vault/resource_ldap_secret_backend_test.go
+++ b/vault/resource_ldap_secret_backend_test.go
@@ -6,7 +6,6 @@ package vault
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -97,10 +96,6 @@ func TestLDAPSecretBackend(t *testing.T) {
 //
 // export AD_URL=ldaps://localhost:2636
 func TestLDAPSecretBackend_SchemaAD(t *testing.T) {
-	// unfortunately it is necessary to sleep here to wait for the AD container
-	// service to become available
-	time.Sleep(20 * time.Second)
-
 	var (
 		path         = acctest.RandomWithPrefix("tf-test-ldap")
 		resourceType = "vault_ldap_secret_backend"

--- a/vault/resource_ldap_secret_backend_test.go
+++ b/vault/resource_ldap_secret_backend_test.go
@@ -6,6 +6,7 @@ package vault
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -96,6 +97,10 @@ func TestLDAPSecretBackend(t *testing.T) {
 //
 // export AD_URL=ldaps://localhost:2636
 func TestLDAPSecretBackend_SchemaAD(t *testing.T) {
+	// unfortunately it is necessary to sleep here to wait for the AD container
+	// service to become available
+	time.Sleep(20 * time.Second)
+
 	var (
 		path         = acctest.RandomWithPrefix("tf-test-ldap")
 		resourceType = "vault_ldap_secret_backend"

--- a/vault/resource_ldap_secret_backend_test.go
+++ b/vault/resource_ldap_secret_backend_test.go
@@ -87,6 +87,8 @@ func TestLDAPSecretBackend(t *testing.T) {
 // schema and tests that the bindpass is not overwritten unless it is
 // explicitly changed in the TF config so that we don't clobber a bindpass that
 // was changed via a rotate-root operation in Vault.
+//
+// use "docker compose up -d ad" to test this locally
 func TestLDAPSecretBackend_SchemaAD(t *testing.T) {
 	var (
 		path         = acctest.RandomWithPrefix("tf-test-ldap")


### PR DESCRIPTION
Prevent bindpass from being overwritten in the event of a rotate-root operation on vault. We will only update the bindpass if the TF config has changed for that field.

closes https://github.com/hashicorp/terraform-provider-vault/issues/1870

I have not been successful at getting the tests to run in CI so they will be local-only tests for now.