### PR TITLE
Add support for roles to both rate limit and lease count quotas

### DIFF
--- a/vault/resource_quota_lease_count.go
+++ b/vault/resource_quota_lease_count.go
@@ -49,7 +49,7 @@ func quotaLeaseCountResource() *schema.Resource {
 				Description:  "The maximum number of leases to be allowed by the quota rule. The max_leases must be positive.",
 				ValidateFunc: validation.IntAtLeast(0),
 			},
-			"role": {
+			consts.FieldRole: {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "If set on a quota where path is set to an auth mount with a concept of roles (such as /auth/approle/), this will make the quota restrict login requests to that mount that are made with the specified role.",

--- a/vault/resource_quota_lease_count.go
+++ b/vault/resource_quota_lease_count.go
@@ -49,6 +49,11 @@ func quotaLeaseCountResource() *schema.Resource {
 				Description:  "The maximum number of leases to be allowed by the quota rule. The max_leases must be positive.",
 				ValidateFunc: validation.IntAtLeast(0),
 			},
+			"role": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "If set on a quota where path is set to an auth mount with a concept of roles (such as /auth/approle/), this will make the quota restrict login requests to that mount that are made with the specified role.",
+			},
 		},
 	}
 }
@@ -68,6 +73,10 @@ func quotaLeaseCountCreate(d *schema.ResourceData, meta interface{}) error {
 	data := map[string]interface{}{}
 	data["path"] = d.Get("path").(string)
 	data["max_leases"] = d.Get("max_leases").(int)
+
+	if v, ok := d.GetOk("role"); ok {
+		data["role"] = v
+	}
 
 	_, err := client.Logical().Write(path, data)
 	if err != nil {
@@ -100,7 +109,7 @@ func quotaLeaseCountRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	for _, k := range []string{"path", "max_leases"} {
+	for _, k := range []string{"path", "role", "max_leases"} {
 		v, ok := resp.Data[k]
 		if ok {
 			if err := d.Set(k, v); err != nil {
@@ -126,6 +135,10 @@ func quotaLeaseCountUpdate(d *schema.ResourceData, meta interface{}) error {
 	data := map[string]interface{}{}
 	data["path"] = d.Get(consts.FieldPath).(string)
 	data["max_leases"] = d.Get("max_leases").(int)
+
+	if v, ok := d.GetOk("role"); ok {
+		data["role"] = v
+	}
 
 	_, err := client.Logical().Write(path, data)
 	if err != nil {

--- a/vault/resource_quota_lease_count.go
+++ b/vault/resource_quota_lease_count.go
@@ -74,8 +74,8 @@ func quotaLeaseCountCreate(d *schema.ResourceData, meta interface{}) error {
 	data["path"] = d.Get("path").(string)
 	data["max_leases"] = d.Get("max_leases").(int)
 
-	if v, ok := d.GetOk("role"); ok {
-		data["role"] = v
+	if v, ok := d.GetOk(consts.FieldRole); ok {
+		data[consts.FieldRole] = v
 	}
 
 	_, err := client.Logical().Write(path, data)
@@ -109,7 +109,7 @@ func quotaLeaseCountRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	for _, k := range []string{"path", "role", "max_leases"} {
+	for _, k := range []string{"path", "max_leases", consts.FieldRole} {
 		v, ok := resp.Data[k]
 		if ok {
 			if err := d.Set(k, v); err != nil {
@@ -136,8 +136,8 @@ func quotaLeaseCountUpdate(d *schema.ResourceData, meta interface{}) error {
 	data["path"] = d.Get(consts.FieldPath).(string)
 	data["max_leases"] = d.Get("max_leases").(int)
 
-	if v, ok := d.GetOk("role"); ok {
-		data["role"] = v
+	if v, ok := d.GetOk(consts.FieldRole); ok {
+		data[consts.FieldRole] = v
 	}
 
 	_, err := client.Logical().Write(path, data)

--- a/vault/resource_quota_lease_count.go
+++ b/vault/resource_quota_lease_count.go
@@ -74,8 +74,10 @@ func quotaLeaseCountCreate(d *schema.ResourceData, meta interface{}) error {
 	data["path"] = d.Get("path").(string)
 	data["max_leases"] = d.Get("max_leases").(int)
 
-	if v, ok := d.GetOk(consts.FieldRole); ok {
-		data[consts.FieldRole] = v
+	if provider.IsAPISupported(meta, provider.VaultVersion112) {
+		if v, ok := d.GetOk(consts.FieldRole); ok {
+			data[consts.FieldRole] = v
+		}
 	}
 
 	_, err := client.Logical().Write(path, data)
@@ -109,7 +111,12 @@ func quotaLeaseCountRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	for _, k := range []string{"path", "max_leases", consts.FieldRole} {
+	fields := []string{"path", "max_leases", "name"}
+	if provider.IsAPISupported(meta, provider.VaultVersion112) {
+		fields = append(fields, consts.FieldRole)
+	}
+
+	for _, k := range fields {
 		v, ok := resp.Data[k]
 		if ok {
 			if err := d.Set(k, v); err != nil {
@@ -136,8 +143,10 @@ func quotaLeaseCountUpdate(d *schema.ResourceData, meta interface{}) error {
 	data["path"] = d.Get(consts.FieldPath).(string)
 	data["max_leases"] = d.Get("max_leases").(int)
 
-	if v, ok := d.GetOk(consts.FieldRole); ok {
-		data[consts.FieldRole] = v
+	if provider.IsAPISupported(meta, provider.VaultVersion112) {
+		if v, ok := d.GetOk(consts.FieldRole); ok {
+			data[consts.FieldRole] = v
+		}
 	}
 
 	_, err := client.Logical().Write(path, data)

--- a/vault/resource_quota_lease_count_test.go
+++ b/vault/resource_quota_lease_count_test.go
@@ -90,7 +90,7 @@ func TestQuotaLeaseCountWithRole(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, consts.FieldRole, role),
 				),
 			},
-			testutil.GetImportTestStep(resourceName, false, nil, "name"),
+			testutil.GetImportTestStep(resourceName, false, nil, "name", consts.FieldRole),
 		},
 	})
 }

--- a/vault/resource_quota_lease_count_test.go
+++ b/vault/resource_quota_lease_count_test.go
@@ -56,6 +56,42 @@ func TestQuotaLeaseCount(t *testing.T) {
 	})
 }
 
+func TestQuotaLeaseCountWithRole(t *testing.T) {
+	name := acctest.RandomWithPrefix("lease-count")
+	backend := acctest.RandomWithPrefix("approle")
+	role := acctest.RandomWithPrefix("test-role")
+	leaseCount := "1001"
+	newLeaseCount := "2001"
+	resourceName := "vault_quota_lease_count.foobar"
+
+	resource.Test(t, resource.TestCase{
+		Providers: testProviders,
+		PreCheck:  func() { testutil.TestEntPreCheck(t) },
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testQuotaLeaseCountCheckDestroy([]string{leaseCount, newLeaseCount}),
+			testAccCheckAppRoleAuthBackendRoleDestroy,
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: testQuotaLeaseCountWithRoleConfig(backend, role, name, leaseCount),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, fmt.Sprintf("auth/%s/", backend)),
+					resource.TestCheckResourceAttr(resourceName, "max_leases", leaseCount),
+				),
+			},
+			{
+				Config: testQuotaLeaseCountWithRoleConfig(backend, role, name, newLeaseCount),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, fmt.Sprintf("auth/%s/", backend)),
+					resource.TestCheckResourceAttr(resourceName, "max_leases", newLeaseCount),
+				),
+			},
+		},
+	})
+}
+
 func testQuotaLeaseCountCheckDestroy(leaseCounts []string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testProvider.Meta().(*provider.ProviderMeta).GetClient()
@@ -88,4 +124,26 @@ resource "vault_quota_lease_count" "foobar" {
   max_leases = %s
 }
 `, ns, name, path, maxLeases)
+}
+
+func testQuotaLeaseCountWithRoleConfig(backend, role, name, maxLeases string) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "approle" {
+  type = "approle"
+  path = "%s"
+}
+
+resource "vault_approle_auth_backend_role" "role" {
+  backend = vault_auth_backend.approle.path
+  role_name = "%s"
+  token_policies = ["default", "dev", "prod"]
+}
+
+resource "vault_quota_lease_count" "foobar" {
+  name = "%s"
+  path = "auth/${vault_auth_backend.approle.path}/"
+  role = vault_approle_auth_backend_role.role.role_name
+  max_leases = %s
+}
+`, backend, role, name, maxLeases)
 }

--- a/vault/resource_quota_lease_count_test.go
+++ b/vault/resource_quota_lease_count_test.go
@@ -90,7 +90,7 @@ func TestQuotaLeaseCountWithRole(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, consts.FieldRole, role),
 				),
 			},
-			testutil.GetImportTestStep(resourceName, false, nil, "name", consts.FieldRole),
+			testutil.GetImportTestStep(resourceName, false, nil, "name"),
 		},
 	})
 }

--- a/vault/resource_quota_lease_count_test.go
+++ b/vault/resource_quota_lease_count_test.go
@@ -66,7 +66,10 @@ func TestQuotaLeaseCountWithRole(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
-		PreCheck:  func() { testutil.TestEntPreCheck(t) },
+		PreCheck: func() {
+			testutil.TestEntPreCheck(t)
+			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion112)
+		},
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			testQuotaLeaseCountCheckDestroy([]string{leaseCount, newLeaseCount}),
 			testAccCheckAppRoleAuthBackendRoleDestroy,
@@ -90,7 +93,7 @@ func TestQuotaLeaseCountWithRole(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, consts.FieldRole, role),
 				),
 			},
-			testutil.GetImportTestStep(resourceName, false, nil, "name"),
+			testutil.GetImportTestStep(resourceName, false, nil),
 		},
 	})
 }

