### PR TITLE
Update pki_secret_backend_role.html.md

### DIFF
--- a/website/docs/r/pki_secret_backend_role.html.md
+++ b/website/docs/r/pki_secret_backend_role.html.md
@@ -167,7 +167,7 @@ resource "vault_pki_secret_backend_role" "role" {
 
 * `basic_constraints_valid_for_non_ca` - (Optional) Flag to mark basic constraints valid when issuing non-CA certificates
 
-* `not_before_duration` - (Optional) Specifies the duration by which to backdate the NotBefore property.
+* `not_before_duration` - (Optional) Specifies the [duration](https://developer.hashicorp.com/vault/docs/concepts/duration-format) by which to backdate the NotBefore property.
 
 * `allowed_serial_numbers` - (Optional) An array of allowed serial numbers to put in Subject
 


### PR DESCRIPTION
Update pki_secret_backend_role.html.md

### Description

Make it clear that not_before_duration is in [duration string format](https://developer.hashicorp.com/vault/docs/concepts/duration-format).

Note that the terraform types don't always map to vault types.  for example, in this doc file,
it says ttl and max_ttl should be integers while [the vault doc](https://developer.hashicorp.com/vault/api-docs/secret/pki#ttl-5) says they are strings.

I often need to check the source code to see what a type really should be.  I am trying to make it clearer here
for `not_before_duration`.


### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

