### PR TITLE
chore: update vault build version matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,9 +46,9 @@ jobs:
       fail-fast: false
       matrix:
         image:
-        - "vault-enterprise:1.11.9-ent"
-        - "vault-enterprise:1.12.5-ent"
-        - "vault-enterprise:1.13.1-ent"
+        - "vault-enterprise:1.11.11-ent"
+        - "vault-enterprise:1.12.7-ent"
+        - "vault-enterprise:1.13.3-ent"
     container:
       image: "docker.mirror.hashicorp.services/golang:${{ needs.go-version.outputs.version }}"
     services:

--- a/website/docs/r/ldap_auth_backend.html.md
+++ b/website/docs/r/ldap_auth_backend.html.md
@@ -40,7 +40,8 @@ The following arguments are supported:
 
 * `case_sensitive_names` - (Optional) Control case senstivity of objects fetched from LDAP, this is used for object matching in vault
 
-* `max_page_size` - (Optional) Sets the max page size for LDAP lookups, by default it's set to -1
+* `max_page_size` - (Optional) Sets the max page size for LDAP lookups, by default it's set to -1.
+   *Available only for Vault 1.11.11+, 1.12.7+, and 1.13.3+*.
 
 * `tls_min_version` - (Optional) Minimum acceptable version of TLS
 


### PR DESCRIPTION
This PR bumps the Vault versions for our CI builds.

Merging https://github.com/hashicorp/terraform-provider-vault/pull/1878 caused our CI builds to fail because the Vault version matrix does not represent the most recent releases that include the `max_page_size` field for LDAP auth. 