### PR TITLE
auth_login: enforce empty client token

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ build: go-version-check fmtcheck
 	go install
 
 test: go-version-check fmtcheck
-	TF_ACC= go test $(TESTARGS) -timeout 10m $(TEST_PATH)
+	TF_ACC= VAULT_TOKEN= go test $(TESTARGS) -timeout 10m $(TEST_PATH)
 
 testacc: fmtcheck
 	TF_ACC=1 go test $(TESTARGS) -timeout 30m $(TEST_PATH)

--- a/internal/provider/auth.go
+++ b/internal/provider/auth.go
@@ -211,6 +211,10 @@ func (l *AuthLoginCommon) copyParamsExcluding(excludes ...string) (map[string]in
 }
 
 func (l *AuthLoginCommon) login(client *api.Client, path string, params map[string]interface{}) (*api.Secret, error) {
+	if client.Token() != "" {
+		return nil, fmt.Errorf("vault login client has a token set")
+	}
+
 	return client.Logical().Write(path, params)
 }
 

--- a/internal/provider/auth_aws_test.go
+++ b/internal/provider/auth_aws_test.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -286,9 +287,29 @@ func TestAuthLoginAWS_Login(t *testing.T) {
 			wantErr:   true,
 			expectErr: authLoginInitCheckError,
 		},
+		{
+			name: "error-vault-token-set",
+			authLogin: &AuthLoginAWS{
+				AuthLoginCommon{
+					authField: "baz",
+					mount:     "foo",
+					params: map[string]interface{}{
+						consts.FieldRole: "bob",
+					},
+					initialized: true,
+				},
+			},
+			handler: &testLoginHandler{
+				handlerFunc: handlerFunc,
+			},
+			token:     "foo",
+			wantErr:   true,
+			expectErr: errors.New("vault login client has a token set"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			testAuthLogin(t, tt)
 		})
 	}

