### PR TITLE
fix cache annotations file exists

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,12 +23,24 @@ jobs:
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version-file: '.go-version'
+          cache: false
       # setup-terraform is used to install the Terraform CLI. If we don't do
       # this then the terraform-plugin-sdk will attempt to download it for each test!
       - uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: '1.4.*'
           terraform_wrapper: false
+
+      - name: Cache go build
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+            ~/Library/Caches/go-build
+          key: ${{ runner.os }}-golang-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-golang-
 
       - name: Build
         run: |
@@ -137,6 +149,7 @@ jobs:
       - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version-file: '.go-version'
+          cache: false
       # setup-terraform is used to install the Terraform CLI. If we don't do
       # this then the terraform-plugin-sdk will attempt to download it for each test!
       - uses: hashicorp/setup-terraform@v2
@@ -145,6 +158,17 @@ jobs:
           terraform_wrapper: false
       - name: Check Terraform CLI version
         run: terraform --version
+
+      - name: Cache go build
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+            ~/Library/Caches/go-build
+          key: ${{ runner.os }}-golang-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-golang-
 
       - name: Acceptance Tests
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,17 +30,6 @@ jobs:
           terraform_version: '1.4.*'
           terraform_wrapper: false
 
-      - name: Cache go build
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-            ~/Library/Caches/go-build
-          key: ${{ runner.os }}-golang-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-golang-
-
       - name: Build
         run: |
           make build
@@ -156,17 +145,6 @@ jobs:
           terraform_wrapper: false
       - name: Check Terraform CLI version
         run: terraform --version
-
-      - name: Cache go build
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-            ~/Library/Caches/go-build
-          key: ${{ runner.os }}-golang-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-golang-
 
       - name: Acceptance Tests
         env:


### PR DESCRIPTION
Attempts to fix the build annotations complaining about `Cannot open: File exists`.

This was happening because `setup-go@v4` also introduces a cache by default, so I think there were conflicts when using `actions/cache`. The solution is to disable the caching introduced by `setup-go`.