### PR TITLE
Downgrade `vault-plugin-auth-jwt` dependency to `v0.17.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ IMPROVEMENTS:
    * `github.com/hashicorp/go-cty` v1.4.1-0.20200414143053-d3edf31b6320 -> v1.4.1-0.20200723130312-85980079f637
    * `github.com/hashicorp/go-retryablehttp` v0.7.1 -> v0.7.4
    * `github.com/hashicorp/terraform-plugin-sdk/v2` v2.16.0 -> v2.29.0
-   * `github.com/hashicorp/vault-plugin-auth-jwt` v0.13.2-0.20221012184020-28cc68ee722b -> v0.17.1
+   * `github.com/hashicorp/vault-plugin-auth-jwt` v0.13.2-0.20221012184020-28cc68ee722b -> v0.17.0
    * `github.com/hashicorp/vault-plugin-auth-kerberos` v0.8.0 -> v0.10.1
    * `github.com/hashicorp/vault-plugin-auth-oci` v0.13.0-pre -> v0.14.2
    * `github.com/hashicorp/vault/api` v1.9.3-0.20230628215639-3ca33976762c -> v1.10.0

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.29.0
 	github.com/hashicorp/vault v1.11.3
-	github.com/hashicorp/vault-plugin-auth-jwt v0.17.1
+	github.com/hashicorp/vault-plugin-auth-jwt v0.17.0
 	github.com/hashicorp/vault-plugin-auth-kerberos v0.10.1
 	github.com/hashicorp/vault-plugin-auth-oci v0.14.2
 	github.com/hashicorp/vault/api v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -2031,8 +2031,8 @@ github.com/hashicorp/vault-plugin-auth-centrify v0.12.0/go.mod h1:3fDbIVdwA/hkOV
 github.com/hashicorp/vault-plugin-auth-cf v0.12.0/go.mod h1:dr0cewrZ0SgpsPFkQ7Vf31J4xg+ylxM3Yv+dk1zWpEQ=
 github.com/hashicorp/vault-plugin-auth-gcp v0.13.2/go.mod h1:tHtTF/qQmrRrY5DEOxWxoW/y5Wk9VoHsBOC339RO3d8=
 github.com/hashicorp/vault-plugin-auth-jwt v0.13.0/go.mod h1:+WL5kaq/0L5OROsA31X15U8yTIX4GTEv1rTLA9d15eo=
-github.com/hashicorp/vault-plugin-auth-jwt v0.17.1 h1:Q64SF3NfHtku/gBGJ+W2eaG881La8iTyqrRzZ9Deaks=
-github.com/hashicorp/vault-plugin-auth-jwt v0.17.1/go.mod h1:R5ZtloCRWHnElOm+MXJadj2jkGMwF9Ybk3sn2kV3L48=
+github.com/hashicorp/vault-plugin-auth-jwt v0.17.0 h1:ZfgyFjZfquIn9qk1bytkaqUfG8mKx71RYaSb620dEh0=
+github.com/hashicorp/vault-plugin-auth-jwt v0.17.0/go.mod h1:R5ZtloCRWHnElOm+MXJadj2jkGMwF9Ybk3sn2kV3L48=
 github.com/hashicorp/vault-plugin-auth-kerberos v0.7.3/go.mod h1:eqjae8tMBpAWgJNk1NjV/vtJYXQRZnYudUkBFowz3bY=
 github.com/hashicorp/vault-plugin-auth-kerberos v0.10.1 h1:nXni7zfOyhOWJBC42iWqIEZA+aYCo3diyVrr1mHs5yo=
 github.com/hashicorp/vault-plugin-auth-kerberos v0.10.1/go.mod h1:S0XEzmbUO+iuC44a8wqnL869l6WH0DUMVqxTIEkITys=


### PR DESCRIPTION
We updated `vault-plugin-auth-jwt` to `v0.17.1`, and the plugin has started using the `syscall.SIGTSTP` signal to close the HTTP listener. PR is [available here](https://github.com/hashicorp/vault-plugin-auth-jwt/pull/251). This signal seems to be undefined on `windows_386`, which is causing TFVP builds on that system to [fail](https://github.com/hashicorp/terraform-provider-vault/actions/runs/6461899972/job/17542528742). Going to downgrade this dependency down to stable version `v0.17.0` until issue has been resolved upstream