### PR TITLE
Stops sending VAULT_TOKEN for login request

### DIFF
--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -237,6 +237,10 @@ func NewProviderMeta(d *schema.ResourceData) (interface{}, error) {
 			return nil, err
 		}
 
+		// Don't need a token for authLogin. Avoid Vault error/crash when the token is set to a namespaced one.
+		// See issue : https://github.com/hashicorp/vault/issues/23216
+		clone.SetToken("")
+
 		if authLogin.Namespace() != "" {
 			// the namespace configured on the auth_login takes precedence over the provider's
 			// for authentication only.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->

Vault token should not be sent for AuthLogin request. It generally doesn't matter ... except if the environment variable VAULT_TOKEN is set with a "namespaced" token issued by a Vault Enterprise.

In this case, we hit a bug in Vault (See https://github.com/hashicorp/vault/issues/23216) OSS where a namespaced token stop the request processing too soon (and the login request return a 500 error).

Fixing a value with `token` attribute of the provider doesn't work since the token parameter evaluation is done if it's not a authLogin configuration. And if no token is defined when we create a new instance of Vault API Client, the VAULT_TOKEN environment is used.


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->


### Checklist
- [X] No user-facing changes
- [X] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc  TESTARGS='-run=TestNewProviderMeta'
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage  [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate  [no test files]
?       github.com/hashicorp/terraform-provider-vault/generated [no test files]
ok      github.com/hashicorp/terraform-provider-vault/codegen   (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/decode    0.940s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/datasources/transform/encode    1.463s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/alphabet    2.101s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/role        1.199s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/template    1.882s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/generated/resources/transform/transformation      1.505s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/mfa     [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/pki      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  1.344s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/provider 1.318s
ok      github.com/hashicorp/terraform-provider-vault/testutil  (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/vault     1.890s [no tests to run]
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