--- a/vault/resource_quota_lease_count_test.go
+++ b/vault/resource_quota_lease_count_test.go
@@ -78,6 +78,7 @@ func TestQuotaLeaseCountWithRole(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, fmt.Sprintf("auth/%s/", backend)),
 					resource.TestCheckResourceAttr(resourceName, "max_leases", leaseCount),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldRole, role),
 				),
 			},
 			{
@@ -86,6 +87,7 @@ func TestQuotaLeaseCountWithRole(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, fmt.Sprintf("auth/%s/", backend)),
 					resource.TestCheckResourceAttr(resourceName, "max_leases", newLeaseCount),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldRole, role),
 				),
 			},
 		},

--- a/vault/resource_quota_lease_count_test.go
+++ b/vault/resource_quota_lease_count_test.go
@@ -90,6 +90,7 @@ func TestQuotaLeaseCountWithRole(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, consts.FieldRole, role),
 				),
 			},
+			testutil.GetImportTestStep(resourceName, false, nil, "name"),
 		},
 	})
 }

--- a/vault/resource_quota_rate_limit.go
+++ b/vault/resource_quota_rate_limit.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
@@ -60,7 +61,7 @@ func quotaRateLimitResource() *schema.Resource {
 				Description:  "If set, when a client reaches a rate limit threshold, the client will be prohibited from any further requests until after the 'block_interval' in seconds has elapsed.",
 				ValidateFunc: validation.IntAtLeast(0),
 			},
