### PR TITLE
Add support for HMAC type to vault_transit_secret_backend_key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 FEATURES:
 * Add support for setting `not_before_duration` argument on `vault_ssh_secret_backend_role`: ([#2019](https://github.com/hashicorp/terraform-provider-vault/pull/2019))
+* Add support for `hmac` key type and key_size to `vault_transit_secret_backend_key`: ([#2034](https://github.com/hashicorp/terraform-provider-vault/pull/2034/))
 
 BUGS:
 * Fix duplicate timestamp and incorrect level messages: ([#2031](https://github.com/hashicorp/terraform-provider-vault/pull/2031))

--- a/vault/resource_transit_secret_backend_key_test.go
+++ b/vault/resource_transit_secret_backend_key_test.go
@@ -164,6 +164,10 @@ func TestTransitSecretBackendKey_hmac(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testTransitSecretBackendKeyConfig_hmac(name, backend),
+				SkipFunc: func() (bool, error) {
+					meta := testProvider.Meta().(*provider.ProviderMeta)
+					return !meta.IsAPISupported(provider.VaultVersion112), nil
+				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "backend", backend),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
@@ -183,6 +187,10 @@ func TestTransitSecretBackendKey_hmac(t *testing.T) {
 			},
 			{
 				Config: testTransitSecretBackendKeyConfig_hmacupdated(name, backend),
+				SkipFunc: func() (bool, error) {
+					meta := testProvider.Meta().(*provider.ProviderMeta)
+					return !meta.IsAPISupported(provider.VaultVersion112), nil
+				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "backend", backend),
 					resource.TestCheckResourceAttr(resourceName, "name", name),

--- a/vault/resource_transit_secret_backend_key_test.go
+++ b/vault/resource_transit_secret_backend_key_test.go
@@ -158,16 +158,15 @@ func TestTransitSecretBackendKey_hmac(t *testing.T) {
 	name := acctest.RandomWithPrefix("key")
 	resourceName := "vault_transit_secret_backend_key.test"
 	resource.Test(t, resource.TestCase{
-		Providers:    testProviders,
-		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		Providers: testProviders,
+		PreCheck: func() {
+			testutil.TestAccPreCheck(t)
+			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion112)
+		},
 		CheckDestroy: testTransitSecretBackendKeyCheckDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testTransitSecretBackendKeyConfig_hmac(name, backend),
-				SkipFunc: func() (bool, error) {
-					meta := testProvider.Meta().(*provider.ProviderMeta)
-					return !meta.IsAPISupported(provider.VaultVersion112), nil
-				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "backend", backend),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
@@ -187,10 +186,6 @@ func TestTransitSecretBackendKey_hmac(t *testing.T) {
 			},
 			{
 				Config: testTransitSecretBackendKeyConfig_hmacupdated(name, backend),
-				SkipFunc: func() (bool, error) {
-					meta := testProvider.Meta().(*provider.ProviderMeta)
-					return !meta.IsAPISupported(provider.VaultVersion112), nil
-				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "backend", backend),
 					resource.TestCheckResourceAttr(resourceName, "name", name),

--- a/vault/resource_transit_secret_backend_key_test.go
+++ b/vault/resource_transit_secret_backend_key_test.go
@@ -73,7 +73,7 @@ func TestTransitSecretBackendKey_basic(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"auto_rotate_interval"},
+				ImportStateVerifyIgnore: []string{"auto_rotate_interval", "key_size"},
 			},
 			{
 				Config:      testTransitSecretBackendKeyConfig_invalidUpdates(name, backend),
@@ -136,6 +136,67 @@ func TestTransitSecretBackendKey_rsa4096(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "supports_encryption", "true"),
 					resource.TestCheckResourceAttr(resourceName, "supports_signing", "true"),
 					resource.TestCheckResourceAttr(resourceName, "min_decryption_version", "1"),
+					resource.TestCheckResourceAttr(resourceName, "min_encryption_version", "0"),
+					resource.TestCheckResourceAttr(resourceName, "deletion_allowed", "true"),
+					resource.TestCheckResourceAttr(resourceName, "exportable", "false"),
+					resource.TestCheckResourceAttr(resourceName, "allow_plaintext_backup", "false"),
+					resource.TestCheckResourceAttr(resourceName, "auto_rotate_period", "0"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"key_size"},
+			},
+		},
+	})
+}
+
+func TestTransitSecretBackendKey_hmac(t *testing.T) {
+	backend := acctest.RandomWithPrefix("transit")
+	name := acctest.RandomWithPrefix("key")
+	resourceName := "vault_transit_secret_backend_key.test"
+	resource.Test(t, resource.TestCase{
+		Providers:    testProviders,
+		PreCheck:     func() { testutil.TestAccPreCheck(t) },
+		CheckDestroy: testTransitSecretBackendKeyCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testTransitSecretBackendKeyConfig_hmac(name, backend),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "deletion_allowed", "true"),
+					resource.TestCheckResourceAttr(resourceName, "convergent_encryption", "false"),
+					resource.TestCheckResourceAttr(resourceName, "derived", "false"),
+					resource.TestCheckResourceAttr(resourceName, "exportable", "false"),
+					resource.TestCheckResourceAttr(resourceName, "key_size", "32"),
+					resource.TestCheckResourceAttr(resourceName, "latest_version", "1"),
+					resource.TestCheckResourceAttr(resourceName, "type", "hmac"),
+					resource.TestCheckResourceAttr(resourceName, "supports_decryption", "false"),
+					resource.TestCheckResourceAttr(resourceName, "supports_derivation", "false"),
+					resource.TestCheckResourceAttr(resourceName, "supports_encryption", "false"),
+					resource.TestCheckResourceAttr(resourceName, "supports_signing", "false"),
+					resource.TestCheckResourceAttr(resourceName, "auto_rotate_period", "0"),
+				),
+			},
+			{
+				Config: testTransitSecretBackendKeyConfig_hmacupdated(name, backend),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "deletion_allowed", "true"),
+					resource.TestCheckResourceAttr(resourceName, "convergent_encryption", "false"),
+					resource.TestCheckResourceAttr(resourceName, "derived", "false"),
+					resource.TestCheckResourceAttr(resourceName, "key_size", "32"),
+					resource.TestCheckResourceAttr(resourceName, "latest_version", "1"),
+					resource.TestCheckResourceAttr(resourceName, "type", "hmac"),
+					resource.TestCheckResourceAttr(resourceName, "supports_decryption", "false"),
+					resource.TestCheckResourceAttr(resourceName, "supports_derivation", "false"),
+					resource.TestCheckResourceAttr(resourceName, "supports_encryption", "false"),
+					resource.TestCheckResourceAttr(resourceName, "supports_signing", "false"),
+					resource.TestCheckResourceAttr(resourceName, "min_decryption_version", "1"),
 					resource.TestCheckResourceAttr(resourceName, "min_encryption_version", "1"),
 					resource.TestCheckResourceAttr(resourceName, "deletion_allowed", "true"),
 					resource.TestCheckResourceAttr(resourceName, "exportable", "true"),
@@ -184,6 +245,23 @@ resource "vault_transit_secret_backend_key" "test" {
 `, path, name)
 }
 
+func testTransitSecretBackendKeyConfig_hmac(name, path string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "transit" {
+  path = "%s"
+  type = "transit"
+}
+
+resource "vault_transit_secret_backend_key" "test" {
+  backend = vault_mount.transit.path
+  name = "%s"
+  deletion_allowed = true
+  type = "hmac"
+  key_size = 32
+}
+`, path, name)
+}
+
 func testTransitSecretBackendKeyConfig_rsa4096updated(name, path string) string {
 	return fmt.Sprintf(`
 resource "vault_mount" "transit" {
@@ -196,6 +274,23 @@ resource "vault_transit_secret_backend_key" "test" {
   name = "%s"
   deletion_allowed = true
   type = "rsa-4096"
+}
+`, path, name)
+}
+
+func testTransitSecretBackendKeyConfig_hmacupdated(name, path string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "transit" {
+  path = "%s"
+  type = "transit"
+}
+
+resource "vault_transit_secret_backend_key" "test" {
+  backend = vault_mount.transit.path
+  name = "%s"
+  deletion_allowed = true
+  type = "hmac"
+  key_size = 32
   min_decryption_version = 1
   min_encryption_version = 1
   exportable             = true

--- a/website/docs/r/transit_secret_backend_key.html.md
+++ b/website/docs/r/transit_secret_backend_key.html.md
@@ -40,7 +40,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name to identify this key within the backend. Must be unique within the backend.
 
-* `type` - (Optional) Specifies the type of key to create. The currently-supported types are: `aes128-gcm96`, `aes256-gcm96` (default), `chacha20-poly1305`, `ed25519`, `ecdsa-p256`, `ecdsa-p384`, `ecdsa-p521`, `rsa-2048`, `rsa-3072` and `rsa-4096`. 
+* `type` - (Optional) Specifies the type of key to create. The currently-supported types are: `aes128-gcm96`, `aes256-gcm96` (default), `chacha20-poly1305`, `ed25519`, `ecdsa-p256`, `ecdsa-p384`, `ecdsa-p521`, `hmac`, `rsa-2048`, `rsa-3072` and `rsa-4096`.
     * Refer to the Vault documentation on transit key types for more information: [Key Types](https://www.vaultproject.io/docs/secrets/transit#key-types)
 
 * `deletion_allowed` - (Optional) Specifies if the keyring is allowed to be deleted. Must be set to 'true' before terraform will be able to destroy keys.
@@ -53,13 +53,15 @@ The following arguments are supported:
 
 * `allow_plaintext_backup` - (Optional) Enables taking backup of entire keyring in the plaintext format. Once set, this cannot be disabled.
     * Refer to Vault API documentation on key backups for more information: [Backup Key](https://www.vaultproject.io/api-docs/secret/transit#backup-key)
-    
+
 * `min_decryption_version` - (Optional) Minimum key version to use for decryption.
 
 * `min_encryption_version` - (Optional) Minimum key version to use for encryption
 
 * `auto_rotate_period` - (Optional) Amount of seconds the key should live before being automatically rotated.
   A value of 0 disables automatic rotation for the key.
+
+* `key_size` - (Optional) The key size in bytes for algorithms that allow variable key sizes. Currently only applicable to HMAC, where it must be between 32 and 512 bytes.
 
 ## Attributes Reference
 
@@ -69,7 +71,7 @@ The following arguments are supported:
         * `name` - Name of keychain
         * `creation_time` - ISO 8601 format timestamp indicating when the key version was created
         * `public_key` - This is the base64-encoded public key for use outside of Vault.
-        
+
 * `latest_version` - Latest key version available. This value is 1-indexed, so if `latest_version` is `1`, then the key's information can be referenced from `keys` by selecting element `0`
 
 * `min_available_version` - Minimum key version available for use. If keys have been archived by increasing `min_decryption_version`, this attribute will reflect that change.


### PR DESCRIPTION
* Add key_size as it is necessary for HMAC. Default to 0 bits as that is the default for all key types _except_ HMAC currently.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->

This PR updates the vault_transit_secret_backend_key to accept the `hmac` key type along with the requisite `key_size` argument so that transit keys of the `hmac` type can be created.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

