### PR TITLE
Bring the Vault provider to gcp sql parity with Vault

### DIFF
--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -1370,6 +1370,7 @@ func setDatabaseConnectionData(d *schema.ResourceData, prefix string, data map[s
 
 func setCloudDatabaseConnectionData(d *schema.ResourceData, prefix string, data map[string]interface{}) {
 	if v, ok := d.GetOk(prefix + "auth_type"); ok {
+		fmt.Println("setting auth_type")
 		data["auth_type"] = v.(string)
 	}
 	if v, ok := d.GetOk(prefix + "service_account_json"); ok {

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -1029,6 +1029,17 @@ func getConnectionDetailsFromResponse(d *schema.ResourceData, prefix string, res
 			result["username_template"] = v.(string)
 		}
 	}
+	if v, ok := data["auth_type"]; ok {
+		result["auth_type"] = v.(string)
+	}
+	if v, ok := d.GetOk(prefix + "service_account_json"); ok {
+		result["service_account_json"] = v.(string)
+	} else {
+		if v, ok := data["service_account_json"]; ok {
+			result["service_account_json"] = v.(string)
+		}
+	}
+
 	return result
 }
 
@@ -1370,7 +1381,6 @@ func setDatabaseConnectionData(d *schema.ResourceData, prefix string, data map[s
 
 func setCloudDatabaseConnectionData(d *schema.ResourceData, prefix string, data map[string]interface{}) {
 	if v, ok := d.GetOk(prefix + "auth_type"); ok {
-		fmt.Println("setting auth_type")
 		data["auth_type"] = v.(string)
 	}
 	if v, ok := d.GetOk(prefix + "service_account_json"); ok {

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -758,12 +758,12 @@ func connectionStringResource(config *connectionStringConfig) *schema.Resource {
 		res.Schema["auth_type"] = &schema.Schema{
 			Type:        schema.TypeString,
 			Optional:    true,
-			Description: "some description",
+			Description: "Specify alternative authorization type. (Only 'gcp_iam' is valid currently)",
 		}
 		res.Schema["service_account_json"] = &schema.Schema{
 			Type:        schema.TypeString,
 			Optional:    true,
-			Description: "some json description",
+			Description: "A JSON encoded credential for use with IAM authorization",
 			Sensitive:   true,
 		}
 	}

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -1029,16 +1029,6 @@ func getConnectionDetailsFromResponse(d *schema.ResourceData, prefix string, res
 			result["username_template"] = v.(string)
 		}
 	}
-	if v, ok := data["auth_type"]; ok {
-		result["auth_type"] = v.(string)
-	}
-	if v, ok := d.GetOk(prefix + "service_account_json"); ok {
-		result["service_account_json"] = v.(string)
-	} else {
-		if v, ok := data["service_account_json"]; ok {
-			result["service_account_json"] = v.(string)
-		}
-	}
 
 	return result
 }
@@ -1059,6 +1049,29 @@ func getMSSQLConnectionDetailsFromResponse(d *schema.ResourceData, prefix string
 	}
 
 	return result, nil
+}
+
+func getPostgresConnectionDetailsFromResponse(d *schema.ResourceData, prefix string, resp *api.Secret) map[string]interface{} {
+	result := getConnectionDetailsFromResponseWithDisableEscaping(d, prefix, resp)
+	details := resp.Data["connection_details"]
+	data, ok := details.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	// cloud specific
+	if v, ok := data["auth_type"]; ok {
+		result["auth_type"] = v.(string)
+	}
+	if v, ok := d.GetOk(prefix + "service_account_json"); ok {
+		result["service_account_json"] = v.(string)
+	} else {
+		if v, ok := data["service_account_json"]; ok {
+			result["service_account_json"] = v.(string)
+		}
+	}
+
+	return result
 }
 
 func getConnectionDetailsFromResponseWithDisableEscaping(d *schema.ResourceData, prefix string, resp *api.Secret) map[string]interface{} {
@@ -1096,6 +1109,19 @@ func getMySQLConnectionDetailsFromResponse(d *schema.ResourceData, prefix string
 			result["tls_ca"] = v.(string)
 		}
 	}
+
+	// cloud specific
+	if v, ok := data["auth_type"]; ok {
+		result["auth_type"] = v.(string)
+	}
+	if v, ok := d.GetOk(prefix + "service_account_json"); ok {
+		result["service_account_json"] = v.(string)
+	} else {
+		if v, ok := data["service_account_json"]; ok {
+			result["service_account_json"] = v.(string)
+		}
+	}
+
 	return result
 }
 
@@ -1855,7 +1881,7 @@ func getDBConnectionConfig(d *schema.ResourceData, engine *dbEngine, idx int,
 	case dbEngineOracle:
 		result = getConnectionDetailsFromResponseWithUserPass(d, prefix, resp)
 	case dbEnginePostgres:
-		result = getConnectionDetailsFromResponseWithDisableEscaping(d, prefix, resp)
+		result = getPostgresConnectionDetailsFromResponse(d, prefix, resp)
 	case dbEngineElasticSearch:
 		result = getElasticsearchConnectionDetailsFromResponse(d, prefix, resp)
 	case dbEngineSnowflake:

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -473,6 +473,12 @@ func TestAccDatabaseSecretBackendConnection_mysql_cloud(t *testing.T) {
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "mysql.0.max_connection_lifetime", "0"),
 				),
 			},
+			{
+				ResourceName:            testDefaultDatabaseSecretBackendResource,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"verify_connection", "mysql.0.service_account_json"},
+			},
 		},
 	})
 }
