### PR TITLE
add not_before_duration to ssh_secret_backend_role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+FEATURES:
+* Add support for setting `not_before_duration` argument on `vault_ssh_secret_backend_role`: ([#2019](https://github.com/hashicorp/terraform-provider-vault/pull/2019))
+
 ## 3.20.1 (Sep 13, 2023)
 IMPROVEMENTS:
 * Update dependencies ([#1958](https://github.com/hashicorp/terraform-provider-vault/pull/1958))

--- a/vault/resource_ssh_secret_backend_role.go
+++ b/vault/resource_ssh_secret_backend_role.go
@@ -187,6 +187,12 @@ func sshSecretBackendRoleResource() *schema.Resource {
 			Optional: true,
 			Computed: true,
 		},
+		"not_before_duration": {
+			Type:        schema.TypeString,
+			Description: "Specifies the duration by which to backdate the ValidAfter property. Uses duration format strings.",
+			Optional:    true,
+			Computed:    true,
+		},
 	}
 
 	return &schema.Resource{
@@ -281,6 +287,10 @@ func sshSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("ttl"); ok {
 		data["ttl"] = v.(string)
+	}
+
+	if v, ok := d.GetOk("not_before_duration"); ok {
+		data["not_before_duration"] = v.(string)
 	}
 
 	var isUserKeyConfig bool
@@ -384,7 +394,7 @@ func sshSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 		"cidr_list", "allowed_extensions", "default_extensions",
 		"default_critical_options", "allowed_users_template",
 		"allowed_users", "default_user", "key_id_format",
-		"max_ttl", "ttl", "algorithm_signer",
+		"max_ttl", "ttl", "algorithm_signer", "not_before_duration",
 	}
 
 	if provider.IsAPISupported(meta, provider.VaultVersion112) {

--- a/vault/resource_ssh_secret_backend_role_test.go
+++ b/vault/resource_ssh_secret_backend_role_test.go
@@ -48,6 +48,7 @@ func TestAccSSHSecretBackendRole(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceName, "algorithm_signer", "default"),
 		resource.TestCheckResourceAttr(resourceName, "max_ttl", "0"),
 		resource.TestCheckResourceAttr(resourceName, "ttl", "0"),
+		resource.TestCheckResourceAttr(resourceName, "not_before_duration", "0"),
 	)
 
 	updateCheckFuncs := append(commonCheckFuncs,
@@ -69,6 +70,7 @@ func TestAccSSHSecretBackendRole(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceName, "algorithm_signer", "rsa-sha2-256"),
 		resource.TestCheckResourceAttr(resourceName, "max_ttl", "86400"),
 		resource.TestCheckResourceAttr(resourceName, "ttl", "43200"),
+		resource.TestCheckResourceAttr(resourceName, "not_before_duration", "30m"),
 	)
 
 	getCheckFuncs := func(isUpdate bool) resource.TestCheckFunc {
@@ -306,6 +308,7 @@ resource "vault_ssh_secret_backend_role" "test_role" {
   algorithm_signer         = "rsa-sha2-256"
   max_ttl                  = "86400"
   ttl                      = "43200"
+  not_before_duration      = "30m"
   %s
 `, name, extraFields))
 

--- a/vault/resource_ssh_secret_backend_role_test.go
+++ b/vault/resource_ssh_secret_backend_role_test.go
@@ -48,7 +48,7 @@ func TestAccSSHSecretBackendRole(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceName, "algorithm_signer", "default"),
 		resource.TestCheckResourceAttr(resourceName, "max_ttl", "0"),
 		resource.TestCheckResourceAttr(resourceName, "ttl", "0"),
-		resource.TestCheckResourceAttr(resourceName, "not_before_duration", "0"),
+		resource.TestCheckResourceAttr(resourceName, "not_before_duration", "30"),
 	)
 
 	updateCheckFuncs := append(commonCheckFuncs,
@@ -70,7 +70,7 @@ func TestAccSSHSecretBackendRole(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceName, "algorithm_signer", "rsa-sha2-256"),
 		resource.TestCheckResourceAttr(resourceName, "max_ttl", "86400"),
 		resource.TestCheckResourceAttr(resourceName, "ttl", "43200"),
-		resource.TestCheckResourceAttr(resourceName, "not_before_duration", "30m"),
+		resource.TestCheckResourceAttr(resourceName, "not_before_duration", "50m"),
 	)
 
 	getCheckFuncs := func(isUpdate bool) resource.TestCheckFunc {
@@ -308,7 +308,7 @@ resource "vault_ssh_secret_backend_role" "test_role" {
   algorithm_signer         = "rsa-sha2-256"
   max_ttl                  = "86400"
   ttl                      = "43200"
-  not_before_duration      = "30m"
+  not_before_duration      = "50m"
   %s
 `, name, extraFields))
 

--- a/vault/resource_ssh_secret_backend_role_test.go
+++ b/vault/resource_ssh_secret_backend_role_test.go
@@ -48,6 +48,8 @@ func TestAccSSHSecretBackendRole(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceName, "algorithm_signer", "default"),
 		resource.TestCheckResourceAttr(resourceName, "max_ttl", "0"),
 		resource.TestCheckResourceAttr(resourceName, "ttl", "0"),
+		// 30s is the default value vault uese.
+		// https://developer.hashicorp.com/vault/api-docs/secret/ssh#not_before_duration
 		resource.TestCheckResourceAttr(resourceName, "not_before_duration", "30"),
 	)
 
@@ -70,7 +72,8 @@ func TestAccSSHSecretBackendRole(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceName, "algorithm_signer", "rsa-sha2-256"),
 		resource.TestCheckResourceAttr(resourceName, "max_ttl", "86400"),
 		resource.TestCheckResourceAttr(resourceName, "ttl", "43200"),
-		resource.TestCheckResourceAttr(resourceName, "not_before_duration", "50m"),
+		// 50m (3000 seconds)
+		resource.TestCheckResourceAttr(resourceName, "not_before_duration", "3000"),
 	)
 
 	getCheckFuncs := func(isUpdate bool) resource.TestCheckFunc {
@@ -308,7 +311,7 @@ resource "vault_ssh_secret_backend_role" "test_role" {
   algorithm_signer         = "rsa-sha2-256"
   max_ttl                  = "86400"
   ttl                      = "43200"
-  not_before_duration      = "50m"
+  not_before_duration      = "3000"
   %s
 `, name, extraFields))
 

--- a/website/docs/r/ssh_secret_backend_role.html.md
+++ b/website/docs/r/ssh_secret_backend_role.html.md
@@ -99,6 +99,9 @@ The following arguments are supported:
 
 * `ttl` - (Optional) Specifies the Time To Live value.
 
+* `not_before_duration` - (Optional) Specifies the duration by which to backdate the ValidAfter property.
+  Uses [duration format strings](https://developer.hashicorp.com/vault/docs/concepts/duration-format).
+
 
 ### Allowed User Key Configuration
 * `type` - (Required) The SSH public key type.  


### PR DESCRIPTION
add not_before_duration to ssh_secret_backend_role

### Description

https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/ssh_secret_backend_role currently don't have
https://developer.hashicorp.com/vault/api-docs/v1.12.x/secret/ssh#not_before_duration.  I can make a good use of it
and thought it'd be a good idea to add it to this repo so many more people can benefit from it.

To comment on why we don't just use [generic_endpoint](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/generic_endpoint) everywhere,
we found that with generic_endpoint, the terraform plan returns way less information.

I ran the unit tests.

```
~/terraform-provider-vault$ make test
...
ok   github.com/hashicorp/terraform-provider-vault/vault 0.326s
```


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

To run the acceptance tests, run `vault server -dev-tls` first to up a vault server with
https/tls enabled.  Then do the following on the other terminal.

```
export VAULT_ADDR='https://127.0.0.1:8200'
export VAULT_CACERT='/tmp/vault-tls.../vault-ca.pem'
export VAULT_TOKEN='xxx'

TESTARGS="--run TestAccSSHSecretBackendRole -v" make testacc
```
The output looks like

```
$ TESTARGS="--run TestAccSSHSecretBackendRole -v" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test --run TestAccSSHSecretBackendRole -v -timeout 30m ./...
?   	github.com/hashicorp/terraform-provider-vault	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/generate	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/codegen	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/generated	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/internal/consts	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/helper	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/mfa	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/group	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/pki	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/internal/identity/entity	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/schema	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/internal/provider	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/testutil	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/util	(cached) [no tests to run]
2023/09/18 11:12:14 [INFO] Using Vault token with the following policies: root
=== RUN   TestAccSSHSecretBackendRole
=== RUN   TestAccSSHSecretBackendRole/vault-1.11-and-below
    resource_ssh_secret_backend_role_test.go:150: Vault server version "1.12.0"
    resource_ssh_secret_backend_role_test.go:150: Vault version >= "1.12.0"
=== RUN   TestAccSSHSecretBackendRole/vault-1.12-and-up
    resource_ssh_secret_backend_role_test.go:162: Vault server version "1.12.0"
--- PASS: TestAccSSHSecretBackendRole (2.75s)
    --- SKIP: TestAccSSHSecretBackendRole/vault-1.11-and-below (0.00s)
    --- PASS: TestAccSSHSecretBackendRole/vault-1.12-and-up (2.75s)
=== RUN   TestAccSSHSecretBackendRoleOTP_basic
--- PASS: TestAccSSHSecretBackendRoleOTP_basic (0.95s)
=== RUN   TestAccSSHSecretBackendRole_template
    resource_ssh_secret_backend_role_test.go:203: Vault server version "1.12.0"
--- PASS: TestAccSSHSecretBackendRole_template (1.26s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/vault	4.981s
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

