### PR TITLE
Add support for retrying kv-v2 secret data writes

### DIFF
--- a/vault/resource_generic_secret.go
+++ b/vault/resource_generic_secret.go
@@ -7,12 +7,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"net/http"
-	"time"
 
-	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
@@ -152,24 +148,8 @@ func genericSecretResourceWrite(d *schema.ResourceData, meta interface{}) error 
 
 	}
 
-	writeData := func() error {
-		if _, err := client.Logical().Write(path, data); err != nil {
-			if respErr, ok := err.(*api.ResponseError); ok && (respErr.StatusCode == http.StatusBadRequest) {
-				return err
-			} else {
-				return backoff.Permanent(err)
-			}
-		}
-		return nil
-	}
-
-	bo := backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Millisecond*500), 10)
-
-	log.Printf("[DEBUG] Writing generic Vault secret to  %s", path)
-	if err := backoff.RetryNotify(writeData, bo, func(err error, duration time.Duration) {
-		log.Printf("[WARN] create generic secret %q failed, retrying in %s", path, duration)
-	}); err != nil {
-		return fmt.Errorf("error creating generic secret: %s", err)
+	if err := writeSecretDataWithRetry(client, path, data); err != nil {
+		return err
 	}
 
 	d.SetId(originalPath)

--- a/vault/resource_kv_secret_v2.go
+++ b/vault/resource_kv_secret_v2.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net/http"
 	"regexp"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
@@ -201,8 +203,8 @@ func kvSecretV2Write(ctx context.Context, d *schema.ResourceData, meta interface
 		data[k] = d.Get(k)
 	}
 
-	if _, err := client.Logical().Write(path, data); err != nil {
-		return diag.Errorf("error writing secret data to %s, err=%s", path, err)
+	if err := writeSecretDataWithRetry(client, path, data); err != nil {
+		return diag.FromErr(err)
 	}
 
 	d.SetId(path)
@@ -387,4 +389,22 @@ func getKVV2SecretMountFromPath(path string) (string, error) {
 		return "", fmt.Errorf("unexpected number of matches (%d) for mount", len(res))
 	}
 	return res[1], nil
+}
+
+func writeSecretDataWithRetry(client *api.Client, path string, data map[string]interface{}) error {
+	return backoff.RetryNotify(
+		func() error {
+			if _, err := client.Logical().Write(path, data); err != nil {
+				e := fmt.Errorf("error writing secret data: %w", err)
+				if respErr, ok := err.(*api.ResponseError); ok && (respErr.StatusCode == http.StatusBadRequest) {
+					return e
+				}
+
+				return backoff.Permanent(e)
+			}
+			return nil
+		}, backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Millisecond*500), 10),
+		func(err error, duration time.Duration) {
+			log.Printf("[WARN] Writing secret data to %q failed, retrying in %s", path, duration)
+		})
 }


### PR DESCRIPTION
Sometimes the kv secrets engine might be performing a migration from v1 to v2, this can cause issues writing secret data to those mounts. Adding a retry should mitigate the effects of the migration.

Extends the work done under #1579  to `vault_kv_secret_v2`
