### PR TITLE
Updates the documentation and field description for the `transit_secret_backend_key/auto_rotate_period` to ensure that the unit of time being used is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 3.20.2 (Sep 13, 2023)
+IMPROVEMENTS:
+* ` to ensure that the unit of time being used is specified ([#2015](https://github.com/hashicorp/terraform-provider-vault/pull/2015))
+
 ## 3.20.1 (Sep 13, 2023)
 IMPROVEMENTS:
 * Update dependencies ([#1958](https://github.com/hashicorp/terraform-provider-vault/pull/1958))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 ## Unreleased
 
-## 3.20.2 (Sep 13, 2023)
-IMPROVEMENTS:
-* ` to ensure that the unit of time being used is specified ([#2015](https://github.com/hashicorp/terraform-provider-vault/pull/2015))
-
 ## 3.20.1 (Sep 13, 2023)
 IMPROVEMENTS:
 * Update dependencies ([#1958](https://github.com/hashicorp/terraform-provider-vault/pull/1958))

--- a/vault/resource_transit_secret_backend_key.go
+++ b/vault/resource_transit_secret_backend_key.go
@@ -90,7 +90,7 @@ func transitSecretBackendKeyResource() *schema.Resource {
 				Type:          schema.TypeInt,
 				Optional:      true,
 				Computed:      true,
-				Description:   "Amount of time the key should live before being automatically rotated. A value of 0 disables automatic rotation for the key.",
+				Description:   "Amount of seconds the key should live before being automatically rotated. A value of 0 disables automatic rotation for the key.",
 				ConflictsWith: []string{"auto_rotate_interval"},
 			},
 			"type": {

--- a/website/docs/r/transit_secret_backend_key.html.md
+++ b/website/docs/r/transit_secret_backend_key.html.md
@@ -58,7 +58,8 @@ The following arguments are supported:
 
 * `min_encryption_version` - (Optional) Minimum key version to use for encryption
 
-* `auto_rotate_period` - (Optional) Amount of seconds the key should live before being automatically rotated. A value of 0 disables automatic rotation for the key.
+* `auto_rotate_period` - (Optional) Amount of seconds the key should live before being automatically rotated.
+  A value of 0 disables automatic rotation for the key.
 
 ## Attributes Reference
 

--- a/website/docs/r/transit_secret_backend_key.html.md
+++ b/website/docs/r/transit_secret_backend_key.html.md
@@ -58,8 +58,7 @@ The following arguments are supported:
 
 * `min_encryption_version` - (Optional) Minimum key version to use for encryption
 
-* `auto_rotate_period` - (Optional) Amount of time the key should live before being automatically rotated.
-  A value of 0 disables automatic rotation for the key.
+* `auto_rotate_period` - (Optional) Amount of seconds the key should live before being automatically rotated. A value of 0 disables automatic rotation for the key.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
This PR Updates the documentation and field description for the `transit_secret_backend_key/auto_rotate_period` to ensure that the unit of time being used is specified (seconds) in order to avoid confusion.

Closes #2015 


### Checklist
- [ x ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ x ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
make testacc TESTARGS='-run=TestTransitSecretBackendKey_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -run=TestTransitSecretBackendKey_basic -timeout 30m ./...
?   	github.com/hashicorp/terraform-provider-vault	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/generate	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/generated	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/codegen	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/helper	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/consts	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/group	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/mfa	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/pki	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/schema	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/internal/identity/entity	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/internal/provider	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/testutil	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/util	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/vault	3.142s
```


