### PR TITLE
make okta auth user groups optional

### DIFF
--- a/vault/resource_okta_auth_backend.go
+++ b/vault/resource_okta_auth_backend.go
@@ -157,7 +157,7 @@ func oktaAuthBackendResource() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"groups": {
 							Type:        schema.TypeSet,
-							Required:    true,
+							Optional:    true,
 							Description: "Groups within the Okta auth backend to associate with this user",
 							Elem: &schema.Schema{
 								Type: schema.TypeString,

--- a/vault/resource_okta_auth_backend_test.go
+++ b/vault/resource_okta_auth_backend_test.go
@@ -127,6 +127,25 @@ func TestAccOktaAuthBackend_invalid_max_ttl(t *testing.T) {
 	})
 }
 
+func TestAccOktaAuthBackend_groups_optional(t *testing.T) {
+	organization := "example"
+	path := resource.PrefixedUniqueId("okta-group-optional")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		Providers:    testProviders,
+		CheckDestroy: testAccOktaAuthBackend_Destroyed(path),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOktaAuthConfig_groups_optional(path, organization),
+				Check: resource.ComposeTestCheckFunc(
+					testAccOktaAuthBackend_UsersCheck(path, "bar", []string{}, []string{"eng", "default"}),
+				),
+			},
+		},
+	})
+}
+
 func TestOktaAuthBackend_remount(t *testing.T) {
 	path := acctest.RandomWithPrefix("tf-test-auth-okta")
 	updatedPath := acctest.RandomWithPrefix("tf-test-auth-okta-updated")
@@ -218,6 +237,21 @@ resource "vault_okta_auth_backend" "test" {
     token = "this must be kept secret"
     ttl = "1h"
     max_ttl = "invalid_max_ttl"
+}
+`, path, organization)
+}
+
+func testAccOktaAuthConfig_groups_optional(path string, organization string) string {
+	return fmt.Sprintf(`
+resource "vault_okta_auth_backend" "test" {
+    description = "Testing the Terraform okta auth backend"
+    path = "%s"
+    organization = "%s"
+    token = "this must be kept secret"
+    user {
+        username = "bar"
+        policies   = ["eng", "default"]
+    }
 }
 `, path, organization)
 }

--- a/website/docs/r/okta_auth_backend.html.md
+++ b/website/docs/r/okta_auth_backend.html.md
@@ -76,7 +76,7 @@ If this is not supplied only locally configured groups will be enabled.
 
 ### Okta User
 
-* `username` - (Required Optional) Name of the user within Okta
+* `username` - (Required) Name of the user within Okta
 
 * `groups` - (Optional) List of Okta groups to associate with this user
 

--- a/website/docs/r/okta_auth_backend_user.html.md
+++ b/website/docs/r/okta_auth_backend_user.html.md
@@ -37,7 +37,7 @@ The following arguments are supported:
 
 * `path` - (Required) The path where the Okta auth backend is mounted
 
-* `username` - (Required Optional) Name of the user within Okta
+* `username` - (Required) Name of the user within Okta
 
 * `groups` - (Optional) List of Okta groups to associate with this user
 


### PR DESCRIPTION
According to the [API docs](https://developer.hashicorp.com/vault/api-docs/auth/okta#register-user), Okta Auth user groups should be optional.

Closes https://github.com/hashicorp/terraform-provider-vault/issues/1866.