-			"role": {
+			consts.FieldRole: {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "If set on a quota where path is set to an auth mount with a concept of roles (such as /auth/approle/), this will make the quota restrict login requests to that mount that are made with the specified role.",

--- a/vault/resource_quota_rate_limit.go
+++ b/vault/resource_quota_rate_limit.go
@@ -60,6 +60,11 @@ func quotaRateLimitResource() *schema.Resource {
 				Description:  "If set, when a client reaches a rate limit threshold, the client will be prohibited from any further requests until after the 'block_interval' in seconds has elapsed.",
 				ValidateFunc: validation.IntAtLeast(0),
 			},
+			"role": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "If set on a quota where path is set to an auth mount with a concept of roles (such as /auth/approle/), this will make the quota restrict login requests to that mount that are made with the specified role.",
+			},
 		},
 	}
 }
@@ -86,6 +91,10 @@ func quotaRateLimitCreate(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("block_interval"); ok {
 		data["block_interval"] = v
+	}
+
+	if v, ok := d.GetOk("role"); ok {
+		data["role"] = v
 	}
 
 	_, err := client.Logical().Write(path, data)
@@ -119,7 +128,7 @@ func quotaRateLimitRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	for _, k := range []string{"path", "rate", "interval", "block_interval"} {
+	for _, k := range []string{"path", "rate", "role", "interval", "block_interval"} {
 		v, ok := resp.Data[k]
 		if ok {
 			if err := d.Set(k, v); err != nil {
@@ -152,6 +161,10 @@ func quotaRateLimitUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("block_interval"); ok {
 		data["block_interval"] = v
+	}
+
+	if v, ok := d.GetOk("role"); ok {
+		data["role"] = v
 	}
 
 	_, err := client.Logical().Write(path, data)

--- a/vault/resource_quota_rate_limit.go
+++ b/vault/resource_quota_rate_limit.go
@@ -94,8 +94,8 @@ func quotaRateLimitCreate(d *schema.ResourceData, meta interface{}) error {
 		data["block_interval"] = v
 	}
 
-	if v, ok := d.GetOk("role"); ok {
-		data["role"] = v
+	if v, ok := d.GetOk(consts.FieldRole); ok {
+		data[consts.FieldRole] = v
 	}
 
 	_, err := client.Logical().Write(path, data)
@@ -129,7 +129,7 @@ func quotaRateLimitRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	for _, k := range []string{"path", "rate", "role", "interval", "block_interval"} {
+	for _, k := range []string{"path", "rate", "interval", "block_interval", consts.FieldRole} {
 		v, ok := resp.Data[k]
 		if ok {
 			if err := d.Set(k, v); err != nil {
@@ -164,8 +164,8 @@ func quotaRateLimitUpdate(d *schema.ResourceData, meta interface{}) error {
 		data["block_interval"] = v
 	}
 
-	if v, ok := d.GetOk("role"); ok {
-		data["role"] = v
+	if v, ok := d.GetOk(consts.FieldRole); ok {
+		data[consts.FieldRole] = v
 	}
 
 	_, err := client.Logical().Write(path, data)

--- a/vault/resource_quota_rate_limit.go
+++ b/vault/resource_quota_rate_limit.go
@@ -94,8 +94,10 @@ func quotaRateLimitCreate(d *schema.ResourceData, meta interface{}) error {
 		data["block_interval"] = v
 	}
 
-	if v, ok := d.GetOk(consts.FieldRole); ok {
-		data[consts.FieldRole] = v
+	if provider.IsAPISupported(meta, provider.VaultVersion112) {
+		if v, ok := d.GetOk(consts.FieldRole); ok {
+			data[consts.FieldRole] = v
+		}
 	}
 
 	_, err := client.Logical().Write(path, data)
@@ -129,7 +131,12 @@ func quotaRateLimitRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	for _, k := range []string{"path", "rate", "interval", "block_interval", consts.FieldRole} {
+	fields := []string{"path", "rate", "interval", "block_interval", "name"}
+	if provider.IsAPISupported(meta, provider.VaultVersion112) {
+		fields = append(fields, consts.FieldRole)
+	}
+
+	for _, k := range fields {
 		v, ok := resp.Data[k]
 		if ok {
 			if err := d.Set(k, v); err != nil {
@@ -164,8 +171,10 @@ func quotaRateLimitUpdate(d *schema.ResourceData, meta interface{}) error {
 		data["block_interval"] = v
 	}
 
-	if v, ok := d.GetOk(consts.FieldRole); ok {
-		data[consts.FieldRole] = v
+	if provider.IsAPISupported(meta, provider.VaultVersion112) {
+		if v, ok := d.GetOk(consts.FieldRole); ok {
+			data[consts.FieldRole] = v
+		}
 	}
 
 	_, err := client.Logical().Write(path, data)

--- a/vault/resource_quota_rate_limit_test.go
+++ b/vault/resource_quota_rate_limit_test.go
@@ -77,7 +77,10 @@ func TestQuotaRateLimitWithRole(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
-		PreCheck:  func() { testutil.TestAccPreCheck(t) },
+		PreCheck: func() {
+			testutil.TestAccPreCheck(t)
+			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion112)
+		},
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			testQuotaRateLimitCheckDestroy([]string{rateLimit}),
 			testAccCheckAppRoleAuthBackendRoleDestroy,
@@ -94,7 +97,7 @@ func TestQuotaRateLimitWithRole(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, consts.FieldRole, role),
 				),
 			},
-			testutil.GetImportTestStep(resourceName, false, nil, "name"),
+			testutil.GetImportTestStep(resourceName, false, nil),
 		},
 	})
 }

--- a/vault/resource_quota_rate_limit_test.go
+++ b/vault/resource_quota_rate_limit_test.go
@@ -91,7 +91,7 @@ func TestQuotaRateLimitWithRole(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "rate", rateLimit),
 					resource.TestCheckResourceAttr(resourceName, "interval", "1"),
 					resource.TestCheckResourceAttr(resourceName, "block_interval", "0"),
-					resource.TestCheckResourceAttr(resourceName, "role", role),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldRole, role),
 				),
 			},
 		},

--- a/vault/resource_quota_rate_limit_test.go
+++ b/vault/resource_quota_rate_limit_test.go
@@ -94,6 +94,7 @@ func TestQuotaRateLimitWithRole(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, consts.FieldRole, role),
 				),
 			},
+			testutil.GetImportTestStep(resourceName, false, nil, "name"),
 		},
 	})
 }

--- a/vault/resource_quota_rate_limit_test.go
+++ b/vault/resource_quota_rate_limit_test.go
@@ -94,7 +94,7 @@ func TestQuotaRateLimitWithRole(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, consts.FieldRole, role),
 				),
 			},
