### PR TITLE
Add tune block support to gcp auth backend and relocate auth mount test functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 BUGS:
 * fix `vault_kv_secret_v2` drift when "data" is in secret name/path ([#2104](https://github.com/hashicorp/terraform-provider-vault/pull/2104))
+FEATURES:
+* Adds support to `vault_gcp_auth_backend` for common backend tune parameters ([#1997](https://github.com/terraform-providers/terraform-provider-vault/pull/1997)).
 
 ## 3.23.0 (Nov 15, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 BUGS:
 * fix `vault_kv_secret_v2` drift when "data" is in secret name/path ([#2104](https://github.com/hashicorp/terraform-provider-vault/pull/2104))
+
 FEATURES:
 * Adds support to `vault_gcp_auth_backend` for common backend tune parameters ([#1997](https://github.com/terraform-providers/terraform-provider-vault/pull/1997)).
 

--- a/vault/resource_auth_backend_test.go
+++ b/vault/resource_auth_backend_test.go
@@ -283,9 +283,6 @@ func checkAuthMount(backend string, checker func(*api.AuthMount) error) resource
 		for serverPath, serverAuth := range auths {
 			if serverPath == backend+"/" {
 				found = true
-				if serverAuth.Type != "github" {
-					return fmt.Errorf("unexpected auth type")
-				}
 
 				if err := checker(serverAuth); err != nil {
 					return err

--- a/vault/resource_auth_backend_test.go
+++ b/vault/resource_auth_backend_test.go
@@ -214,7 +214,9 @@ func TestResourceAuthTune(t *testing.T) {
 			{
 				Config: testResourceAuthTune_initialConfig(backend),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAuthMountExists(resName, &resAuthFirst),
+					testutil.TestAccCheckAuthMountExists(resName,
+						&resAuthFirst,
+						testProvider.Meta().(*provider.ProviderMeta).GetClient()),
 					resource.TestCheckResourceAttr(resName, "path", backend),
 					resource.TestCheckResourceAttr(resName, "id", backend),
 					resource.TestCheckResourceAttr(resName, "type", "github"),
@@ -283,6 +285,9 @@ func checkAuthMount(backend string, checker func(*api.AuthMount) error) resource
 		for serverPath, serverAuth := range auths {
 			if serverPath == backend+"/" {
 				found = true
+				if serverAuth.Type != "github" && serverAuth.Type != "gcp" {
+					return fmt.Errorf("unexpected auth type")
+				}
 
 				if err := checker(serverAuth); err != nil {
 					return err

--- a/vault/resource_auth_backend_test.go
+++ b/vault/resource_auth_backend_test.go
@@ -216,7 +216,7 @@ func TestResourceAuthTune(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testutil.TestAccCheckAuthMountExists(resName,
 						&resAuthFirst,
-						testProvider.Meta().(*provider.ProviderMeta).GetClient()),
+						testProvider.Meta().(*provider.ProviderMeta).MustGetClient()),
 					resource.TestCheckResourceAttr(resName, "path", backend),
 					resource.TestCheckResourceAttr(resName, "id", backend),
 					resource.TestCheckResourceAttr(resName, "type", "github"),

--- a/vault/resource_gcp_auth_backend.go
+++ b/vault/resource_gcp_auth_backend.go
@@ -267,6 +267,7 @@ func gcpAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	gcpPath := d.Id()
+	gcpAuthPath := "auth/" + gcpPath
 	path := gcpAuthBackendConfigPath(gcpPath)
 
 	log.Printf("[DEBUG] Reading gcp auth backend config %q", path)
@@ -315,8 +316,8 @@ func gcpAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 		d.SetId("")
 		return nil
 	}
-	log.Printf("[DEBUG] Reading %q auth tune from '%q/tune'", gcpPath, gcpPath)
-	rawTune, err := authMountTuneGet(client, "auth/"+gcpPath)
+	log.Printf("[DEBUG] Reading %s auth tune from '%q/tune'", gcpAuthType, gcpAuthPath)
+	rawTune, err := authMountTuneGet(client, gcpAuthPath)
 	if err != nil {
 		return fmt.Errorf("error reading tune information from Vault: %w", err)
 	}

--- a/vault/resource_gcp_auth_backend.go
+++ b/vault/resource_gcp_auth_backend.go
@@ -228,9 +228,9 @@ func gcpAuthBackendUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("tune") {
-		log.Printf("[INFO] %s Auth '%q' tune configuration changed", gcpAuthType, gcpAuthPath)
+		log.Printf("[INFO] %s Auth %q tune configuration changed", gcpAuthType, gcpAuthPath)
 		if raw, ok := d.GetOk("tune"); ok {
-			log.Printf("[DEBUG] Writing %s auth tune to '%q'", gcpAuthType, gcpAuthPath)
+			log.Printf("[DEBUG] Writing %s auth tune to %q", gcpAuthType, gcpAuthPath)
 			err := authMountTune(client, gcpAuthPath, raw)
 			if err != nil {
 				return nil
@@ -243,12 +243,12 @@ func gcpAuthBackendUpdate(d *schema.ResourceData, meta interface{}) error {
 		tune := api.MountConfigInput{Description: &description}
 		err := client.Sys().TuneMount(gcpAuthPath, tune)
 		if err != nil {
-			log.Printf("[ERROR] Error updating %s auth description to '%q'", gcpAuthType, gcpAuthPath)
+			log.Printf("[ERROR] Error updating %s auth description at %q", gcpAuthType, gcpAuthPath)
 			return err
 		}
 	}
 
-	log.Printf("[DEBUG] Writing %s config %q", gcpAuthType, path)
+	log.Printf("[DEBUG] Writing %s config at path %q", gcpAuthType, path)
 	_, err := client.Logical().Write(path, data)
 	if err != nil {
 		d.SetId("")
@@ -316,7 +316,7 @@ func gcpAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 		d.SetId("")
 		return nil
 	}
-	log.Printf("[DEBUG] Reading %s auth tune from '%q/tune'", gcpAuthType, gcpAuthPath)
+	log.Printf("[DEBUG] Reading %s auth tune from '%s/tune'", gcpAuthType, gcpAuthPath)
 	rawTune, err := authMountTuneGet(client, gcpAuthPath)
 	if err != nil {
 		return fmt.Errorf("error reading tune information from Vault: %w", err)
@@ -328,6 +328,9 @@ func gcpAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if err := d.Set("accessor", mount.Accessor); err != nil {
+		return err
+	}
+	if err := d.Set("description", mount.Description); err != nil {
 		return err
 	}
 	// set the auth backend's path

--- a/vault/resource_gcp_auth_backend_test.go
+++ b/vault/resource_gcp_auth_backend_test.go
@@ -48,7 +48,9 @@ func TestGCPAuthBackend_basic(t *testing.T) {
 			{
 				Config: testGCPAuthBackendConfig_update(path, gcpJSONCredentials),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAuthMountExists("vault_gcp_auth_backend.test", &resAuthFirst),
+					testutil.TestAccCheckAuthMountExists("vault_gcp_auth_backend.test",
+						&resAuthFirst,
+						testProvider.Meta().(*provider.ProviderMeta).GetClient()),
 					testGCPAuthBackendCheck_attrs(),
 					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
 						"custom_endpoint.#", "1"),
@@ -83,7 +85,9 @@ func TestGCPAuthBackend_basic(t *testing.T) {
 			{
 				Config: testGCPAuthBackendConfig_update_partial(path, gcpJSONCredentials),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAuthMountExists("vault_gcp_auth_backend.test", &resAuthFirst),
+					testutil.TestAccCheckAuthMountExists("vault_gcp_auth_backend.test",
+						&resAuthFirst,
+						testProvider.Meta().(*provider.ProviderMeta).GetClient()),
 					testGCPAuthBackendCheck_attrs(),
 					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
 						"custom_endpoint.#", "1"),

--- a/vault/resource_gcp_auth_backend_test.go
+++ b/vault/resource_gcp_auth_backend_test.go
@@ -62,13 +62,22 @@ func TestGCPAuthBackend_basic(t *testing.T) {
 						"custom_endpoint.0.crm", "cloudresourcemanager.googleapis.com"),
 					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
 						"custom_endpoint.0.compute", "compute.googleapis.com"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.default_lease_ttl", "60s"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.max_lease_ttl", "3600s"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.listing_visibility", "unauth"),
-					resource.TestCheckResourceAttrPtr("vault_gcp_auth_backend.test", "accessor", &resAuthFirst.Accessor),
-					checkAuthMount("gcp", listingVisibility("unauth")),
-					checkAuthMount("gcp", defaultLeaseTtl(60)),
-					checkAuthMount("gcp", maxLeaseTtl(3600)),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.default_lease_ttl", "10m"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.max_lease_ttl", "20m"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.listing_visibility", "hidden"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.audit_non_hmac_request_keys.#", "2"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.audit_non_hmac_request_keys.0", "key1"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.audit_non_hmac_request_keys.1", "key2"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.audit_non_hmac_response_keys.#", "2"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.audit_non_hmac_response_keys.0", "key3"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.audit_non_hmac_response_keys.1", "key4"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.passthrough_request_headers.#", "2"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.passthrough_request_headers.0", "X-Custom-Header"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.passthrough_request_headers.1", "X-Forwarded-To"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.allowed_response_headers.#", "2"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.allowed_response_headers.0", "X-Custom-Response-Header"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.allowed_response_headers.1", "X-Forwarded-Response-To"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.token_type", "batch"),
 				),
 			},
 			{
@@ -88,13 +97,21 @@ func TestGCPAuthBackend_basic(t *testing.T) {
 						"custom_endpoint.0.crm", "example.com:9200"),
 					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
 						"custom_endpoint.0.compute", "compute.example.com"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.default_lease_ttl", "60s"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.max_lease_ttl", "7200s"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.listing_visibility", ""),
-					resource.TestCheckResourceAttrPtr("vault_gcp_auth_backend.test", "accessor", &resAuthFirst.Accessor),
-					checkAuthMount("gcp", listingVisibility("unauth")),
-					checkAuthMount("gcp", defaultLeaseTtl(60)),
-					checkAuthMount("gcp", maxLeaseTtl(7200)),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.default_lease_ttl", "50m"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.max_lease_ttl", "1h10m"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.listing_visibility", "unauth"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.audit_non_hmac_request_keys.#", "1"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.audit_non_hmac_request_keys.0", "key1"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.audit_non_hmac_response_keys.#", "0"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.passthrough_request_headers.#", "3"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.passthrough_request_headers.0", "X-Custom-Header"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.passthrough_request_headers.1", "X-Forwarded-To"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.passthrough_request_headers.2", "X-Mas"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.allowed_response_headers.#", "3"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.allowed_response_headers.0", "X-Custom-Response-Header"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.allowed_response_headers.1", "X-Forwarded-Response-To"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.allowed_response_headers.2", "X-Mas-Response"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.token_type", "default-batch"),
 				),
 			},
 			{
@@ -103,6 +120,7 @@ func TestGCPAuthBackend_basic(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"credentials",
+					"disable_remount",
 				},
 			},
 			{
@@ -119,6 +137,7 @@ func TestGCPAuthBackend_basic(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"credentials",
+					"disable_remount",
 				},
 			},
 		},
@@ -248,9 +267,14 @@ resource "vault_gcp_auth_backend" "test" {
     compute = "compute.googleapis.com"
   }
   tune {
-    listing_visibility = "unauth"
-    max_lease_ttl      = "3600s"
-    default_lease_ttl  = "60s"
+	default_lease_ttl = "10m"
+	max_lease_ttl = "20m"
+	listing_visibility = "hidden"
+	audit_non_hmac_request_keys = ["key1", "key2"]
+	audit_non_hmac_response_keys = ["key3", "key4"]
+	passthrough_request_headers = ["X-Custom-Header", "X-Forwarded-To"]
+	allowed_response_headers = ["X-Custom-Response-Header", "X-Forwarded-Response-To"]
+	token_type = "batch"
   }
 }
 `, credentials, path)
@@ -271,8 +295,13 @@ resource "vault_gcp_auth_backend" "test" {
     compute = "compute.example.com"
   }
   tune {
-    max_lease_ttl      = "7200s"
-    default_lease_ttl  = "60s"
+    default_lease_ttl = "50m"
+    max_lease_ttl = "1h10m"
+    audit_non_hmac_request_keys = ["key1"]
+    listing_visibility = "unauth"
+    passthrough_request_headers = ["X-Custom-Header", "X-Forwarded-To", "X-Mas"]
+    allowed_response_headers = ["X-Custom-Response-Header", "X-Forwarded-Response-To", "X-Mas-Response"]
+    token_type = "default-batch"
   }
 }
 `, credentials, path)

--- a/vault/resource_gcp_auth_backend_test.go
+++ b/vault/resource_gcp_auth_backend_test.go
@@ -62,7 +62,13 @@ func TestGCPAuthBackend_basic(t *testing.T) {
 						"custom_endpoint.0.crm", "cloudresourcemanager.googleapis.com"),
 					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
 						"custom_endpoint.0.compute", "compute.googleapis.com"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.default_lease_ttl", "60s"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.max_lease_ttl", "3600s"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.listing_visibility", "unauth"),
 					resource.TestCheckResourceAttrPtr("vault_gcp_auth_backend.test", "accessor", &resAuthFirst.Accessor),
+					checkAuthMount("gcp", listingVisibility("unauth")),
+					checkAuthMount("gcp", defaultLeaseTtl(60)),
+					checkAuthMount("gcp", maxLeaseTtl(3600)),
 				),
 			},
 			{
@@ -82,7 +88,13 @@ func TestGCPAuthBackend_basic(t *testing.T) {
 						"custom_endpoint.0.crm", "example.com:9200"),
 					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
 						"custom_endpoint.0.compute", "compute.example.com"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.default_lease_ttl", "60s"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.max_lease_ttl", "7200s"),
+					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.listing_visibility", ""),
 					resource.TestCheckResourceAttrPtr("vault_gcp_auth_backend.test", "accessor", &resAuthFirst.Accessor),
+					checkAuthMount("gcp", listingVisibility("unauth")),
+					checkAuthMount("gcp", defaultLeaseTtl(60)),
+					checkAuthMount("gcp", maxLeaseTtl(7200)),
 				),
 			},
 			{
@@ -235,6 +247,11 @@ resource "vault_gcp_auth_backend" "test" {
     crm     = "cloudresourcemanager.googleapis.com"
     compute = "compute.googleapis.com"
   }
+  tune {
+    listing_visibility = "unauth"
+    max_lease_ttl      = "3600s"
+    default_lease_ttl  = "60s"
+  }
 }
 `, credentials, path)
 }
@@ -252,6 +269,10 @@ resource "vault_gcp_auth_backend" "test" {
   custom_endpoint {
     crm     = "example.com:9200"
     compute = "compute.example.com"
+  }
+  tune {
+    max_lease_ttl      = "7200s"
+    default_lease_ttl  = "60s"
   }
 }
 `, credentials, path)

--- a/vault/resource_gcp_auth_backend_test.go
+++ b/vault/resource_gcp_auth_backend_test.go
@@ -36,6 +36,9 @@ func TestGCPAuthBackend_basic(t *testing.T) {
 
 	var resAuthFirst api.AuthMount
 	path := resource.PrefixedUniqueId("gcp-basic-")
+	resourceType := "vault_gcp_auth_backend"
+	resourceName := resourceType + ".test"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testutil.TestAccPreCheck(t) },
 		ProviderFactories: providerFactories,
@@ -43,83 +46,83 @@ func TestGCPAuthBackend_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testGCPAuthBackendConfig_basic(path, gcpJSONCredentials),
-				Check:  testGCPAuthBackendCheck_attrs(),
+				Check:  testGCPAuthBackendCheck_attrs(resourceName),
 			},
 			{
 				Config: testGCPAuthBackendConfig_update(path, gcpJSONCredentials),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testutil.TestAccCheckAuthMountExists("vault_gcp_auth_backend.test",
+					testutil.TestAccCheckAuthMountExists(resourceName,
 						&resAuthFirst,
 						testProvider.Meta().(*provider.ProviderMeta).GetClient()),
-					testGCPAuthBackendCheck_attrs(),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
+					testGCPAuthBackendCheck_attrs(resourceName),
+					resource.TestCheckResourceAttr(resourceName,
 						"custom_endpoint.#", "1"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
+					resource.TestCheckResourceAttr(resourceName,
 						"custom_endpoint.0.%", "4"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
+					resource.TestCheckResourceAttr(resourceName,
 						"custom_endpoint.0.api", "www.googleapis.com"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
+					resource.TestCheckResourceAttr(resourceName,
 						"custom_endpoint.0.iam", "iam.googleapis.com"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
+					resource.TestCheckResourceAttr(resourceName,
 						"custom_endpoint.0.crm", "cloudresourcemanager.googleapis.com"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
+					resource.TestCheckResourceAttr(resourceName,
 						"custom_endpoint.0.compute", "compute.googleapis.com"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.default_lease_ttl", "10m"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.max_lease_ttl", "20m"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.listing_visibility", "hidden"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.audit_non_hmac_request_keys.#", "2"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.audit_non_hmac_request_keys.0", "key1"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.audit_non_hmac_request_keys.1", "key2"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.audit_non_hmac_response_keys.#", "2"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.audit_non_hmac_response_keys.0", "key3"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.audit_non_hmac_response_keys.1", "key4"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.passthrough_request_headers.#", "2"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.passthrough_request_headers.0", "X-Custom-Header"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.passthrough_request_headers.1", "X-Forwarded-To"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.allowed_response_headers.#", "2"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.allowed_response_headers.0", "X-Custom-Response-Header"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.allowed_response_headers.1", "X-Forwarded-Response-To"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.token_type", "batch"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.default_lease_ttl", "10m"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.max_lease_ttl", "20m"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.listing_visibility", "hidden"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.audit_non_hmac_request_keys.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.audit_non_hmac_request_keys.0", "key1"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.audit_non_hmac_request_keys.1", "key2"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.audit_non_hmac_response_keys.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.audit_non_hmac_response_keys.0", "key3"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.audit_non_hmac_response_keys.1", "key4"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.passthrough_request_headers.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.passthrough_request_headers.0", "X-Custom-Header"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.passthrough_request_headers.1", "X-Forwarded-To"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.allowed_response_headers.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.allowed_response_headers.0", "X-Custom-Response-Header"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.allowed_response_headers.1", "X-Forwarded-Response-To"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.token_type", "batch"),
 				),
 			},
 			{
 				Config: testGCPAuthBackendConfig_update_partial(path, gcpJSONCredentials),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testutil.TestAccCheckAuthMountExists("vault_gcp_auth_backend.test",
+					testutil.TestAccCheckAuthMountExists(resourceName,
 						&resAuthFirst,
 						testProvider.Meta().(*provider.ProviderMeta).GetClient()),
-					testGCPAuthBackendCheck_attrs(),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
+					testGCPAuthBackendCheck_attrs(resourceName),
+					resource.TestCheckResourceAttr(resourceName,
 						"custom_endpoint.#", "1"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
+					resource.TestCheckResourceAttr(resourceName,
 						"custom_endpoint.0.%", "4"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
+					resource.TestCheckResourceAttr(resourceName,
 						"custom_endpoint.0.api", ""),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
+					resource.TestCheckResourceAttr(resourceName,
 						"custom_endpoint.0.iam", ""),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
+					resource.TestCheckResourceAttr(resourceName,
 						"custom_endpoint.0.crm", "example.com:9200"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
+					resource.TestCheckResourceAttr(resourceName,
 						"custom_endpoint.0.compute", "compute.example.com"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.default_lease_ttl", "50m"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.max_lease_ttl", "1h10m"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.listing_visibility", "unauth"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.audit_non_hmac_request_keys.#", "1"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.audit_non_hmac_request_keys.0", "key1"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.audit_non_hmac_response_keys.#", "0"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.passthrough_request_headers.#", "3"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.passthrough_request_headers.0", "X-Custom-Header"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.passthrough_request_headers.1", "X-Forwarded-To"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.passthrough_request_headers.2", "X-Mas"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.allowed_response_headers.#", "3"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.allowed_response_headers.0", "X-Custom-Response-Header"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.allowed_response_headers.1", "X-Forwarded-Response-To"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.allowed_response_headers.2", "X-Mas-Response"),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test", "tune.0.token_type", "default-batch"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.default_lease_ttl", "50m"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.max_lease_ttl", "1h10m"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.listing_visibility", "unauth"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.audit_non_hmac_request_keys.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.audit_non_hmac_request_keys.0", "key1"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.audit_non_hmac_response_keys.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.passthrough_request_headers.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.passthrough_request_headers.0", "X-Custom-Header"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.passthrough_request_headers.1", "X-Forwarded-To"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.passthrough_request_headers.2", "X-Mas"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.allowed_response_headers.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.allowed_response_headers.0", "X-Custom-Response-Header"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.allowed_response_headers.1", "X-Forwarded-Response-To"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.allowed_response_headers.2", "X-Mas-Response"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.token_type", "default-batch"),
 				),
 			},
 			{
-				ResourceName:      "vault_gcp_auth_backend.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
@@ -130,13 +133,13 @@ func TestGCPAuthBackend_basic(t *testing.T) {
 			{
 				Config: testGCPAuthBackendConfig_basic(path, gcpJSONCredentials),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					testGCPAuthBackendCheck_attrs(),
-					resource.TestCheckResourceAttr("vault_gcp_auth_backend.test",
+					testGCPAuthBackendCheck_attrs(resourceName),
+					resource.TestCheckResourceAttr(resourceName,
 						"custom_endpoint.#", "0"),
 				),
 			},
 			{
-				ResourceName:      "vault_gcp_auth_backend.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
@@ -150,6 +153,8 @@ func TestGCPAuthBackend_basic(t *testing.T) {
 
 func TestGCPAuthBackend_import(t *testing.T) {
 	path := resource.PrefixedUniqueId("gcp-import-")
+	resourceType := "vault_gcp_auth_backend"
+	resourceName := resourceType + ".test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testutil.TestAccPreCheck(t) },
@@ -158,10 +163,10 @@ func TestGCPAuthBackend_import(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testGCPAuthBackendConfig_basic(path, gcpJSONCredentials),
-				Check:  testGCPAuthBackendCheck_attrs(),
+				Check:  testGCPAuthBackendCheck_attrs(resourceName),
 			},
 			{
-				ResourceName:      "vault_gcp_auth_backend.test",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
@@ -176,8 +181,8 @@ func TestGCPAuthBackend_import(t *testing.T) {
 func TestGCPAuthBackend_remount(t *testing.T) {
 	path := acctest.RandomWithPrefix("tf-test-auth-gcp")
 	updatedPath := acctest.RandomWithPrefix("tf-test-auth-gcp-updated")
-
-	resourceName := "vault_gcp_auth_backend.test"
+	resourceType := "vault_gcp_auth_backend"
+	resourceName := resourceType + ".test"
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
@@ -186,14 +191,14 @@ func TestGCPAuthBackend_remount(t *testing.T) {
 			{
 				Config: testGCPAuthBackendConfig_basic(path, gcpJSONCredentials),
 				Check: resource.ComposeTestCheckFunc(
-					testGCPAuthBackendCheck_attrs(),
+					testGCPAuthBackendCheck_attrs(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "path", path),
 				),
 			},
 			{
 				Config: testGCPAuthBackendConfig_basic(updatedPath, gcpJSONCredentials),
 				Check: resource.ComposeTestCheckFunc(
-					testGCPAuthBackendCheck_attrs(),
+					testGCPAuthBackendCheck_attrs(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "path", updatedPath),
 				),
 			},
@@ -224,9 +229,9 @@ func testGCPAuthBackendDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testGCPAuthBackendCheck_attrs() resource.TestCheckFunc {
+func testGCPAuthBackendCheck_attrs(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		resourceState := s.Modules[0].Resources["vault_gcp_auth_backend.test"]
+		resourceState := s.Modules[0].Resources[resourceName]
 		if resourceState == nil {
 			return fmt.Errorf("resource not found in state")
 		}

--- a/vault/resource_github_auth_backend_test.go
+++ b/vault/resource_github_auth_backend_test.go
@@ -41,7 +41,7 @@ func TestAccGithubAuthBackend_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testutil.TestAccCheckAuthMountExists(resourceName,
 						&resAuth,
-						testProvider.Meta().(*provider.ProviderMeta).GetClient()),
+						testProvider.Meta().(*provider.ProviderMeta).MustGetClient()),
 					resource.TestCheckResourceAttr(resourceName, "id", path),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
 					resource.TestCheckResourceAttr(resourceName, "organization", testGHOrg),
@@ -57,7 +57,7 @@ func TestAccGithubAuthBackend_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testutil.TestAccCheckAuthMountExists(resourceName,
 						&resAuth,
-						testProvider.Meta().(*provider.ProviderMeta).GetClient()),
+						testProvider.Meta().(*provider.ProviderMeta).MustGetClient()),
 					resource.TestCheckResourceAttr(resourceName, "id", path),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
 					resource.TestCheckResourceAttr(resourceName, "organization", "unknown"),
@@ -92,7 +92,7 @@ func TestAccGithubAuthBackend_ns(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testutil.TestAccCheckAuthMountExists(resourceName,
 						&resAuth,
-						testProvider.Meta().(*provider.ProviderMeta).GetClient()),
+						testProvider.Meta().(*provider.ProviderMeta).MustGetClient()),
 					resource.TestCheckResourceAttr(resourceName, "id", path),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
 					resource.TestCheckResourceAttr(resourceName, "organization", testGHOrg),
@@ -127,7 +127,7 @@ func TestAccGithubAuthBackend_tuning(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testutil.TestAccCheckAuthMountExists(resourceName,
 						&resAuth,
-						testProvider.Meta().(*provider.ProviderMeta).GetClient()),
+						testProvider.Meta().(*provider.ProviderMeta).MustGetClient()),
 					resource.TestCheckResourceAttr(resourceName, "id", backend),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, backend),
 					resource.TestCheckResourceAttr(resourceName, "organization", testGHOrg),
@@ -155,7 +155,7 @@ func TestAccGithubAuthBackend_tuning(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testutil.TestAccCheckAuthMountExists(resourceName,
 						&resAuth,
-						testProvider.Meta().(*provider.ProviderMeta).GetClient()),
+						testProvider.Meta().(*provider.ProviderMeta).MustGetClient()),
 					resource.TestCheckResourceAttr(resourceName, "id", backend),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, backend),
 					resource.TestCheckResourceAttr(resourceName, "organization", testGHOrg),
@@ -200,7 +200,7 @@ func TestAccGithubAuthBackend_description(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testutil.TestAccCheckAuthMountExists(resourceName,
 						&resAuth,
-						testProvider.Meta().(*provider.ProviderMeta).GetClient()),
+						testProvider.Meta().(*provider.ProviderMeta).MustGetClient()),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
 					resource.TestCheckResourceAttr(resourceName, "organization", testGHOrg),
 					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(orgMeta.ID)),
@@ -212,7 +212,7 @@ func TestAccGithubAuthBackend_description(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testutil.TestAccCheckAuthMountExists(resourceName,
 						&resAuth,
-						testProvider.Meta().(*provider.ProviderMeta).GetClient()),
+						testProvider.Meta().(*provider.ProviderMeta).MustGetClient()),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
 					resource.TestCheckResourceAttr(resourceName, "organization", orgMeta.Login),
 					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(orgMeta.ID)),
@@ -237,7 +237,7 @@ func TestAccGithubAuthBackend_importTuning(t *testing.T) {
 				Config: testAccGithubAuthBackendConfig_tuning(path),
 				Check: testutil.TestAccCheckAuthMountExists(resourceName,
 					&resAuth,
-					testProvider.Meta().(*provider.ProviderMeta).GetClient()),
+					testProvider.Meta().(*provider.ProviderMeta).MustGetClient()),
 			},
 			testutil.GetImportTestStep(resourceName, false, nil, "disable_remount"),
 		},
@@ -264,7 +264,7 @@ func TestGithubAuthBackend_remount(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testutil.TestAccCheckAuthMountExists(resourceName,
 						&resAuth,
-						testProvider.Meta().(*provider.ProviderMeta).GetClient()),
+						testProvider.Meta().(*provider.ProviderMeta).MustGetClient()),
 					resource.TestCheckResourceAttr(resourceName, "id", path),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
 					resource.TestCheckResourceAttr(resourceName, "organization", testGHOrg),
@@ -280,7 +280,7 @@ func TestGithubAuthBackend_remount(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testutil.TestAccCheckAuthMountExists(resourceName,
 						&resAuth,
-						testProvider.Meta().(*provider.ProviderMeta).GetClient()),
+						testProvider.Meta().(*provider.ProviderMeta).MustGetClient()),
 					resource.TestCheckResourceAttr(resourceName, "id", updatedPath),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, updatedPath),
 					resource.TestCheckResourceAttr(resourceName, "organization", testGHOrg),

--- a/vault/resource_github_auth_backend_test.go
+++ b/vault/resource_github_auth_backend_test.go
@@ -5,14 +5,11 @@ package vault
 
 import (
 	"fmt"
-	"log"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/vault/api"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
@@ -42,7 +39,9 @@ func TestAccGithubAuthBackend_basic(t *testing.T) {
 			{
 				Config: testAccGithubAuthBackendConfig_basic(path, testGHOrg),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAuthMountExists(resourceName, &resAuth),
+					testutil.TestAccCheckAuthMountExists(resourceName,
+						&resAuth,
+						testProvider.Meta().(*provider.ProviderMeta).GetClient()),
 					resource.TestCheckResourceAttr(resourceName, "id", path),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
 					resource.TestCheckResourceAttr(resourceName, "organization", testGHOrg),
@@ -56,7 +55,9 @@ func TestAccGithubAuthBackend_basic(t *testing.T) {
 			{
 				Config: testAccGithubAuthBackendConfig_updated(path, "unknown", 2999),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAuthMountExists(resourceName, &resAuth),
+					testutil.TestAccCheckAuthMountExists(resourceName,
+						&resAuth,
+						testProvider.Meta().(*provider.ProviderMeta).GetClient()),
 					resource.TestCheckResourceAttr(resourceName, "id", path),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
 					resource.TestCheckResourceAttr(resourceName, "organization", "unknown"),
@@ -89,7 +90,9 @@ func TestAccGithubAuthBackend_ns(t *testing.T) {
 			{
 				Config: testAccGithubAuthBackendConfig_ns(ns, path, testGHOrg),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAuthMountExists(resourceName, &resAuth),
+					testutil.TestAccCheckAuthMountExists(resourceName,
+						&resAuth,
+						testProvider.Meta().(*provider.ProviderMeta).GetClient()),
 					resource.TestCheckResourceAttr(resourceName, "id", path),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
 					resource.TestCheckResourceAttr(resourceName, "organization", testGHOrg),
@@ -122,7 +125,9 @@ func TestAccGithubAuthBackend_tuning(t *testing.T) {
 			{
 				Config: testAccGithubAuthBackendConfig_tuning(backend),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAuthMountExists(resourceName, &resAuth),
+					testutil.TestAccCheckAuthMountExists(resourceName,
+						&resAuth,
+						testProvider.Meta().(*provider.ProviderMeta).GetClient()),
 					resource.TestCheckResourceAttr(resourceName, "id", backend),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, backend),
 					resource.TestCheckResourceAttr(resourceName, "organization", testGHOrg),
@@ -148,7 +153,9 @@ func TestAccGithubAuthBackend_tuning(t *testing.T) {
 			{
 				Config: testAccGithubAuthBackendConfig_tuningUpdated(backend),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAuthMountExists(resourceName, &resAuth),
+					testutil.TestAccCheckAuthMountExists(resourceName,
+						&resAuth,
+						testProvider.Meta().(*provider.ProviderMeta).GetClient()),
 					resource.TestCheckResourceAttr(resourceName, "id", backend),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, backend),
 					resource.TestCheckResourceAttr(resourceName, "organization", testGHOrg),
@@ -191,7 +198,9 @@ func TestAccGithubAuthBackend_description(t *testing.T) {
 			{
 				Config: testAccGithubAuthBackendConfig_description(path, testGHOrg, "Github Auth Mount"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAuthMountExists(resourceName, &resAuth),
+					testutil.TestAccCheckAuthMountExists(resourceName,
+						&resAuth,
+						testProvider.Meta().(*provider.ProviderMeta).GetClient()),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
 					resource.TestCheckResourceAttr(resourceName, "organization", testGHOrg),
 					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(orgMeta.ID)),
@@ -201,7 +210,9 @@ func TestAccGithubAuthBackend_description(t *testing.T) {
 			{
 				Config: testAccGithubAuthBackendConfig_description(path, testGHOrg, "Github Auth Mount Updated"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAuthMountExists(resourceName, &resAuth),
+					testutil.TestAccCheckAuthMountExists(resourceName,
+						&resAuth,
+						testProvider.Meta().(*provider.ProviderMeta).GetClient()),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
 					resource.TestCheckResourceAttr(resourceName, "organization", orgMeta.Login),
 					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(orgMeta.ID)),
@@ -224,7 +235,9 @@ func TestAccGithubAuthBackend_importTuning(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccGithubAuthBackendConfig_tuning(path),
-				Check:  testAccCheckAuthMountExists(resourceName, &resAuth),
+				Check: testutil.TestAccCheckAuthMountExists(resourceName,
+					&resAuth,
+					testProvider.Meta().(*provider.ProviderMeta).GetClient()),
 			},
 			testutil.GetImportTestStep(resourceName, false, nil, "disable_remount"),
 		},
@@ -249,7 +262,9 @@ func TestGithubAuthBackend_remount(t *testing.T) {
 			{
 				Config: testAccGithubAuthBackendConfig_basic(path, testGHOrg),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAuthMountExists(resourceName, &resAuth),
+					testutil.TestAccCheckAuthMountExists(resourceName,
+						&resAuth,
+						testProvider.Meta().(*provider.ProviderMeta).GetClient()),
 					resource.TestCheckResourceAttr(resourceName, "id", path),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
 					resource.TestCheckResourceAttr(resourceName, "organization", testGHOrg),
@@ -263,7 +278,9 @@ func TestGithubAuthBackend_remount(t *testing.T) {
 			{
 				Config: testAccGithubAuthBackendConfig_basic(updatedPath, testGHOrg),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAuthMountExists(resourceName, &resAuth),
+					testutil.TestAccCheckAuthMountExists(resourceName,
+						&resAuth,
+						testProvider.Meta().(*provider.ProviderMeta).GetClient()),
 					resource.TestCheckResourceAttr(resourceName, "id", updatedPath),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, updatedPath),
 					resource.TestCheckResourceAttr(resourceName, "organization", testGHOrg),
@@ -277,42 +294,6 @@ func TestGithubAuthBackend_remount(t *testing.T) {
 			testutil.GetImportTestStep(resourceName, false, nil, "disable_remount"),
 		},
 	})
-}
-
-func testAccCheckAuthMountExists(n string, out *api.AuthMount) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		return authMountExistsHelper(n, s, out)
-	}
-}
-
-func authMountExistsHelper(resourceName string, s *terraform.State, out *api.AuthMount) error {
-	rs, ok := s.RootModule().Resources[resourceName]
-	if !ok {
-		return fmt.Errorf("Not found: %s", resourceName)
-	}
-
-	if rs.Primary.ID == "" {
-		return fmt.Errorf("No id for %s is set", resourceName)
-	}
-
-	client, e := provider.GetClient(rs.Primary, testProvider.Meta())
-	if e != nil {
-		return e
-	}
-
-	auths, err := client.Sys().ListAuth()
-	if err != nil {
-		return fmt.Errorf("error reading from Vault: %s", err)
-	}
-
-	resp := auths[strings.Trim(rs.Primary.ID, "/")+"/"]
-	if resp == nil {
-		return fmt.Errorf("auth mount %s not present", rs.Primary.ID)
-	}
-	log.Printf("[INFO] Auth mount resource '%v' confirmed to exist at path: %v", resourceName, rs.Primary.ID)
-	*out = *resp
-
-	return nil
 }
 
 func testAccGithubAuthBackendConfig_basic(path, org string) string {

--- a/website/docs/r/gcp_auth_backend.html.md
+++ b/website/docs/r/gcp_auth_backend.html.md
@@ -60,6 +60,37 @@ The following arguments are supported:
   The endpoint value provided for a given key has the form of `scheme://host:port`.
   The `scheme://` and `:port` portions of the endpoint value are optional.
 
+* `tune` - (Optional) Extra configuration block. Structure is documented below.
+
+The `tune` block is used to tune the auth backend:
+
+* `default_lease_ttl` - (Optional) Specifies the default time-to-live.
+  If set, this overrides the global default.
+  Must be a valid [duration string](https://golang.org/pkg/time/#ParseDuration)
+
+* `max_lease_ttl` - (Optional) Specifies the maximum time-to-live.
+  If set, this overrides the global default.
+  Must be a valid [duration string](https://golang.org/pkg/time/#ParseDuration)
+
+* `audit_non_hmac_response_keys` - (Optional) Specifies the list of keys that will
+  not be HMAC'd by audit devices in the response data object.
+
+* `audit_non_hmac_request_keys` - (Optional) Specifies the list of keys that will
+  not be HMAC'd by audit devices in the request data object.
+
+* `listing_visibility` - (Optional) Specifies whether to show this mount in
+  the UI-specific listing endpoint. Valid values are "unauth" or "hidden".
+
+* `passthrough_request_headers` - (Optional) List of headers to whitelist and
+  pass from the request to the backend.
+
+* `allowed_response_headers` - (Optional) List of headers to whitelist and allowing
+  a plugin to include them in the response.
+
+* `token_type` - (Optional) Specifies the type of tokens that should be returned by
+  the mount. Valid values are "default-service", "default-batch", "service", "batch".
+
+
 For more details on the usage of each argument consult the [Vault GCP API documentation](https://www.vaultproject.io/api-docs/auth/gcp#configure).
 
 ## Attribute Reference


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
This PR closes https://github.com/hashicorp/terraform-provider-vault/issues/882 by adding `tune` block support, adding the arguments shown [here](https://github.com/hashicorp/terraform-provider-vault/blob/main/vault/auth_mount.go#L26-L78), such as `default_lease_ttl`, etc. In order to accomplish this, the specific changes in this PR are:

- Update `./vault/resource_gcp_auth_backend.go` (using `vault/resource_github_auth_backend_test.go` as a reference) to:
  - Add the `tune` field to the resource schema
  - Update the resource's `Read` and `Update` methods to properly apply `tune` changes to the GCP auth mount
- Using `./vault/resource_github_auth_backend_test.go` as a reference, update `./vault/resource_gcp_auth_backend_test.go` to incorporate assertions against `tune` block settings (along with small cosmetic changes) 
- Based on [discussion](https://github.com/hashicorp/terraform-provider-vault/pull/1980#discussion_r1297794666) during the review of #1980, relocate auth mount test utility functions to `./testutil/testutil.go`
- Update the following test files to use the newly re-homed auth mount test utility functions:
  - `./vault/resource_gcp_auth_backend_test.go`
  - `./vault/resource_github_auth_backend_test.go`
  - `./vault/resource_auth_backend_test.go`


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:
I ran the following tests, which are affected/updated by these changes, against Vault `1.14.1` (non-enterprise), running as a Docker container on my local machine. All commands shown below had passing tests except one test, which failed since it involved namespaces and I do not have a Vault enterprise server.

Results file for GithubAuthBackend tests:  [github_auth_backend_acc_output.txt](https://github.com/hashicorp/terraform-provider-vault/files/12491882/github_auth_backend_acc_output.txt)
```
$ make testacc TESTARGS='-run=TestAccGithubAuthBackend*'
```

Results file for the GcpAuthBackend* tests:  [gcp_auth_backend_acc_output.txt](https://github.com/hashicorp/terraform-provider-vault/files/12491892/gcp_auth_backend_acc_output.txt)
```
$ make testacc TESTARGS='-run=TestGCPAuthBackend*'
```

Results file for the TestResourceAuthTune test:  [auth_backend_acc_output.txt](https://github.com/hashicorp/terraform-provider-vault/files/12491899/auth_backend_acc_output.txt)
```
$ make testacc TESTARGS='-run=TestResourceAuthTune'
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

