### PR TITLE
Update `resource_azure_secret_backend_role` to include `permanently_delete` arg

### DIFF
--- a/vault/resource_azure_secret_backend_role.go
+++ b/vault/resource_azure_secret_backend_role.go
@@ -166,10 +166,7 @@ func azureSecretBackendRoleUpdateFields(_ context.Context, d *schema.ResourceDat
 		}
 	}
 
-	if v, ok := d.GetOk("permanently_delete"); ok {
-		data["permanently_delete"] = v.(bool)
-	}
-
+	data["permanently_delete"] = d.Get("permanently_delete").(bool)
 	return nil
 }
 

--- a/vault/resource_azure_secret_backend_role.go
+++ b/vault/resource_azure_secret_backend_role.go
@@ -99,7 +99,7 @@ func azureSecretBackendRoleResource() *schema.Resource {
 			"permanently_delete": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     false,
+				Computed:    true,
 				Description: "Indicates whether the applications and service principals created by Vault will be permanently deleted when the corresponding leases expire.",
 			},
 			"ttl": {

--- a/vault/resource_azure_secret_backend_role.go
+++ b/vault/resource_azure_secret_backend_role.go
@@ -96,6 +96,12 @@ func azureSecretBackendRoleResource() *schema.Resource {
 				Optional:    true,
 				Description: "Application Object ID for an existing service principal that will be used instead of creating dynamic service principals.",
 			},
+			"permanently_delete": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Indicates whether the applications and service principals created by Vault will be permanently deleted when the corresponding leases expire.",
+			},
 			"ttl": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -150,16 +156,18 @@ func azureSecretBackendRoleUpdateFields(_ context.Context, d *schema.ResourceDat
 		data["azure_groups"] = jsonAzureListString
 	}
 
