### PR TITLE
fix(oidc_client): omit client_secret when client_type == "public"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+BUGS:
+* Fix panic when readnig client_secret from a public oidc client ([#2048](https://github.com/hashicorp/terraform-provider-vault/pull/2048))
+
 ## 3.21.0 (Oct 9, 2023)
 
 FEATURES:

--- a/vault/data_identity_oidc_client_creds.go
+++ b/vault/data_identity_oidc_client_creds.go
@@ -56,14 +56,21 @@ func readOIDCClientCredsResource(d *schema.ResourceData, meta interface{}) error
 	}
 
 	clientId := creds.Data["client_id"].(string)
-
 	if clientId == "" {
 		return fmt.Errorf("client_id is not set in response")
 	}
 
-	clientSecret := creds.Data["client_secret"].(string)
-	if clientSecret == "" {
-		return fmt.Errorf("client_secret is not set in response")
+	clientType := creds.Data["client_type"].(string)
+	if clientType == "" {
+		return fmt.Errorf("client_type is not set in response")
+	}
+
+	clientSecret := ""
+	if clientType != "public" {
+		clientSecret = creds.Data["client_secret"].(string)
+		if clientSecret == "" {
+			return fmt.Errorf("client_secret is not set in response")
+		}
 	}
 
 	d.SetId(path)

--- a/vault/data_identity_oidc_client_creds_test.go
+++ b/vault/data_identity_oidc_client_creds_test.go
@@ -27,6 +27,13 @@ func TestDataSourceIdentityOIDCClientCreds(t *testing.T) {
 					resource.TestCheckResourceAttr("data.vault_identity_oidc_client_creds.creds", "name", name),
 				),
 			},
+			{
+				Config: testDataSourceIdentityOIDCPublicClientCreds_config(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.vault_identity_oidc_client_creds.creds_public", "name", name),
+					resource.TestCheckResourceAttr("data.vault_identity_oidc_client_creds.creds_public", "client_secret", ""),
+				),
+			},
 		},
 	})
 }
