### PR TITLE
add local var for aws secret engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 IMPROVEMENTS:
 * Update dependencies ([#1958](https://github.com/hashicorp/terraform-provider-vault/pull/1958))
   * github.com/hashicorp/go-secure-stdlib/awsutil `v0.1.6` -> `v0.2.3`
+* Add `local` variable to `aws_secret_backend` resource, in order to mark the mount as non - replicated
 
 ## 3.20.0 (Aug 30, 2023)
 FEATURES:

--- a/vault/resource_aws_secret_backend.go
+++ b/vault/resource_aws_secret_backend.go
@@ -268,6 +268,7 @@ func awsSecretBackendRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("description", mount.Description)
 	d.Set("default_lease_ttl_seconds", mount.Config.DefaultLeaseTTL)
 	d.Set("max_lease_ttl_seconds", mount.Config.MaxLeaseTTL)
+	d.Set("local", mount.Local)
 
 	return nil
 }

--- a/vault/resource_aws_secret_backend.go
+++ b/vault/resource_aws_secret_backend.go
@@ -98,6 +98,13 @@ func awsSecretBackendResource() *schema.Resource {
 				Computed:    true,
 				Description: "Template describing how dynamic usernames are generated.",
 			},
+			"local": {
+				Type:        schema.TypeBool,
+				ForceNew:    true,
+				Optional:    true,
+				Default:     false,
+				Description: "Specifies if the secret backend is local only",
+			},
 		},
 	})
 }
@@ -143,12 +150,14 @@ func awsSecretBackendCreate(d *schema.ResourceData, meta interface{}) error {
 	iamEndpoint := d.Get("iam_endpoint").(string)
 	stsEndpoint := d.Get("sts_endpoint").(string)
 	usernameTemplate := d.Get("username_template").(string)
+	local := d.Get("local").(bool)
 
 	d.Partial(true)
 	log.Printf("[DEBUG] Mounting AWS backend at %q", path)
 	err := client.Sys().Mount(path, &api.MountInput{
 		Type:        consts.MountTypeAWS,
 		Description: description,
+		Local:       local,
 		Config: api.MountConfigInput{
 			DefaultLeaseTTL: fmt.Sprintf("%ds", defaultTTL),
 			MaxLeaseTTL:     fmt.Sprintf("%ds", maxTTL),

--- a/vault/resource_aws_secret_backend_test.go
+++ b/vault/resource_aws_secret_backend_test.go
@@ -36,6 +36,7 @@ func TestAccAWSSecretBackend_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "region", "us-east-1"),
 					resource.TestCheckResourceAttr(resourceName, "iam_endpoint", ""),
 					resource.TestCheckResourceAttr(resourceName, "sts_endpoint", ""),
+					resource.TestCheckResourceAttr(resourceName, "local", "false"),
 					resource.TestCheckResourceAttrSet(resourceName, "username_template"),
 				),
 			},
@@ -52,6 +53,7 @@ func TestAccAWSSecretBackend_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "region", "us-west-1"),
 					resource.TestCheckResourceAttr(resourceName, "iam_endpoint", "https://iam.amazonaws.com"),
 					resource.TestCheckResourceAttr(resourceName, "sts_endpoint", "https://sts.us-west-1.amazonaws.com"),
+					resource.TestCheckResourceAttr(resourceName, "local", "false"),
 				),
 			},
 			{
@@ -66,6 +68,7 @@ func TestAccAWSSecretBackend_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "region", "us-west-1"),
 					resource.TestCheckResourceAttr(resourceName, "iam_endpoint", ""),
 					resource.TestCheckResourceAttr(resourceName, "sts_endpoint", ""),
+					resource.TestCheckResourceAttr(resourceName, "local", "false"),
 				),
 			},
 		},

--- a/website/docs/r/aws_secret_backend.html.md
+++ b/website/docs/r/aws_secret_backend.html.md
@@ -77,6 +77,8 @@ for credentials issued by this backend.
 
 * `username_template` - (Optional)  Template describing how dynamic usernames are generated. The username template is used to generate both IAM usernames (capped at 64 characters) and STS usernames (capped at 32 characters). If no template is provided the field defaults to the template:
 
+* `local` - (Optional) Specifies whether the secrets mount will be marked as local. Local mounts are not replicated to performance replicas.
+
 ```
 {{ if (eq .Type "STS") }}
     {{ printf "vault-%s-%s" (unix_time) (random 20) | truncate 32 }}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
Vault core supports marking mounts as [local](https://developer.hashicorp.com/vault/api-docs/system/mounts#local) in order to keep a mount from being replicated to performance replicas. This implementation mimics what has been done in other backend mounts such as the [consul mount](https://github.com/hashicorp/terraform-provider-vault/blob/main/vault/resource_consul_secret_backend.go).


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

