### PR TITLE
docs: set type in config for kv example

### DIFF
--- a/website/docs/r/mount.html.md
+++ b/website/docs/r/mount.html.md
@@ -22,7 +22,11 @@ resource "vault_mount" "example" {
 ```hcl
 resource "vault_mount" "kvv2-example" {
   path        = "version2-example"
-  type        = "kv-v2"
+  options = {
+    version = "2"
+    type    = "kv-v2"
+  }
+  type = "kv-v2"
   description = "This is an example KV Version 2 secret engine mount"
 }
 ```

--- a/website/docs/r/mount.html.md
+++ b/website/docs/r/mount.html.md
@@ -22,11 +22,11 @@ resource "vault_mount" "example" {
 ```hcl
 resource "vault_mount" "kvv2-example" {
   path        = "version2-example"
+  type        = "kv-v2"
   options = {
     version = "2"
     type    = "kv-v2"
   }
-  type = "kv-v2"
   description = "This is an example KV Version 2 secret engine mount"
 }
 ```


### PR DESCRIPTION
### Description
This change updates the kvv2 example for vault_mount to include the type in the config. This is required to prevent future imports of the resource to fail. In the long term we need to address the root cause of the import bug for kv.


