### PR TITLE
Fixes panic when lookup-self returns nil token info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+BUGS:
+* Fixes a panic that can occur when Vault [lookup-self](https://developer.hashicorp.com/vault/api-docs/auth/token#lookup-a-token-self) API returns nil token info ([#1978](https://github.com/hashicorp/terraform-provider-vault/pull/1978))
+
 ## 3.19.0 (Aug 2, 2023)
 FEATURES:
 * Add support for User ID configuration for PKI Secrets Engine: ([#1936](https://github.com/hashicorp/terraform-provider-vault/pull/1936))

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -273,6 +273,9 @@ func NewProviderMeta(d *schema.ResourceData) (interface{}, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to lookup token, err=%w", err)
 	}
+	if tokenInfo == nil {
+		return nil, fmt.Errorf("no token information returned from self lookup")
+	}
 
 	warnMinTokenTTL(tokenInfo)
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->

This PR fixes a panic that can occur when [`LookupSelf()`](https://github.com/hashicorp/vault/blob/main/api/auth_token.go#L87) returns `nil, nil`. The exact location in the panic stack can be seen by checking out v3.18.0. I don't know how to reproduce this but can see how this could panic. See the related issue for details.

This can happen at the following lines within the eventual `ParseSecret()` function call:
- https://github.com/hashicorp/vault/blob/main/api/secret.go#L338
- https://github.com/hashicorp/vault/blob/main/api/secret.go#L362

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1977 

### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

N/A - Will rely on CI tests.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