@@ -57,26 +64,7 @@ data "vault_identity_oidc_client_creds" "creds" {
 }`, name)
 }
 
-func TestDataSourceIdentityOIDCClientCreds_PublicClient(t *testing.T) {
-	t.Parallel()
-	name := acctest.RandomWithPrefix("test-public-client")
-
-	resource.Test(t, resource.TestCase{
-		ProviderFactories: providerFactories,
-		PreCheck:          func() { testutil.TestAccPreCheck(t) },
-		Steps: []resource.TestStep{
-			{
-				Config: testDataSourceIdentityOIDCClientCreds_PublicClientConfig(name),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.vault_identity_oidc_client_creds.creds", "name", name),
-					resource.TestCheckResourceAttr("data.vault_identity_oidc_client_creds.creds", "client_secret", ""),
-				),
-			},
-		},
-	})
-}
-
-func testDataSourceIdentityOIDCClientCreds_PublicClientConfig(name string) string {
+func testDataSourceIdentityOIDCPublicClientCreds_config(name string) string {
 	return fmt.Sprintf(`
 resource "vault_identity_oidc_key" "key" {
   name               = "key"
@@ -85,7 +73,7 @@ resource "vault_identity_oidc_key" "key" {
   verification_ttl   = 3600
 }
 
-resource "vault_identity_oidc_client" "test" {
+resource "vault_identity_oidc_client" "test_public" {
   name             = "%s"
   client_type      = "public"
   key              = vault_identity_oidc_key.key.name
@@ -98,7 +86,7 @@ resource "vault_identity_oidc_client" "test" {
   access_token_ttl = 7200
 }
 
-data "vault_identity_oidc_client_creds" "creds" {
-  name = vault_identity_oidc_client.test.name
+data "vault_identity_oidc_client_creds" "creds_public" {
+  name = vault_identity_oidc_client.test_public.name
 }`, name)
 }

--- a/vault/data_identity_oidc_client_creds_test.go
+++ b/vault/data_identity_oidc_client_creds_test.go
@@ -44,7 +44,53 @@ resource "vault_identity_oidc_client" "test" {
   name          = "%s"
   key           = vault_identity_oidc_key.key.name
   redirect_uris = [
-	"http://127.0.0.1:9200/v1/auth-methods/oidc:authenticate:callback", 
+	"http://127.0.0.1:9200/v1/auth-methods/oidc:authenticate:callback",
+	"http://127.0.0.1:8251/callback",
+	"http://127.0.0.1:8080/callback"
+  ]
+  id_token_ttl     = 2400
+  access_token_ttl = 7200
+}
+
+data "vault_identity_oidc_client_creds" "creds" {
+  name = vault_identity_oidc_client.test.name
+}`, name)
+}
+
+func TestDataSourceIdentityOIDCClientCreds_PublicClient(t *testing.T) {
+	t.Parallel()
+	name := acctest.RandomWithPrefix("test-public-client")
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		PreCheck:          func() { testutil.TestAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceIdentityOIDCClientCreds_PublicClientConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.vault_identity_oidc_client_creds.creds", "name", name),
+					resource.TestCheckResourceAttr("data.vault_identity_oidc_client_creds.creds", "client_secret", ""),
+				),
+			},
+		},
+	})
+}
+
+func testDataSourceIdentityOIDCClientCreds_PublicClientConfig(name string) string {
+	return fmt.Sprintf(`
+resource "vault_identity_oidc_key" "key" {
+  name               = "key"
+  allowed_client_ids = ["*"]
+  rotation_period    = 3600
+  verification_ttl   = 3600
+}
+
+resource "vault_identity_oidc_client" "test" {
+  name             = "%s"
+  client_type      = "public"
+  key              = vault_identity_oidc_key.key.name
+  redirect_uris    = [
+	"http://127.0.0.1:9200/v1/auth-methods/oidc:authenticate:callback",
 	"http://127.0.0.1:8251/callback",
 	"http://127.0.0.1:8080/callback"
   ]

--- a/website/docs/d/identity_oidc_client_creds.html.md
+++ b/website/docs/d/identity_oidc_client_creds.html.md
@@ -56,3 +56,4 @@ In addition to the arguments above, the following attributes are exported:
 * `client_id` - The Client ID returned by Vault.
 
 * `client_secret` - The Client Secret Key returned by Vault.
+   For public OpenID Clients `client_secret` is set to an empty string `""`


### PR DESCRIPTION
Public OpenID Clients don't have a client_secret so accessing it results in a

    panic: interface conversion: interface {} is nil, not string

### Description

This change explicitly ignores `vault_identity_oidc_client_creds`'s `client_secret` and sets it to an empty string for public clients


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```

### Steps to reproduce

Create a public oidc client and attemt to query it's creds
```terraform
resource "vault_identity_oidc_client" "test" {
  name             = "test"
  client_type      = "public"
  redirect_uris    = ["http://0.0.0.0:80/"]
  assignments      = ["allow_all"]
  key              = vault_identity_oidc_key.test.id
  id_token_ttl     = 600
  access_token_ttl = 1200
}

data "vault_identity_oidc_client_creds" "test" {
  name = vault_identity_oidc_client.test.name
}
```

You will get this error
```
Stack trace from the terraform-provider-vault_v3.21.0_x5 plugin:

panic: interface conversion: interface {} is nil, not string

goroutine 64 [running]:
github.com/hashicorp/terraform-provider-vault/vault.readOIDCClientCredsResource(0x0?, {0x148a680?, 0xc0008f61c0?})
	github.com/hashicorp/terraform-provider-vault/vault/data_identity_oidc_client_creds.go:64 +0x41b
github.com/hashicorp/terraform-provider-vault/internal/provider.ReadWrapper.func1(0x0?, {0x148a680, 0xc0008f61c0})
	github.com/hashicorp/terraform-provider-vault/internal/provider/provider.go:241 +0x5a
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0x19ce8e8?, {0x19ce8e8?, 0xc000e67950?}, 0xd?, {0x148a680?, 0xc0008f61c0?})
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.29.0/helper/schema/resource.go:783 +0x178
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).ReadDataApply(0xc00082c540, {0x19ce8e8, 0xc000e67950}, 0xc000326e00, {0x148a680, 0xc0008f61c0})
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.29.0/helper/schema/resource.go:1015 +0x150
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ReadDataSource(0xc000a24a50, {0x19ce8e8?, 0xc000e67830?}, 0xc000ddb560)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.29.0/helper/schema/grpc_provider.go:1237 +0x38f
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ReadDataSource(0xc00078c320, {0x19ce8e8?, 0xc000e66ea0?}, 0xc000e50870)
	github.com/hashicorp/terraform-plugin-go@v0.19.0/tfprotov5/tf5server/server.go:699 +0x403
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ReadDataSource_Handler({0x156c320?, 0xc00078c320}, {0x19ce8e8, 0xc000e66ea0}, 0xc000134c40, 0x0)
	github.com/hashicorp/terraform-plugin-go@v0.19.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:503 +0x170
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0007a0b40, {0x19d4260, 0xc000a2aea0}, 0xc000e698c0, 0xc000a28390, 0x23cf3a8, 0x0)
	google.golang.org/grpc@v1.58.2/server.go:1376 +0xdd2
google.golang.org/grpc.(*Server).handleStream(0xc0007a0b40, {0x19d4260, 0xc000a2aea0}, 0xc000e698c0, 0x0)
	google.golang.org/grpc@v1.58.2/server.go:1753 +0xa36
google.golang.org/grpc.(*Server).serveStreams.func1.1()
	google.golang.org/grpc@v1.58.2/server.go:998 +0x98
created by google.golang.org/grpc.(*Server).serveStreams.func1
	google.golang.org/grpc@v1.58.2/server.go:996 +0x18c
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