@@ -839,6 +845,12 @@ func TestAccDatabaseSecretBackendConnection_postgresql_cloud(t *testing.T) {
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "postgresql.0.disable_escaping", "true"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "postgresql.0.auth_type", "gcp_iam"),
 				),
+			},
+			{
+				ResourceName:            testDefaultDatabaseSecretBackendResource,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"verify_connection", "postgres.0.service_account_json"},
 			},
 		},
 	})

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -450,8 +450,11 @@ func TestAccDatabaseSecretBackendConnection_mysql_cloud(t *testing.T) {
 	backend := acctest.RandomWithPrefix("tf-test-db")
 	name := acctest.RandomWithPrefix("db")
 	resource.Test(t, resource.TestCase{
-		Providers:    testProviders,
-		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		PreCheck: func() {
+			testutil.TestAccPreCheck(t)
+			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion115)
+		},
 		CheckDestroy: testAccDatabaseSecretBackendConnectionCheckDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -816,8 +819,11 @@ func TestAccDatabaseSecretBackendConnection_postgresql_cloud(t *testing.T) {
 	backend := acctest.RandomWithPrefix("tf-test-db")
 	name := acctest.RandomWithPrefix("db")
 	resource.Test(t, resource.TestCase{
-		Providers:    testProviders,
-		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		PreCheck: func() {
+			testutil.TestAccPreCheck(t)
+			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion115)
+		},
 		CheckDestroy: testAccDatabaseSecretBackendConnectionCheckDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -467,8 +467,7 @@ func TestAccDatabaseSecretBackendConnection_mysql_cloud(t *testing.T) {
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "root_rotation_statements.0", "FOOBAR"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "verify_connection", "true"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "mysql.0.connection_url", connURL),
-					// vault needs to be updated to return this value if it exists, i think?
-					//resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "mysql.0.auth_type", "gcp_iam"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "mysql.0.auth_type", "gcp_iam"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "mysql.0.max_open_connections", "2"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "mysql.0.max_idle_connections", "0"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "mysql.0.max_connection_lifetime", "0"),

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -444,7 +444,7 @@ func TestAccDatabaseSecretBackendConnection_mssql(t *testing.T) {
 
 func TestAccDatabaseSecretBackendConnection_mysql_cloud(t *testing.T) {
 	// wanted this to be the included with the following test, but the env-var check is different
-	values := testutil.SkipTestEnvUnset(t, "MYSQL_CONNECTION_URL", "MYSQL_CONNECTION_SERVICE_ACCOUNT_JSON")
+	values := testutil.SkipTestEnvUnset(t, "MYSQL_CLOUD_CONNECTION_URL", "MYSQL_CLOUD_CONNECTION_SERVICE_ACCOUNT_JSON")
 	connURL, saJSON := values[0], values[1]
 
 	backend := acctest.RandomWithPrefix("tf-test-db")
@@ -813,7 +813,7 @@ func TestAccDatabaseSecretBackendConnection_postgresql(t *testing.T) {
 
 func TestAccDatabaseSecretBackendConnection_postgresql_cloud(t *testing.T) {
 	// wanted this to be the included with the following test, but the env-var check is different
-	values := testutil.SkipTestEnvUnset(t, "POSTGRES_URL", "POSTGRES_SERVICE_ACCOUNT_JSON")
+	values := testutil.SkipTestEnvUnset(t, "POSTGRES_CLOUD_URL", "POSTGRES_CLOUD_SERVICE_ACCOUNT_JSON")
 	connURL, saJSON := values[0], values[1]
 
 	backend := acctest.RandomWithPrefix("tf-test-db")
@@ -1656,7 +1656,7 @@ resource "vault_database_secret_backend_connection" "test" {
 `, path, name, parsedURL.String())
 }
 
-func testAccDatabaseSecretBackendConnectionConfig_postgres_cloud(name, path string, parsedURL *url.URL, authType, serviceAccountJSON string) string {
+func testAccDatabaseSecretBackendConnectionConfig_postgres_cloud(name, path, connURL, authType, serviceAccountJSON string) string {
 	return fmt.Sprintf(`
 resource "vault_mount" "db" {
   path = "%s"
@@ -1676,7 +1676,7 @@ resource "vault_database_secret_backend_connection" "test" {
       disable_escaping        = true
   }
 }
-`, path, name, parsedURL.String(), authType, serviceAccountJSON)
+`, path, name, connURL, authType, serviceAccountJSON)
 }
 
 func testAccDatabaseSecretBackendConnectionConfig_snowflake(name, path, url, username, password, userTempl string) string {

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -1670,10 +1670,9 @@ resource "vault_database_secret_backend_connection" "test" {
   root_rotation_statements = ["FOOBAR"]
 
   postgresql {
-      connection_url          = "%s"
-		auth_type = "%s"
+      connection_url       = "%s"
+		auth_type            = "%s"
 		service_account_json = "%s"
-      disable_escaping        = true
   }
 }
 `, path, name, connURL, authType, serviceAccountJSON)

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -827,7 +827,7 @@ func TestAccDatabaseSecretBackendConnection_postgresql_cloud(t *testing.T) {
 		CheckDestroy: testAccDatabaseSecretBackendConnectionCheckDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDatabaseSecretBackendConnectionConfig_mysql_cloud(name, backend, connURL, "gcp_iam", saJSON),
+				Config: testAccDatabaseSecretBackendConnectionConfig_postgres_cloud(name, backend, connURL, "gcp_iam", saJSON),
 				Check: testComposeCheckFuncCommonDatabaseSecretBackend(name, backend, dbEngineMySQL.DefaultPluginName(),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "allowed_roles.#", "2"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "allowed_roles.0", "dev"),
@@ -1654,6 +1654,29 @@ resource "vault_database_secret_backend_connection" "test" {
   }
 }
 `, path, name, parsedURL.String())
+}
+
+func testAccDatabaseSecretBackendConnectionConfig_postgres_cloud(name, path string, parsedURL *url.URL, authType, serviceAccountJSON string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "db" {
+  path = "%s"
+  type = "database"
+}
+
+resource "vault_database_secret_backend_connection" "test" {
+  backend = vault_mount.db.path
+  name = "%s"
+  allowed_roles = ["dev", "prod"]
+  root_rotation_statements = ["FOOBAR"]
+
+  postgresql {
+      connection_url          = "%s"
+		auth_type = "%s"
+		service_account_json = "%s"
+      disable_escaping        = true
+  }
+}
+`, path, name, parsedURL.String(), authType, serviceAccountJSON)
 }
 
 func testAccDatabaseSecretBackendConnectionConfig_snowflake(name, path, url, username, password, userTempl string) string {

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -467,7 +467,8 @@ func TestAccDatabaseSecretBackendConnection_mysql_cloud(t *testing.T) {
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "root_rotation_statements.0", "FOOBAR"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "verify_connection", "true"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "mysql.0.connection_url", connURL),
-					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "mysql.0.auth_type", "gcp_iam"),
+					// vault needs to be updated to return this value if it exists, i think?
+					//resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "mysql.0.auth_type", "gcp_iam"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "mysql.0.max_open_connections", "2"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "mysql.0.max_idle_connections", "0"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "mysql.0.max_connection_lifetime", "0"),
@@ -1600,7 +1601,7 @@ resource "vault_database_secret_backend_connection" "test" {
   allowed_roles = ["dev", "prod"]
   root_rotation_statements = ["FOOBAR"]
 
-  mysql_cloud {
+  mysql {
 	  connection_url       = "%s"
 	  auth_type            = "%s"
 	  service_account_json = "%s"

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -442,6 +442,38 @@ func TestAccDatabaseSecretBackendConnection_mssql(t *testing.T) {
 	})
 }
 
+func TestAccDatabaseSecretBackendConnection_mysql_cloud(t *testing.T) {
+	// wanted this to be the included with the following test, but the env-var check is different
+	values := testutil.SkipTestEnvUnset(t, "MYSQL_CONNECTION_URL", "MYSQL_CONNECTION_SERVICE_ACCOUNT_JSON")
+	connURL, saJSON := values[0], values[1]
+
+	backend := acctest.RandomWithPrefix("tf-test-db")
+	name := acctest.RandomWithPrefix("db")
+	resource.Test(t, resource.TestCase{
+		Providers:    testProviders,
+		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		CheckDestroy: testAccDatabaseSecretBackendConnectionCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseSecretBackendConnectionConfig_mysql_cloud(name, backend, connURL, "gcp_iam", saJSON),
+				Check: testComposeCheckFuncCommonDatabaseSecretBackend(name, backend, dbEngineMySQL.DefaultPluginName(),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "verify_connection", "true"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "mysql.0.connection_url", connURL),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "mysql.0.auth_type", "gcp_iam"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "mysql.0.max_open_connections", "2"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "mysql.0.max_idle_connections", "0"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "mysql.0.max_connection_lifetime", "0"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDatabaseSecretBackendConnection_mysql(t *testing.T) {
 	MaybeSkipDBTests(t, dbEngineMySQL)
 
@@ -770,6 +802,36 @@ func TestAccDatabaseSecretBackendConnection_postgresql(t *testing.T) {
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "postgresql.0.password", ""),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "postgresql.0.disable_escaping", "false"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "postgresql.0.username_template", ""),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatabaseSecretBackendConnection_postgresql_cloud(t *testing.T) {
+	// wanted this to be the included with the following test, but the env-var check is different
+	values := testutil.SkipTestEnvUnset(t, "POSTGRES_URL", "POSTGRES_SERVICE_ACCOUNT_JSON")
+	connURL, saJSON := values[0], values[1]
+
+	backend := acctest.RandomWithPrefix("tf-test-db")
+	name := acctest.RandomWithPrefix("db")
+	resource.Test(t, resource.TestCase{
+		Providers:    testProviders,
+		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		CheckDestroy: testAccDatabaseSecretBackendConnectionCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseSecretBackendConnectionConfig_mysql_cloud(name, backend, connURL, "gcp_iam", saJSON),
+				Check: testComposeCheckFuncCommonDatabaseSecretBackend(name, backend, dbEngineMySQL.DefaultPluginName(),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "root_rotation_statements.#", "1"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "verify_connection", "true"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "postgresql.0.connection_url", connURL),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "postgresql.0.disable_escaping", "true"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "postgresql.0.auth_type", "gcp_iam"),
 				),
 			},
 		},
@@ -1517,6 +1579,28 @@ resource "vault_database_secret_backend_connection" "test" {
   }
 }
 `, path, name, connURL, username, password)
+}
+
+func testAccDatabaseSecretBackendConnectionConfig_mysql_cloud(name, path, connURL, authType, serviceAccountJSON string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "db" {
+  path = "%s"
+  type = "database"
+}
+
+resource "vault_database_secret_backend_connection" "test" {
+  backend = vault_mount.db.path
+  name = "%s"
+  allowed_roles = ["dev", "prod"]
+  root_rotation_statements = ["FOOBAR"]
+
+  mysql_cloud {
+	  connection_url       = "%s"
+	  auth_type            = "%s"
+	  service_account_json = "%s"
+  }
+}
+`, path, name, connURL, authType, serviceAccountJSON)
 }
 
 func testAccDatabaseSecretBackendConnectionConfig_postgresql(name, path, userTempl, username, password, openConn, idleConn, maxConnLifetime string, parsedURL *url.URL) string {

--- a/vault/resource_database_secrets_mount.go
+++ b/vault/resource_database_secrets_mount.go
@@ -296,7 +296,7 @@ func databaseSecretsMountRead(d *schema.ResourceData, meta interface{}) error {
 	store := &dbConfigStore{}
 	if v, ok := resp.Data["keys"]; ok {
 		for _, v := range v.([]interface{}) {
-			if err := readDBEngineConfig(d, client, store, v.(string)); err != nil {
+			if err := readDBEngineConfig(d, client, store, v.(string), meta); err != nil {
 				return err
 			}
 		}
@@ -315,7 +315,7 @@ func databaseSecretsMountDelete(d *schema.ResourceData, meta interface{}) error 
 	return mountDelete(d, meta)
 }
 
-func readDBEngineConfig(d *schema.ResourceData, client *api.Client, store *dbConfigStore, name string) error {
+func readDBEngineConfig(d *schema.ResourceData, client *api.Client, store *dbConfigStore, name string, meta interface{}) error {
 	root := d.Id()
 
 	path := databaseSecretBackendConnectionPath(root, name)
@@ -336,7 +336,7 @@ func readDBEngineConfig(d *schema.ResourceData, client *api.Client, store *dbCon
 	}
 
 	idx := len(store.Get(engine))
-	result, err := getDBConnectionConfig(d, engine, idx, resp)
+	result, err := getDBConnectionConfig(d, engine, idx, resp, meta)
 	if err != nil {
 		return err
 	}

--- a/vault/resource_database_secrets_mount.go
+++ b/vault/resource_database_secrets_mount.go
@@ -246,7 +246,7 @@ func databaseSecretsMountCreateOrUpdate(d *schema.ResourceData, meta interface{}
 					return fmt.Errorf("duplicate name %q for engine %#v", name, engine)
 				}
 				seen[name] = true
-				if err := writeDatabaseSecretConfig(d, client, engine, i, true, path); err != nil {
+				if err := writeDatabaseSecretConfig(d, client, engine, i, true, path, meta); err != nil {
 					return err
 				}
 				count++

--- a/website/docs/r/database_secret_backend_connection.md
+++ b/website/docs/r/database_secret_backend_connection.md
@@ -293,6 +293,10 @@ See the [Vault
 
 * `password` - (Optional) The root credential password used in the connection URL.
 
+* `auth_type` - (Optional) Enable IAM authentication to a Google Cloud instance when set to `gcp_iam`
+
+* `service_account_json` - (Optional) JSON encoding of an IAM access key. Requires `auth_type` to be `gcp_iam`.
+
 * `tls_certificate_key` - (Optional) x509 certificate for connecting to the database. This must be a PEM encoded version of the private key and the certificate combined.
 
 * `tls_ca` - (Optional) x509 CA file for validating the certificate presented by the MySQL server. Must be PEM encoded.
@@ -320,6 +324,10 @@ See the [Vault
 * `username` - (Optional) The root credential username used in the connection URL.
 
 * `password` - (Optional) The root credential password used in the connection URL.
+
+* `auth_type` - (Optional) Enable IAM authentication to a Google Cloud instance when set to `gcp_iam`
+
+* `service_account_json` - (Optional) JSON encoding of an IAM access key. Requires `auth_type` to be `gcp_iam`.
 
 * `disable_escaping` - (Optional) Disable special character escaping in username and password.
 


### PR DESCRIPTION
This PR adds the two fields for mysql and postgres databases that were added in vault 1.15 to allow Vault to use GCP IAM roles to access databases.

The change on vault added two fields, "auth_type", for which the currently only valid values is "gcp_iam", and "service_account_json", for supplying a specific json encoding of an access token.
