### PR TITLE
Add x509 support to static database roles

### DIFF
--- a/.test-env
+++ b/.test-env
@@ -1,6 +1,6 @@
 export VAULT_ADDR="http://localhost:8200"
 export VAULT_TOKEN="TEST"
-export MYSQL_URL="vault:vault@tcp(mysql:3306)/"
+export MYSQL_URL="root:mysql@tcp(mysql:3306)/"
 export ELASTIC_URL="http://elastic:9200"
 export ELASTIC_USERNAME="elastic"
 export ELASTIC_PASSWORD="elastic"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,3 +26,73 @@ services:
       MYSQL_DATABASE: "main"
       MYSQL_USER: "vault"
       MYSQL_PASSWORD: "vault"
+
+  elastic:
+    image: elasticsearch:7.17.10
+    ports:
+      - "9200:9200"
+    environment:
+      "discovery.type": "single-node"
+      "xpack.security.enabled": "true"
+      "ELASTIC_PASSWORD": "elastic"
+
+  influxdb:
+    image: influxdb:1.8.10
+    ports:
+      - "8086:8086"
+    environment:
+      "DOCKER_INFLUXDB_INIT_MODE": "setup"
+      "DOCKER_INFLUXDB_INIT_USERNAME": "admin"
+      "DOCKER_INFLUXDB_INIT_PASSWORD": "password"
+      "DOCKER_INFLUXDB_INIT_ORG": "test"
+      "DOCKER_INFLUXDB_INIT_BUCKET": "test"
+
+  openldap:
+    image: docker.io/bitnami/openldap:2.6
+    ports:
+      - '1389:1389'
+      - '1636:1636'
+    environment:
+      - LDAP_ADMIN_USERNAME=admin
+      - LDAP_ADMIN_PASSWORD=adminpassword
+      - LDAP_USERS=alice,bob,foo
+      - LDAP_PASSWORDS=password1,password2,password3
+
+  # this container will take at least 20 seconds for the ad service to be
+  # available so manual test runs should take this into account
+  ad:
+    image: laslabs/alpine-samba-dc:0.1.0
+    cap_add:
+      - "SYS_ADMIN"
+    ports:
+      - '2389:389'
+      - '2636:636'
+    environment:
+      - SAMBA_DC_REALM=corp.example.net
+      - SAMBA_DC_DOMAIN=EXAMPLE
+      - SAMBA_DC_ADMIN_PASSWD=SuperSecretPassw0rd
+      - SAMBA_DC_DNS_BACKEND=SAMBA_INTERNAL
+
+  redis:
+    image: redis:7.0.11
+    ports:
+      - '6379:6379'
+    command: >
+      --requirepass password
+
+  couchbase:
+    image: couchbase:7.2.0
+    ports:
+      - '8091-8097:8091-8097'
+      - '9123:9123'
+      - '11207:11207'
+      - '11210:11210'
+      - '11280:11280'
+      - '18097:18097'
+
+  cassandra:
+    image: cassandra:4.0
+    ports:
+      - "9042:9042"
+    volumes:
+      - ./testdata/cassandra.yaml:/etc/cassandra/cassandra.yaml

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
   elastic:
     image: elasticsearch:7.17.10
     ports:
-      - "9200:9200"
+    - "9200:9200"
     environment:
       "discovery.type": "single-node"
       "xpack.security.enabled": "true"
@@ -39,7 +39,7 @@ services:
   influxdb:
     image: influxdb:1.8.10
     ports:
-      - "8086:8086"
+    - "8086:8086"
     environment:
       "DOCKER_INFLUXDB_INIT_MODE": "setup"
       "DOCKER_INFLUXDB_INIT_USERNAME": "admin"
@@ -63,7 +63,7 @@ services:
   ad:
     image: laslabs/alpine-samba-dc:0.1.0
     cap_add:
-      - "SYS_ADMIN"
+    - "SYS_ADMIN"
     ports:
       - '2389:389'
       - '2636:636'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,7 @@ version: "2.2"
 
 services:
   vault:
-    image: vault:latest
+    image: hashicorp/vault:latest
     cap_add:
     - "IPC_LOCK"
     ports:
@@ -22,77 +22,7 @@ services:
     ports:
     - "3306:3306"
     environment:
-      MYSQL_ROOT_PASSWORD: "root"
+      MYSQL_ROOT_PASSWORD: "mysql"
       MYSQL_DATABASE: "main"
       MYSQL_USER: "vault"
       MYSQL_PASSWORD: "vault"
