### PR TITLE
secret/pki: fix key_usage panic and unset function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ FEATURES:
 
 BUGS:
 * Fix duplicate timestamp and incorrect level messages: ([#2031](https://github.com/hashicorp/terraform-provider-vault/pull/2031))
+* Fix panic when setting `key_usage` to an array of empty string and enable it to unset the key usage constraints: ([#2036](https://github.com/hashicorp/terraform-provider-vault/pull/2036))
 
 ## 3.20.1 (Sep 13, 2023)
 IMPROVEMENTS:

--- a/vault/resource_pki_secret_backend_role.go
+++ b/vault/resource_pki_secret_backend_role.go
@@ -557,7 +557,6 @@ func pkiSecretBackendRoleRead(_ context.Context, d *schema.ResourceData, meta in
 
 	listFields := append(pkiSecretListFields, consts.FieldKeyUsage)
 	// handle TypeList
-	// for _, k := range pkiSecretListFields {
 	for _, k := range listFields {
 		list := expandStringSlice(secret.Data[k].([]interface{}))
 
@@ -565,11 +564,6 @@ func pkiSecretBackendRoleRead(_ context.Context, d *schema.ResourceData, meta in
 			d.Set(k, list)
 		}
 	}
-	// special handling for key_usage because an empty array or array with
-	// empty string means we do not want to specify key usage constraints
-	// if keyUsage, ok := secret.Data[consts.FieldKeyUsage]; ok {
-	// 	d.Set(consts.FieldKeyUsage, keyUsage)
-	// }
 
 	// handle TypeBool
 	for _, k := range pkiSecretBooleanFields {

--- a/vault/resource_pki_secret_backend_role.go
+++ b/vault/resource_pki_secret_backend_role.go
@@ -451,7 +451,14 @@ func pkiSecretBackendRoleCreate(ctx context.Context, d *schema.ResourceData, met
 			ifcList := v.([]interface{})
 			list := make([]string, 0, len(ifcList))
 			for _, ifc := range ifcList {
-				list = append(list, ifc.(string))
+				if ifc != nil {
+					list = append(list, ifc.(string))
+				} else if ifc == nil && k == consts.FieldKeyUsage {
+					// special handling for key_usage because an array with an
+					// empty string means we do not want to specify key usage
+					// constraints
+					list = append(list, "")
+				}
 			}
 
 			if len(list) > 0 {

--- a/vault/resource_pki_secret_backend_role_test.go
+++ b/vault/resource_pki_secret_backend_role_test.go
@@ -321,6 +321,13 @@ func TestPkiSecretBackendRole_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testPkiSecretBackendRoleConfig_basic(name, backend, 3600, 7200, `key_usage = [""]`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "key_usage.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "key_usage.0", ""),
+				),
+			},
 		},
 	})
 }

--- a/vault/resource_pki_secret_backend_role_test.go
+++ b/vault/resource_pki_secret_backend_role_test.go
@@ -328,6 +328,12 @@ func TestPkiSecretBackendRole_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "key_usage.0", ""),
 				),
 			},
+			{
+				Config: testPkiSecretBackendRoleConfig_basic(name, backend, 3600, 7200, `key_usage = []`),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "key_usage.#", "0"),
+				),
+			},
 		},
 	})
 }

--- a/website/docs/r/pki_secret_backend_role.html.md
+++ b/website/docs/r/pki_secret_backend_role.html.md
@@ -96,7 +96,7 @@ The following arguments are supported:
 * `key_bits` - (Optional) The number of bits of generated keys
 
 * `key_usage` - (Optional) Specify the allowed key usage constraint on issued
-  certificates. Deafults to `["DigitalSignature", "KeyAgreement", "KeyEncipherment"])`.
+  certificates. Defaults to `["DigitalSignature", "KeyAgreement", "KeyEncipherment"])`.
   Set to an array of empty string `[""]` to unset the default key usage
   constraints.
 

--- a/website/docs/r/pki_secret_backend_role.html.md
+++ b/website/docs/r/pki_secret_backend_role.html.md
@@ -95,7 +95,10 @@ The following arguments are supported:
 
 * `key_bits` - (Optional) The number of bits of generated keys
 
-* `key_usage` - (Optional) Specify the allowed key usage constraint on issued certificates
+* `key_usage` - (Optional) Specify the allowed key usage constraint on issued
+  certificates. Deafults to `["DigitalSignature", "KeyAgreement", "KeyEncipherment"])`.
+  Set to an array of empty string `[""]` to unset the default key usage
+  constraints.
 
 * `ext_key_usage` - (Optional) Specify the allowed extended key usage constraint on issued certificates
 

--- a/website/docs/r/pki_secret_backend_role.html.md
+++ b/website/docs/r/pki_secret_backend_role.html.md
@@ -97,8 +97,7 @@ The following arguments are supported:
 
 * `key_usage` - (Optional) Specify the allowed key usage constraint on issued
   certificates. Defaults to `["DigitalSignature", "KeyAgreement", "KeyEncipherment"])`.
-  Set to an array of empty string `[""]` to unset the default key usage
-  constraints.
+  To specify no default key usage constraints, set this to an empty list `[]`.
 
 * `ext_key_usage` - (Optional) Specify the allowed extended key usage constraint on issued certificates
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
Do not panic when setting `key_usage` to an array of empty string. Also make this unset the key usage constraints on the pki engine.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1533, closes #2028

### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

