### PR TITLE
Harmonize all auth_login Init() tests

### DIFF
--- a/internal/provider/auth_aws.go
+++ b/internal/provider/auth_aws.go
@@ -140,11 +140,11 @@ type AuthLoginAWS struct {
 }
 
 func (l *AuthLoginAWS) Init(d *schema.ResourceData, authField string) (AuthLogin, error) {
-	if err := l.AuthLoginCommon.Init(d, authField); err != nil {
-		return nil, err
-	}
-
-	if err := l.checkRequiredFields(d, consts.FieldRole); err != nil {
+	if err := l.AuthLoginCommon.Init(d, authField,
+		func(data *schema.ResourceData) error {
+			return l.checkRequiredFields(d, consts.FieldRole)
+		},
+	); err != nil {
 		return nil, err
 	}
 

--- a/internal/provider/auth_aws_test.go
+++ b/internal/provider/auth_aws_test.go
@@ -19,14 +19,7 @@ import (
 )
 
 func TestAuthLoginAWS_Init(t *testing.T) {
-	tests := []struct {
-		name         string
-		authField    string
-		raw          map[string]interface{}
-		wantErr      bool
-		expectParams map[string]interface{}
-		expectErr    error
-	}{
+	tests := []authLoginInitTest{
 		{
 			name:      "basic",
 			authField: consts.FieldAuthLoginAWS,
@@ -96,25 +89,7 @@ func TestAuthLoginAWS_Init(t *testing.T) {
 			s := map[string]*schema.Schema{
 				tt.authField: GetAWSLoginSchema(tt.authField),
 			}
-
-			d := schema.TestResourceDataRaw(t, s, tt.raw)
-			l := &AuthLoginAWS{}
-			_, err := l.Init(d, tt.authField)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("Init() error = %v, wantErr %v", err, tt.wantErr)
-			}
-
-			if err != nil {
-				if tt.expectErr != nil {
-					if !reflect.DeepEqual(tt.expectErr, err) {
-						t.Errorf("Init() expected error %#v, actual %#v", tt.expectErr, err)
-					}
-				}
-			} else {
-				if !reflect.DeepEqual(tt.expectParams, l.params) {
-					t.Errorf("Init() expected params %#v, actual %#v", tt.expectParams, l.params)
-				}
-			}
+			assertAuthLoginInit(t, tt, s, &AuthLoginAWS{})
 		})
 	}
 }

--- a/internal/provider/auth_azure.go
+++ b/internal/provider/auth_azure.go
@@ -122,15 +122,15 @@ func (l *AuthLoginAzure) LoginPath() string {
 }
 
 func (l *AuthLoginAzure) Init(d *schema.ResourceData, authField string) (AuthLogin, error) {
-	if err := l.AuthLoginCommon.Init(d, authField); err != nil {
-		return nil, err
-	}
-
-	if err := l.checkRequiredFields(d, l.requiredParams()...); err != nil {
-		return nil, err
-	}
-
-	if err := l.checkFieldsOneOf(d, consts.FieldVMName, consts.FieldVMSSName); err != nil {
+	if err := l.AuthLoginCommon.Init(d, authField,
+		func(data *schema.ResourceData) error {
+			err := l.checkRequiredFields(d, l.requiredParams()...)
+			if err != nil {
+				return err
+			}
+			return l.checkFieldsOneOf(d, consts.FieldVMName, consts.FieldVMSSName)
+		},
+	); err != nil {
 		return nil, err
 	}
 

--- a/internal/provider/auth_azure_test.go
+++ b/internal/provider/auth_azure_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -20,14 +19,7 @@ import (
 const envVarTFAccAzureAuth = "TF_ACC_AZURE_AUTH"
 
 func TestAuthLoginAzure_Init(t *testing.T) {
-	tests := []struct {
-		name         string
-		authField    string
-		raw          map[string]interface{}
-		wantErr      bool
-		expectParams map[string]interface{}
-		expectErr    error
-	}{
+	tests := []authLoginInitTest{
 		{
 			name:      "basic",
 			authField: consts.FieldAuthLoginAzure,
@@ -107,25 +99,7 @@ func TestAuthLoginAzure_Init(t *testing.T) {
 			s := map[string]*schema.Schema{
 				tt.authField: GetAzureLoginSchema(tt.authField),
 			}
-
-			d := schema.TestResourceDataRaw(t, s, tt.raw)
-			l := &AuthLoginAzure{}
-			_, err := l.Init(d, tt.authField)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("Init() error = %v, wantErr %v", err, tt.wantErr)
-			}
-
-			if err != nil {
-				if tt.expectErr != nil {
-					if !reflect.DeepEqual(tt.expectErr, err) {
-						t.Errorf("Init() expected error %#v, actual %#v", tt.expectErr, err)
-					}
-				}
-			} else {
-				if !reflect.DeepEqual(tt.expectParams, l.params) {
-					t.Errorf("Init() expected params %#v, actual %#v", tt.expectParams, l.params)
-				}
-			}
+			assertAuthLoginInit(t, tt, s, &AuthLoginAzure{})
 		})
 	}
 }

--- a/internal/provider/auth_cert_test.go
+++ b/internal/provider/auth_cert_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -17,10 +16,6 @@ import (
 )
 
 func TestAuthLoginCert_Init(t *testing.T) {
-	type fields struct {
-		AuthLoginCommon AuthLoginCommon
-	}
-
 	s := map[string]*schema.Schema{
 		consts.FieldCACertFile: {
 			Type:     schema.TypeString,
@@ -40,15 +35,7 @@ func TestAuthLoginCert_Init(t *testing.T) {
 		},
 	}
 
-	tests := []struct {
-		name         string
-		authField    string
-		raw          map[string]interface{}
-		wantErr      bool
-		expectMount  string
-		expectParams map[string]interface{}
-		expectErr    error
-	}{
+	tests := []authLoginInitTest{
 		{
 			name: "without-role-name",
 			raw: map[string]interface{}{
@@ -160,22 +147,7 @@ func TestAuthLoginCert_Init(t *testing.T) {
 			t.Cleanup(func() {
 				delete(s, tt.authField)
 			})
-
-			d := schema.TestResourceDataRaw(t, s, tt.raw)
-			l := &AuthLoginCert{}
-
-			_, err := l.Init(d, tt.authField)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Init() error = %v, wantErr %v", err, tt.wantErr)
-			}
-
-			if !reflect.DeepEqual(tt.expectErr, err) {
-				t.Errorf("Init() expected error %#v, actual %#v", tt.expectErr, err)
-			}
-
-			if !reflect.DeepEqual(tt.expectParams, l.params) {
-				t.Errorf("Init() expected params %#v, actual %#v", tt.expectParams, l.params)
-			}
+			assertAuthLoginInit(t, tt, s, &AuthLoginCert{})
 		})
 	}
 }

--- a/internal/provider/auth_gcp_test.go
+++ b/internal/provider/auth_gcp_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"reflect"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -21,21 +20,9 @@ import (
 const envVarGCPServiceAccount = "TF_ACC_GOOGLE_SERVICE_ACCOUNT"
 
 func TestAuthLoginGCP_Init(t *testing.T) {
-	type fields struct {
-		AuthLoginCommon AuthLoginCommon
-	}
-
 	s := map[string]*schema.Schema{}
 
-	tests := []struct {
-		name         string
-		authField    string
-		raw          map[string]interface{}
-		wantErr      bool
-		expectMount  string
-		expectParams map[string]interface{}
-		expectErr    error
-	}{
+	tests := []authLoginInitTest{
 		{
 			name:         "error-missing-resource",
 			authField:    consts.FieldAuthLoginGCP,
@@ -50,22 +37,7 @@ func TestAuthLoginGCP_Init(t *testing.T) {
 			t.Cleanup(func() {
 				delete(s, tt.authField)
 			})
-
-			d := schema.TestResourceDataRaw(t, s, tt.raw)
-			l := &AuthLoginGCP{}
-
-			_, err := l.Init(d, tt.authField)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Init() error = %v, wantErr %v", err, tt.wantErr)
-			}
-
-			if !reflect.DeepEqual(tt.expectErr, err) {
-				t.Errorf("Init() expected error %#v, actual %#v", tt.expectErr, err)
-			}
-
-			if !reflect.DeepEqual(tt.expectParams, l.params) {
-				t.Errorf("Init() expected params %#v, actual %#v", tt.expectParams, l.params)
-			}
+			assertAuthLoginInit(t, tt, s, &AuthLoginGCP{})
 		})
 	}
 }

--- a/internal/provider/auth_jwt.go
+++ b/internal/provider/auth_jwt.go
@@ -71,11 +71,11 @@ func (l *AuthLoginJWT) LoginPath() string {
 }
 
 func (l *AuthLoginJWT) Init(d *schema.ResourceData, authField string) (AuthLogin, error) {
-	if err := l.AuthLoginCommon.Init(d, authField); err != nil {
-		return nil, err
-	}
-
-	if err := l.checkRequiredFields(d, consts.FieldRole, consts.FieldJWT); err != nil {
+	if err := l.AuthLoginCommon.Init(d, authField,
+		func(data *schema.ResourceData) error {
+			return l.checkRequiredFields(d, consts.FieldRole, consts.FieldJWT)
+		},
+	); err != nil {
 		return nil, err
 	}
 

--- a/internal/provider/auth_jwt_test.go
+++ b/internal/provider/auth_jwt_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -17,14 +16,7 @@ import (
 )
 
 func TestAuthLoginJWT_Init(t *testing.T) {
-	tests := []struct {
-		name         string
-		authField    string
-		raw          map[string]interface{}
-		wantErr      bool
-		expectParams map[string]interface{}
-		expectErr    error
-	}{
+	tests := []authLoginInitTest{
 		{
 			name:      "basic",
 			authField: consts.FieldAuthLoginJWT,
@@ -74,25 +66,7 @@ func TestAuthLoginJWT_Init(t *testing.T) {
 			s := map[string]*schema.Schema{
 				tt.authField: GetJWTLoginSchema(tt.authField),
 			}
-
-			d := schema.TestResourceDataRaw(t, s, tt.raw)
-			l := &AuthLoginJWT{}
-			_, err := l.Init(d, tt.authField)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("Init() error = %v, wantErr %v", err, tt.wantErr)
-			}
-
-			if err != nil {
-				if tt.expectErr != nil {
-					if !reflect.DeepEqual(tt.expectErr, err) {
-						t.Errorf("Init() expected error %#v, actual %#v", tt.expectErr, err)
-					}
-				}
-			} else {
-				if !reflect.DeepEqual(tt.expectParams, l.params) {
-					t.Errorf("Init() expected params %#v, actual %#v", tt.expectParams, l.params)
-				}
-			}
+			assertAuthLoginInit(t, tt, s, &AuthLoginJWT{})
 		})
 	}
 }

--- a/internal/provider/auth_kerberos.go
+++ b/internal/provider/auth_kerberos.go
@@ -125,28 +125,21 @@ func (l *AuthLoginKerberos) LoginPath() string {
 }
 
 func (l *AuthLoginKerberos) Init(d *schema.ResourceData, authField string) (AuthLogin, error) {
-	if err := l.AuthLoginCommon.Init(d, authField); err != nil {
-		return nil, err
-	}
-
-	if _, ok := l.getOk(d, consts.FieldToken); !ok {
-		required := []string{
-			consts.FieldUsername,
-			consts.FieldService,
-			consts.FieldRealm,
-			consts.FieldKeytabPath,
-			consts.FieldKRB5ConfPath,
-		}
-		var missing []string
-		for _, f := range required {
-			if _, ok := l.getOk(d, f); !ok {
-				missing = append(missing, f)
+	if err := l.AuthLoginCommon.Init(d, authField,
+		func(data *schema.ResourceData) error {
+			if _, ok := l.getOk(d, consts.FieldToken); !ok {
+				return l.checkRequiredFields(d,
+					consts.FieldUsername,
+					consts.FieldService,
+					consts.FieldRealm,
+					consts.FieldKeytabPath,
+					consts.FieldKRB5ConfPath,
+				)
 			}
-		}
-
-		if len(missing) > 0 {
-			return nil, fmt.Errorf("required fields are unset: %v", missing)
-		}
+			return nil
+		},
+	); err != nil {
+		return nil, err
 	}
 
 	return l, nil

--- a/internal/provider/auth_kerberos_test.go
+++ b/internal/provider/auth_kerberos_test.go
@@ -26,15 +26,7 @@ const (
 )
 
 func TestAuthLoginKerberos_Init(t *testing.T) {
-	tests := []struct {
-		name         string
-		authField    string
-		raw          map[string]interface{}
-		wantErr      bool
-		expectMount  string
-		expectParams map[string]interface{}
-		expectErr    error
-	}{
+	tests := []authLoginInitTest{
 		{
 			name: "with-token",
 			raw: map[string]interface{}{
@@ -91,25 +83,7 @@ func TestAuthLoginKerberos_Init(t *testing.T) {
 			s := map[string]*schema.Schema{
 				tt.authField: GetKerberosLoginSchema(tt.authField),
 			}
-
-			d := schema.TestResourceDataRaw(t, s, tt.raw)
-			l := &AuthLoginKerberos{}
-			_, err := l.Init(d, tt.authField)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("Init() error = %v, wantErr %v", err, tt.wantErr)
-			}
-
-			if err != nil {
-				if tt.expectErr != nil {
-					if !reflect.DeepEqual(tt.expectErr, err) {
-						t.Errorf("Init() expected error %#v, actual %#v", tt.expectErr, err)
-					}
-				}
-			} else {
-				if !reflect.DeepEqual(tt.expectParams, l.params) {
-					t.Errorf("Init() expected params %#v, actual %#v", tt.expectParams, l.params)
-				}
-			}
+			assertAuthLoginInit(t, tt, s, &AuthLoginKerberos{})
 		})
 	}
 }

--- a/internal/provider/auth_oci.go
+++ b/internal/provider/auth_oci.go
@@ -84,11 +84,11 @@ func (l *AuthLoginOCI) LoginPath() string {
 }
 
 func (l *AuthLoginOCI) Init(d *schema.ResourceData, authField string) (AuthLogin, error) {
-	if err := l.AuthLoginCommon.Init(d, authField); err != nil {
-		return nil, err
-	}
-
-	if err := l.checkRequiredFields(d, consts.FieldRole, consts.FieldAuthType); err != nil {
+	if err := l.AuthLoginCommon.Init(d, authField,
+		func(data *schema.ResourceData) error {
+			return l.checkRequiredFields(d, consts.FieldRole, consts.FieldAuthType)
+		},
+	); err != nil {
 		return nil, err
 	}
 

--- a/internal/provider/auth_oci_test.go
+++ b/internal/provider/auth_oci_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -20,14 +19,7 @@ import (
 const envVarTFAccOCIAuth = "TF_ACC_OCI_AUTH"
 
 func TestAuthLoginOCI_Init(t *testing.T) {
-	tests := []struct {
-		name         string
-		authField    string
-		raw          map[string]interface{}
-		wantErr      bool
-		expectParams map[string]interface{}
-		expectErr    error
-	}{
+	tests := []authLoginInitTest{
 		{
 			name:      "basic",
 			authField: consts.FieldAuthLoginOCI,
@@ -77,25 +69,7 @@ func TestAuthLoginOCI_Init(t *testing.T) {
 			s := map[string]*schema.Schema{
 				tt.authField: GetOCILoginSchema(tt.authField),
 			}
-
-			d := schema.TestResourceDataRaw(t, s, tt.raw)
-			l := &AuthLoginOCI{}
-			_, err := l.Init(d, tt.authField)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("Init() error = %v, wantErr %v", err, tt.wantErr)
-			}
-
-			if err != nil {
-				if tt.expectErr != nil {
-					if !reflect.DeepEqual(tt.expectErr, err) {
-						t.Errorf("Init() expected error %#v, actual %#v", tt.expectErr, err)
-					}
-				}
-			} else {
-				if !reflect.DeepEqual(tt.expectParams, l.params) {
-					t.Errorf("Init() expected params %#v, actual %#v", tt.expectParams, l.params)
-				}
-			}
+			assertAuthLoginInit(t, tt, s, &AuthLoginOCI{})
 		})
 	}
 }

--- a/internal/provider/auth_oidc.go
+++ b/internal/provider/auth_oidc.go
@@ -85,11 +85,11 @@ func (l *AuthLoginOIDC) LoginPath() string {
 }
 
 func (l *AuthLoginOIDC) Init(d *schema.ResourceData, authField string) (AuthLogin, error) {
-	if err := l.AuthLoginCommon.Init(d, authField); err != nil {
-		return nil, err
-	}
-
-	if err := l.checkRequiredFields(d, consts.FieldRole); err != nil {
+	if err := l.AuthLoginCommon.Init(d, authField,
+		func(data *schema.ResourceData) error {
+			return l.checkRequiredFields(d, consts.FieldRole)
+		},
+	); err != nil {
 		return nil, err
 	}
 

--- a/internal/provider/auth_oidc_test.go
+++ b/internal/provider/auth_oidc_test.go
@@ -18,14 +18,7 @@ import (
 )
 
 func TestAuthLoginOIDC_Init(t *testing.T) {
-	tests := []struct {
-		name         string
-		authField    string
-		raw          map[string]interface{}
-		wantErr      bool
-		expectParams map[string]interface{}
-		expectErr    error
-	}{
+	tests := []authLoginInitTest{
 		{
 			name:      "basic",
 			authField: consts.FieldAuthLoginOIDC,
@@ -73,25 +66,7 @@ func TestAuthLoginOIDC_Init(t *testing.T) {
 			s := map[string]*schema.Schema{
 				tt.authField: GetOIDCLoginSchema(tt.authField),
 			}
-
-			d := schema.TestResourceDataRaw(t, s, tt.raw)
-			l := &AuthLoginOIDC{}
-			_, err := l.Init(d, tt.authField)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("Init() error = %v, wantErr %v", err, tt.wantErr)
-			}
-
-			if err != nil {
-				if tt.expectErr != nil {
-					if !reflect.DeepEqual(tt.expectErr, err) {
-						t.Errorf("Init() expected error %#v, actual %#v", tt.expectErr, err)
-					}
-				}
-			} else {
-				if !reflect.DeepEqual(tt.expectParams, l.params) {
-					t.Errorf("Init() expected params %#v, actual %#v", tt.expectParams, l.params)
-				}
-			}
+			assertAuthLoginInit(t, tt, s, &AuthLoginOIDC{})
 		})
 	}
 }

--- a/internal/provider/auth_radius.go
+++ b/internal/provider/auth_radius.go
@@ -72,11 +72,11 @@ func (l *AuthLoginRadius) LoginPath() string {
 }
 
 func (l *AuthLoginRadius) Init(d *schema.ResourceData, authField string) (AuthLogin, error) {
-	if err := l.AuthLoginCommon.Init(d, authField); err != nil {
-		return nil, err
-	}
-
-	if err := l.checkRequiredFields(d, consts.FieldUsername, consts.FieldPassword); err != nil {
+	if err := l.AuthLoginCommon.Init(d, authField,
+		func(data *schema.ResourceData) error {
+			return l.checkRequiredFields(d, consts.FieldUsername, consts.FieldPassword)
+		},
+	); err != nil {
 		return nil, err
 	}
 

--- a/internal/provider/auth_radius_test.go
+++ b/internal/provider/auth_radius_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"reflect"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -17,14 +16,7 @@ import (
 )
 
 func TestAuthLoginRadius_Init(t *testing.T) {
-	tests := []struct {
-		name         string
-		authField    string
-		raw          map[string]interface{}
-		wantErr      bool
-		expectParams map[string]interface{}
-		expectErr    error
-	}{
+	tests := []authLoginInitTest{
 		{
 			name:      "basic",
 			authField: consts.FieldAuthLoginRadius,
@@ -74,25 +66,7 @@ func TestAuthLoginRadius_Init(t *testing.T) {
 			s := map[string]*schema.Schema{
 				tt.authField: GetRadiusLoginSchema(tt.authField),
 			}
-
-			d := schema.TestResourceDataRaw(t, s, tt.raw)
-			l := &AuthLoginRadius{}
-			_, err := l.Init(d, tt.authField)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("Init() error = %v, wantErr %v", err, tt.wantErr)
-			}
-
-			if err != nil {
-				if tt.expectErr != nil {
-					if !reflect.DeepEqual(tt.expectErr, err) {
-						t.Errorf("Init() expected error %#v, actual %#v", tt.expectErr, err)
-					}
-				}
-			} else {
-				if !reflect.DeepEqual(tt.expectParams, l.params) {
-					t.Errorf("Init() expected params %#v, actual %#v", tt.expectParams, l.params)
-				}
-			}
+			assertAuthLoginInit(t, tt, s, &AuthLoginRadius{})
 		})
 	}
 }

--- a/internal/provider/auth_test.go
+++ b/internal/provider/auth_test.go
@@ -35,6 +35,16 @@ type authLoginTest struct {
 	skipFunc           func(t *testing.T)
 }
 
+type authLoginInitTest struct {
+	name         string
+	authField    string
+	raw          map[string]interface{}
+	wantErr      bool
+	expectMount  string
+	expectParams map[string]interface{}
+	expectErr    error
+}
+
 type testLoginHandler struct {
 	requestCount  int
 	paths         []string
@@ -193,5 +203,34 @@ func TestGetAuthLogin_registered(t *testing.T) {
 				t.Errorf("GetAuthLogin() error = %v, wantErr false", err)
 			}
 		})
+	}
+}
+
+func assertAuthLoginEqual(t *testing.T, expected, actual AuthLogin) {
+	t.Helper()
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("AuthLogin instances not equal, expected %#v, actual %#v", expected, actual)
+	}
+}
+
+func assertAuthLoginInit(t *testing.T, tt authLoginInitTest, s map[string]*schema.Schema, l AuthLogin) {
+	d := schema.TestResourceDataRaw(t, s, tt.raw)
+	actual, err := l.Init(d, tt.authField)
+	if (err != nil) != tt.wantErr {
+		t.Fatalf("Init() error = %v, wantErr %v", err, tt.wantErr)
+	}
+
+	if !reflect.DeepEqual(tt.expectErr, err) {
+		t.Errorf("Init() expected error %#v, actual %#v", tt.expectErr, err)
+	}
+
+	if !reflect.DeepEqual(tt.expectParams, l.Params()) {
+		t.Errorf("Init() expected params %#v, actual %#v", tt.expectParams, l.Params())
+	}
+
+	if err != nil {
+		assertAuthLoginEqual(t, nil, actual)
+	} else {
+		assertAuthLoginEqual(t, l, actual)
 	}
 }

--- a/internal/provider/auth_userpass.go
+++ b/internal/provider/auth_userpass.go
@@ -76,10 +76,15 @@ type AuthLoginUserpass struct {
 	AuthLoginCommon
 }
 
-func (l *AuthLoginUserpass) Init(d *schema.ResourceData, field string) (AuthLogin, error) {
-	if err := l.AuthLoginCommon.Init(d, field); err != nil {
+func (l *AuthLoginUserpass) Init(d *schema.ResourceData, authField string) (AuthLogin, error) {
+	if err := l.AuthLoginCommon.Init(d, authField,
+		func(data *schema.ResourceData) error {
+			return l.checkRequiredFields(d, consts.FieldUsername)
+		},
+	); err != nil {
 		return nil, err
 	}
+
 	return l, nil
 }
 


### PR DESCRIPTION
Add support for passing validation funcs to AuthLoginCommon.Init(), which will prevent an AuthLogin from being partially initialized.