### PR TITLE
 Add support for max_page_size in the vault_ldap_auth_backend

### DIFF
--- a/vault/resource_ldap_auth_backend.go
+++ b/vault/resource_ldap_auth_backend.go
@@ -67,6 +67,11 @@ func ldapAuthBackendResource() *schema.Resource {
 			Optional: true,
 			Computed: true,
 		},
+		"max_page_size": {
+			Type:     schema.TypeInt,
+			Default:  -1,
+			Optional: true,
+		},
 		"userdn": {
 			Type:     schema.TypeString,
 			Optional: true,
@@ -266,6 +271,11 @@ func ldapAuthBackendUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	if v, ok := d.GetOkExists("case_sensitive_names"); ok {
 		data["case_sensitive_names"] = v.(bool)
 	}
+
+	if v, ok := d.GetOkExists("max_page_size"); ok {
+		data["max_page_size"] = v
+	}
+
 	if v, ok := d.GetOk("userdn"); ok {
 		data["userdn"] = v.(string)
 	}
@@ -381,6 +391,7 @@ func ldapAuthBackendRead(_ context.Context, d *schema.ResourceData, meta interfa
 	d.Set("certificate", resp.Data["certificate"])
 	d.Set("binddn", resp.Data["binddn"])
 	d.Set("case_sensitive_names", resp.Data["case_sensitive_names"])
+	d.Set("max_page_size", resp.Data["max_page_size"])
 	d.Set("userdn", resp.Data["userdn"])
 	d.Set("userattr", resp.Data["userattr"])
 	d.Set("userfilter", resp.Data["userfilter"])

--- a/vault/resource_ldap_auth_backend_test.go
+++ b/vault/resource_ldap_auth_backend_test.go
@@ -211,6 +211,7 @@ func testLDAPAuthBackendCheck_attrs(resourceName string, name string) resource.T
 			"url":                  "url",
 			"starttls":             "starttls",
 			"case_sensitive_names": "case_sensitive_names",
+			"max_page_size":        "max_page_size",
 			"tls_min_version":      "tls_min_version",
 			"tls_max_version":      "tls_max_version",
 			"insecure_tls":         "insecure_tls",
@@ -260,6 +261,7 @@ resource "vault_ldap_auth_backend" "test" {
     url                    = "ldaps://example.org"
     starttls               = true
     case_sensitive_names   = false
+	max_page_size          = -1
     tls_min_version        = "tls11"
     tls_max_version        = "tls12"
     insecure_tls           = false

--- a/website/docs/r/ldap_auth_backend.html.md
+++ b/website/docs/r/ldap_auth_backend.html.md
@@ -40,6 +40,8 @@ The following arguments are supported:
 
 * `case_sensitive_names` - (Optional) Control case senstivity of objects fetched from LDAP, this is used for object matching in vault
 
+* `max_page_size` - (Optional) Sets the max page size for LDAP lookups, by default it's set to -1
+
 * `tls_min_version` - (Optional) Minimum acceptable version of TLS
 
 * `tls_max_version` - (Optional) Maximum acceptable version of TLS


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #1862 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Fixes #1862 by adding max_page_size parameter and setting it to -1 by default to make it backwards compatible.
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
