### PR TITLE
ci: fix docker pull consul

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,7 +123,7 @@ jobs:
           --health-timeout 5s
           --health-retries 60
       consul:
-        image: docker.mirror.hashicorp.services/consul:latest
+        image: docker.mirror.hashicorp.services/hashicorp/consul:latest
         env:
           CONSUL_LOCAL_CONFIG: "{\"acl\":{\"enabled\":true}}"
         ports:


### PR DESCRIPTION
Consul used to be a docker hub repo but now is hosted at docker.mirror.hashicorp.services/hashicorp/consul:latest