-	if v, ok := d.GetOk("application_object_id"); ok {
-		data["application_object_id"] = v.(string)
+	for _, k := range []string{
+		"ttl",
+		"max_ttl",
+		"application_object_id",
+	} {
+		if v, ok := d.GetOk(k); ok {
+			data[k] = v.(string)
+		}
 	}
 
-	if v, ok := d.GetOk("ttl"); ok {
-		data["ttl"] = v.(string)
-	}
-
-	if v, ok := d.GetOk("max_ttl"); ok {
-		data["max_ttl"] = v.(string)
+	if v, ok := d.GetOk("permanently_delete"); ok {
+		data["permanently_delete"] = v.(bool)
 	}
 
 	return nil
@@ -218,6 +226,7 @@ func azureSecretBackendRoleRead(_ context.Context, d *schema.ResourceData, meta 
 		"ttl",
 		"max_ttl",
 		"application_object_id",
+		"permanently_delete",
 	} {
 		if v, ok := resp.Data[k]; ok {
 			if err := d.Set(k, v); err != nil {

--- a/vault/resource_azure_secret_backend_role.go
+++ b/vault/resource_azure_secret_backend_role.go
@@ -116,7 +116,7 @@ func azureSecretBackendRoleResource() *schema.Resource {
 	}
 }
 
-func azureSecretBackendRoleUpdateFields(_ context.Context, d *schema.ResourceData, data map[string]interface{}) diag.Diagnostics {
+func azureSecretBackendRoleUpdateFields(_ context.Context, d *schema.ResourceData, meta interface{}, data map[string]interface{}) diag.Diagnostics {
 	if v, ok := d.GetOk("azure_roles"); ok {
 		rawAzureList := v.(*schema.Set).List()
 
@@ -166,7 +166,10 @@ func azureSecretBackendRoleUpdateFields(_ context.Context, d *schema.ResourceDat
 		}
 	}
 
-	data["permanently_delete"] = d.Get("permanently_delete").(bool)
+	if provider.IsAPISupported(meta, provider.VaultVersion112) {
+		data["permanently_delete"] = d.Get("permanently_delete").(bool)
+	}
+
 	return nil
 }
 
@@ -182,7 +185,7 @@ func azureSecretBackendRoleCreate(ctx context.Context, d *schema.ResourceData, m
 	path := azureSecretRoleResourcePath(backend, role)
 
 	data := map[string]interface{}{}
-	if diags := azureSecretBackendRoleUpdateFields(ctx, d, data); diags != nil {
+	if diags := azureSecretBackendRoleUpdateFields(ctx, d, meta, data); diags != nil {
 		return diags
 	}
 

--- a/vault/resource_azure_secret_backend_role_test.go
+++ b/vault/resource_azure_secret_backend_role_test.go
@@ -138,11 +138,11 @@ resource "vault_azure_secret_backend_role" "test_azure_roles" {
 }
 
 resource "vault_azure_secret_backend_role" "test_azure_groups" {
-  backend     		 = vault_azure_secret_backend.azure.path
-  role        		 = "%[6]s-azure-groups"
-  ttl         		 = 300
-  max_ttl     		 = 600
-  description 		 = "Test for Vault Provider"
+  backend            = vault_azure_secret_backend.azure.path
+  role               = "%[6]s-azure-groups"
+  ttl                = 300
+  max_ttl            = 600
+  description        = "Test for Vault Provider"
   permanently_delete = true
 
   azure_groups {

--- a/vault/resource_azure_secret_backend_role_test.go
+++ b/vault/resource_azure_secret_backend_role_test.go
@@ -40,12 +40,14 @@ func TestAzureSecretBackendRole(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_azure_secret_backend_role.test_azure_roles", "role", role+"-azure-roles"),
 					resource.TestCheckResourceAttr("vault_azure_secret_backend_role.test_azure_roles", "description", "Test for Vault Provider"),
+					resource.TestCheckResourceAttr("vault_azure_secret_backend_role.test_azure_roles", "permanently_delete", "false"),
 					resource.TestCheckResourceAttr("vault_azure_secret_backend_role.test_azure_roles", "azure_roles.#", "1"),
 					resource.TestCheckResourceAttr("vault_azure_secret_backend_role.test_azure_roles", "azure_roles.0.role_name", "Reader"),
 					resource.TestCheckResourceAttrSet("vault_azure_secret_backend_role.test_azure_roles", "azure_roles.0.scope"),
 					resource.TestCheckResourceAttrSet("vault_azure_secret_backend_role.test_azure_roles", "azure_roles.0.role_id"),
 					resource.TestCheckResourceAttr("vault_azure_secret_backend_role.test_azure_groups", "role", role+"-azure-groups"),
 					resource.TestCheckResourceAttr("vault_azure_secret_backend_role.test_azure_groups", "description", "Test for Vault Provider"),
+					resource.TestCheckResourceAttr("vault_azure_secret_backend_role.test_azure_groups", "permanently_delete", "true"),
 					resource.TestCheckResourceAttr("vault_azure_secret_backend_role.test_azure_groups", "azure_groups.#", "1"),
 					resource.TestCheckResourceAttr("vault_azure_secret_backend_role.test_azure_groups", "azure_groups.0.group_name", "foobar"),
 					resource.TestCheckResourceAttrSet("vault_azure_secret_backend_role.test_azure_groups", "azure_groups.0.object_id"),
@@ -136,11 +138,12 @@ resource "vault_azure_secret_backend_role" "test_azure_roles" {
 }
 
 resource "vault_azure_secret_backend_role" "test_azure_groups" {
-  backend     = vault_azure_secret_backend.azure.path
-  role        = "%[6]s-azure-groups"
-  ttl         = 300
-  max_ttl     = 600
-  description = "Test for Vault Provider"
+  backend     		 = vault_azure_secret_backend.azure.path
+  role        		 = "%[6]s-azure-groups"
+  ttl         		 = 300
+  max_ttl     		 = 600
+  description 		 = "Test for Vault Provider"
+  permanently_delete = true
 
   azure_groups {
     group_name = "foobar"

--- a/vault/resource_azure_secret_backend_role_test.go
+++ b/vault/resource_azure_secret_backend_role_test.go
@@ -40,6 +40,27 @@ func TestAzureSecretBackendRole(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_azure_secret_backend_role.test_azure_roles", "role", role+"-azure-roles"),
 					resource.TestCheckResourceAttr("vault_azure_secret_backend_role.test_azure_roles", "description", "Test for Vault Provider"),
+					resource.TestCheckResourceAttr("vault_azure_secret_backend_role.test_azure_roles", "azure_roles.#", "1"),
+					resource.TestCheckResourceAttr("vault_azure_secret_backend_role.test_azure_roles", "azure_roles.0.role_name", "Reader"),
+					resource.TestCheckResourceAttrSet("vault_azure_secret_backend_role.test_azure_roles", "azure_roles.0.scope"),
+					resource.TestCheckResourceAttrSet("vault_azure_secret_backend_role.test_azure_roles", "azure_roles.0.role_id"),
+					resource.TestCheckResourceAttr("vault_azure_secret_backend_role.test_azure_groups", "role", role+"-azure-groups"),
+					resource.TestCheckResourceAttr("vault_azure_secret_backend_role.test_azure_groups", "description", "Test for Vault Provider"),
+					resource.TestCheckResourceAttr("vault_azure_secret_backend_role.test_azure_groups", "azure_groups.#", "1"),
+					resource.TestCheckResourceAttr("vault_azure_secret_backend_role.test_azure_groups", "azure_groups.0.group_name", "foobar"),
+					resource.TestCheckResourceAttrSet("vault_azure_secret_backend_role.test_azure_groups", "azure_groups.0.object_id"),
+				),
+			},
+			{
+				// permanently delete application registration when true
+				SkipFunc: func() (bool, error) {
+					meta := testProvider.Meta().(*provider.ProviderMeta)
+					return !meta.IsAPISupported(provider.VaultVersion112), nil
+				},
+				Config: testAzureSecretBackendRolePermanentlyDelete(subscriptionID, tenantID, clientID, clientSecret, path, role, resourceGroup),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_azure_secret_backend_role.test_azure_roles", "role", role+"-azure-roles"),
+					resource.TestCheckResourceAttr("vault_azure_secret_backend_role.test_azure_roles", "description", "Test for Vault Provider"),
 					resource.TestCheckResourceAttr("vault_azure_secret_backend_role.test_azure_roles", "permanently_delete", "false"),
 					resource.TestCheckResourceAttr("vault_azure_secret_backend_role.test_azure_roles", "azure_roles.#", "1"),
 					resource.TestCheckResourceAttr("vault_azure_secret_backend_role.test_azure_roles", "azure_roles.0.role_name", "Reader"),
@@ -115,6 +136,43 @@ resource "vault_azure_secret_backend_role" "test_azure_roles_error" {
 }
 
 func testAzureSecretBackendRoleInitialConfig(subscriptionID string, tenantID string, clientID string, clientSecret string, path string, role string, resourceGroup string) string {
+	return fmt.Sprintf(`
+resource "vault_azure_secret_backend" "azure" {
+  subscription_id = "%s"
+  tenant_id       = "%s"
+  client_id       = "%s"
+  client_secret   = "%s"
+  path            = "%s"
+}
+
+resource "vault_azure_secret_backend_role" "test_azure_roles" {
+  backend     = vault_azure_secret_backend.azure.path
+  role        = "%[6]s-azure-roles"
+  ttl         = 300
+  max_ttl     = 600
+  description = "Test for Vault Provider"
+
+  azure_roles {
+    role_name = "Reader"
+    scope =  "/subscriptions/%[1]s/resourceGroups/%[7]s"
+  }
+}
+
+resource "vault_azure_secret_backend_role" "test_azure_groups" {
+  backend     = vault_azure_secret_backend.azure.path
+  role        = "%[6]s-azure-groups"
+  ttl         = 300
+  max_ttl     = 600
+  description = "Test for Vault Provider"
+
+  azure_groups {
+    group_name = "foobar"
+  }
+}
+`, subscriptionID, tenantID, clientID, clientSecret, path, role, resourceGroup)
+}
+
+func testAzureSecretBackendRolePermanentlyDelete(subscriptionID string, tenantID string, clientID string, clientSecret string, path string, role string, resourceGroup string) string {
 	return fmt.Sprintf(`
 resource "vault_azure_secret_backend" "azure" {
   subscription_id = "%s"

--- a/website/docs/r/azure_secret_backend_role.html.md
+++ b/website/docs/r/azure_secret_backend_role.html.md
@@ -66,7 +66,7 @@ The following arguments are supported:
 * `application_object_id` - (Optional) Application Object ID for an existing service principal that will
   be used instead of creating dynamic service principals. If present, `azure_roles` and `permanently_delete` will be ignored.
 * `permanently_delete` - (Optional) Indicates whether the applications and service principals created by Vault will be permanently
-  deleted when the corresponding leases expire. Defaults to `false`.
+  deleted when the corresponding leases expire. Defaults to `false`. For Vault v1.12+.
 * `ttl` – (Optional) Specifies the default TTL for service principals generated using this role.
   Accepts time suffixed strings ("1h") or an integer number of seconds. Defaults to the system/engine default TTL time.
 * `max_ttl` – (Optional) Specifies the maximum TTL for service principals generated using this role. Accepts time

--- a/website/docs/r/azure_secret_backend_role.html.md
+++ b/website/docs/r/azure_secret_backend_role.html.md
@@ -64,7 +64,9 @@ The following arguments are supported:
 * `azure_groups` - List of Azure groups to be assigned to the generated service principal.
 * `azure_roles` - List of Azure roles to be assigned to the generated service principal.
 * `application_object_id` - Application Object ID for an existing service principal that will
-   be used instead of creating dynamic service principals. If present, `azure_roles` will be ignored.
+   be used instead of creating dynamic service principals. If present, `azure_roles` and `permanently_delete` will be ignored.
+* `permanently_delete` - Indicates whether the applications and service principals created by Vault will be permanently
+   deleted when the corresponding leases expire. Defaults to `false`.
 * `ttl` – (Optional) Specifies the default TTL for service principals generated using this role.
    Accepts time suffixed strings ("1h") or an integer number of seconds. Defaults to the system/engine default TTL time.
 * `max_ttl` – (Optional) Specifies the maximum TTL for service principals generated using this role. Accepts time

--- a/website/docs/r/azure_secret_backend_role.html.md
+++ b/website/docs/r/azure_secret_backend_role.html.md
@@ -6,7 +6,7 @@ description: |-
   Creates an azure secret backend role for Vault.
 ---
 
-# vault\_azure\_secret\_backend\_role
+# vault_azure_secret_backend_role
 
 Creates an Azure Secret Backend Role for Vault.
 
@@ -54,23 +54,23 @@ resource "vault_azure_secret_backend_role" "existing_object_id" {
 
 The following arguments are supported:
 
-* `namespace` - (Optional) The namespace to provision the resource in.
+- `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
   The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
-   *Available only for Vault Enterprise*.
+  _Available only for Vault Enterprise_.
 
-* `role` - (Required) Name of the Azure role
-* `backend` - Path to the mounted Azure auth backend
-* `azure_groups` - List of Azure groups to be assigned to the generated service principal.
-* `azure_roles` - List of Azure roles to be assigned to the generated service principal.
-* `application_object_id` - Application Object ID for an existing service principal that will
-   be used instead of creating dynamic service principals. If present, `azure_roles` and `permanently_delete` will be ignored.
-* `permanently_delete` - Indicates whether the applications and service principals created by Vault will be permanently
-   deleted when the corresponding leases expire. Defaults to `false`.
-* `ttl` – (Optional) Specifies the default TTL for service principals generated using this role.
-   Accepts time suffixed strings ("1h") or an integer number of seconds. Defaults to the system/engine default TTL time.
-* `max_ttl` – (Optional) Specifies the maximum TTL for service principals generated using this role. Accepts time
-   suffixed strings ("1h") or an integer number of seconds. Defaults to the system/engine max TTL time.
+- `role` - (Required) Name of the Azure role
+- `backend` - (Optional) Path to the mounted Azure auth backend
+- `azure_groups` - (Optional) List of Azure groups to be assigned to the generated service principal.
+- `azure_roles` - (Optional) List of Azure roles to be assigned to the generated service principal.
+- `application_object_id` - (Optional) Application Object ID for an existing service principal that will
+  be used instead of creating dynamic service principals. If present, `azure_roles` and `permanently_delete` will be ignored.
+- `permanently_delete` - (Optional) Indicates whether the applications and service principals created by Vault will be permanently
+  deleted when the corresponding leases expire. Defaults to `false`.
+- `ttl` – (Optional) Specifies the default TTL for service principals generated using this role.
+  Accepts time suffixed strings ("1h") or an integer number of seconds. Defaults to the system/engine default TTL time.
+- `max_ttl` – (Optional) Specifies the maximum TTL for service principals generated using this role. Accepts time
+  suffixed strings ("1h") or an integer number of seconds. Defaults to the system/engine max TTL time.
 
 ## Attributes Reference
 

--- a/website/docs/r/azure_secret_backend_role.html.md
+++ b/website/docs/r/azure_secret_backend_role.html.md
@@ -6,7 +6,7 @@ description: |-
   Creates an azure secret backend role for Vault.
 ---
 
-# vault_azure_secret_backend_role
+# vault\_azure\_secret\_backend\_role
 
 Creates an Azure Secret Backend Role for Vault.
 
@@ -54,22 +54,22 @@ resource "vault_azure_secret_backend_role" "existing_object_id" {
 
 The following arguments are supported:
 
-- `namespace` - (Optional) The namespace to provision the resource in.
+* `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
   The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
-  _Available only for Vault Enterprise_.
+  *Available only for Vault Enterprise*.
 
-- `role` - (Required) Name of the Azure role
-- `backend` - (Optional) Path to the mounted Azure auth backend
-- `azure_groups` - (Optional) List of Azure groups to be assigned to the generated service principal.
-- `azure_roles` - (Optional) List of Azure roles to be assigned to the generated service principal.
-- `application_object_id` - (Optional) Application Object ID for an existing service principal that will
+* `role` - (Required) Name of the Azure role
+* `backend` - (Optional) Path to the mounted Azure auth backend
+* `azure_groups` - (Optional) List of Azure groups to be assigned to the generated service principal.
+* `azure_roles` - (Optional) List of Azure roles to be assigned to the generated service principal.
+* `application_object_id` - (Optional) Application Object ID for an existing service principal that will
   be used instead of creating dynamic service principals. If present, `azure_roles` and `permanently_delete` will be ignored.
-- `permanently_delete` - (Optional) Indicates whether the applications and service principals created by Vault will be permanently
+* `permanently_delete` - (Optional) Indicates whether the applications and service principals created by Vault will be permanently
   deleted when the corresponding leases expire. Defaults to `false`.
-- `ttl` – (Optional) Specifies the default TTL for service principals generated using this role.
+* `ttl` – (Optional) Specifies the default TTL for service principals generated using this role.
   Accepts time suffixed strings ("1h") or an integer number of seconds. Defaults to the system/engine default TTL time.
-- `max_ttl` – (Optional) Specifies the maximum TTL for service principals generated using this role. Accepts time
+* `max_ttl` – (Optional) Specifies the maximum TTL for service principals generated using this role. Accepts time
   suffixed strings ("1h") or an integer number of seconds. Defaults to the system/engine max TTL time.
 
 ## Attributes Reference


### PR DESCRIPTION
This PR updates the TF provider to reflect the change in https://github.com/hashicorp/vault-plugin-secrets-azure/pull/104 to the Azure secrets engine role. Summary of that change is as follows:

Without the `permanently_delete` argument set to `true`, the Vault secrets engine does not permanently delete the service principals/apps from AzureAD when leases expire. Instead, the objects are placed in a "recycle bin," and they count toward the [limit of AzureAD objects in a tenant](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits#active-directory-limits) (that limit ranges from 50k to 500k objects). So after 50k-500k leases, Vault hits the limit of objects in an Azure AD and causes all create operations on the tenant to fail.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/vault-plugin-secrets-azure/pull/104

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
* Add support for setting `permanently_delete` argument on `resource_azure_secret_backend_role`
```

Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAzureSecretBackendRole'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -run=TestAzureSecretBackendRole -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
ok      github.com/hashicorp/terraform-provider-vault/codegen   (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/mfa     [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/pki      [no test files]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/provider (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/testutil  (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/vault     0.524s
```
