### PR TITLE
Add state migrator for `external_member_group_ids` in Identity Group

### DIFF
--- a/vault/resource_identity_group_test.go
+++ b/vault/resource_identity_group_test.go
@@ -5,6 +5,7 @@ package vault
 
 import (
 	"fmt"
+	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -152,6 +153,40 @@ resource "vault_identity_group" "test_upper" {
 			},
 		},
 	})
+}
+
+func TestSecretsAuthDisableRemountUpgradeV0(t *testing.T) {
+	tests := []struct {
+		name     string
+		rawState map[string]interface{}
+		want     map[string]interface{}
+		wantErr  bool
+	}{
+		{
+			name: "basic",
+			rawState: map[string]interface{}{
+				fieldExternalMemberGroupIDs: nil,
+			},
+			want: map[string]interface{}{
+				fieldExternalMemberGroupIDs: false,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := identityGroupExternalGroupIDsUpgradeV0(nil, tt.rawState, nil)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("identityGroupExternalGroupIDsUpgradeV0() error = %#v, wantErr %#v", err, tt.wantErr)
+				}
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("identityGroupExternalGroupIDsUpgradeV0() got = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
 }
 
 func testAccCheckIdentityGroupDestroy(s *terraform.State) error {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
Adds a state migrator for the `external_member_group_ids` parameter that was added to the Identity Group resource in v3.10.0. Since the parameter is an internal constant with a default value, it should be set to users' TF configs when they upgrade to the new version. Since it was previously not being set for users upon an upgrade, the regression led to the value being `null` in the TF state. This PR ensures that upon upgrading, if the TF state value is `null`, set it to the desired default of `false`

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1690 


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestSecretsAuthDisableRemountUpgradeV0'
=== RUN   TestSecretsAuthDisableRemountUpgradeV0
=== RUN   TestSecretsAuthDisableRemountUpgradeV0/basic
--- PASS: TestSecretsAuthDisableRemountUpgradeV0 (0.00s)
    --- PASS: TestSecretsAuthDisableRemountUpgradeV0/basic (0.00s)
PASS
```