--- a/internal/provider/auth_azure_test.go
+++ b/internal/provider/auth_azure_test.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -241,6 +242,27 @@ func TestAuthLoginAzure_Login(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "error-vault-token-set",
+			authLogin: &AuthLoginAzure{
+				AuthLoginCommon: AuthLoginCommon{
+					authField: consts.FieldAuthLoginAzure,
+					params: map[string]interface{}{
+						consts.FieldRole:              "alice",
+						consts.FieldJWT:               "jwt1",
+						consts.FieldSubscriptionID:    "sub1",
+						consts.FieldResourceGroupName: "res1",
+						consts.FieldVMSSName:          "vmss1",
+					},
+					initialized: true,
+				},
+			},
+			handler: &testLoginHandler{
+				handlerFunc: handlerFunc,
+			},
+			wantErr:   true,
+			expectErr: errors.New("vault login client has a token set"),
+		},
+		{
 			name: "error-uninitialized",
 			authLogin: &AuthLoginAzure{
 				AuthLoginCommon: AuthLoginCommon{
@@ -258,6 +280,7 @@ func TestAuthLoginAzure_Login(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			testAuthLogin(t, tt)
 		})
 	}

--- a/internal/provider/auth_cert_test.go
+++ b/internal/provider/auth_cert_test.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -295,6 +296,28 @@ func TestAuthLoginCert_Login(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "error-vault-token-set",
+			authLogin: &AuthLoginCert{
+				AuthLoginCommon{
+					authField: "baz",
+					mount:     "qux",
+					params: map[string]interface{}{
+						consts.FieldName:          "bob",
+						consts.FieldCertFile:      certFile,
+						consts.FieldKeyFile:       keyFile,
+						consts.FieldSkipTLSVerify: true,
+					},
+					initialized: true,
+				},
+			},
+			handler: &testLoginHandler{
+				handlerFunc: handlerFunc,
+			},
+			token:     "foo",
+			wantErr:   true,
+			expectErr: errors.New("vault login client has a token set"),
+		},
+		{
 			name: "error-uninitialized",
 			authLogin: &AuthLoginCert{
 				AuthLoginCommon{
@@ -312,6 +335,7 @@ func TestAuthLoginCert_Login(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			testAuthLogin(t, tt)
 		})
 	}

--- a/internal/provider/auth_jwt_test.go
+++ b/internal/provider/auth_jwt_test.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -158,6 +159,25 @@ func TestAuthLoginJWT_Login(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "error-vault-token-set",
+			authLogin: &AuthLoginJWT{
+				AuthLoginCommon: AuthLoginCommon{
+					authField: consts.FieldAuthLoginJWT,
+					params: map[string]interface{}{
+						consts.FieldRole: "alice",
+						consts.FieldJWT:  "jwt1",
+					},
+					initialized: true,
+				},
+			},
+			handler: &testLoginHandler{
+				handlerFunc: handlerFunc,
+			},
+			token:     "foo",
+			wantErr:   true,
+			expectErr: errors.New("vault login client has a token set"),
+		},
+		{
 			name: "error-uninitialized",
 			authLogin: &AuthLoginJWT{
 				AuthLoginCommon: AuthLoginCommon{
@@ -175,6 +195,7 @@ func TestAuthLoginJWT_Login(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			testAuthLogin(t, tt)
 		})
 	}

--- a/internal/provider/auth_oci_test.go
+++ b/internal/provider/auth_oci_test.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -188,6 +189,25 @@ func TestAuthLoginOCI_Login(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "error-vault-token-set",
+			authLogin: &AuthLoginOCI{
+				AuthLoginCommon: AuthLoginCommon{
+					authField: consts.FieldAuthLoginOCI,
+					params: map[string]interface{}{
+						consts.FieldRole:     "alice",
+						consts.FieldAuthType: ociAuthTypeAPIKeys,
+					},
+					initialized: true,
+				},
+			},
+			handler: &testLoginHandler{
+				handlerFunc: handlerFunc,
+			},
+			token:     "foo",
+			wantErr:   true,
+			expectErr: errors.New("vault login client has a token set"),
+		},
+		{
 			name: "error-uninitialized",
 			authLogin: &AuthLoginOCI{
 				AuthLoginCommon: AuthLoginCommon{
@@ -205,6 +225,7 @@ func TestAuthLoginOCI_Login(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			testAuthLogin(t, tt)
 		})
 	}

--- a/internal/provider/auth_oidc_test.go
+++ b/internal/provider/auth_oidc_test.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -230,6 +231,25 @@ func TestAuthLoginOIDC_Login(t *testing.T) {
 
 	tests := []authLoginTest{
 		{
+			name: "error-vault-token-set",
+			authLogin: &AuthLoginOIDC{
+				AuthLoginCommon{
+					authField: "baz",
+					mount:     "foo",
+					params: map[string]interface{}{
+						consts.FieldRole: "bob",
+					},
+					initialized: true,
+				},
+			},
+			handler: &testLoginHandler{
+				handlerFunc: handlerFunc,
+			},
+			token:     "foo",
+			wantErr:   true,
+			expectErr: errors.New("vault login client has a token set"),
+		},
+		{
 			name: "error-uninitialized",
 			authLogin: &AuthLoginOIDC{
 				AuthLoginCommon{
@@ -246,6 +266,7 @@ func TestAuthLoginOIDC_Login(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			testAuthLogin(t, tt)
 		})
 	}

--- a/internal/provider/auth_radius_test.go
+++ b/internal/provider/auth_radius_test.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -158,6 +159,25 @@ func TestAuthLoginRadius_Login(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "error-vault-token-set",
+			authLogin: &AuthLoginRadius{
+				AuthLoginCommon: AuthLoginCommon{
+					authField: consts.FieldAuthLoginRadius,
+					params: map[string]interface{}{
+						consts.FieldUsername: "alice",
+						consts.FieldPassword: "password1",
+					},
+					initialized: true,
+				},
+			},
+			handler: &testLoginHandler{
+				handlerFunc: handlerFunc,
+			},
+			token:     "foo",
+			wantErr:   true,
+			expectErr: errors.New("vault login client has a token set"),
+		},
+		{
 			name: "error-uninitialized",
 			authLogin: &AuthLoginRadius{
 				AuthLoginCommon: AuthLoginCommon{
@@ -175,6 +195,7 @@ func TestAuthLoginRadius_Login(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			testAuthLogin(t, tt)
 		})
 	}

--- a/internal/provider/auth_test.go
+++ b/internal/provider/auth_test.go
@@ -35,6 +35,7 @@ type authLoginTest struct {
 	skipFunc           func(t *testing.T)
 	tls                bool
 	preLoginFunc       func(t *testing.T)
+	token              string
 }
 
 type authLoginInitTest struct {
@@ -118,6 +119,14 @@ func testAuthLogin(t *testing.T, tt authLoginTest) {
 	c, err := api.NewClient(config)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	// clear the vault token to avoid issues where it is picked up from one of its
+	// default sources.
+	c.ClearToken()
+
+	if tt.token != "" {
+		c.SetToken(tt.token)
 	}
 
 	got, err := tt.authLogin.Login(c)

--- a/internal/provider/auth_token_file_test.go
+++ b/internal/provider/auth_token_file_test.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -145,6 +146,38 @@ func TestAuthLoginTokenFile_Login(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "error-vault-token-set",
+			authLogin: &AuthLoginTokenFile{
+				AuthLoginCommon{
+					authField: "baz",
+					mount:     consts.MountTypeNone,
+					params: map[string]interface{}{
+						consts.FieldFilename: path.Join(tempDir, "basic"),
+					},
+					initialized: true,
+				},
+			},
+			handler: &testLoginHandler{
+				handlerFunc: handlerFunc,
+			},
+			preLoginFunc: func(t *testing.T) {
+				t.Helper()
+
+				filename := path.Join(tempDir, "basic")
+				t.Cleanup(func() {
+					if err := os.Remove(filename); err != nil {
+						t.Error(err)
+					}
+				})
+				if err := os.WriteFile(filename, []byte("qux\n"), 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			token:     "foo",
+			wantErr:   true,
+			expectErr: errors.New("vault login client has a token set"),
+		},
+		{
 			name: "error-invalid-file-mode",
 			authLogin: &AuthLoginTokenFile{
 				AuthLoginCommon{
@@ -223,6 +256,7 @@ func TestAuthLoginTokenFile_Login(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			testAuthLogin(t, tt)
 		})
 	}

--- a/internal/provider/auth_userpass_test.go
+++ b/internal/provider/auth_userpass_test.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -226,6 +227,26 @@ func TestAuthLoginUserpass_Login(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "error-vault-token-set",
+			authLogin: &AuthLoginUserpass{
+				AuthLoginCommon{
+					authField: "baz",
+					mount:     "foo",
+					params: map[string]interface{}{
+						consts.FieldUsername: "bob",
+						consts.FieldPassword: "baz",
+					},
+					initialized: true,
+				},
+			},
+			handler: &testLoginHandler{
+				handlerFunc: handlerFunc,
+			},
+			token:     "foo",
+			wantErr:   true,
+			expectErr: errors.New("vault login client has a token set"),
+		},
+		{
 			name: "error-no-username",
 			authLogin: &AuthLoginUserpass{
 				AuthLoginCommon{
@@ -263,6 +284,7 @@ func TestAuthLoginUserpass_Login(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			testAuthLogin(t, tt)
 		})
 	}

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -237,6 +237,12 @@ func NewProviderMeta(d *schema.ResourceData) (interface{}, error) {
 			return nil, err
 		}
 
+		if clone.Token() != "" {
+			log.Printf("[WARN] A vault token was set from the runtime environment, "+
+				"clearing it for auth_login method %q", authLogin.Method())
+			clone.ClearToken()
+		}
+
 		if authLogin.Namespace() != "" {
 			// the namespace configured on the auth_login takes precedence over the provider's
 			// for authentication only.


### PR DESCRIPTION
Fixes a failure when an `auth_login` is specified and a vault token is picked up from the runtime/execution environment. In the meantime the workaround is to ensure that `VAULT_TOKEN` is unset, and there exists no vault token on disk e.g: `~/.vault-token`

other fixes:
- parallelize AuthLogin tests
- ensure VAULT_TOKEN is not set from the test make targets

Relates to https://github.com/hashicorp/vault/issues/23216 #2026 

- [x] add vault token test to all AuthLogin.Login() tests