### PR TITLE
Update vault_identity_entity to exclude policies from Vault request if external_policies = true.

### DIFF
--- a/vault/resource_identity_entity.go
+++ b/vault/resource_identity_entity.go
@@ -103,7 +103,7 @@ func identityEntityUpdateFields(d *schema.ResourceData, data map[string]interfac
 			// should be configured on the entity.
 			data["external_policies"] = d.Get("external_policies").(bool)
 			if data["external_policies"].(bool) {
-				data["policies"] = nil
+				delete(data, "policies")
 			}
 		}
 	}

--- a/vault/resource_identity_entity_policies_test.go
+++ b/vault/resource_identity_entity_policies_test.go
@@ -69,6 +69,16 @@ func TestAccIdentityEntityPoliciesNonExclusive(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_identity_entity_policies.test", "policies.0", "foo"),
 				),
 			},
+			{
+				Config: testAccIdentityEntityPoliciesConfigNonExclusiveUpdateEntity(entity),
+				Check: resource.ComposeTestCheckFunc(
+					testAccIdentityEntityPoliciesCheckLogical("vault_identity_entity.entity", []string{"dev", "foo"}),
+					resource.TestCheckResourceAttr("vault_identity_entity_policies.dev", "policies.#", "1"),
+					resource.TestCheckResourceAttr("vault_identity_entity_policies.dev", "policies.0", "dev"),
+					resource.TestCheckResourceAttr("vault_identity_entity_policies.test", "policies.#", "1"),
+					resource.TestCheckResourceAttr("vault_identity_entity_policies.test", "policies.0", "foo"),
+				),
+			},
 		},
 	})
 }
@@ -257,6 +267,31 @@ func testAccIdentityEntityPoliciesConfigNonExclusiveUpdate(entity string) string
 resource "vault_identity_entity" "entity" {
   name = "%s"
   external_policies = true
+}
+
+resource "vault_identity_entity_policies" "dev" {
+	entity_id = vault_identity_entity.entity.id
+  exclusive = false
+  policies = ["dev"]
+}
+
+
+resource "vault_identity_entity_policies" "test" {
+  entity_id = vault_identity_entity.entity.id
+  exclusive = false
+  policies = ["foo"]
+}
+`, entity)
+}
+
+func testAccIdentityEntityPoliciesConfigNonExclusiveUpdateEntity(entity string) string {
+	return fmt.Sprintf(`
+resource "vault_identity_entity" "entity" {
+  name = "%s"
+  external_policies = true
+  metadata = {
+    version = "1"
+  }
 }
 
 resource "vault_identity_entity_policies" "dev" {


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1942

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Updates vault_identity_entity to ensure externally managed policies are unchanged if external_policies = true
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-test.run TestAccIdentityEntity'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -test.run TestAccIdentityEntity -timeout 30m ./...
?   	github.com/hashicorp/terraform-provider-vault	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/generate	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/codegen	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/generated	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/helper	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/consts	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/internal/identity/entity	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/group	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/mfa	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/pki	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/internal/provider	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/schema	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/testutil	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/util	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/vault	611.600s
```

As an additional note / maybe a needed change, the acceptance test was added to `resource_identity_entity_policies_test.go` because the symptoms of the underlying error were already being tested there  as part of the `testAccIdentityEntityPoliciesCheckLogical` check. I'm not sure it's the most natural place for the tests but it is the simplest.

With the updated test but before the change to `vault_identity_entity` you'd get this, which reflects the problem described in #1942:
```
2023/07/24 12:49:57 [INFO] Using Vault token with the following policies: root
--- FAIL: TestAccIdentityEntityPoliciesNonExclusive (63.73s)
    resource_identity_entity_policies_test.go:48: Step 3/3 error: Check failed: Check 1/5 error: expected entity 74be4bbd-193a-e262-1f3b-e29d790da279 to have 2 policies, has 0
FAIL
FAIL	github.com/hashicorp/terraform-provider-vault/vault	115.320s
FAIL
```