-
-  elastic:
-    image: elasticsearch:7.17.10
-    ports:
-    - "9200:9200"
-    environment:
-      "discovery.type": "single-node"
-      "xpack.security.enabled": "true"
-      "ELASTIC_PASSWORD": "elastic"
-
-  influxdb:
-    image: influxdb:1.8.10
-    ports:
-    - "8086:8086"
-    environment:
-      "DOCKER_INFLUXDB_INIT_MODE": "setup"
-      "DOCKER_INFLUXDB_INIT_USERNAME": "admin"
-      "DOCKER_INFLUXDB_INIT_PASSWORD": "password"
-      "DOCKER_INFLUXDB_INIT_ORG": "test"
-      "DOCKER_INFLUXDB_INIT_BUCKET": "test"
-
-  openldap:
-    image: docker.io/bitnami/openldap:2.6
-    ports:
-      - '1389:1389'
-      - '1636:1636'
-    environment:
-      - LDAP_ADMIN_USERNAME=admin
-      - LDAP_ADMIN_PASSWORD=adminpassword
-      - LDAP_USERS=alice,bob,foo
-      - LDAP_PASSWORDS=password1,password2,password3
-
-  # this container will take at least 20 seconds for the ad service to be
-  # available so manual test runs should take this into account
-  ad:
-    image: laslabs/alpine-samba-dc:0.1.0
-    cap_add:
-    - "SYS_ADMIN"
-    ports:
-      - '2389:389'
-      - '2636:636'
-    environment:
-      - SAMBA_DC_REALM=corp.example.net
-      - SAMBA_DC_DOMAIN=EXAMPLE
-      - SAMBA_DC_ADMIN_PASSWD=SuperSecretPassw0rd
-      - SAMBA_DC_DNS_BACKEND=SAMBA_INTERNAL
-
-  redis:
-    image: redis:7.0.11
-    ports:
-      - '6379:6379'
-    command: >
-      --requirepass password
-
-  couchbase:
-    image: couchbase:7.2.0
-    ports:
-      - '8091-8097:8091-8097'
-      - '9123:9123'
-      - '11207:11207'
-      - '11210:11210'
-      - '11280:11280'
-      - '18097:18097'
-
-  cassandra:
-    image: cassandra:4.0
-    ports:
-      - "9042:9042"
-    volumes:
-      - ./testdata/cassandra.yaml:/etc/cassandra/cassandra.yaml

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -352,6 +352,7 @@ const (
 	FieldCredentialType                = "credential_type"
 	FieldFilename                      = "filename"
 	FieldDefault                       = "default"
+	FieldRotationStatements            = "rotation_statements"
 	/*
 		common environment variables
 	*/

--- a/vault/resource_database_secret_backend_static_role_test.go
+++ b/vault/resource_database_secret_backend_static_role_test.go
@@ -327,7 +327,7 @@ resource "vault_database_secret_backend_connection" "test" {
 resource "vault_database_secret_backend_static_role" "test" {
   backend             = vault_mount.db.path
   name                = "%s"
-  username 			  = "%s"
+  username            = "%s"
   db_name             = vault_database_secret_backend_connection.test.name
   rotation_period     = 3600
   credential_type     = "client_certificate"

--- a/vault/resource_database_secret_backend_static_role_test.go
+++ b/vault/resource_database_secret_backend_static_role_test.go
@@ -19,6 +19,9 @@ import (
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
+// Prior running basic tests:
+// 1. docker-compose up -d vault mysql
+// 2. source .test-env
 func TestAccDatabaseSecretBackendStaticRole_import(t *testing.T) {
 	connURL := os.Getenv("MYSQL_URL")
 	if connURL == "" {
@@ -46,6 +49,7 @@ func TestAccDatabaseSecretBackendStaticRole_import(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_database_secret_backend_static_role.test", "username", username),
 					resource.TestCheckResourceAttr("vault_database_secret_backend_static_role.test", "db_name", dbName),
 					resource.TestCheckResourceAttr("vault_database_secret_backend_static_role.test", "rotation_period", "3600"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_static_role.test", "credential_type", "password"),
 				),
 			},
 			{
@@ -84,6 +88,7 @@ func TestAccDatabaseSecretBackendStaticRole_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_database_secret_backend_static_role.test", "username", username),
 					resource.TestCheckResourceAttr("vault_database_secret_backend_static_role.test", "db_name", dbName),
 					resource.TestCheckResourceAttr("vault_database_secret_backend_static_role.test", "rotation_period", "3600"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_static_role.test", "credential_type", "password"),
 				),
 			},
 			{
@@ -95,8 +100,95 @@ func TestAccDatabaseSecretBackendStaticRole_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_database_secret_backend_static_role.test", "db_name", dbName),
 					resource.TestCheckResourceAttr("vault_database_secret_backend_static_role.test", "rotation_period", "1800"),
 					resource.TestCheckResourceAttr("vault_database_secret_backend_static_role.test", "rotation_statements.0", "SELECT 1;"),
+					resource.TestCheckResourceAttr("vault_database_secret_backend_static_role.test", "credential_type", "password"),
 				),
 			},
+		},
+	})
+}
+
+// This test requires some prior setup using a configured
+// MongoDB Atlas account, making it a local-only test
+// Below are the environment variables required to run this test
+//  1. MONGODB_ATLAS_PRIVATE_KEY:
+//     The Private Programmatic API Key used to connect with MongoDB Atlas API.
+//  2. MONGODB_ATLAS_PUBLIC_KEY:
+//     The Public Programmatic API Key used to authenticate with the MongoDB Atlas API.
+//  3. MONGODB_ATLAS_PROJECT_ID:
+//     The Project ID the Database User should be created within.
+//  4. MONGODB_ATLAS_CA_CERT:
+//     Path to the PEM-encoded CA certificate.
+//  5. MONGODB_ATLAS_CA_KEY:
+//     Path to the PEM-encoded private key for the CA cert.
+//
+// The above variables can be obtained via the MongoDB Atlas Portal
+// by generating the API keys under your MongoDB Atlas Organization.
+// The CA certs you should generate by yourself with openssl. Then configure
+// MongoDB Atlas "Self-managed X.509 Authentication" in Security -> Advanced
+func TestAccDatabaseSecretBackendStaticRole_ClientCertificate(t *testing.T) {
+	privateKey, publicKey := testutil.GetTestMDBACreds(t)
+	projectID := testutil.SkipTestEnvUnset(t, "MONGODB_ATLAS_PROJECT_ID")[0]
+	backend := acctest.RandomWithPrefix("tf-test-db")
+	name := acctest.RandomWithPrefix("staticrole")
+	username := acctest.RandomWithPrefix("user")
+	dbName := acctest.RandomWithPrefix("db")
+	caCert := testutil.SkipTestEnvUnset(t, "MONGODB_ATLAS_CA_CERT")[0]
+	caKey := testutil.SkipTestEnvUnset(t, "MONGODB_ATLAS_CA_KEY")[0]
+
+	resourceName := "vault_database_secret_backend_static_role.test"
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testProviders,
+		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		CheckDestroy: testAccDatabaseSecretBackendStaticRoleCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseSecretBackendStaticRoleConfig_ClientCertificate(name, username, dbName, backend, privateKey, publicKey, projectID,
+					caCert,
+					caKey,
+					"rsa",
+					"2048",
+					"256",
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "db_name", dbName),
+					resource.TestCheckResourceAttr(resourceName, "rotation_period", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "credential_type", "client_certificate"),
+					resource.TestCheckResourceAttr(resourceName, "credential_config.key_type", "rsa"),
+					resource.TestCheckResourceAttr(resourceName, "credential_config.key_bits", "2048"),
+					resource.TestCheckResourceAttr(resourceName, "credential_config.signature_bits", "256"),
+					resource.TestCheckResourceAttrSet(resourceName, "credential_config.ca_cert"),
+					resource.TestCheckResourceAttrSet(resourceName, "credential_config.ca_private_key"),
+					resource.TestCheckResourceAttr(resourceName, "credential_config.common_name_template", "{{.DisplayName}}_{{.RoleName}}"),
+				),
+			},
+			{
+				Config: testAccDatabaseSecretBackendStaticRoleConfig_ClientCertificate(name, username, dbName, backend, privateKey, publicKey, projectID,
+					caCert,
+					caKey,
+					"ec",
+					"224",
+					"384",
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "db_name", dbName),
+					resource.TestCheckResourceAttr(resourceName, "rotation_period", "3600"),
+					resource.TestCheckResourceAttr(resourceName, "credential_type", "client_certificate"),
+					resource.TestCheckResourceAttr(resourceName, "credential_config.key_type", "ec"),
+					resource.TestCheckResourceAttr(resourceName, "credential_config.key_bits", "224"),
+					resource.TestCheckResourceAttr(resourceName, "credential_config.signature_bits", "384"),
+					resource.TestCheckResourceAttr(resourceName, "credential_config.common_name_template", "{{.DisplayName}}_{{.RoleName}}"),
+					resource.TestCheckResourceAttrSet(resourceName, "credential_config.ca_cert"),
+					resource.TestCheckResourceAttrSet(resourceName, "credential_config.ca_private_key"),
+				),
+			},
+			testutil.GetImportTestStep(resourceName, false, nil),
 		},
 	})
 }
