### PR TITLE
Add new auth_login_token_file method

### DIFF
--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -381,6 +381,8 @@ const (
 	EnvVarRadiusUsername = "RADIUS_USERNAME"
 	// EnvVarRadiusPassword for the Radius auth login
 	EnvVarRadiusPassword = "RADIUS_PASSWORD"
+	// EnvVarTokenFilename for the TokenFile auth login.
+	EnvVarTokenFilename = "TERRAFORM_VAULT_TOKEN_FILENAME"
 
 	/*
 		common mount types

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -114,6 +114,7 @@ const (
 	FieldAuthLoginOIDC                 = "auth_login_oidc"
 	FieldAuthLoginJWT                  = "auth_login_jwt"
 	FieldAuthLoginAzure                = "auth_login_azure"
+	FieldAuthLoginTokenFile            = "auth_login_token_file"
 	FieldIAMHttpRequestMethod          = "iam_http_request_method"
 	FieldIAMRequestURL                 = "iam_request_url"
 	FieldIAMRequestBody                = "iam_request_body"
@@ -347,6 +348,7 @@ const (
 	FieldRollbackStatements            = "rollback_statements"
 	FieldRenewStatements               = "renew_statements"
 	FieldCredentialType                = "credential_type"
+	FieldFilename                      = "filename"
 
 	/*
 		common environment variables
@@ -405,6 +407,7 @@ const (
 	MountTypeLDAP         = "ldap"
 	MountTypeConsul       = "consul"
 	MountTypeTerraform    = "terraform"
+	MountTypeNone         = "none"
 
 	/*
 		Vault version constants

--- a/internal/provider/auth_cert_test.go
+++ b/internal/provider/auth_cert_test.go
@@ -184,10 +184,11 @@ func TestAuthLoginCert_LoginPath(t *testing.T) {
 func TestAuthLoginCert_Login(t *testing.T) {
 	handlerFunc := func(t *testLoginHandler, w http.ResponseWriter, req *http.Request) {
 		role := "default"
-		if v, ok := t.params[len(t.params)-1][consts.FieldName]; ok {
-			role = v.(string)
+		if t.params != nil {
+			if v, ok := t.params[len(t.params)-1][consts.FieldName]; ok {
+				role = v.(string)
+			}
 		}
-
 		m, err := json.Marshal(
 			&api.Secret{
 				Auth: &api.SecretAuth{
@@ -223,7 +224,7 @@ func TestAuthLoginCert_Login(t *testing.T) {
 			expectReqPaths: []string{
 				"/v1/auth/cert/login",
 			},
-			expectReqParams: []map[string]interface{}{{}},
+			expectReqParams: nil,
 			want: &api.Secret{
 				Auth: &api.SecretAuth{
 					Metadata: map[string]string{

--- a/internal/provider/auth_test.go
+++ b/internal/provider/auth_test.go
@@ -6,7 +6,7 @@ package provider
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"testing"
@@ -19,7 +19,7 @@ import (
 
 // expectedRegisteredAuthLogin value should be modified when adding
 // registering/de-registering AuthLogin resources.
-const expectedRegisteredAuthLogin = 11
+const expectedRegisteredAuthLogin = 12
 
 type authLoginTest struct {
 	name               string
@@ -33,6 +33,7 @@ type authLoginTest struct {
 	wantErr            bool
 	expectErr          error
 	skipFunc           func(t *testing.T)
+	preLoginFunc       func(t *testing.T)
 }
 
 type authLoginInitTest struct {
@@ -59,28 +60,34 @@ func (t *testLoginHandler) handler() http.HandlerFunc {
 
 		t.paths = append(t.paths, req.URL.Path)
 
-		if req.Method != http.MethodPut {
+		switch req.Method {
+		case http.MethodPut, http.MethodGet:
+		default:
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
 
-		b, err := ioutil.ReadAll(req.Body)
+		b, err := io.ReadAll(req.Body)
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 
 		var params map[string]interface{}
-		if err := json.Unmarshal(b, &params); err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			return
+		if len(b) > 0 {
+			if err := json.Unmarshal(b, &params); err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
 		}
 
 		for _, p := range t.excludeParams {
 			delete(params, p)
 		}
 
-		t.params = append(t.params, params)
+		if len(params) > 0 {
+			t.params = append(t.params, params)
+		}
 
 		t.handlerFunc(t, w, req)
 	}
@@ -91,6 +98,10 @@ func testAuthLogin(t *testing.T, tt authLoginTest) {
 
 	if tt.skipFunc != nil {
 		tt.skipFunc(t)
+	}
+
+	if tt.preLoginFunc != nil {
+		tt.preLoginFunc(t)
 	}
 
 	config, ln := testutil.TestHTTPServer(t, tt.handler.handler())

--- a/internal/provider/auth_test.go
+++ b/internal/provider/auth_test.go
@@ -41,6 +41,7 @@ type authLoginInitTest struct {
 	authField    string
 	raw          map[string]interface{}
 	wantErr      bool
+	envVars      map[string]string
 	expectMount  string
 	expectParams map[string]interface{}
 	expectErr    error
@@ -225,7 +226,12 @@ func assertAuthLoginEqual(t *testing.T, expected, actual AuthLogin) {
 }
 
 func assertAuthLoginInit(t *testing.T, tt authLoginInitTest, s map[string]*schema.Schema, l AuthLogin) {
+	for k, v := range tt.envVars {
+		t.Setenv(k, v)
+	}
+
 	d := schema.TestResourceDataRaw(t, s, tt.raw)
+
 	actual, err := l.Init(d, tt.authField)
 	if (err != nil) != tt.wantErr {
 		t.Fatalf("Init() error = %v, wantErr %v", err, tt.wantErr)

--- a/internal/provider/auth_token_file.go
+++ b/internal/provider/auth_token_file.go
@@ -1,0 +1,165 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+)
+
+func init() {
+	field := consts.FieldAuthLoginTokenFile
+	if err := globalAuthLoginRegistry.Register(field,
+		func(r *schema.ResourceData) (AuthLogin, error) {
+			a := &AuthLoginTokenFile{}
+			return a.Init(r, field)
+		}, GetTokenFileSchema); err != nil {
+		panic(err)
+	}
+}
+
+// GetTokenFileSchema for the token file.
+func GetTokenFileSchema(authField string) *schema.Schema {
+	return getLoginSchema(
+		authField,
+		//  TODO: come up with a meaningful description
+		"Login to vault using ",
+		GetTokenFileSchemaResource,
+	)
+}
+
+// GetTokenFileSchemaResource for pre-authenticated token-from-file.
+func GetTokenFileSchemaResource(_ string) *schema.Resource {
+	return mustAddLoginSchema(&schema.Resource{
+		Schema: map[string]*schema.Schema{
+			consts.FieldFilename: {
+				Type:     schema.TypeString,
+				Required: true,
+				Description: "The name of a file containing a single " +
+					"line that is a valid Vault token",
+			},
+		},
+	}, consts.MountTypeNone)
+}
+
+var _ AuthLogin = (*AuthLoginTokenFile)(nil)
+
+type AuthLoginTokenFile struct {
+	AuthLoginCommon
+}
+
+// MountPath is unused
+func (l *AuthLoginTokenFile) MountPath() string {
+	return ""
+}
+
+// LoginPath is unused
+func (l *AuthLoginTokenFile) LoginPath() string {
+	return ""
+}
+
+func (l *AuthLoginTokenFile) Init(d *schema.ResourceData,
+	authField string,
+) (AuthLogin, error) {
+	l.mount = consts.MountTypeNone
+
+	if err := l.AuthLoginCommon.Init(d, authField,
+		func(data *schema.ResourceData) error {
+			return l.checkRequiredFields(d, consts.FieldFilename)
+		},
+	); err != nil {
+		return nil, err
+	}
+
+	return l, nil
+}
+
+// Method is unused.
+func (l *AuthLoginTokenFile) Method() string {
+	return ""
+}
+
+// Login provides a pseudo mechanism fetching a Vault token from a local file.
+func (l *AuthLoginTokenFile) Login(c *api.Client) (*api.Secret, error) {
+	if err := l.validate(); err != nil {
+		return nil, err
+	}
+
+	token, err := l.readTokenFile()
+	if err != nil {
+		return nil, err
+	}
+
+	clone, err := c.Clone()
+	if err != nil {
+		return nil, err
+	}
+
+	clone.SetToken(token)
+	resp, err := clone.Auth().Token().LookupSelf()
+	if err != nil {
+		return nil, err
+	}
+
+	if resp == nil {
+		return nil, fmt.Errorf("empty token lookup response")
+	}
+
+	resp.Auth = &api.SecretAuth{
+		ClientToken: token,
+	}
+
+	return resp, nil
+}
+
+func (l *AuthLoginTokenFile) readTokenFile() (string, error) {
+	filename := l.params[consts.FieldFilename].(string)
+	fh, err := os.Open(filename)
+	if err != nil {
+		return "", err
+	}
+
+	st, err := fh.Stat()
+	if err != nil {
+		return "", err
+	}
+
+	mode := st.Mode()
+	if !mode.IsRegular() {
+		return "", fmt.Errorf("token path %q is not regular file", filename)
+	}
+
+	// require only user access
+	v := mode.Perm() & 0o077
+	if v != 0 {
+		return "", fmt.Errorf("token path %q has an invalid mode %v", filename, mode.Perm())
+	}
+
+	var lines [][]byte
+	s := bufio.NewScanner(fh)
+	for s.Scan() {
+		lines = append(lines, s.Bytes())
+		if len(lines) > 1 {
+			return "", fmt.Errorf("token path %q contains more than one line", filename)
+		}
+	}
+
+	var token string
+	if len(lines) == 1 {
+		token = strings.TrimSuffix(string(lines[0]), "\n")
+	}
+
+	if token == "" {
+		return "", fmt.Errorf("no token found in %q", filename)
+	}
+
+	return token, nil
+}

--- a/internal/provider/auth_token_file.go
+++ b/internal/provider/auth_token_file.go
@@ -41,8 +41,9 @@ func GetTokenFileSchemaResource(_ string) *schema.Resource {
 	return mustAddLoginSchema(&schema.Resource{
 		Schema: map[string]*schema.Schema{
 			consts.FieldFilename: {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc(consts.EnvVarTokenFilename, nil),
 				Description: "The name of a file containing a single " +
 					"line that is a valid Vault token",
 			},

--- a/internal/provider/auth_token_file_test.go
+++ b/internal/provider/auth_token_file_test.go
@@ -25,13 +25,30 @@ func TestAuthLoginTokenFile_Init(t *testing.T) {
 			raw: map[string]interface{}{
 				consts.FieldAuthLoginTokenFile: []interface{}{
 					map[string]interface{}{
-						consts.FieldFilename: "cert.key",
+						consts.FieldFilename: "vault-token",
 					},
 				},
 			},
 			expectParams: map[string]interface{}{
 				consts.FieldNamespace: "",
-				consts.FieldFilename:  "cert.key",
+				consts.FieldFilename:  "vault-token",
+			},
+			wantErr: false,
+		},
+		{
+			name:      "basic-from-env",
+			authField: consts.FieldAuthLoginTokenFile,
+			raw: map[string]interface{}{
+				consts.FieldAuthLoginTokenFile: []interface{}{
+					map[string]interface{}{},
+				},
+			},
+			envVars: map[string]string{
+				consts.EnvVarTokenFilename: "/tmp/vault-token",
+			},
+			expectParams: map[string]interface{}{
+				consts.FieldNamespace: "",
+				consts.FieldFilename:  "/tmp/vault-token",
 			},
 			wantErr: false,
 		},

--- a/internal/provider/auth_token_file_test.go
+++ b/internal/provider/auth_token_file_test.go
@@ -1,0 +1,321 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+)
+
+func TestAuthLoginTokenFile_Init(t *testing.T) {
+	tests := []authLoginInitTest{
+		{
+			name:      "basic",
+			authField: consts.FieldAuthLoginTokenFile,
+			raw: map[string]interface{}{
+				consts.FieldAuthLoginTokenFile: []interface{}{
+					map[string]interface{}{
+						consts.FieldFilename: "cert.key",
+					},
+				},
+			},
+			expectParams: map[string]interface{}{
+				consts.FieldNamespace: "",
+				consts.FieldFilename:  "cert.key",
+			},
+			wantErr: false,
+		},
+		{
+			name:         "error-missing-resource",
+			authField:    consts.FieldAuthLoginTokenFile,
+			expectParams: nil,
+			wantErr:      true,
+			expectErr:    fmt.Errorf("resource data missing field %q", consts.FieldAuthLoginTokenFile),
+		},
+		{
+			name:      "error-missing-required",
+			authField: consts.FieldAuthLoginTokenFile,
+			raw: map[string]interface{}{
+				consts.FieldAuthLoginTokenFile: []interface{}{
+					map[string]interface{}{},
+				},
+			},
+			expectParams: nil,
+			wantErr:      true,
+			expectErr: fmt.Errorf("required fields are unset: %v", []string{
+				consts.FieldFilename,
+			}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := map[string]*schema.Schema{
+				tt.authField: GetTokenFileSchema(tt.authField),
+			}
+			assertAuthLoginInit(t, tt, s, &AuthLoginTokenFile{})
+		})
+	}
+}
+
+func TestAuthLoginTokenFile_Login(t *testing.T) {
+	handlerFunc := func(t *testLoginHandler, w http.ResponseWriter, req *http.Request) {
+		m, err := json.Marshal(
+			&api.Secret{
+				Auth: &api.SecretAuth{},
+			},
+		)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		if _, err := w.Write(m); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	}
+
+	tempDir := t.TempDir()
+	tests := []authLoginTest{
+		{
+			name: "basic",
+			authLogin: &AuthLoginTokenFile{
+				AuthLoginCommon{
+					authField: "baz",
+					mount:     consts.MountTypeNone,
+					params: map[string]interface{}{
+						consts.FieldFilename: path.Join(tempDir, "basic"),
+					},
+					initialized: true,
+				},
+			},
+			handler: &testLoginHandler{
+				handlerFunc: handlerFunc,
+			},
+			expectReqCount: 1,
+			expectReqPaths: []string{
+				"/v1/auth/token/lookup-self",
+			},
+			expectReqParams: nil,
+			want: &api.Secret{
+				Auth: &api.SecretAuth{
+					ClientToken: "qux",
+				},
+			},
+			preLoginFunc: func(t *testing.T) {
+				t.Helper()
+
+				filename := path.Join(tempDir, "basic")
+				t.Cleanup(func() {
+					if err := os.Remove(filename); err != nil {
+						t.Error(err)
+					}
+				})
+				if err := os.WriteFile(filename, []byte("qux\n"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "error-invalid-file-mode",
+			authLogin: &AuthLoginTokenFile{
+				AuthLoginCommon{
+					authField: "baz",
+					mount:     consts.MountTypeNone,
+					params: map[string]interface{}{
+						consts.FieldFilename: path.Join(tempDir, "error-invalid-file-mode"),
+					},
+					initialized: true,
+				},
+			},
+			handler: &testLoginHandler{
+				handlerFunc: handlerFunc,
+			},
+			expectReqCount: 0,
+			preLoginFunc: func(t *testing.T) {
+				t.Helper()
+
+				filename := path.Join(tempDir, "error-invalid-file-mode")
+				t.Cleanup(func() {
+					if err := os.Remove(filename); err != nil {
+						t.Error(err)
+					}
+				})
+				if err := os.WriteFile(filename, []byte("qux\n"), 0o660); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantErr: true,
+		},
+		{
+			name: "error-not-a-file",
+			authLogin: &AuthLoginTokenFile{
+				AuthLoginCommon{
+					authField: "baz",
+					mount:     consts.MountTypeNone,
+					params: map[string]interface{}{
+						consts.FieldFilename: path.Join(tempDir, "error-not-a-file"),
+					},
+					initialized: true,
+				},
+			},
+			handler: &testLoginHandler{
+				handlerFunc: handlerFunc,
+			},
+			expectReqCount: 0,
+			preLoginFunc: func(t *testing.T) {
+				t.Helper()
+
+				filename := path.Join(tempDir, "error-not-a-file")
+				t.Cleanup(func() {
+					if err := os.RemoveAll(filename); err != nil {
+						t.Error(err)
+					}
+				})
+				if err := os.Mkdir(filename, 0o770); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantErr: true,
+		},
+		{
+			name: "error-uninitialized",
+			authLogin: &AuthLoginTokenFile{
+				AuthLoginCommon{
+					initialized: false,
+				},
+			},
+			handler: &testLoginHandler{
+				handlerFunc: handlerFunc,
+			},
+			want:      nil,
+			wantErr:   true,
+			expectErr: authLoginInitCheckError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testAuthLogin(t, tt)
+		})
+	}
+}
+
+func TestAuthLoginTokenFile_readTokenFile(t *testing.T) {
+	tempDir := t.TempDir()
+
+	tests := []struct {
+		name     string
+		mode     os.FileMode
+		asDir    bool
+		contents []byte
+		want     string
+		wantErr  bool
+	}{
+		{
+			name:     "basic",
+			contents: []byte("foo"),
+			want:     "foo",
+			mode:     0o600,
+			wantErr:  false,
+		},
+		{
+			name:     "invalid-empty",
+			contents: make([]byte, 0),
+			mode:     0o600,
+			wantErr:  true,
+		},
+		{
+			name:     "invalid-empty-with-newline",
+			contents: []byte("\n"),
+			mode:     0o600,
+			wantErr:  true,
+		},
+		{
+			name:     "invalid-file-perms-0640",
+			contents: []byte("foo"),
+			mode:     0o640,
+			wantErr:  true,
+		},
+		{
+			name:     "invalid-file-perms-0644",
+			contents: []byte("foo"),
+			mode:     0o644,
+			wantErr:  true,
+		},
+		{
+			name:     "invalid-file-perms-0604",
+			contents: []byte("foo"),
+			mode:     0o604,
+			wantErr:  true,
+		},
+		{
+			name:     "invalid-multi-line",
+			contents: []byte("foo\nbaz"),
+			mode:     0o600,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var filename string
+			if tt.asDir {
+				dirname, err := os.MkdirTemp(tempDir, "test-")
+				if err != nil {
+					t.Fatal(err)
+				}
+				filename = dirname
+			} else {
+				fh, err := os.CreateTemp(tempDir, "test-")
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := fh.Write(tt.contents); err != nil {
+					t.Fatal(err)
+				}
+				if err := fh.Close(); err != nil {
+					t.Fatal(err)
+				}
+
+				filename = fh.Name()
+				if err := os.Chmod(fh.Name(), tt.mode); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			t.Cleanup(func() {
+				if err := os.RemoveAll(filename); err != nil {
+					t.Fatal(err)
+				}
+			})
+
+			l := &AuthLoginTokenFile{
+				AuthLoginCommon{
+					params: map[string]interface{}{
+						consts.FieldFilename: filename,
+					},
+				},
+			}
+
+			got, err := l.readTokenFile()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("readTokenFile() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("readTokenFile() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -568,7 +568,8 @@ The `auth_login_token_file` configuration block accepts the following arguments:
   *Available only for Vault Enterprise*.
 
 * `filename` - (Required) The filename containing a Vault token. The file must contain a single Vault token 
-  and be user readable e.g. perms=`0600`.
+  and be user readable e.g. perms=`0600`. May be set via the `TERRAFORM_VAULT_TOKEN_FILENAME`
+  environment variable.
 
 ### Generic
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -152,6 +152,8 @@ variables in order to keep credential information out of the configuration.
 
 * `auth_login_azure` - (Optional) Utilizes the `azure` authentication engine. *[See usage details below.](#azure)*
 
+* `auth_login_token_file` - (Optional) Utilizes a local file containing a Vault token. *[See usage details below.](#token-file)*
+* 
 * `auth_login` - (Optional) A configuration block, described below, that
   attempts to authenticate using the `auth/<method>/login` path to
   acquire a token which Terraform will use. Terraform still issues itself
@@ -551,6 +553,22 @@ The `auth_login_azure` configuration block accepts the following arguments:
 
 * `scope` - (Optional) The scopes to include in the token request. Defaults to `https://management.azure.com/`
 
+
+### Token File
+
+Provides support for "authenticating" to Vault using a local file containing a Vault token.
+
+~> Using `auth_login_token_file` is not recommended, since it relies on a Vault token that is persisted to disk.
+Please ensure you have processes in place that will remove the token file between Terraform executions.
+
+The `auth_login_token_file` configuration block accepts the following arguments:
+
+* `namespace` - (Optional) The path to the namespace that has the mounted auth method.
+  This defaults to the root namespace. Cannot contain any leading or trailing slashes.
+  *Available only for Vault Enterprise*.
+
+* `filename` - (Required) The filename containing a Vault token. The file must contain a single Vault token 
+  and be user readable e.g. perms=`0600`.
 
 ### Generic
 


### PR DESCRIPTION
The new method is targeted for use in the context of a Terraform Cloud run. It's use outside of that context are not recommended, since the method requires storing vault tokens on disk.