### PR TITLE
feat(pki): Add resource for cluster configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,15 @@
 BUGS:
 * Handle graceful destruction of resources when approle is deleted out-of-band ([#2142](https://github.com/hashicorp/terraform-provider-vault/pull/2142)).
 
+FEATURES:
+* Add support for PKI Secrets Engine cluster configuration. Requires Vault 1.13+ ([#1949](https://github.com/hashicorp/terraform-provider-vault/pull/1949)).
+
 ## 3.25.0 (Feb 14, 2024)
 
 FEATURES:
 * Add destination and association resources to support Secrets Sync. Requires Vault 1.16+ ([#2098](https://github.com/hashicorp/terraform-provider-vault/pull/2098)).
 * Add support for configuration of plugin WIF to the AWS Secret Backend. Requires Vault 1.16+ ([#2138](https://github.com/hashicorp/terraform-provider-vault/pull/2138)).
-* Add support for Oracle database plugin configuration options `split_statements` and `disconnect_sessions`: ([#2085](https://github.com/hashicorp/terraform-provider-vault/pull/2085)).
-* Add support for PKI Secrets Engine cluster configuration. Requires Vault 1.13+ ([#1949](https://github.com/hashicorp/terraform-provider-vault/pull/1949)).
+* Add support for Oracle database plugin configuration options `split_statements` and `disconnect_sessions`: ([#2085](https://github.com/hashicorp/terraform-provider-vault/pull/2085))
 
 IMPROVEMENTS:
 * Add an API client lock to the `vault_identity_group_alias` resource: ([#2140](https://github.com/hashicorp/terraform-provider-vault/pull/2140))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ BUGS:
 FEATURES:
 * Add destination and association resources to support Secrets Sync. Requires Vault 1.16+ ([#2098](https://github.com/hashicorp/terraform-provider-vault/pull/2098)).
 * Add support for configuration of plugin WIF to the AWS Secret Backend. Requires Vault 1.16+ ([#2138](https://github.com/hashicorp/terraform-provider-vault/pull/2138)).
-* Add support for Oracle database plugin configuration options `split_statements` and `disconnect_sessions`: ([#2085](https://github.com/hashicorp/terraform-provider-vault/pull/2085))
+* Add support for Oracle database plugin configuration options `split_statements` and `disconnect_sessions`: ([#2085](https://github.com/hashicorp/terraform-provider-vault/pull/2085)).
+* Add support for PKI Secrets Engine cluster configuration. Requires Vault 1.13+ ([#1949](https://github.com/hashicorp/terraform-provider-vault/pull/1949)).
 
 IMPROVEMENTS:
 * Add an API client lock to the `vault_identity_group_alias` resource: ([#2140](https://github.com/hashicorp/terraform-provider-vault/pull/2140))

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -388,6 +388,7 @@ const (
 	FieldSecretID                      = "secret_id"
 	FieldWrappingToken                 = "wrapping_token"
 	FieldWithWrappedAccessor           = "with_wrapped_accessor"
+	FieldAIAPath                       = "aia_path"
 
 	/*
 		common environment variables

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -569,6 +569,10 @@ var (
 			Resource:      UpdateSchemaResource(pkiSecretBackendConfigCAResource()),
 			PathInventory: []string{"/pki/config/ca"},
 		},
+		"vault_pki_secret_backend_config_cluster": {
+			Resource:      UpdateSchemaResource(pkiSecretBackendConfigClusterResource()),
+			PathInventory: []string{"/pki/config/cluster"},
+		},
 		"vault_pki_secret_backend_config_urls": {
 			Resource:      UpdateSchemaResource(pkiSecretBackendConfigUrlsResource()),
 			PathInventory: []string{"/pki/config/urls"},

--- a/vault/resource_pki_secret_backend_config_cluster.go
+++ b/vault/resource_pki_secret_backend_config_cluster.go
@@ -1,0 +1,142 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package vault
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+	"github.com/hashicorp/terraform-provider-vault/util"
+)
+
+var pkiClusterFields = []string{
+	consts.FieldPath,
+	consts.FieldAIAPath,
+}
+
+func pkiSecretBackendConfigClusterResource() *schema.Resource {
+	return &schema.Resource{
+		Create: pkiSecretBackendConfigClusterCreateUpdate,
+		Read:   provider.ReadWrapper(pkiSecretBackendConfigClusterRead),
+		Update: pkiSecretBackendConfigClusterCreateUpdate,
+		Delete: pkiSecretBackendConfigClusterDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: func(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				id := d.Id()
+				if id == "" {
+					return nil, fmt.Errorf("no path set for import, id=%q", id)
+				}
+
+				parts := strings.Split(util.NormalizeMountPath(id), "/")
+				if err := d.Set("backend", parts[0]); err != nil {
+					return nil, err
+				}
+
+				return []*schema.ResourceData{d}, nil
+			},
+		},
+
+		Schema: map[string]*schema.Schema{
+			consts.FieldBackend: {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The path of the PKI secret backend the resource belongs to.",
+			},
+			consts.FieldPath: {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Specifies the path to this performance replication cluster's API mount path.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			consts.FieldAIAPath: {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Specifies the path to this performance replication cluster's AIA distribution point.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func pkiSecretBackendConfigClusterCreateUpdate(d *schema.ResourceData, meta interface{}) error {
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
+	backend := d.Get("backend").(string)
+
+	path := pkiSecretBackendConfigClusterPath(backend)
+
+	action := "Create"
+	if !d.IsNewResource() {
+		action = "Update"
+	}
+
+	data := map[string]interface{}{}
+
+	for _, k := range pkiClusterFields {
+		if v, ok := d.GetOk(k); ok {
+			data[k] = v
+		}
+	}
+
+	log.Printf("[DEBUG] %s cluster config on PKI secret backend %q", action, backend)
+	_, err := client.Logical().Write(path, data)
+	if err != nil {
+		return fmt.Errorf("error writing PKI cluster config to %q: %w", backend, err)
+	}
+	log.Printf("[DEBUG] %sd cluster config on PKI secret backend %q", action, backend)
+
+	if d.IsNewResource() {
+		d.SetId(fmt.Sprintf("%s/config/cluster", backend))
+	}
+
+	return pkiSecretBackendConfigClusterRead(d, meta)
+}
+
+func pkiSecretBackendConfigClusterRead(d *schema.ResourceData, meta interface{}) error {
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return e
+	}
+
+	path := d.Id()
+
+	if path == "" {
+		return fmt.Errorf("no path set, id=%q", d.Id())
+	}
+
+	log.Printf("[DEBUG] Reading cluster config from PKI secret path %q", path)
+	config, err := client.Logical().Read(path)
+	if err != nil {
+		return fmt.Errorf("error reading cluster config on PKI secret backend %q: %s", path, err)
+	}
+
+	if config == nil {
+		log.Printf("[WARN] Removing cluster config path %q as its ID is invalid", path)
+		d.SetId("")
+		return nil
+	}
+
+	for _, k := range pkiClusterFields {
+		d.Set(k, config.Data[k])
+	}
+
+	return nil
+}
+
+func pkiSecretBackendConfigClusterDelete(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func pkiSecretBackendConfigClusterPath(backend string) string {
+	return strings.Trim(backend, "/") + "/config/cluster"
+}

--- a/vault/resource_pki_secret_backend_config_cluster.go
+++ b/vault/resource_pki_secret_backend_config_cluster.go
@@ -148,7 +148,7 @@ func pkiSecretBackendConfigClusterRead(ctx context.Context, d *schema.ResourceDa
 
 	for _, k := range fields {
 		if err := d.Set(k, resp.Data[k]); err != nil {
-			return diag.Errorf("error setting state key %q for issuer, err=%s",
+			return diag.Errorf("error setting state key %q for cluster config, err=%s",
 				k, err)
 		}
 	}

--- a/vault/resource_pki_secret_backend_config_cluster.go
+++ b/vault/resource_pki_secret_backend_config_cluster.go
@@ -48,12 +48,12 @@ func pkiSecretBackendConfigClusterResource() *schema.Resource {
 			},
 			consts.FieldPath: {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				Description: "Path to the cluster's API mount path.",
 			},
 			consts.FieldAIAPath: {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				Description: "Path to the cluster's AIA distribution point.",
 			},
 		},
@@ -134,9 +134,7 @@ func pkiSecretBackendConfigClusterRead(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if resp == nil {
-		backend := d.Get(consts.FieldBackend).(string)
-		path := fmt.Sprintf("%s/config/cluster", backend)
-		d.SetId(path)
+		d.SetId("")
 
 		return nil
 	}

--- a/vault/resource_pki_secret_backend_config_cluster_test.go
+++ b/vault/resource_pki_secret_backend_config_cluster_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package vault
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+	"github.com/hashicorp/terraform-provider-vault/testutil"
+)
+
+func TestPkiSecretBackendConfigCluster_basic(t *testing.T) {
+	rootPath := "pki-root-" + strconv.Itoa(acctest.RandInt())
+
+	clusterPath := "http://127.0.0.1:8200/v1/pki"
+	clusterAiaPath := "http://127.0.0.1:8200/v1/pki"
+
+	resourceType := "vault_pki_secret_backend_config_cluster"
+	resourceName := resourceType + ".test"
+	getChecks := func(p, a string) []resource.TestCheckFunc {
+		checks := []resource.TestCheckFunc{
+			resource.TestCheckResourceAttr(
+				resourceName, "path", p),
+			resource.TestCheckResourceAttr(
+				resourceName, "aia_path", a),
+		}
+		return checks
+	}
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testProviders,
+		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		CheckDestroy: testCheckMountDestroyed("vault_mount", consts.MountTypePKI, consts.FieldPath),
+		Steps: []resource.TestStep{
+			{
+				// Test that reading from an unconfigured mount succeeds
+				Config: testPkiSecretBackendCertConfigClusterMountConfig(rootPath),
+				Check:  testPkiSecretBackendConfigClusterEmptyRead,
+			},
+			{
+				Config: testPkiSecretBackendCertConfigClusterConfig(
+					rootPath, clusterPath, clusterAiaPath),
+				Check: resource.ComposeTestCheckFunc(
+					getChecks(clusterPath, clusterAiaPath)...,
+				),
+			},
+			{
+				Config: testPkiSecretBackendCertConfigClusterConfig(
+					rootPath, clusterPath, clusterAiaPath),
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testPkiSecretBackendCertConfigClusterConfig(
+					rootPath, clusterPath+"/new", clusterAiaPath+"/new"),
+				Check: resource.ComposeTestCheckFunc(
+					getChecks(clusterPath+"/new", clusterAiaPath+"/new")...,
+				),
+			},
+		},
+	})
+}
+
+func testPkiSecretBackendConfigClusterEmptyRead(s *terraform.State) error {
+	paths, err := listPkiClusterPaths(s)
+	if err != nil {
+		return err
+	}
+	for _, path := range paths {
+		d := &schema.ResourceData{}
+		d.SetId(path)
+		if err := pkiSecretBackendConfigClusterRead(d, testProvider.Meta()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func listPkiClusterPaths(s *terraform.State) ([]string, error) {
+	var paths []string
+
+	client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
+
+	mounts, err := client.Sys().ListMounts()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "vault_mount" {
+			continue
+		}
+		for path, mount := range mounts {
+			path = strings.Trim(path, "/")
+			rsPath := strings.Trim(rs.Primary.Attributes["path"], "/")
+			if mount.Type == "pki" && path == rsPath {
+				paths = append(paths, path)
+			}
+		}
+	}
+
+	return paths, nil
+}
+
+func testPkiSecretBackendCertConfigClusterMountConfig(rootPath string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "test-root" {
+  path                      = "%s"
+  type                      = "pki"
+  description               = "test root"
+  default_lease_ttl_seconds = 8640000
+  max_lease_ttl_seconds     = 8640000
+}
+`, rootPath)
+}
+
+func testPkiSecretBackendCertConfigClusterConfig(rootPath string, clusterPath string, clusterAiaPath string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "vault_pki_secret_backend_config_cluster" "test" {
+  backend  = vault_mount.test-root.path
+  path     = "%s"
+  aia_path = "%s"
+}
+`,
+		testPkiSecretBackendCertConfigClusterMountConfig(rootPath),
+		clusterPath, clusterAiaPath)
+}

--- a/website/docs/r/pki_secret_backend_config_cluster.html.md
+++ b/website/docs/r/pki_secret_backend_config_cluster.html.md
@@ -1,0 +1,58 @@
+---
+layout: "vault"
+page_title: "Vault: vault_pki_secret_backend_config_cluster resource"
+sidebar_current: "docs-vault-resource-pki-secret-backend-config-cluster"
+description: |-
+  Sets the cluster configuration on an PKI Secret Backend for Vault.
+---
+
+# vault\_pki\_secret\_backend\_config\_cluster
+
+Allows setting the cluster-local's API mount path and AIA distribution point on a particular performance replication cluster.
+
+## Example Usage
+
+```hcl
+resource "vault_mount" "root" {
+  path                      = "pki-root"
+  type                      = "pki"
+  description               = "root PKI"
+  default_lease_ttl_seconds = 8640000
+  max_lease_ttl_seconds     = 8640000
+}
+
+resource "vault_pki_secret_backend_config_cluster" "example" {
+  backend  = vault_mount.root.path
+  path     = "http://127.0.0.1:8200/v1/pki-root"
+  aia_path = "http://127.0.0.1:8200/v1/pki-root"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+   *Available only for Vault Enterprise*.
+
+* `backend` - (Required) The path the PKI secret backend is mounted at, with no leading or trailing `/`s.
+
+* `path` - (Required) Specifies the path to this performance replication cluster's API mount path.
+
+* `aia_path` - (Required) Specifies the path to this performance replication cluster's AIA distribution point.
+
+## Attributes Reference
+
+No additional attributes are exported by this resource.
+
+## Import
+
+The PKI config cluster can be imported using the resource's `id`. 
+In the case of the example above the `id` would be `pki-root/config/cluster`, 
+where the `pki-root` component is the resource's `backend`, e.g.
+
+```
+$ terraform import vault_pki_secret_backend_config_cluster.example pki-root/config/cluster
+```

--- a/website/vault.erb
+++ b/website/vault.erb
@@ -529,6 +529,10 @@
                             <a href="/docs/providers/vault/r/pki_secret_backend_config_ca.html">vault_pki_secret_backend_config_ca</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-vault-resource-pki-secret-backend-config-cluster") %>>
+                            <a href="/docs/providers/vault/r/pki_secret_backend_config_cluster.html">vault_pki_secret_backend_config_cluster</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-vault-resource-pki-secret-backend-config-urls") %>>
                             <a href="/docs/providers/vault/r/pki_secret_backend_config_urls.html">vault_pki_secret_backend_config_urls</a>
                         </li>


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #1947

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* Add support to set cluster configuration for PKI Secrets Engine
```

Output from acceptance testing:

```
$ TESTARGS="--run TestPkiSecretBackendConfigCluster_basic" make testacc'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test --run TestPkiSecretBackendConfigCluster_basic -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
ok      github.com/hashicorp/terraform-provider-vault/codegen   0.036s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    0.071s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    0.055s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    0.075s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        0.079s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    0.020s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/mfa     [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/pki      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      0.056s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  0.062s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/provider 0.047s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/testutil  0.011s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util      0.005s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/vault     4.934s
```
