### PR TITLE
Resolve TF state for PKI Multi-Issuer workflows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/denisenkom/go-mssqldb v0.12.0
 	github.com/docker/distribution v2.8.1+incompatible // indirect
 	github.com/go-sql-driver/mysql v1.6.0
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.0 // indirect
 	github.com/gosimple/slug v1.11.0
 	github.com/hashicorp/errwrap v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/denisenkom/go-mssqldb v0.12.0
 	github.com/docker/distribution v2.8.1+incompatible // indirect
 	github.com/go-sql-driver/mysql v1.6.0
-	github.com/google/uuid v1.3.0 // indirect
+	github.com/google/uuid v1.3.0
 	github.com/googleapis/enterprise-certificate-proxy v0.2.0 // indirect
 	github.com/gosimple/slug v1.11.0
 	github.com/hashicorp/errwrap v1.1.0

--- a/util/util.go
+++ b/util/util.go
@@ -51,6 +51,10 @@ func ToStringArray(input []interface{}) []string {
 	return output
 }
 
+func Is500(err error) bool {
+	return ErrorContainsHTTPCode(err, http.StatusInternalServerError)
+}
+
 func Is404(err error) bool {
 	return ErrorContainsHTTPCode(err, http.StatusNotFound)
 }
@@ -61,6 +65,14 @@ func ErrorContainsHTTPCode(err error, codes ...int) bool {
 			return true
 		}
 	}
+	return false
+}
+
+func ErrorContainsString(err error, s string) bool {
+	if strings.Contains(err.Error(), s) {
+		return true
+	}
+
 	return false
 }
 

--- a/util/util.go
+++ b/util/util.go
@@ -69,11 +69,7 @@ func ErrorContainsHTTPCode(err error, codes ...int) bool {
 }
 
 func ErrorContainsString(err error, s string) bool {
-	if strings.Contains(err.Error(), s) {
-		return true
-	}
-
-	return false
+	return strings.Contains(err.Error(), s)
 }
 
 // CalculateConflictsWith returns a slice of field names that conflict with