-			testutil.GetImportTestStep(resourceName, false, nil, "name", consts.FieldRole),
+			testutil.GetImportTestStep(resourceName, false, nil, "name"),
 		},
 	})
 }

--- a/vault/resource_quota_rate_limit_test.go
+++ b/vault/resource_quota_rate_limit_test.go
@@ -94,7 +94,7 @@ func TestQuotaRateLimitWithRole(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, consts.FieldRole, role),
 				),
 			},
-			testutil.GetImportTestStep(resourceName, false, nil, "name"),
+			testutil.GetImportTestStep(resourceName, false, nil, "name", consts.FieldRole),
 		},
 	})
 }

--- a/website/docs/r/quota_lease_count.md
+++ b/website/docs/r/quota_lease_count.md
@@ -48,6 +48,8 @@ The following arguments are supported:
 * `max_leases` - (Required) The maximum number of leases to be allowed by the quota
   rule. The `max_leases` must be positive.
 
+* `role` - (Optional) If set on a quota where `path` is set to an auth mount with a concept of roles (such as /auth/approle/), this will make the quota restrict login requests to that mount that are made with the specified role.
+
 ## Attributes Reference
 
 No additional attributes are exported by this resource.

--- a/website/docs/r/quota_rate_limit.md
+++ b/website/docs/r/quota_rate_limit.md
@@ -51,6 +51,8 @@ The following arguments are supported:
 * `block_interval` - (Optional) If set, when a client reaches a rate limit threshold, the client will
   be prohibited from any further requests until after the 'block_interval' in seconds has elapsed.
 