@@ -209,4 +301,44 @@ resource "vault_database_secret_backend_static_role" "test" {
   rotation_statements = ["SELECT 1;"]
 }
 `, path, db, connURL, name, username)
+}
+
+func testAccDatabaseSecretBackendStaticRoleConfig_ClientCertificate(name, username, db, path, privateKey, publicKey, projectID string,
+	caCert, caKey, keyType, keyBits, signatureBits string,
+) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "db" {
+  path = "%s"
+  type = "database"
+}
+
+resource "vault_database_secret_backend_connection" "test" {
+  backend       = vault_mount.db.path
+  name          = "%s"
+  allowed_roles = ["*"]
+
+  mongodbatlas {
+    private_key = "%s"
+    public_key  = "%s"
+    project_id  = "%s"
+  }
+}
+
+resource "vault_database_secret_backend_static_role" "test" {
+  backend             = vault_mount.db.path
+  name                = "%s"
+  username 			  = "%s"
+  db_name             = vault_database_secret_backend_connection.test.name
+  rotation_period     = 3600
+  credential_type     = "client_certificate"
+  credential_config = {
+    ca_cert = file("%s")
+    ca_private_key = file("%s")
+	key_type = "%s"
+	key_bits = "%s"
+	signature_bits = "%s"
+	common_name_template = "{{.DisplayName}}_{{.RoleName}}"
+  }
+}
+`, path, db, privateKey, publicKey, projectID, name, username, caCert, caKey, keyType, keyBits, signatureBits)
 }