--- a/vault/resource_pki_secret_backend_intermediate_cert_request.go
+++ b/vault/resource_pki_secret_backend_intermediate_cert_request.go
@@ -5,9 +5,11 @@ package vault
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -231,7 +233,8 @@ func pkiSecretBackendIntermediateCertRequestCreate(ctx context.Context, d *schem
 
 	backend := d.Get(consts.FieldBackend).(string)
 	intermediateType := d.Get(consts.FieldType).(string)
-	path := pkiSecretBackendIntermediateGeneratePath(backend, intermediateType)
+
+	path := pkiSecretBackendIntermediateGeneratePath(backend, intermediateType, provider.IsAPISupported(meta, provider.VaultVersion111))
 
 	intermediateCertAPIFields := []string{
 		consts.FieldCommonName,
@@ -262,15 +265,19 @@ func pkiSecretBackendIntermediateCertRequestCreate(ctx context.Context, d *schem
 
 	// add multi-issuer write API fields if supported
 	isIssuerAPISupported := provider.IsAPISupported(meta, provider.VaultVersion111)
+	isKeyBeingGenerated := !(intermediateType == keyTypeKMS || intermediateType == consts.FieldExisting)
 
-	if !(intermediateType == keyTypeKMS || intermediateType == consts.FieldExisting) {
-		// if kms or existing type,
+	if isKeyBeingGenerated {
 		intermediateCertAPIFields = append(intermediateCertAPIFields, consts.FieldKeyType, consts.FieldKeyBits)
 		if isIssuerAPISupported {
-			intermediateCertAPIFields = append(intermediateCertAPIFields, consts.FieldKeyRef)
+			intermediateCertAPIFields = append(intermediateCertAPIFields, consts.FieldKeyName)
 		}
-	} else if isIssuerAPISupported {
-		intermediateCertAPIFields = append(intermediateCertAPIFields, consts.FieldKeyName)
+	} else {
+		intermediateCertAPIFields = append(intermediateCertAPIFields, consts.FieldKeyRef)
+	}
+
+	if isIssuerAPISupported {
+		intermediateCertAPIFields = append(intermediateCertAPIFields, consts.FieldIssuerName)
 	}
 
 	data := map[string]interface{}{}
@@ -329,7 +336,15 @@ func pkiSecretBackendIntermediateCertRequestCreate(ctx context.Context, d *schem
 
 	}
 
-	d.SetId(path)
+	id := path
+	if provider.IsAPISupported(meta, provider.VaultVersion111) {
+		// multiple CSRs can be generated
+		// ensure unique IDs
+		uniqueSuffix := uuid.New()
+		id = fmt.Sprintf("%s/%s", path, uniqueSuffix)
+	}
+
+	d.SetId(id)
 	return pkiSecretBackendIntermediateCertRequestRead(ctx, d, meta)
 }
 
@@ -341,6 +356,9 @@ func pkiSecretBackendIntermediateCertRequestDelete(ctx context.Context, d *schem
 	return nil
 }
 
-func pkiSecretBackendIntermediateGeneratePath(backend string, intermediateType string) string {
+func pkiSecretBackendIntermediateGeneratePath(backend, intermediateType string, isMultiIssuerSupported bool) string {
+	if isMultiIssuerSupported {
+		return strings.Trim(backend, "/") + "/issuers/generate/intermediate/" + strings.Trim(intermediateType, "/")
+	}
 	return strings.Trim(backend, "/") + "/intermediate/generate/" + strings.Trim(intermediateType, "/")
 }

--- a/vault/resource_pki_secret_backend_intermediate_cert_request.go
+++ b/vault/resource_pki_secret_backend_intermediate_cert_request.go
@@ -265,19 +265,19 @@ func pkiSecretBackendIntermediateCertRequestCreate(ctx context.Context, d *schem
 
 	// add multi-issuer write API fields if supported
 	isIssuerAPISupported := provider.IsAPISupported(meta, provider.VaultVersion111)
-	isKeyBeingGenerated := !(intermediateType == keyTypeKMS || intermediateType == consts.FieldExisting)
 
-	if isKeyBeingGenerated {
+	// Fields only used when we are generating a key
+	if !(intermediateType == keyTypeKMS || intermediateType == consts.FieldExisting) {
 		intermediateCertAPIFields = append(intermediateCertAPIFields, consts.FieldKeyType, consts.FieldKeyBits)
-		if isIssuerAPISupported {
-			intermediateCertAPIFields = append(intermediateCertAPIFields, consts.FieldKeyName)
-		}
-	} else {
-		intermediateCertAPIFields = append(intermediateCertAPIFields, consts.FieldKeyRef)
 	}
 
 	if isIssuerAPISupported {
-		intermediateCertAPIFields = append(intermediateCertAPIFields, consts.FieldIssuerName)
+		// Note: CSR generation does not persist an issuer, just a key, so consts.FieldIssuerName is not supported
+		if intermediateType == consts.FieldExisting {
+			intermediateCertAPIFields = append(intermediateCertAPIFields, consts.FieldKeyRef)
+		} else {
+			intermediateCertAPIFields = append(intermediateCertAPIFields, consts.FieldKeyName)
+		}
 	}
 
 	data := map[string]interface{}{}

--- a/vault/resource_pki_secret_backend_issuer.go
+++ b/vault/resource_pki_secret_backend_issuer.go
@@ -205,6 +205,11 @@ func pkiSecretBackendIssuerRead(ctx context.Context, d *schema.ResourceData, met
 
 	log.Printf("[DEBUG] Reading %s from Vault", path)
 	resp, err := client.Logical().ReadWithContext(ctx, path)
+	if resp == nil {
+		d.SetId("")
+		return nil
+	}
+
 	if err != nil {
 		return diag.Errorf("error reading from Vault: %s", err)
 	}
@@ -232,9 +237,11 @@ func pkiSecretBackendIssuerRead(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	for _, k := range fields {
-		if err := d.Set(k, resp.Data[k]); err != nil {
-			return diag.Errorf("error setting state key %q for issuer, err=%s",
-				k, err)
+		if v, ok := resp.Data[k]; ok {
+			if err := d.Set(k, v); err != nil {
+				return diag.Errorf("error setting state key %q for issuer, err=%s",
+					k, err)
+			}
 		}
 	}
 

--- a/vault/resource_pki_secret_backend_key_test.go
+++ b/vault/resource_pki_secret_backend_key_test.go
@@ -86,14 +86,16 @@ func TestAccPKISecretBackendKey_basic(t *testing.T) {
 
 func testAccPKISecretBackendKey_basic(path, keyName, keyType, keyBits string) string {
 	return fmt.Sprintf(`
-resource "vault_mount" "pki" {
-	path        = "%s"
-	type        = "pki"
-    description = "PKI secret engine mount"
+resource "vault_mount" "test" {
+  path                      = "%s"
+  type                      = "pki"
+  description               = "test"
+  default_lease_ttl_seconds = "86400"
+  max_lease_ttl_seconds     = "86400"
 }
 
 resource "vault_pki_secret_backend_key" "test" {
-  backend  = vault_mount.pki.path
+  backend  = vault_mount.test.path
   type     = "exported"
   key_name = "%s"
   key_type = "%s"

--- a/vault/resource_pki_secret_backend_root_cert.go
+++ b/vault/resource_pki_secret_backend_root_cert.go
@@ -65,7 +65,7 @@ func pkiSecretBackendRootCertResource() *schema.Resource {
 				if e != nil {
 					// Check if this is an out-of-band change on the issuer
 					if util.Is500(e) && util.ErrorContainsString(e, issuerNotFoundErr) {
-						log.Printf("issuer deleted out-of-band. re-creating root cert")
+						log.Printf("[WARN] issuer deleted out-of-band. re-creating root cert")
 						// Force a change on the issuer ID field since
 						// it no longer exists and must be re-created
 						if e = d.SetNewComputed(consts.FieldIssuerID); e != nil {

--- a/vault/resource_pki_secret_backend_root_cert.go
+++ b/vault/resource_pki_secret_backend_root_cert.go
@@ -382,19 +382,21 @@ func pkiSecretBackendRootCertCreate(_ context.Context, d *schema.ResourceData, m
 
 	// add multi-issuer write API fields if supported
 	isIssuerAPISupported := provider.IsAPISupported(meta, provider.VaultVersion111)
-	isKeyBeingGenerated := !(rootType == keyTypeKMS || rootType == consts.FieldExisting)
 
-	if isKeyBeingGenerated {
+	// Fields only used when we are generating a key
+	if !(rootType == keyTypeKMS || rootType == consts.FieldExisting) {
 		rootCertAPIFields = append(rootCertAPIFields, consts.FieldKeyType, consts.FieldKeyBits)
-		if isIssuerAPISupported {
-			rootCertAPIFields = append(rootCertAPIFields, consts.FieldKeyName)
-		}
-	} else {
-		rootCertAPIFields = append(rootCertAPIFields, consts.FieldKeyRef)
 	}
 
 	if isIssuerAPISupported {
+		// We always can specify the issuer name we are generating root certs
 		rootCertAPIFields = append(rootCertAPIFields, consts.FieldIssuerName)
+
+		if rootType == consts.FieldExisting {
+			rootCertAPIFields = append(rootCertAPIFields, consts.FieldKeyRef)
+		} else {
+			rootCertAPIFields = append(rootCertAPIFields, consts.FieldKeyName)
+		}
 	}
 
 	data := map[string]interface{}{}

--- a/vault/resource_pki_secret_backend_root_cert.go
+++ b/vault/resource_pki_secret_backend_root_cert.go
@@ -518,11 +518,20 @@ func pkiSecretBackendRootCertDelete(ctx context.Context, d *schema.ResourceData,
 
 	backend := d.Get(consts.FieldBackend).(string)
 
-	var path string
+	path := pkiSecretBackendDeleteRootPath(backend)
+
 	if provider.IsAPISupported(meta, provider.VaultVersion111) {
-		path = d.Id()
-	} else {
-		path = pkiSecretBackendDeleteRootPath(backend)
+		// @TODO can be removed in future versions of the Provider
+		// this is added to allow a seamless upgrade for users
+		// from v3.18.0 and v3.19.0 of the Provider
+		if !strings.Contains(d.Id(), "/root/generate/") {
+			// Provide an actionable log
+			log.Printf("[WARN] This resource was created with an older version of the provider. " +
+				"If you have not already done so, we recommend upgrading to a newer version " +
+				"(>=v3.20.0) of the provider once this resource has been destroyed")
+		} else {
+			path = d.Id()
+		}
 	}
 
 	log.Printf("[DEBUG] Deleting root cert from PKI secret backend %q", path)

--- a/vault/resource_pki_secret_backend_root_cert.go
+++ b/vault/resource_pki_secret_backend_root_cert.go
@@ -523,13 +523,8 @@ func pkiSecretBackendRootCertDelete(ctx context.Context, d *schema.ResourceData,
 	if provider.IsAPISupported(meta, provider.VaultVersion111) {
 		// @TODO can be removed in future versions of the Provider
 		// this is added to allow a seamless upgrade for users
-		// from v3.18.0 and v3.19.0 of the Provider
+		// from v3.18.0/v3.19.0 of the Provider
 		if !strings.Contains(d.Id(), "/root/generate/") {
-			// Provide an actionable log
-			log.Printf("[WARN] This resource was created with an older version of the provider. " +
-				"If you have not already done so, we recommend upgrading to a newer version " +
-				"(>=v3.20.0) of the provider once this resource has been destroyed")
-		} else {
 			path = d.Id()
 		}
 	}

--- a/vault/resource_pki_secret_backend_root_cert_test.go
+++ b/vault/resource_pki_secret_backend_root_cert_test.go
@@ -84,7 +84,9 @@ func TestPkiSecretBackendRootCertificate_basic(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					genPath := pkiSecretBackendGenerateRootPath(path, "internal", false)
+
+					isMultiIssuerSupported := testProvider.Meta().(*provider.ProviderMeta).IsAPISupported(provider.VaultVersion111)
+					genPath := pkiSecretBackendGenerateRootPath(path, "internal", isMultiIssuerSupported)
 					resp, err := client.Logical().Write(genPath,
 						map[string]interface{}{
 							consts.FieldCommonName: "out-of-band",


### PR DESCRIPTION
This PR aims to address/fix the following issues:

- Some Key Fields (`key_name`, `key_ref`) not being written to Vault due to inaccurate conditionals.
- Nil check on Issuer Read that was causing a panic when reading from a fresh Vault server
- Root certs were being destroyed and recreated due to the `CustomizeDiff` function not accounting for multi-issuer support. Previously, we were comparing the serials for all root certs to the `default` issuer's PEM certificate. The function has now been updated to read the PEM certificate for a specific issuer with an `issuer_id` and compare with the correct serial
- Ensures all root cert and intermediate cert resources have unique IDs since there can now be multiple resources for each type.

Fixes #1943 #1944 #1968 

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):

```release-note
Resolve the TF state for PKI Multi-Issuer workflows.
```