+* `role` - (Optional) If set on a quota where `path` is set to an auth mount with a concept of roles (such as /auth/approle/), this will make the quota restrict login requests to that mount that are made with the specified role.
+
 ## Attributes Reference
 
 No additional attributes are exported by this resource.


### PR DESCRIPTION
This adds support for the `role` attribute for both [rate limit](https://developer.hashicorp.com/vault/api-docs/system/rate-limit-quotas#role) and [lease count](https://developer.hashicorp.com/vault/api-docs/system/lease-count-quotas#role) quotas.

Closes #1782 

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
```release-note
Add support for the `role` attribute for both rate limit and lease count quotas
```

### Output from acceptance testing:

```
~/s/h/terraform-provider-vault ❯❯❯ (vault-14105) env TF_ACC=1 VAULT_TOKEN=root VAULT_ADDR=http://127.0.0.1:8200 go test -v -count=1 -run="^TestQuotaRateLimitWithRole\$" ./vault
2023/08/29 16:08:26 [INFO] Using Vault token with the following policies: root
=== RUN   TestQuotaRateLimitWithRole
--- PASS: TestQuotaRateLimitWithRole (0.80s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     1.336s
~/s/h/terraform-provider-vault ❯❯❯ (vault-14105) env TF_ACC=1 TF_ACC_ENTERPRISE=1 VAULT_TOKEN=root VAULT_ADDR=http://127.0.0.1:8200 go test -v -count=1 -run="^TestQuotaLeaseCountWithRole\$" ./vault
2023/08/29 16:08:38 [INFO] Using Vault token with the following policies: root
=== RUN   TestQuotaLeaseCountWithRole
--- PASS: TestQuotaLeaseCountWithRole (1.21s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     1.617s
~/s/h/terraform-provider-vault ❯❯❯ (vault-14105)

```