--- a/website/docs/r/database_secret_backend_static_role.md
+++ b/website/docs/r/database_secret_backend_static_role.md
@@ -61,6 +61,40 @@ The following arguments are supported:
 
 * `rotation_statements` - (Optional) Database statements to execute to rotate the password for the configured database user.
 
+* `credential_type` (Optional) – Specifies the type of credential that
+  will be generated for the role. Options include: `password`, `rsa_private_key`, `client_certificate`.
+  See the plugin's API page for credential types supported by individual databases.
+
+* `credential_config` (Optional) – Specifies the configuration
+  for the given `credential_type`.
+
+  The following options are available for each `credential_type` value:
+
+    * `password`
+        * `password_policy` (Optional) - The [policy](/vault/docs/concepts/password-policies)
+          used for password generation. If not provided, defaults to the password policy of the
+          database [configuration](/vault/api-docs/secret/databases#password_policy).
+
+    * `rsa_private_key`
+        * `key_bits` (Optional) - The bit size of the RSA key to generate. Options include:
+          `2048`, `3072`, `4096`.
+        * `format` (Optional) - The output format of the generated private key
+          credential. The private key will be returned from the API in PEM encoding. Options
+          include: `pkcs8`.
+
+    * `client_certificate`
+        * `common_name_template` (Optional) - A [username template](/vault/docs/concepts/username-templating)
+          to be used for the client certificate common name.
+        * `ca_cert` (Optional) - The PEM-encoded CA certificate.
+        * `ca_private_key` (Optional) - The PEM-encoded private key for the given `ca_cert`.
+        * `key_type` (Required) - Specifies the desired key type. Options include:
+          `rsa`, `ed25519`, `ec`.
+        * `key_bits` (Optional) - Number of bits to use for the generated keys. Options include:
+          `2048` (default), `3072`, `4096`; with `key_type=ec`, allowed values are: `224`, `256` (default),
+          `384`, `521`; ignored with `key_type=ed25519`.
+        * `signature_bits` (Optional) - The number of bits to use in the signature algorithm. Options include:
+          `256` (default), `384`, `512`.
+
 ## Attributes Reference
 
 No additional attributes are exported by this resource.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
This PR updates the `vault_database_secret_backend_static_role` resource by allowing to set the `credential_type` field in Vault for the static database roles. Therefore enabling x509 support for them.

The changes are similar to https://github.com/hashicorp/terraform-provider-vault/pull/1901 but for the static role.
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

