### PR TITLE
Add accessor computed attribute for gcp auth backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-FEATURES:
+IMPROVEMENTS:
 * Add accessor attribute for `vault_gcp_auth_backend` resource: ([#1980](https://github.com/hashicorp/terraform-provider-vault/pull/1980))
 
 BUGS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+FEATURES:
+* Add accessor attribute for `vault_gcp_auth_backend` resource: ([#1980](https://github.com/hashicorp/terraform-provider-vault/pull/1980))
 
 BUGS:
 * Fixes a panic that can occur when Vault [lookup-self](https://developer.hashicorp.com/vault/api-docs/auth/token#lookup-a-token-self) API returns nil token info ([#1978](https://github.com/hashicorp/terraform-provider-vault/pull/1978))

--- a/vault/resource_gcp_auth_backend.go
+++ b/vault/resource_gcp_auth_backend.go
@@ -88,6 +88,11 @@ func gcpAuthBackendResource() *schema.Resource {
 					Schema: gcpAuthCustomEndpointSchema(),
 				},
 			},
+			"accessor": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The accessor of the auth backend",
+			},
 		},
 	})
 }
@@ -256,6 +261,7 @@ func gcpAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 		"project_id",
 		"client_email",
 		"local",
+		"accessor",
 	}
 
 	for _, param := range params {

--- a/vault/resource_gcp_auth_backend.go
+++ b/vault/resource_gcp_auth_backend.go
@@ -261,7 +261,6 @@ func gcpAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 		"project_id",
 		"client_email",
 		"local",
-		"accessor",
 	}
 
 	for _, param := range params {
@@ -278,6 +277,18 @@ func gcpAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 		if err := d.Set("custom_endpoint", []map[string]interface{}{endpoints}); err != nil {
 			return err
 		}
+	}
+	// fetch AuthMount in order to set accessor attribute
+	mount, err := getAuthMountIfPresent(client, d.Id())
+	if err != nil {
+		return err
+	}
+	if mount == nil {
+		d.SetId("")
+		return nil
+	}
+	if err := d.Set("accessor", mount.Accessor); err != nil {
+		return err
 	}
 
 	// set the auth backend's path

--- a/vault/resource_gcp_auth_backend_test.go
+++ b/vault/resource_gcp_auth_backend_test.go
@@ -34,7 +34,6 @@ const gcpJSONCredentials string = `
 func TestGCPAuthBackend_basic(t *testing.T) {
 	testutil.SkipTestEnvSet(t, testutil.EnvVarSkipVaultNext)
 
-	resName := "vault_gcp_auth_backend.test"
 	var resAuthFirst api.AuthMount
 	path := resource.PrefixedUniqueId("gcp-basic-")
 	resource.Test(t, resource.TestCase{
@@ -49,7 +48,7 @@ func TestGCPAuthBackend_basic(t *testing.T) {
 			{
 				Config: testGCPAuthBackendConfig_update(path, gcpJSONCredentials),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAuthMountExists(resName, &resAuthFirst),
+					testAccCheckAuthMountExists("vault_gcp_auth_backend.test", &resAuthFirst),
 					testGCPAuthBackendCheck_attrs(),
 					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
 						"custom_endpoint.#", "1"),
@@ -63,13 +62,13 @@ func TestGCPAuthBackend_basic(t *testing.T) {
 						"custom_endpoint.0.crm", "cloudresourcemanager.googleapis.com"),
 					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
 						"custom_endpoint.0.compute", "compute.googleapis.com"),
-					resource.TestCheckResourceAttrPtr(resName, "accessor", &resAuthFirst.Accessor),
+					resource.TestCheckResourceAttrPtr("vault_gcp_auth_backend.test", "accessor", &resAuthFirst.Accessor),
 				),
 			},
 			{
 				Config: testGCPAuthBackendConfig_update_partial(path, gcpJSONCredentials),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAuthMountExists(resName, &resAuthFirst),
+					testAccCheckAuthMountExists("vault_gcp_auth_backend.test", &resAuthFirst),
 					testGCPAuthBackendCheck_attrs(),
 					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
 						"custom_endpoint.#", "1"),
@@ -83,7 +82,7 @@ func TestGCPAuthBackend_basic(t *testing.T) {
 						"custom_endpoint.0.crm", "example.com:9200"),
 					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
 						"custom_endpoint.0.compute", "compute.example.com"),
-					resource.TestCheckResourceAttrPtr(resName, "accessor", &resAuthFirst.Accessor),
+					resource.TestCheckResourceAttrPtr("vault_gcp_auth_backend.test", "accessor", &resAuthFirst.Accessor),
 				),
 			},
 			{

--- a/vault/resource_gcp_auth_backend_test.go
+++ b/vault/resource_gcp_auth_backend_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/vault/api"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
@@ -33,6 +34,8 @@ const gcpJSONCredentials string = `
 func TestGCPAuthBackend_basic(t *testing.T) {
 	testutil.SkipTestEnvSet(t, testutil.EnvVarSkipVaultNext)
 
+	resName := "vault_gcp_auth_backend.test"
+	var resAuthFirst api.AuthMount
 	path := resource.PrefixedUniqueId("gcp-basic-")
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testutil.TestAccPreCheck(t) },
@@ -46,6 +49,7 @@ func TestGCPAuthBackend_basic(t *testing.T) {
 			{
 				Config: testGCPAuthBackendConfig_update(path, gcpJSONCredentials),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAuthMountExists(resName, &resAuthFirst),
 					testGCPAuthBackendCheck_attrs(),
 					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
 						"custom_endpoint.#", "1"),
@@ -59,11 +63,13 @@ func TestGCPAuthBackend_basic(t *testing.T) {
 						"custom_endpoint.0.crm", "cloudresourcemanager.googleapis.com"),
 					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
 						"custom_endpoint.0.compute", "compute.googleapis.com"),
+					resource.TestCheckResourceAttrPtr(resName, "accessor", &resAuthFirst.Accessor),
 				),
 			},
 			{
 				Config: testGCPAuthBackendConfig_update_partial(path, gcpJSONCredentials),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAuthMountExists(resName, &resAuthFirst),
 					testGCPAuthBackendCheck_attrs(),
 					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
 						"custom_endpoint.#", "1"),
@@ -77,6 +83,7 @@ func TestGCPAuthBackend_basic(t *testing.T) {
 						"custom_endpoint.0.crm", "example.com:9200"),
 					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
 						"custom_endpoint.0.compute", "compute.example.com"),
+					resource.TestCheckResourceAttrPtr(resName, "accessor", &resAuthFirst.Accessor),
 				),
 			},
 			{

--- a/website/docs/r/gcp_auth_backend.html.md
+++ b/website/docs/r/gcp_auth_backend.html.md
@@ -74,6 +74,8 @@ In addition to the fields above, the following attributes are also exposed:
 
 * `client_email` - The clients email associated with the credentials
 
+* `accessor` - The mount accessor related to the auth mount. It is useful for integration with [Identity Secrets Engine](https://www.vaultproject.io/docs/secrets/identity/index.html).
+
 ## Import
 
 GCP authentication backends can be imported using the backend name, e.g.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
This PR updates the schema and read functionality for the `vault_gcp_auth_backend` resource in order to define, set, and expose the `accessor` attribute.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes https://github.com/hashicorp/terraform-provider-vault/issues/1964 since this will expose the `accessor` attribute for the `vault_gcp_auth_backend` resource.


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

