### PR TITLE
[Phase 1] Multiplex provider - minimal TF Plugin Framework provider implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework v1.4.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
 	github.com/hashicorp/terraform-plugin-go v0.19.0
+	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-mux v0.12.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.29.0
 	github.com/hashicorp/vault v1.11.3
@@ -134,7 +135,6 @@ require (
 	github.com/hashicorp/serf v0.9.7 // indirect
 	github.com/hashicorp/terraform-exec v0.19.0 // indirect
 	github.com/hashicorp/terraform-json v0.17.1 // indirect
-	github.com/hashicorp/terraform-plugin-log v0.9.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.2 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/hashicorp/go-secure-stdlib/awsutil v0.2.3
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.7
 	github.com/hashicorp/go-version v1.6.0
+	github.com/hashicorp/terraform-plugin-framework v1.4.1
 	github.com/hashicorp/terraform-plugin-go v0.19.0
 	github.com/hashicorp/terraform-plugin-mux v0.12.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.29.0

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.7
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/terraform-plugin-framework v1.4.1
+	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
 	github.com/hashicorp/terraform-plugin-go v0.19.0
 	github.com/hashicorp/terraform-plugin-mux v0.12.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.29.0

--- a/go.sum
+++ b/go.sum
@@ -1581,6 +1581,8 @@ github.com/hashicorp/terraform-json v0.17.1 h1:eMfvh/uWggKmY7Pmb3T85u86E2EQg6EQH
 github.com/hashicorp/terraform-json v0.17.1/go.mod h1:Huy6zt6euxaY9knPAFKjUITn8QxUFIe9VuSzb4zn/0o=
 github.com/hashicorp/terraform-plugin-framework v1.4.1 h1:ZC29MoB3Nbov6axHdgPbMz7799pT5H8kIrM8YAsaVrs=
 github.com/hashicorp/terraform-plugin-framework v1.4.1/go.mod h1:XC0hPcQbBvlbxwmjxuV/8sn8SbZRg4XwGMs22f+kqV0=
+github.com/hashicorp/terraform-plugin-framework-validators v0.12.0 h1:HOjBuMbOEzl7snOdOoUfE2Jgeto6JOjLVQ39Ls2nksc=
+github.com/hashicorp/terraform-plugin-framework-validators v0.12.0/go.mod h1:jfHGE/gzjxYz6XoUwi/aYiiKrJDeutQNUtGQXkaHklg=
 github.com/hashicorp/terraform-plugin-go v0.19.0 h1:BuZx/6Cp+lkmiG0cOBk6Zps0Cb2tmqQpDM3iAtnhDQU=
 github.com/hashicorp/terraform-plugin-go v0.19.0/go.mod h1:EhRSkEPNoylLQntYsk5KrDHTZJh9HQoumZXbOGOXmec=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=

--- a/go.sum
+++ b/go.sum
@@ -1579,6 +1579,8 @@ github.com/hashicorp/terraform-exec v0.19.0 h1:FpqZ6n50Tk95mItTSS9BjeOVUb4eg81Sp
 github.com/hashicorp/terraform-exec v0.19.0/go.mod h1:tbxUpe3JKruE9Cuf65mycSIT8KiNPZ0FkuTE3H4urQg=
 github.com/hashicorp/terraform-json v0.17.1 h1:eMfvh/uWggKmY7Pmb3T85u86E2EQg6EQHgyRwf3RkyA=
 github.com/hashicorp/terraform-json v0.17.1/go.mod h1:Huy6zt6euxaY9knPAFKjUITn8QxUFIe9VuSzb4zn/0o=
+github.com/hashicorp/terraform-plugin-framework v1.4.1 h1:ZC29MoB3Nbov6axHdgPbMz7799pT5H8kIrM8YAsaVrs=
+github.com/hashicorp/terraform-plugin-framework v1.4.1/go.mod h1:XC0hPcQbBvlbxwmjxuV/8sn8SbZRg4XwGMs22f+kqV0=
 github.com/hashicorp/terraform-plugin-go v0.19.0 h1:BuZx/6Cp+lkmiG0cOBk6Zps0Cb2tmqQpDM3iAtnhDQU=
 github.com/hashicorp/terraform-plugin-go v0.19.0/go.mod h1:EhRSkEPNoylLQntYsk5KrDHTZJh9HQoumZXbOGOXmec=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -104,7 +104,6 @@ const (
 	FieldUsername                      = "username"
 	FieldPassword                      = "password"
 	FieldPasswordFile                  = "password_file"
-	FieldClientAuth                    = "client_auth"
 	FieldAuthLoginGeneric              = "auth_login"
 	FieldAuthLoginUserpass             = "auth_login_userpass"
 	FieldAuthLoginAWS                  = "auth_login_aws"
@@ -363,7 +362,6 @@ const (
 	FieldServiceAccountJWT             = "service_account_jwt"
 	FieldDisableISSValidation          = "disable_iss_validation"
 	FieldPEMKeys                       = "pem_keys"
-	FieldSetNamespaceFromToken         = "set_namespace_from_token"
 	/*
 		common environment variables
 	*/

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -368,7 +368,6 @@ const (
 		common environment variables
 	*/
 	EnvVarVaultNamespaceImport = "TERRAFORM_VAULT_NAMESPACE_IMPORT"
-	EnvVarSkipChildToken       = "TERRAFORM_VAULT_SKIP_CHILD_TOKEN"
 	// EnvVarUsername to get the username for the userpass auth method
 	EnvVarUsername = "TERRAFORM_VAULT_USERNAME"
 	// EnvVarPassword to get the password for the userpass auth method

--- a/internal/framework/base/base.go
+++ b/internal/framework/base/base.go
@@ -1,0 +1,43 @@
+package base
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/framework/validators"
+)
+
+// BaseModel describes common fields for all of the Terraform resource data models
+type BaseModel struct {
+	Namespace types.String `tfsdk:"namespace"`
+}
+
+func baseSchema() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		consts.FieldNamespace: schema.StringAttribute{
+			Optional: true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+			MarkdownDescription: "Target namespace. (requires Enterprise)",
+			Validators: []validator.String{
+				validators.PathValidator(),
+			},
+		},
+	}
+}
+
+func MustAddBaseSchema(s *schema.Schema) {
+	for k, v := range baseSchema() {
+		if _, ok := s.Attributes[k]; ok {
+			panic(fmt.Sprintf("cannot add schema field %q, already exists in the Schema map", k))
+		}
+
+		s.Attributes[k] = v
+	}
+}

--- a/internal/framework/client/client.go
+++ b/internal/framework/client/client.go
@@ -1,0 +1,39 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+	"github.com/hashicorp/vault/api"
+)
+
+func GetClient(ctx context.Context, meta interface{}, namespace string) (*api.Client, error) {
+	var p *provider.ProviderMeta
+
+	switch v := meta.(type) {
+	case *provider.ProviderMeta:
+		p = v
+	default:
+		return nil, fmt.Errorf("meta argument must be a %T, not %T", p, meta)
+	}
+
+	ns := namespace
+	if namespace == "" {
+		// in order to import namespaced resources the user must provide
+		// the namespace from an environment variable.
+		ns = os.Getenv(consts.EnvVarVaultNamespaceImport)
+		if ns != "" {
+			tflog.Debug(ctx, fmt.Sprintf("Value for %q set from environment", consts.FieldNamespace))
+		}
+	}
+
+	if ns != "" {
+		return p.GetNSClient(ns)
+	}
+
+	return p.GetClient()
+}

--- a/internal/framework/validators/README.md
+++ b/internal/framework/validators/README.md
@@ -1,0 +1,3 @@
+# Terraform Plugin Framework Validators
+
+This package contains custom Terraform Plugin Framework [validators](https://developer.hashicorp.com/terraform/plugin/framework/validation).

--- a/internal/framework/validators/file_exists.go
+++ b/internal/framework/validators/file_exists.go
@@ -1,0 +1,62 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validators
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/mitchellh/go-homedir"
+)
+
+var _ validator.String = fileExists{}
+
+// fileExists validates that a given token is a valid initialization token
+type fileExists struct{}
+
+// Description describes the validation in plain text formatting.
+func (v fileExists) Description(_ context.Context) string {
+	return "value must be a valid path to an existing file"
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (v fileExists) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// ValidateString performs the validation.
+func (v fileExists) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	value := request.ConfigValue.ValueString()
+	if value == "" {
+		response.Diagnostics.AddError("invalid file", "value cannot be empty")
+		return
+	}
+
+	filename, err := homedir.Expand(value)
+	if err != nil {
+		response.Diagnostics.AddError("invalid file", err.Error())
+		return
+	}
+
+	st, err := os.Stat(filename)
+	if err != nil {
+		response.Diagnostics.AddError("invalid file", fmt.Sprintf("failed to stat path %q, err=%s", filename, err))
+		return
+	}
+
+	if st.IsDir() {
+		response.Diagnostics.AddError("invalid file", fmt.Sprintf("path %q is not a file", filename))
+		return
+	}
+}
+
+func FileExistsValidator() validator.String {
+	return fileExists{}
+}

--- a/internal/framework/validators/file_exists_test.go
+++ b/internal/framework/validators/file_exists_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validators
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const testFilePath = "./testdata/fake_account.json"
+
+func TestFrameworkProvider_FileExistsValidator(t *testing.T) {
+	cases := map[string]struct {
+		configValue        func(t *testing.T) types.String
+		expectedErrorCount int
+	}{
+		"file-is-valid": {
+			configValue: func(t *testing.T) types.String {
+				return types.StringValue(testFilePath) // Path to a test fixture
+			},
+		},
+		"non-existant-file-is-not-valid": {
+			configValue: func(t *testing.T) types.String {
+				return types.StringValue("./this/path/doesnt/exist.json") // Doesn't exist
+			},
+			expectedErrorCount: 1,
+		},
+		"empty-string-is-not-valid": {
+			configValue: func(t *testing.T) types.String {
+				return types.StringValue("")
+			},
+			expectedErrorCount: 1,
+		},
+		"unconfigured-is-valid": {
+			configValue: func(t *testing.T) types.String {
+				return types.StringNull()
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			// Arrange
+			req := validator.StringRequest{
+				ConfigValue: tc.configValue(t),
+			}
+
+			resp := validator.StringResponse{
+				Diagnostics: diag.Diagnostics{},
+			}
+
+			f := FileExistsValidator()
+
+			// Act
+			f.ValidateString(context.Background(), req, &resp)
+
+			// Assert
+			if resp.Diagnostics.ErrorsCount() != tc.expectedErrorCount {
+				t.Errorf("Expected %d errors, got %d", tc.expectedErrorCount, resp.Diagnostics.ErrorsCount())
+			}
+		})
+	}
+}

--- a/internal/framework/validators/gcp.go
+++ b/internal/framework/validators/gcp.go
@@ -1,0 +1,49 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validators
+
+import (
+	"context"
+	"os"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	googleoauth "golang.org/x/oauth2/google"
+)
+
+// Credentials Validator
+var _ validator.String = credentialsValidator{}
+
+// credentialsValidator validates that a string Attribute's is valid JSON credentials.
+type credentialsValidator struct{}
+
+// Description describes the validation in plain text formatting.
+func (v credentialsValidator) Description(_ context.Context) string {
+	return "value must be a path to valid JSON credentials or valid, raw, JSON credentials"
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (v credentialsValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// ValidateString performs the validation.
+func (v credentialsValidator) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	value := request.ConfigValue.ValueString()
+
+	// if this is a path and we can stat it, assume it's ok
+	if _, err := os.Stat(value); err == nil {
+		return
+	}
+	if _, err := googleoauth.CredentialsFromJSON(context.Background(), []byte(value)); err != nil {
+		response.Diagnostics.AddError("JSON credentials are not valid", err.Error())
+	}
+}
+
+func GCPCredentialsValidator() validator.String {
+	return credentialsValidator{}
+}

--- a/internal/framework/validators/gcp_test.go
+++ b/internal/framework/validators/gcp_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validators
+
+import (
+	"context"
+	"io/ioutil"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const testFakeCredentialsPath = "./testdata/fake_account.json"
+
+func TestFrameworkProvider_CredentialsValidator(t *testing.T) {
+	cases := map[string]struct {
+		configValue        func(t *testing.T) types.String
+		expectedErrorCount int
+	}{
+		"configuring credentials as a path to a credentials JSON file is valid": {
+			configValue: func(t *testing.T) types.String {
+				return types.StringValue(testFakeCredentialsPath) // Path to a test fixture
+			},
+		},
+		"configuring credentials as a path to a non-existant file is NOT valid": {
+			configValue: func(t *testing.T) types.String {
+				return types.StringValue("./this/path/doesnt/exist.json") // Doesn't exist
+			},
+			expectedErrorCount: 1,
+		},
+		"configuring credentials as a credentials JSON string is valid": {
+			configValue: func(t *testing.T) types.String {
+				contents, err := ioutil.ReadFile(testFakeCredentialsPath)
+				if err != nil {
+					t.Fatalf("Unexpected error: %s", err)
+				}
+				stringContents := string(contents)
+				return types.StringValue(stringContents)
+			},
+		},
+		"configuring credentials as an empty string is not valid": {
+			configValue: func(t *testing.T) types.String {
+				return types.StringValue("")
+			},
+			expectedErrorCount: 1,
+		},
+		"leaving credentials unconfigured is valid": {
+			configValue: func(t *testing.T) types.String {
+				return types.StringNull()
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			// Arrange
+			req := validator.StringRequest{
+				ConfigValue: tc.configValue(t),
+			}
+
+			resp := validator.StringResponse{
+				Diagnostics: diag.Diagnostics{},
+			}
+
+			cv := GCPCredentialsValidator()
+
+			// Act
+			cv.ValidateString(context.Background(), req, &resp)
+
+			// Assert
+			if resp.Diagnostics.ErrorsCount() != tc.expectedErrorCount {
+				t.Errorf("Expected %d errors, got %d", tc.expectedErrorCount, resp.Diagnostics.ErrorsCount())
+			}
+		})
+	}
+}

--- a/internal/framework/validators/kerberos.go
+++ b/internal/framework/validators/kerberos.go
@@ -1,0 +1,62 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validators
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/jcmturner/gokrb5/v8/spnego"
+)
+
+var _ validator.String = krbNegToken{}
+
+// krbNegToken validates that a given token is a valid initialization token
+type krbNegToken struct{}
+
+// Description describes the validation in plain text formatting.
+func (v krbNegToken) Description(_ context.Context) string {
+	return "value must be a valid initialization token"
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (v krbNegToken) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// ValidateString performs the validation.
+func (v krbNegToken) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	value := request.ConfigValue.ValueString()
+	if value == "" {
+		response.Diagnostics.AddError("invalid token", "value cannot be empty")
+		return
+	}
+
+	b, err := base64.StdEncoding.DecodeString(value)
+	if err != nil {
+		response.Diagnostics.AddError("invalid token", "value cannot be empty")
+		return
+	}
+
+	isNeg, _, err := spnego.UnmarshalNegToken(b)
+	if err != nil {
+		response.Diagnostics.AddError("invalid token", fmt.Sprintf("failed to unmarshal token, err=%s", err))
+		return
+	}
+
+	if !isNeg {
+		response.Diagnostics.AddError("invalid token", "not an initialization token")
+		return
+	}
+}
+
+func KRBNegTokenValidator() validator.String {
+	return krbNegToken{}
+}

--- a/internal/framework/validators/kerberos_test.go
+++ b/internal/framework/validators/kerberos_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validators
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const (
+	// base64 encoded SPNEGO request token
+	testNegTokenInit = "oIICqjCCAqagJzAlBgkqhkiG9xIBAgIGBSsFAQUCBgkqhkiC9xIBAgIGBisGAQUCBaKCAnkEggJ1YIICcQYJKoZIhvcSAQICAQBuggJgMIICXKADAgEFoQMCAQ6iBwMFAAAAAACjggFwYYIBbDCCAWigAwIBBaENGwtURVNULkdPS1JCNaIjMCGgAwIBA6EaMBgbBEhUVFAbEGhvc3QudGVzdC5nb2tyYjWjggErMIIBJ6ADAgESoQMCAQKiggEZBIIBFdS9iQq8RW9E4uei6BEb1nZ6vwMmbfzal8Ypry7ORQpa4fFF5KTRvCyEjmamxrMdl0CyawPNvSVwv88SbpCt9fXrzp4oP/UIbaR7EpsU/Aqr1NHfnB88crgMxhTfwoeDRQsse3dJZR9DK0eqov8VjABmt1fz+wDde09j1oJ2x2Nz7N0/GcZuvEOoHld/PCY7h4NW9X6NbE7M1Ye4FTjnA5LPfnP8Eqb3xTeolKe7VWbIOsTWl1eqMgpR2NaQAXrr+VKt0Yia38Mwew5s2Mm1fPhYn75SgArLZGHCVHPUn6ob3OuLzj9h2yP5zWoJ1a3OtBHhxFRrMLMzMeVw/WvFCqQDVX519IjnWXUOoDiqtkVGZ9m2T0GkgdIwgc+gAwIBEqKBxwSBxNZ7oq5M9dkXyqsdhjYFJJMg6QSCVjZi7ZJAilQ7atXt64+TdekGCiBUkd8IL9Kl/sk9+3b0EBK7YMriDwetu3ehqlbwUh824eoQ3J+3YpArJU3XZk0LzG91HyAD5BmQrxtDMNEEd7+tY4ufC3BKyAzEdzH47I2AF2K62IhLjekK2x2+f8ew/6/Tj7Xri2VHzuMNiYcygc5jrXAEKhNHixp8K93g8iOs5i27hOLQbxBw9CZfZuBUREkzXi/MTQruW/gcWZk="
+	// base64 encoded response token
+	testNegTokenResp = "oRQwEqADCgEAoQsGCSqGSIb3EgECAg=="
+)
+
+func TestFrameworkProvider_KRBNegTokenValidator(t *testing.T) {
+	cases := map[string]struct {
+		configValue        func(t *testing.T) types.String
+		expectedErrorCount int
+	}{
+		"basic": {
+			configValue: func(t *testing.T) types.String {
+				return types.StringValue(testNegTokenInit)
+			},
+		},
+		"error-b64-decoding": {
+			configValue: func(t *testing.T) types.String {
+				return types.StringValue("Negotiation foo")
+			},
+			expectedErrorCount: 1,
+		},
+		"error-unmarshal": {
+			configValue: func(t *testing.T) types.String {
+				return types.StringValue(base64.StdEncoding.EncodeToString([]byte(testNegTokenInit)))
+			},
+			expectedErrorCount: 1,
+		},
+		"error-not-init-token": {
+			configValue: func(t *testing.T) types.String {
+				return types.StringValue(testNegTokenResp)
+			},
+			expectedErrorCount: 1,
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			// Arrange
+			req := validator.StringRequest{
+				ConfigValue: tc.configValue(t),
+			}
+
+			resp := validator.StringResponse{
+				Diagnostics: diag.Diagnostics{},
+			}
+
+			k := KRBNegTokenValidator()
+
+			// Act
+			k.ValidateString(context.Background(), req, &resp)
+
+			// Assert
+			if resp.Diagnostics.ErrorsCount() != tc.expectedErrorCount {
+				t.Errorf("Expected %d errors, got %d", tc.expectedErrorCount, resp.Diagnostics.ErrorsCount())
+			}
+		})
+	}
+}

--- a/internal/framework/validators/path.go
+++ b/internal/framework/validators/path.go
@@ -1,0 +1,48 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validators
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+)
+
+var _ validator.String = pathValidator{}
+
+// pathValidator  validates that a given path is a valid Vault path format
+type pathValidator struct{}
+
+// Description describes the validation in plain text formatting.
+func (v pathValidator) Description(_ context.Context) string {
+	return "value must be a valid Vault path format"
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (v pathValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// ValidateString performs the validation.
+func (v pathValidator) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	value := request.ConfigValue.ValueString()
+	if value == "" {
+		response.Diagnostics.AddError("invalid Vault path", "value cannot be empty")
+		return
+	}
+
+	if provider.RegexpPath.MatchString(value) {
+		response.Diagnostics.AddError("invalid Vault path", fmt.Sprintf("value %s contains leading/trailing \"/\"", value))
+	}
+}
+
+func PathValidator() validator.String {
+	return pathValidator{}
+}

--- a/internal/framework/validators/path_test.go
+++ b/internal/framework/validators/path_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validators
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestFrameworkProvider_PathValidator(t *testing.T) {
+	cases := map[string]struct {
+		configValue        func(t *testing.T) types.String
+		expectedErrorCount int
+	}{
+		"valid": {
+			configValue: func(t *testing.T) types.String {
+				return types.StringValue("foo")
+			},
+		},
+		"invalid-leading": {
+			configValue: func(t *testing.T) types.String {
+				return types.StringValue("/foo")
+			},
+			expectedErrorCount: 1,
+		},
+		"invalid-trailing": {
+			configValue: func(t *testing.T) types.String {
+				return types.StringValue("foo/")
+			},
+			expectedErrorCount: 1,
+		},
+		"invalid-both": {
+			configValue: func(t *testing.T) types.String {
+				return types.StringValue("/foo/")
+			},
+			expectedErrorCount: 1,
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			// Arrange
+			req := validator.StringRequest{
+				ConfigValue: tc.configValue(t),
+			}
+
+			resp := validator.StringResponse{
+				Diagnostics: diag.Diagnostics{},
+			}
+
+			cv := PathValidator()
+
+			// Act
+			cv.ValidateString(context.Background(), req, &resp)
+
+			// Assert
+			if resp.Diagnostics.ErrorsCount() != tc.expectedErrorCount {
+				t.Errorf("Expected %d errors, got %d: %s", tc.expectedErrorCount, resp.Diagnostics.ErrorsCount(), resp.Diagnostics.Errors())
+			}
+		})
+	}
+}

--- a/internal/framework/validators/testdata/fake_account.json
+++ b/internal/framework/validators/testdata/fake_account.json
@@ -1,0 +1,7 @@
+{
+    "private_key_id": "foo",
+    "private_key": "bar",
+    "client_email": "foo@bar.com",
+    "client_id": "id@foo.com",
+    "type": "service_account"
+}

--- a/internal/framework/validators/uri.go
+++ b/internal/framework/validators/uri.go
@@ -1,0 +1,77 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validators
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+var _ validator.String = uriValidator{}
+
+// uriValidator validates that the raw url is a valid request URI, and
+// optionally contains supported scheme(s).
+type uriValidator struct {
+	schemes []string
+}
+
+// Description describes the validation in plain text formatting.
+func (v uriValidator) Description(_ context.Context) string {
+	return "Invalid URI"
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (v uriValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// ValidateString performs the validation.
+func (v uriValidator) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	value := request.ConfigValue.ValueString()
+	if value == "" {
+		response.Diagnostics.AddError(v.Description(ctx), "value cannot be empty")
+		return
+	}
+
+	u, err := url.ParseRequestURI(value)
+	if err != nil {
+		response.Diagnostics.AddError(v.Description(ctx), fmt.Sprintf("Failed to parse URL, err=%s", err))
+		return
+	}
+
+	if len(v.schemes) == 0 {
+		return
+	}
+
+	for _, scheme := range v.schemes {
+		if scheme == u.Scheme {
+			return
+		}
+	}
+
+	response.Diagnostics.AddError(
+		v.Description(ctx),
+		fmt.Sprintf(
+			"Unsupported scheme %q. Valid schemes are: %s",
+			u.Scheme,
+			strings.Join(v.schemes, ", "),
+		),
+	)
+}
+
+// URIValidator validates that the raw url is a valid request URI, and
+// optionally contains supported scheme(s).
+func URIValidator(schemes []string) validator.String {
+	return uriValidator{
+		schemes: schemes,
+	}
+}

--- a/internal/framework/validators/uri_test.go
+++ b/internal/framework/validators/uri_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validators
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestFrameworkProvider_URIValidator(t *testing.T) {
+	cases := map[string]struct {
+		configValue        func(t *testing.T) types.String
+		schemes            []string
+		expectedErrorCount int
+	}{
+		"basic": {
+			configValue: func(t *testing.T) types.String {
+				return types.StringValue("http://foo.baz:8080/qux")
+			},
+			schemes: []string{"http"},
+		},
+		"invalid-scheme": {
+			configValue: func(t *testing.T) types.String {
+				return types.StringValue("https://foo.baz:8080/qux")
+			},
+			schemes:            []string{"http", "tcp"},
+			expectedErrorCount: 1,
+		},
+		"invalid-url": {
+			configValue: func(t *testing.T) types.String {
+				return types.StringValue("foo.bar")
+			},
+			schemes:            []string{"http", "tcp"},
+			expectedErrorCount: 1,
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			// Arrange
+			req := validator.StringRequest{
+				ConfigValue: tc.configValue(t),
+			}
+
+			resp := validator.StringResponse{
+				Diagnostics: diag.Diagnostics{},
+			}
+
+			cv := URIValidator(tc.schemes)
+
+			// Act
+			cv.ValidateString(context.Background(), req, &resp)
+
+			// Assert
+			if resp.Diagnostics.ErrorsCount() != tc.expectedErrorCount {
+				t.Errorf("Expected %d errors, got %d: %s", tc.expectedErrorCount, resp.Diagnostics.ErrorsCount(), resp.Diagnostics.Errors())
+			}
+		})
+	}
+}

--- a/internal/provider/auth_azure.go
+++ b/internal/provider/auth_azure.go
@@ -46,7 +46,6 @@ func GetAzureLoginSchemaResource(authField string) *schema.Resource {
 				Optional: true,
 				Description: "A signed JSON Web Token. If not specified on will be " +
 					"created automatically",
-				DefaultFunc: schema.EnvDefaultFunc(consts.EnvVarAzureAuthJWT, nil),
 			},
 			consts.FieldRole: {
 				Type:        schema.TypeString,
@@ -94,7 +93,6 @@ func GetAzureLoginSchemaResource(authField string) *schema.Resource {
 			consts.FieldScope: {
 				Type:          schema.TypeString,
 				Optional:      true,
-				Default:       defaultAzureScope,
 				Description:   "The scopes to include in the token request.",
 				ConflictsWith: []string{fmt.Sprintf("%s.0.%s", authField, consts.FieldJWT)},
 			},
@@ -122,12 +120,30 @@ func (l *AuthLoginAzure) LoginPath() string {
 }
 
 func (l *AuthLoginAzure) Init(d *schema.ResourceData, authField string) (AuthLogin, error) {
+	defaults := authDefaults{
+		{
+			field:      consts.FieldJWT,
+			envVars:    []string{consts.EnvVarAzureAuthJWT},
+			defaultVal: "",
+		},
+		{
+			field:      consts.FieldScope,
+			envVars:    []string{""},
+			defaultVal: defaultAzureScope,
+		},
+	}
 	if err := l.AuthLoginCommon.Init(d, authField,
-		func(data *schema.ResourceData) error {
-			err := l.checkRequiredFields(d, l.requiredParams()...)
+		func(data *schema.ResourceData, params map[string]interface{}) error {
+			err := l.setDefaultFields(d, defaults, params)
 			if err != nil {
 				return err
 			}
+
+			err = l.checkRequiredFields(d, params, l.requiredParams()...)
+			if err != nil {
+				return err
+			}
+
 			return l.checkFieldsOneOf(d, consts.FieldVMName, consts.FieldVMSSName)
 		},
 	); err != nil {

--- a/internal/provider/auth_cert.go
+++ b/internal/provider/auth_cert.go
@@ -79,8 +79,8 @@ func (l *AuthLoginCert) LoginPath() string {
 
 func (l *AuthLoginCert) Init(d *schema.ResourceData, authField string) (AuthLogin, error) {
 	if err := l.AuthLoginCommon.Init(d, authField,
-		func(data *schema.ResourceData) error {
-			return l.checkRequiredFields(d, consts.FieldCertFile, consts.FieldKeyFile)
+		func(data *schema.ResourceData, params map[string]interface{}) error {
+			return l.checkRequiredFields(d, params, consts.FieldCertFile, consts.FieldKeyFile)
 		},
 	); err != nil {
 		return nil, err

--- a/internal/provider/auth_jwt_test.go
+++ b/internal/provider/auth_jwt_test.go
@@ -40,6 +40,29 @@ func TestAuthLoginJWT_Init(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:      "basic-with-env",
+			authField: consts.FieldAuthLoginJWT,
+			raw: map[string]interface{}{
+				consts.FieldAuthLoginJWT: []interface{}{
+					map[string]interface{}{
+						consts.FieldNamespace: "ns1",
+						consts.FieldRole:      "alice",
+					},
+				},
+			},
+			envVars: map[string]string{
+				consts.EnvVarVaultAuthJWT: "jwt1",
+			},
+			expectParams: map[string]interface{}{
+				consts.FieldNamespace:        "ns1",
+				consts.FieldUseRootNamespace: false,
+				consts.FieldMount:            consts.MountTypeJWT,
+				consts.FieldRole:             "alice",
+				consts.FieldJWT:              "jwt1",
+			},
+			wantErr: false,
+		},
+		{
 			name:         "error-missing-resource",
 			authField:    consts.FieldAuthLoginJWT,
 			expectParams: nil,

--- a/internal/provider/auth_oci.go
+++ b/internal/provider/auth_oci.go
@@ -85,8 +85,8 @@ func (l *AuthLoginOCI) LoginPath() string {
 
 func (l *AuthLoginOCI) Init(d *schema.ResourceData, authField string) (AuthLogin, error) {
 	if err := l.AuthLoginCommon.Init(d, authField,
-		func(data *schema.ResourceData) error {
-			return l.checkRequiredFields(d, consts.FieldRole, consts.FieldAuthType)
+		func(data *schema.ResourceData, params map[string]interface{}) error {
+			return l.checkRequiredFields(d, params, consts.FieldRole, consts.FieldAuthType)
 		},
 	); err != nil {
 		return nil, err

--- a/internal/provider/auth_oidc.go
+++ b/internal/provider/auth_oidc.go
@@ -86,8 +86,8 @@ func (l *AuthLoginOIDC) LoginPath() string {
 
 func (l *AuthLoginOIDC) Init(d *schema.ResourceData, authField string) (AuthLogin, error) {
 	if err := l.AuthLoginCommon.Init(d, authField,
-		func(data *schema.ResourceData) error {
-			return l.checkRequiredFields(d, consts.FieldRole)
+		func(data *schema.ResourceData, params map[string]interface{}) error {
+			return l.checkRequiredFields(d, params, consts.FieldRole)
 		},
 	); err != nil {
 		return nil, err

--- a/internal/provider/auth_radius_test.go
+++ b/internal/provider/auth_radius_test.go
@@ -40,6 +40,29 @@ func TestAuthLoginRadius_Init(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:      "basic-with-env",
+			authField: consts.FieldAuthLoginRadius,
+			raw: map[string]interface{}{
+				consts.FieldAuthLoginRadius: []interface{}{
+					map[string]interface{}{
+						consts.FieldNamespace: "ns1",
+					},
+				},
+			},
+			envVars: map[string]string{
+				consts.EnvVarRadiusUsername: "alice",
+				consts.EnvVarRadiusPassword: "password1",
+			},
+			expectParams: map[string]interface{}{
+				consts.FieldNamespace:        "ns1",
+				consts.FieldUseRootNamespace: false,
+				consts.FieldMount:            consts.MountTypeRadius,
+				consts.FieldUsername:         "alice",
+				consts.FieldPassword:         "password1",
+			},
+			wantErr: false,
+		},
+		{
 			name:         "error-missing-resource",
 			authField:    consts.FieldAuthLoginRadius,
 			expectParams: nil,

--- a/internal/provider/auth_token_file_test.go
+++ b/internal/provider/auth_token_file_test.go
@@ -49,9 +49,7 @@ func TestAuthLoginTokenFile_Init(t *testing.T) {
 				consts.EnvVarTokenFilename: "/tmp/vault-token",
 			},
 			expectParams: map[string]interface{}{
-				consts.FieldNamespace:        "",
-				consts.FieldUseRootNamespace: false,
-				consts.FieldFilename:         "/tmp/vault-token",
+				consts.FieldFilename: "/tmp/vault-token",
 			},
 			wantErr: false,
 		},

--- a/internal/provider/fwprovider/auth.go
+++ b/internal/provider/fwprovider/auth.go
@@ -1,0 +1,61 @@
+package fwprovider
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/boolvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/framework/validators"
+)
+
+func mustAddLoginSchema(s *schema.ListNestedBlock, defaultMount string) schema.Block {
+	m := map[string]schema.Attribute{
+		consts.FieldNamespace: schema.StringAttribute{
+			Optional: true,
+			Description: fmt.Sprintf(
+				"The authentication engine's namespace. Conflicts with %s",
+				consts.FieldUseRootNamespace,
+			),
+			Validators: []validator.String{
+				stringvalidator.ConflictsWith(
+					path.MatchRelative().AtParent().AtName(consts.FieldUseRootNamespace),
+				),
+			},
+		},
+		consts.FieldUseRootNamespace: schema.BoolAttribute{
+			Optional: true,
+			Description: fmt.Sprintf(
+				"Authenticate to the root Vault namespace. Conflicts with %s",
+				consts.FieldNamespace,
+			),
+			Validators: []validator.Bool{
+				boolvalidator.ConflictsWith(
+					path.MatchRelative().AtParent().AtName(consts.FieldUseRootNamespace),
+				),
+			},
+		},
+	}
+	if defaultMount != consts.MountTypeNone {
+		m[consts.FieldMount] = &schema.StringAttribute{
+			Optional:    true,
+			Description: "The path where the authentication engine is mounted.",
+			Validators: []validator.String{
+				validators.PathValidator(),
+			},
+		}
+	}
+
+	for k, v := range m {
+		if _, ok := s.NestedObject.Attributes[k]; ok {
+			panic(fmt.Sprintf("cannot add schema field %q,  already exists in the Schema map", k))
+		}
+
+		s.NestedObject.Attributes[k] = v
+	}
+
+	return s
+}

--- a/internal/provider/fwprovider/auth_aws.go
+++ b/internal/provider/fwprovider/auth_aws.go
@@ -1,0 +1,82 @@
+package fwprovider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/framework/validators"
+)
+
+func AuthLoginAWSSchema() schema.Block {
+	return mustAddLoginSchema(&schema.ListNestedBlock{
+		Description: "Login to vault using the AWS method",
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				consts.FieldRole: schema.StringAttribute{
+					Required:    true,
+					Description: `The Vault role to use when logging into Vault.`,
+				},
+				// static credential fields
+				consts.FieldAWSAccessKeyID: schema.StringAttribute{
+					Optional:    true,
+					Description: `The AWS access key ID.`,
+				},
+				consts.FieldAWSSecretAccessKey: schema.StringAttribute{
+					Optional:    true,
+					Description: `The AWS secret access key.`,
+				},
+				consts.FieldAWSSessionToken: schema.StringAttribute{
+					Optional:    true,
+					Description: `The AWS session token.`,
+				},
+				consts.FieldAWSProfile: schema.StringAttribute{
+					Optional:    true,
+					Description: `The name of the AWS profile.`,
+				},
+				consts.FieldAWSSharedCredentialsFile: schema.StringAttribute{
+					Optional:    true,
+					Description: `Path to the AWS shared credentials file.`,
+				},
+				consts.FieldAWSWebIdentityTokenFile: schema.StringAttribute{
+					Optional: true,
+					Description: `Path to the file containing an OAuth 2.0 access token or OpenID ` +
+						`Connect ID token.`,
+				},
+				// STS assume role fields
+				consts.FieldAWSRoleARN: schema.StringAttribute{
+					Optional: true,
+					Description: `The ARN of the AWS Role to assume.` +
+						`Used during STS AssumeRole`,
+				},
+				consts.FieldAWSRoleSessionName: schema.StringAttribute{
+					Optional: true,
+					Description: `Specifies the name to attach to the AWS role session. ` +
+						`Used during STS AssumeRole`,
+				},
+				consts.FieldAWSRegion: schema.StringAttribute{
+					Optional:    true,
+					Description: `The AWS region.`,
+				},
+				consts.FieldAWSSTSEndpoint: schema.StringAttribute{
+					Optional:    true,
+					Description: `The STS endpoint URL.`,
+					Validators: []validator.String{
+						validators.URIValidator([]string{"http", "https"}),
+					},
+				},
+				consts.FieldAWSIAMEndpoint: schema.StringAttribute{
+					Optional:    true,
+					Description: `The IAM endpoint URL.`,
+					Validators: []validator.String{
+						validators.URIValidator([]string{"http", "https"}),
+					},
+				},
+				consts.FieldHeaderValue: schema.StringAttribute{
+					Optional:    true,
+					Description: `The Vault header value to include in the STS signing request.`,
+				},
+			},
+		},
+	}, consts.MountTypeAWS)
+}

--- a/internal/provider/fwprovider/auth_azure.go
+++ b/internal/provider/fwprovider/auth_azure.go
@@ -1,0 +1,82 @@
+package fwprovider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+)
+
+func AuthLoginAzureSchema() schema.Block {
+	return mustAddLoginSchema(&schema.ListNestedBlock{
+		Description: "Login to vault using the azure method",
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				consts.FieldJWT: schema.StringAttribute{
+					Optional: true,
+					Description: "A signed JSON Web Token. If not specified on will be " +
+						"created automatically",
+				},
+				consts.FieldRole: schema.StringAttribute{
+					Required:    true,
+					Description: "Name of the login role.",
+				},
+				consts.FieldSubscriptionID: schema.StringAttribute{
+					Required: true,
+					Description: "The subscription ID for the machine that generated the MSI token. " +
+						"This information can be obtained through instance metadata.",
+				},
+				consts.FieldResourceGroupName: schema.StringAttribute{
+					Required: true,
+					Description: "The resource group for the machine that generated the MSI token. " +
+						"This information can be obtained through instance metadata.",
+				},
+				consts.FieldVMName: schema.StringAttribute{
+					Optional: true,
+					Description: "The virtual machine name for the machine that generated the MSI token. " +
+						"This information can be obtained through instance metadata.",
+				},
+				consts.FieldVMSSName: schema.StringAttribute{
+					Optional: true,
+					Description: "The virtual machine scale set name for the machine that generated " +
+						"the MSI token. This information can be obtained through instance metadata.",
+					Validators: []validator.String{
+						stringvalidator.ConflictsWith(
+							path.MatchRelative().AtName(consts.FieldVMName),
+						),
+					},
+				},
+				consts.FieldTenantID: schema.StringAttribute{
+					Optional: true,
+					Description: "Provides the tenant ID to use in a multi-tenant " +
+						"authentication scenario.",
+					Validators: []validator.String{
+						stringvalidator.ConflictsWith(
+							path.MatchRelative().AtName(consts.FieldJWT),
+						),
+					},
+				},
+				consts.FieldClientID: schema.StringAttribute{
+					Optional:    true,
+					Description: "The identity's client ID.",
+					Validators: []validator.String{
+						stringvalidator.ConflictsWith(
+							path.MatchRelative().AtName(consts.FieldJWT),
+						),
+					},
+				},
+				consts.FieldScope: schema.StringAttribute{
+					Optional:    true,
+					Description: "The scopes to include in the token request.",
+					Validators: []validator.String{
+						stringvalidator.ConflictsWith(
+							path.MatchRelative().AtName(consts.FieldJWT),
+						),
+					},
+				},
+			},
+		},
+	}, consts.MountTypeAzure)
+}

--- a/internal/provider/fwprovider/auth_cert.go
+++ b/internal/provider/fwprovider/auth_cert.go
@@ -1,0 +1,29 @@
+package fwprovider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+)
+
+func AuthLoginCertSchema() schema.Block {
+	return mustAddLoginSchema(&schema.ListNestedBlock{
+		Description: "Login to vault using the cert method",
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				consts.FieldName: schema.StringAttribute{
+					Optional:    true,
+					Description: "Name of the certificate's role",
+				},
+				consts.FieldCertFile: schema.StringAttribute{
+					Required:    true,
+					Description: "Path to a file containing the client certificate.",
+				},
+				consts.FieldKeyFile: schema.StringAttribute{
+					Required:    true,
+					Description: "Path to a file containing the private key that the certificate was issued for.",
+				},
+			},
+		},
+	}, consts.MountTypeCert)
+}

--- a/internal/provider/fwprovider/auth_gcp.go
+++ b/internal/provider/fwprovider/auth_gcp.go
@@ -1,0 +1,54 @@
+package fwprovider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/framework/validators"
+)
+
+func AuthLoginGCPSchema() schema.Block {
+	return mustAddLoginSchema(&schema.ListNestedBlock{
+		Description: "Login to vault using the gcp method",
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				consts.FieldRole: schema.StringAttribute{
+					Required:    true,
+					Description: "Name of the login role.",
+				},
+				consts.FieldJWT: schema.StringAttribute{
+					Optional:    true,
+					Description: "A signed JSON Web Token.",
+					Validators: []validator.String{
+						stringvalidator.ConflictsWith(
+							path.MatchRelative().AtName(consts.FieldCredentials),
+						),
+					},
+				},
+				consts.FieldCredentials: schema.StringAttribute{
+					Optional:    true,
+					Description: "Path to the Google Cloud credentials file.",
+					Validators: []validator.String{
+						stringvalidator.ConflictsWith(
+							path.MatchRelative().AtName(consts.FieldJWT),
+						),
+						stringvalidator.LengthAtLeast(1),
+						validators.GCPCredentialsValidator(),
+					},
+				},
+				consts.FieldServiceAccount: schema.StringAttribute{
+					Optional:    true,
+					Description: "IAM service account.",
+					Validators: []validator.String{
+						stringvalidator.ConflictsWith(
+							path.MatchRelative().AtName(consts.FieldJWT),
+						),
+					},
+				},
+			},
+		},
+	}, consts.MountTypeGCP)
+}

--- a/internal/provider/fwprovider/auth_generic.go
+++ b/internal/provider/fwprovider/auth_generic.go
@@ -1,0 +1,29 @@
+package fwprovider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+)
+
+func AuthLoginGenericSchema() schema.Block {
+	return mustAddLoginSchema(&schema.ListNestedBlock{
+		Description: "Login to vault with an existing auth method using auth/<mount>/login",
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				consts.FieldPath: schema.StringAttribute{
+					Required: true,
+				},
+				consts.FieldParameters: schema.MapAttribute{
+					Optional:    true,
+					ElementType: types.StringType,
+					Sensitive:   true,
+				},
+				consts.FieldMethod: schema.StringAttribute{
+					Optional: true,
+				},
+			},
+		},
+	}, consts.MountTypeNone)
+}

--- a/internal/provider/fwprovider/auth_jwt.go
+++ b/internal/provider/fwprovider/auth_jwt.go
@@ -1,0 +1,26 @@
+package fwprovider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+)
+
+func AuthLoginJWTSchema() schema.Block {
+	return mustAddLoginSchema(&schema.ListNestedBlock{
+		Description: "Login to vault using the jwt method",
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				consts.FieldRole: schema.StringAttribute{
+					Required:    true,
+					Description: "Name of the login role.",
+				},
+				consts.FieldJWT: schema.StringAttribute{
+					// can be set via an env var
+					Optional:    true,
+					Description: "A signed JSON Web Token.",
+				},
+			},
+		},
+	}, consts.MountTypeJWT)
+}

--- a/internal/provider/fwprovider/auth_kerberos.go
+++ b/internal/provider/fwprovider/auth_kerberos.go
@@ -1,0 +1,94 @@
+package fwprovider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/boolvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/framework/validators"
+)
+
+func AuthLoginKerberosSchema() schema.Block {
+	return mustAddLoginSchema(&schema.ListNestedBlock{
+		Description: "Login to vault using the kerberos method",
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				consts.FieldToken: schema.StringAttribute{
+					Optional:    true,
+					Description: "Simple and Protected GSSAPI Negotiation Mechanism (SPNEGO) token",
+					Validators: []validator.String{
+						validators.KRBNegTokenValidator(),
+					},
+				},
+				consts.FieldUsername: schema.StringAttribute{
+					Optional:    true,
+					Description: "The username to login into Kerberos with.",
+					Validators: []validator.String{
+						stringvalidator.ConflictsWith(
+							path.MatchRelative().AtName(consts.FieldToken),
+						),
+					},
+				},
+				consts.FieldService: schema.StringAttribute{
+					Optional:    true,
+					Description: "The service principle name.",
+					Validators: []validator.String{
+						stringvalidator.ConflictsWith(
+							path.MatchRelative().AtName(consts.FieldToken),
+						),
+					},
+				},
+				consts.FieldRealm: schema.StringAttribute{
+					Optional:    true,
+					Description: "The Kerberos server's authoritative authentication domain",
+					Validators: []validator.String{
+						stringvalidator.ConflictsWith(
+							path.MatchRelative().AtName(consts.FieldToken),
+						),
+					},
+				},
+				consts.FieldKRB5ConfPath: schema.StringAttribute{
+					Optional:    true,
+					Description: "A valid Kerberos configuration file e.g. /etc/krb5.conf.",
+					Validators: []validator.String{
+						validators.FileExistsValidator(),
+						stringvalidator.ConflictsWith(
+							path.MatchRelative().AtName(consts.FieldToken),
+						),
+					},
+				},
+				consts.FieldKeytabPath: schema.StringAttribute{
+					Optional:    true,
+					Description: "The Kerberos keytab file containing the entry of the login entity.",
+					Validators: []validator.String{
+						validators.FileExistsValidator(),
+						stringvalidator.ConflictsWith(
+							path.MatchRelative().AtName(consts.FieldToken),
+						),
+					},
+				},
+				consts.FieldDisableFastNegotiation: schema.BoolAttribute{
+					Optional: true,
+					Validators: []validator.Bool{
+						boolvalidator.ConflictsWith(
+							path.MatchRelative().AtName(consts.FieldToken),
+						),
+					},
+					Description: "Disable the Kerberos FAST negotiation.",
+				},
+				consts.FieldRemoveInstanceName: schema.BoolAttribute{
+					Optional: true,
+					Validators: []validator.Bool{
+						boolvalidator.ConflictsWith(
+							path.MatchRelative().AtName(consts.FieldToken),
+						),
+					},
+					Description: "Strip the host from the username found in the keytab.",
+				},
+			},
+		},
+	}, consts.MountTypeKerberos)
+}

--- a/internal/provider/fwprovider/auth_oci.go
+++ b/internal/provider/fwprovider/auth_oci.go
@@ -1,0 +1,35 @@
+package fwprovider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+)
+
+const (
+	ociAuthTypeInstance = "instance"
+	ociAuthTypeAPIKeys  = "apikey"
+)
+
+func AuthLoginOCISchema() schema.Block {
+	return mustAddLoginSchema(&schema.ListNestedBlock{
+		Description: "Login to vault using the OCI method",
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				consts.FieldRole: schema.StringAttribute{
+					Required:    true,
+					Description: "Name of the login role.",
+				},
+				consts.FieldAuthType: schema.StringAttribute{
+					Required:    true,
+					Description: "Authentication type to use when getting OCI credentials.",
+					Validators: []validator.String{
+						stringvalidator.OneOf([]string{ociAuthTypeInstance, ociAuthTypeAPIKeys}...),
+					},
+				},
+			},
+		},
+	}, consts.MountTypeOCI)
+}

--- a/internal/provider/fwprovider/auth_oidc.go
+++ b/internal/provider/fwprovider/auth_oidc.go
@@ -1,0 +1,38 @@
+package fwprovider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/framework/validators"
+)
+
+func AuthLoginOIDCSchema() schema.Block {
+	return mustAddLoginSchema(&schema.ListNestedBlock{
+		Description: "Login to vault using the oidc method",
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				consts.FieldRole: schema.StringAttribute{
+					Required:    true,
+					Description: "Name of the login role.",
+				},
+
+				consts.FieldCallbackListenerAddress: schema.StringAttribute{
+					Optional:    true,
+					Description: "The callback listener's address. Must be a valid URI without the path.",
+					Validators: []validator.String{
+						validators.URIValidator([]string{"tcp"}),
+					},
+				},
+				consts.FieldCallbackAddress: schema.StringAttribute{
+					Optional:    true,
+					Description: "The callback address. Must be a valid URI without the path.",
+					Validators: []validator.String{
+						validators.URIValidator([]string{"http", "https"}),
+					},
+				},
+			},
+		},
+	}, consts.MountTypeOIDC)
+}

--- a/internal/provider/fwprovider/auth_radius.go
+++ b/internal/provider/fwprovider/auth_radius.go
@@ -1,0 +1,27 @@
+package fwprovider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+)
+
+func AuthLoginRadiusSchema() schema.Block {
+	return mustAddLoginSchema(&schema.ListNestedBlock{
+		Description: "Login to vault using the radius method",
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				consts.FieldUsername: schema.StringAttribute{
+					Description: "The Radius username.",
+					// can be set via an env var
+					Optional: true,
+				},
+				consts.FieldPassword: schema.StringAttribute{
+					// can be set via an env var
+					Optional:    true,
+					Description: "The Radius password for username.",
+				},
+			},
+		},
+	}, consts.MountTypeRadius)
+}

--- a/internal/provider/fwprovider/auth_token_file.go
+++ b/internal/provider/fwprovider/auth_token_file.go
@@ -1,0 +1,22 @@
+package fwprovider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+)
+
+func AuthLoginTokenFileSchema() schema.Block {
+	return mustAddLoginSchema(&schema.ListNestedBlock{
+		Description: "Login to vault using ",
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				consts.FieldFilename: schema.StringAttribute{
+					// can be set via an env var
+					Optional: true,
+					Description: "The name of a file containing a single " +
+						"line that is a valid Vault token",
+				},
+			},
+		},
+	}, consts.MountTypeNone)
+}

--- a/internal/provider/fwprovider/auth_userpass.go
+++ b/internal/provider/fwprovider/auth_userpass.go
@@ -1,0 +1,38 @@
+package fwprovider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+)
+
+func AuthLoginUserpassSchema() schema.Block {
+	return mustAddLoginSchema(&schema.ListNestedBlock{
+		Description: "Login to vault using the userpass method",
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				consts.FieldUsername: schema.StringAttribute{
+					// can be set via an env var
+					Optional:    true,
+					Description: "Login with username",
+				},
+				consts.FieldPassword: schema.StringAttribute{
+					Optional:    true,
+					Description: "Login with password",
+				},
+				consts.FieldPasswordFile: schema.StringAttribute{
+					Optional:    true,
+					Description: "Login with password from a file",
+					Validators: []validator.String{
+						stringvalidator.ConflictsWith(
+							path.MatchRelative().AtName(consts.FieldPassword),
+						),
+					},
+				},
+			},
+		},
+	}, consts.MountTypeUserpass)
+}

--- a/internal/provider/fwprovider/provider.go
+++ b/internal/provider/fwprovider/provider.go
@@ -7,37 +7,63 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 )
+
+// Ensure the implementation satisfies the provider.Provider interface
+var _ provider.Provider = &fwprovider{}
+
+// New returns a new, initialized Terraform Plugin Framework-style provider instance.
+//
+// The provider instance is fully configured once the `Configure` method has been called.
+func New(primary interface{ Meta() interface{} }) provider.Provider {
+	return &fwprovider{
+		Primary: primary,
+	}
+}
 
 // Provider implements the terraform-plugin-framework's provider.Provider
 // interface
-// https://developer.hashicorp.com/terraform/plugin/framework
-type Provider struct{}
-
-// New returns a new, initialized Terraform Plugin Framework-style provider instance.
-// The provider instance is fully configured once the `Configure` method has been called.
-func New() provider.Provider {
-	return &Provider{}
+//
+// See: https://developer.hashicorp.com/terraform/plugin/framework
+type fwprovider struct {
+	Primary interface{ Meta() interface{} }
 }
 
 // Metadata returns the metadata for the provider, such as a type name and
 // version data.
-func (p *Provider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
+func (p *fwprovider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
 	resp.TypeName = "vault"
 	// TODO: inject provider version during build time
 	// resp.Version = "0.0.0-dev"
 }
 
 // Schema returns the schema for this provider's configuration.
-func (p *Provider) Schema(ctx context.Context, req provider.SchemaRequest, resp *provider.SchemaResponse) {
+//
+// Schema is called during validate, plan and apply.
+func (p *fwprovider) Schema(ctx context.Context, req provider.SchemaRequest, resp *provider.SchemaResponse) {
 	// TODO: must this match exactly to the SDKv2 provider's schema?
-	resp.Schema = schema.Schema{}
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			consts.FieldAddress: schema.StringAttribute{
+				Required:    true,
+				Description: "URL of the root of the target Vault server.",
+			},
+		},
+	}
 }
 
-// Configure is called at the beginning of the provider lifecycle, when
-// Terraform sends to the provider the values the user specified in the
-// provider configuration block.
-func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
+// Configure handles the configuration of any provider-level data or clients.
+// These configuration values may be from the practitioner Terraform
+// configuration, environment variables, or other means such as reading
+// vendor-specific configuration files.
+//
+// Configure is called during plan and apply.
+func (p *fwprovider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
+	// Provider's parsed configuration (its instance state) is available through the primary provider's Meta() method.
+	v := p.Primary.Meta()
+	resp.DataSourceData = v
+	resp.ResourceData = v
 }
 
 // Resources returns a slice of functions to instantiate each Resource
@@ -45,7 +71,7 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 //
 // The resource type name is determined by the Resource implementing
 // the Metadata method. All resources must have unique names.
-func (p *Provider) Resources(ctx context.Context) []func() resource.Resource {
+func (p *fwprovider) Resources(ctx context.Context) []func() resource.Resource {
 	return []func() resource.Resource{}
 }
 
@@ -54,6 +80,6 @@ func (p *Provider) Resources(ctx context.Context) []func() resource.Resource {
 //
 // The data source type name is determined by the DataSource implementing
 // the Metadata method. All data sources must have unique names.
-func (p *Provider) DataSources(ctx context.Context) []func() datasource.DataSource {
+func (p *fwprovider) DataSources(ctx context.Context) []func() datasource.DataSource {
 	return []func() datasource.DataSource{}
 }

--- a/internal/provider/fwprovider/provider.go
+++ b/internal/provider/fwprovider/provider.go
@@ -2,7 +2,6 @@ package fwprovider
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -46,19 +45,23 @@ func (p *fwprovider) Metadata(ctx context.Context, req provider.MetadataRequest,
 //
 // Schema is called during validate, plan and apply.
 func (p *fwprovider) Schema(ctx context.Context, req provider.SchemaRequest, resp *provider.SchemaResponse) {
-	// TODO: must this match exactly to the SDKv2 provider's schema?
+	// TODO(JM): This schema must match exactly to the SDKv2 provider's schema
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
+			// Not `Required` but must be set via config or env. Otherwise we
+			// return an error.
 			consts.FieldAddress: schema.StringAttribute{
-				Required:    true,
+				Optional:    true,
 				Description: "URL of the root of the target Vault server.",
 			},
 			"add_address_to_env": schema.StringAttribute{
 				Optional:    true,
 				Description: "If true, adds the value of the `address` argument to the Terraform process environment.",
 			},
+			// Not `Required` but must be set via config, env, or token helper.
+			// Otherwise we return an error.
 			"token": schema.StringAttribute{
-				Required:    true,
+				Optional:    true,
 				Description: "Token to use to authenticate to Vault.",
 			},
 			"token_name": schema.StringAttribute{
@@ -122,23 +125,6 @@ func (p *fwprovider) Schema(ctx context.Context, req provider.SchemaRequest, res
 			},
 		},
 		Blocks: map[string]schema.Block{
-			consts.FieldClientAuth: schema.ListNestedBlock{
-				Description:        "Client authentication credentials.",
-				DeprecationMessage: fmt.Sprintf("Use %s instead", consts.FieldAuthLoginCert),
-				NestedObject: schema.NestedBlockObject{
-					Attributes: map[string]schema.Attribute{
-						consts.FieldCertFile: schema.StringAttribute{
-							Required:    true,
-							Description: "Path to a file containing the client certificate.",
-						},
-						consts.FieldKeyFile: schema.StringAttribute{
-							Required:    true,
-							Description: "Path to a file containing the private key that the certificate was issued for.",
-						},
-					},
-				},
-			},
-
 			"headers": schema.ListNestedBlock{
 				Description: "The headers to send with each Vault request.",
 				NestedObject: schema.NestedBlockObject{

--- a/internal/provider/fwprovider/provider.go
+++ b/internal/provider/fwprovider/provider.go
@@ -10,7 +10,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/sys"
 )
 
 // Ensure the implementation satisfies the provider.Provider interface
@@ -142,6 +144,18 @@ func (p *fwprovider) Schema(ctx context.Context, req provider.SchemaRequest, res
 					},
 				},
 			},
+			consts.FieldAuthLoginAWS:       AuthLoginAWSSchema(),
+			consts.FieldAuthLoginAzure:     AuthLoginAzureSchema(),
+			consts.FieldAuthLoginCert:      AuthLoginCertSchema(),
+			consts.FieldAuthLoginGCP:       AuthLoginGCPSchema(),
+			consts.FieldAuthLoginGeneric:   AuthLoginGenericSchema(),
+			consts.FieldAuthLoginJWT:       AuthLoginJWTSchema(),
+			consts.FieldAuthLoginKerberos:  AuthLoginKerberosSchema(),
+			consts.FieldAuthLoginOCI:       AuthLoginOCISchema(),
+			consts.FieldAuthLoginOIDC:      AuthLoginOIDCSchema(),
+			consts.FieldAuthLoginRadius:    AuthLoginRadiusSchema(),
+			consts.FieldAuthLoginTokenFile: AuthLoginTokenFileSchema(),
+			consts.FieldAuthLoginUserpass:  AuthLoginUserpassSchema(),
 		},
 	}
 }
@@ -165,7 +179,9 @@ func (p *fwprovider) Configure(ctx context.Context, req provider.ConfigureReques
 // The resource type name is determined by the Resource implementing
 // the Metadata method. All resources must have unique names.
 func (p *fwprovider) Resources(ctx context.Context) []func() resource.Resource {
-	return []func() resource.Resource{}
+	return []func() resource.Resource{
+		sys.NewPasswordPolicyResource,
+	}
 }
 
 // DataSources returns a slice of functions to instantiate each DataSource

--- a/internal/provider/fwprovider/provider.go
+++ b/internal/provider/fwprovider/provider.go
@@ -1,0 +1,59 @@
+package fwprovider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+)
+
+// Provider implements the terraform-plugin-framework's provider.Provider
+// interface
+// https://developer.hashicorp.com/terraform/plugin/framework
+type Provider struct{}
+
+// New returns a new, initialized Terraform Plugin Framework-style provider instance.
+// The provider instance is fully configured once the `Configure` method has been called.
+func New() provider.Provider {
+	return &Provider{}
+}
+
+// Metadata returns the metadata for the provider, such as a type name and
+// version data.
+func (p *Provider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
+	resp.TypeName = "vault"
+	// TODO: inject provider version during build time
+	// resp.Version = "0.0.0-dev"
+}
+
+// Schema returns the schema for this provider's configuration.
+func (p *Provider) Schema(ctx context.Context, req provider.SchemaRequest, resp *provider.SchemaResponse) {
+	// TODO: must this match exactly to the SDKv2 provider's schema?
+	resp.Schema = schema.Schema{}
+}
+
+// Configure is called at the beginning of the provider lifecycle, when
+// Terraform sends to the provider the values the user specified in the
+// provider configuration block.
+func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
+}
+
+// Resources returns a slice of functions to instantiate each Resource
+// implementation.
+//
+// The resource type name is determined by the Resource implementing
+// the Metadata method. All resources must have unique names.
+func (p *Provider) Resources(ctx context.Context) []func() resource.Resource {
+	return []func() resource.Resource{}
+}
+
+// DataSources returns a slice of functions to instantiate each DataSource
+// implementation.
+//
+// The data source type name is determined by the DataSource implementing
+// the Metadata method. All data sources must have unique names.
+func (p *Provider) DataSources(ctx context.Context) []func() datasource.DataSource {
+	return []func() datasource.DataSource{}
+}

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -188,7 +188,7 @@ func (p *ProviderMeta) setClient() error {
 
 	addr := GetResourceDataStr(d, consts.FieldAddress, api.EnvVaultAddress, "")
 	if addr == "" {
-		return nil, fmt.Errorf("failed to configure Vault address")
+		return fmt.Errorf("failed to configure Vault address")
 	}
 	clientConfig.Address = addr
 
@@ -340,12 +340,20 @@ func (p *ProviderMeta) setClient() error {
 			"Future releases may not support this type of configuration.", tokenNamespace)
 
 		namespace = tokenNamespace
+
 		// set the namespace on the provider to ensure that all child
 		// namespace paths are properly honoured.
-		if v, ok := d.Get(consts.FieldSetNamespaceFromToken).(bool); ok && v {
+		// We default to setting the namespace from the token unless the
+		// env var is set to false.
+		setFromToken, err := strconv.ParseBool(os.Getenv("VAULT_SET_NAMESPACE_FROM_TOKEN"))
+		if err == nil && setFromToken || err != nil {
 			if err := d.Set(consts.FieldNamespace, namespace); err != nil {
 				return err
 			}
+		} else {
+			log.Printf("[WARN] VAULT_SET_NAMESPACE_FROM_TOKEN environment "+
+				"variable is set to \"false\". The token namespace %q will "+
+				"not be used as the root namespace for all resources.", tokenNamespace)
 		}
 	}
 

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -184,27 +185,20 @@ func (p *ProviderMeta) setClient() error {
 
 	d := p.resourceData
 	clientConfig := api.DefaultConfig()
-	addr := d.Get(consts.FieldAddress).(string)
-	if addr != "" {
-		clientConfig.Address = addr
+
+	addr := GetResourceDataStr(d, consts.FieldAddress, api.EnvVaultAddress, "")
+	if addr == "" {
+		return nil, fmt.Errorf("failed to configure Vault address")
 	}
+	clientConfig.Address = addr
+
 	clientConfig.CloneTLSConfig = true
 
 	tlsConfig := &api.TLSConfig{
-		CACert:        d.Get(consts.FieldCACertFile).(string),
-		CAPath:        d.Get(consts.FieldCACertDir).(string),
+		CACert:        GetResourceDataStr(d, consts.FieldCACertFile, api.EnvVaultCACert, ""),
+		CAPath:        GetResourceDataStr(d, consts.FieldCACertDir, api.EnvVaultCAPath, ""),
 		Insecure:      d.Get(consts.FieldSkipTLSVerify).(bool),
-		TLSServerName: d.Get(consts.FieldTLSServerName).(string),
-	}
-
-	if _, ok := d.GetOk(consts.FieldClientAuth); ok {
-		prefix := fmt.Sprintf("%s.0.", consts.FieldClientAuth)
-		if v, ok := d.GetOk(prefix + consts.FieldCertFile); ok {
-			tlsConfig.ClientCert = v.(string)
-		}
-		if v, ok := d.GetOk(prefix + consts.FieldKeyFile); ok {
-			tlsConfig.ClientKey = v.(string)
-		}
+		TLSServerName: GetResourceDataStr(d, consts.FieldTLSServerName, api.EnvVaultTLSServerName, ""),
 	}
 
 	err := clientConfig.ConfigureTLS(tlsConfig)
@@ -251,12 +245,12 @@ func (p *ProviderMeta) setClient() error {
 	}
 	client.SetHeaders(parsedHeaders)
 
-	client.SetMaxRetries(d.Get("max_retries").(int))
+	client.SetMaxRetries(GetResourceDataInt(d, "max_retries", "VAULT_MAX_RETRIES", DefaultMaxHTTPRetries))
 
-	MaxHTTPRetriesCCC = d.Get("max_retries_ccc").(int)
+	MaxHTTPRetriesCCC = GetResourceDataInt(d, "max_retries_ccc", "VAULT_MAX_RETRIES_CCC", DefaultMaxHTTPRetriesCCC)
 
 	// Set the namespace to the requested namespace, if provided
-	namespace := d.Get(consts.FieldNamespace).(string)
+	namespace := GetResourceDataStr(d, consts.FieldNamespace, "VAULT_NAMESPACE", "")
 
 	authLogin, err := GetAuthLogin(d)
 	if err != nil {
@@ -554,10 +548,7 @@ func getVaultVersion(client *api.Client) (*version.Version, error) {
 }
 
 func createChildToken(d *schema.ResourceData, c *api.Client, namespace string) (string, error) {
-	tokenName := d.Get("token_name").(string)
-	if tokenName == "" {
-		tokenName = "terraform"
-	}
+	tokenName := GetResourceDataStr(d, "token_name", "VAULT_TOKEN_NAME", "terraform")
 
 	// the clone is only used to auth to Vault
 	clone, err := c.Clone()
@@ -581,10 +572,11 @@ func createChildToken(d *schema.ResourceData, c *api.Client, namespace string) (
 	// Caution is still required with state files since not all secrets
 	// can explicitly be revoked, and this limited scope won't apply to
 	// any secrets that are *written* by Terraform to Vault.
+	ttl := GetResourceDataInt(d, "max_lease_ttl_seconds", "TERRAFORM_VAULT_MAX_TTL", 1200)
 	childTokenLease, err := clone.Auth().Token().Create(&api.TokenCreateRequest{
 		DisplayName:    tokenName,
-		TTL:            fmt.Sprintf("%ds", d.Get("max_lease_ttl_seconds").(int)),
-		ExplicitMaxTTL: fmt.Sprintf("%ds", d.Get("max_lease_ttl_seconds").(int)),
+		TTL:            fmt.Sprintf("%ds", ttl),
+		ExplicitMaxTTL: fmt.Sprintf("%ds", ttl),
 		Renewable:      pointer.Bool(false),
 	})
 	if err != nil {
@@ -599,8 +591,49 @@ func createChildToken(d *schema.ResourceData, c *api.Client, namespace string) (
 	return childToken, nil
 }
 
+// GetResourceDataStr returns the value for a given ResourceData field
+// If the value is the zero value, then it checks the environment variable. If
+// the environment variable is empty, the default dv is returned
+func GetResourceDataStr(d *schema.ResourceData, field, env, dv string) string {
+	if s := d.Get(field).(string); s != "" {
+		return s
+	}
+
+	if env != "" {
+		if s := os.Getenv(env); s != "" {
+			return s
+		}
+	}
+
+	// return default
+	return dv
+}
+
+// GetResourceDataInt returns the value for a given ResourceData field
+// If the value is the zero value, then it checks the environment variable. If
+// the environment variable is empty, the default dv is returned
+func GetResourceDataInt(d *schema.ResourceData, field, env string, dv int) int {
+	if v := d.Get(field).(int); v != 0 {
+		return v
+	}
+	if env != "" {
+		if s := os.Getenv(env); s != "" {
+			ret, err := strconv.Atoi(s)
+			if err == nil {
+				return ret
+			}
+			// swallow the error and return the default because that is the
+			// behavior we had when using SDKv2's schema.EnvDefaultFunc
+		}
+	}
+	// return default
+	return dv
+}
+
 func GetToken(d *schema.ResourceData) (string, error) {
 	if token := d.Get("token").(string); token != "" {
+		return token, nil
+	} else if token = os.Getenv(api.EnvVaultToken); token != "" {
 		return token, nil
 	}
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -64,114 +64,78 @@ func NewProvider(
 	}
 
 	r := &schema.Provider{
+		// This schema must match exactly the fwprovider (Terraform Plugin Framework) schema.
+		// Notably the attributes can have no Default values.
 		Schema: map[string]*schema.Schema{
+			// Not `Required` but must be set via config or env. Otherwise we
+			// return an error.
 			consts.FieldAddress: {
-				Type:     schema.TypeString,
-				Required: true,
-				// DefaultFunc: schema.EnvDefaultFunc(api.EnvVaultAddress, nil),
+				Type:        schema.TypeString,
+				Optional:    true,
 				Description: "URL of the root of the target Vault server.",
 			},
 			"add_address_to_env": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     false,
 				Description: "If true, adds the value of the `address` argument to the Terraform process environment.",
 			},
+			// Not `Required` but must be set via config, env, or token helper.
+			// Otherwise we return an error.
 			"token": {
-				Type:     schema.TypeString,
-				Required: true,
-				// DefaultFunc: schema.EnvDefaultFunc(api.EnvVaultToken, ""),
+				Type:        schema.TypeString,
+				Optional:    true,
 				Description: "Token to use to authenticate to Vault.",
 			},
 			"token_name": {
-				Type:     schema.TypeString,
-				Optional: true,
-				// DefaultFunc: schema.EnvDefaultFunc("VAULT_TOKEN_NAME", ""),
+				Type:        schema.TypeString,
+				Optional:    true,
 				Description: "Token name to use for creating the Vault child token.",
 			},
 			"skip_child_token": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				// DefaultFunc: schema.EnvDefaultFunc("TERRAFORM_VAULT_SKIP_CHILD_TOKEN", false),
-
 				// Setting to true will cause max_lease_ttl_seconds and token_name to be ignored (not used).
 				// Note that this is strongly discouraged due to the potential of exposing sensitive secret data.
 				Description: "Set this to true to prevent the creation of ephemeral child token used by this provider.",
 			},
 			consts.FieldCACertFile: {
-				Type:     schema.TypeString,
-				Optional: true,
-				// DefaultFunc: schema.EnvDefaultFunc(api.EnvVaultCACert, ""),
+				Type:        schema.TypeString,
+				Optional:    true,
 				Description: "Path to a CA certificate file to validate the server's certificate.",
 			},
 			consts.FieldCACertDir: {
-				Type:     schema.TypeString,
-				Optional: true,
-				// DefaultFunc: schema.EnvDefaultFunc(api.EnvVaultCAPath, ""),
+				Type:        schema.TypeString,
+				Optional:    true,
 				Description: "Path to directory containing CA certificate files to validate the server's certificate.",
 			},
-			consts.FieldClientAuth: {
-				Type:        schema.TypeList,
-				Optional:    true,
-				Description: "Client authentication credentials.",
-				MaxItems:    1,
-				Deprecated:  fmt.Sprintf("Use %s instead", consts.FieldAuthLoginCert),
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						consts.FieldCertFile: {
-							Type:     schema.TypeString,
-							Required: true,
-							// DefaultFunc: schema.EnvDefaultFunc(api.EnvVaultClientCert, ""),
-							Description: "Path to a file containing the client certificate.",
-						},
-						consts.FieldKeyFile: {
-							Type:     schema.TypeString,
-							Required: true,
-							// DefaultFunc: schema.EnvDefaultFunc(api.EnvVaultClientKey, ""),
-							Description: "Path to a file containing the private key that the certificate was issued for.",
-						},
-					},
-				},
-			},
 			consts.FieldSkipTLSVerify: {
-				Type:     schema.TypeBool,
-				Optional: true,
-				// DefaultFunc: schema.EnvDefaultFunc("VAULT_SKIP_VERIFY", false),
+				Type:        schema.TypeBool,
+				Optional:    true,
 				Description: "Set this to true only if the target Vault server is an insecure development instance.",
 			},
 			consts.FieldTLSServerName: {
-				Type:     schema.TypeString,
-				Optional: true,
-				// DefaultFunc: schema.EnvDefaultFunc(api.EnvVaultTLSServerName, ""),
+				Type:        schema.TypeString,
+				Optional:    true,
 				Description: "Name to use as the SNI host when connecting via TLS.",
 			},
 			"max_lease_ttl_seconds": {
-				Type:     schema.TypeInt,
-				Optional: true,
-
-				// Default is 20min, which is intended to be enough time for
-				// a reasonable Terraform run can complete but not
-				// significantly longer, so that any leases are revoked shortly
-				// after Terraform has finished running.
-				// DefaultFunc: schema.EnvDefaultFunc("TERRAFORM_VAULT_MAX_TTL", 1200),
+				Type:        schema.TypeInt,
+				Optional:    true,
 				Description: "Maximum TTL for secret leases requested by this provider.",
 			},
 			"max_retries": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				// DefaultFunc: schema.EnvDefaultFunc("VAULT_MAX_RETRIES", DefaultMaxHTTPRetries),
+				Type:        schema.TypeInt,
+				Optional:    true,
 				Description: "Maximum number of retries when a 5xx error code is encountered.",
 			},
 			"max_retries_ccc": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				// DefaultFunc: schema.EnvDefaultFunc("VAULT_MAX_RETRIES_CCC", DefaultMaxHTTPRetriesCCC),
+				Type:        schema.TypeInt,
+				Optional:    true,
 				Description: "Maximum number of retries for Client Controlled Consistency related operations",
 			},
 			consts.FieldNamespace: {
-				Type:     schema.TypeString,
-				Optional: true,
-				// DefaultFunc: schema.EnvDefaultFunc("VAULT_NAMESPACE", ""),
+				Type:        schema.TypeString,
+				Optional:    true,
 				Description: "The namespace to use. Available only for Vault Enterprise.",
 			},
 			consts.FieldSetNamespaceFromToken: {
@@ -204,9 +168,8 @@ func NewProvider(
 				},
 			},
 			consts.FieldSkipGetVaultVersion: {
-				Type:     schema.TypeBool,
-				Optional: true,
-				// Default:     false,
+				Type:        schema.TypeBool,
+				Optional:    true,
 				Description: "Skip the dynamic fetching of the Vault server version.",
 			},
 			consts.FieldVaultVersionOverride: {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/vault/api"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 )
@@ -67,9 +66,9 @@ func NewProvider(
 	r := &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			consts.FieldAddress: {
-				Type:        schema.TypeString,
-				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc(api.EnvVaultAddress, nil),
+				Type:     schema.TypeString,
+				Required: true,
+				// DefaultFunc: schema.EnvDefaultFunc(api.EnvVaultAddress, nil),
 				Description: "URL of the root of the target Vault server.",
 			},
 			"add_address_to_env": {
@@ -79,36 +78,36 @@ func NewProvider(
 				Description: "If true, adds the value of the `address` argument to the Terraform process environment.",
 			},
 			"token": {
-				Type:        schema.TypeString,
-				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc(api.EnvVaultToken, ""),
+				Type:     schema.TypeString,
+				Required: true,
+				// DefaultFunc: schema.EnvDefaultFunc(api.EnvVaultToken, ""),
 				Description: "Token to use to authenticate to Vault.",
 			},
 			"token_name": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("VAULT_TOKEN_NAME", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				// DefaultFunc: schema.EnvDefaultFunc("VAULT_TOKEN_NAME", ""),
 				Description: "Token name to use for creating the Vault child token.",
 			},
 			"skip_child_token": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("TERRAFORM_VAULT_SKIP_CHILD_TOKEN", false),
+				Type:     schema.TypeBool,
+				Optional: true,
+				// DefaultFunc: schema.EnvDefaultFunc("TERRAFORM_VAULT_SKIP_CHILD_TOKEN", false),
 
 				// Setting to true will cause max_lease_ttl_seconds and token_name to be ignored (not used).
 				// Note that this is strongly discouraged due to the potential of exposing sensitive secret data.
 				Description: "Set this to true to prevent the creation of ephemeral child token used by this provider.",
 			},
 			consts.FieldCACertFile: {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc(api.EnvVaultCACert, ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				// DefaultFunc: schema.EnvDefaultFunc(api.EnvVaultCACert, ""),
 				Description: "Path to a CA certificate file to validate the server's certificate.",
 			},
 			consts.FieldCACertDir: {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc(api.EnvVaultCAPath, ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				// DefaultFunc: schema.EnvDefaultFunc(api.EnvVaultCAPath, ""),
 				Description: "Path to directory containing CA certificate files to validate the server's certificate.",
 			},
 			consts.FieldClientAuth: {
@@ -120,30 +119,30 @@ func NewProvider(
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						consts.FieldCertFile: {
-							Type:        schema.TypeString,
-							Required:    true,
-							DefaultFunc: schema.EnvDefaultFunc(api.EnvVaultClientCert, ""),
+							Type:     schema.TypeString,
+							Required: true,
+							// DefaultFunc: schema.EnvDefaultFunc(api.EnvVaultClientCert, ""),
 							Description: "Path to a file containing the client certificate.",
 						},
 						consts.FieldKeyFile: {
-							Type:        schema.TypeString,
-							Required:    true,
-							DefaultFunc: schema.EnvDefaultFunc(api.EnvVaultClientKey, ""),
+							Type:     schema.TypeString,
+							Required: true,
+							// DefaultFunc: schema.EnvDefaultFunc(api.EnvVaultClientKey, ""),
 							Description: "Path to a file containing the private key that the certificate was issued for.",
 						},
 					},
 				},
 			},
 			consts.FieldSkipTLSVerify: {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("VAULT_SKIP_VERIFY", false),
+				Type:     schema.TypeBool,
+				Optional: true,
+				// DefaultFunc: schema.EnvDefaultFunc("VAULT_SKIP_VERIFY", false),
 				Description: "Set this to true only if the target Vault server is an insecure development instance.",
 			},
 			consts.FieldTLSServerName: {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc(api.EnvVaultTLSServerName, ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				// DefaultFunc: schema.EnvDefaultFunc(api.EnvVaultTLSServerName, ""),
 				Description: "Name to use as the SNI host when connecting via TLS.",
 			},
 			"max_lease_ttl_seconds": {
@@ -154,25 +153,25 @@ func NewProvider(
 				// a reasonable Terraform run can complete but not
 				// significantly longer, so that any leases are revoked shortly
 				// after Terraform has finished running.
-				DefaultFunc: schema.EnvDefaultFunc("TERRAFORM_VAULT_MAX_TTL", 1200),
+				// DefaultFunc: schema.EnvDefaultFunc("TERRAFORM_VAULT_MAX_TTL", 1200),
 				Description: "Maximum TTL for secret leases requested by this provider.",
 			},
 			"max_retries": {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("VAULT_MAX_RETRIES", DefaultMaxHTTPRetries),
+				Type:     schema.TypeInt,
+				Optional: true,
+				// DefaultFunc: schema.EnvDefaultFunc("VAULT_MAX_RETRIES", DefaultMaxHTTPRetries),
 				Description: "Maximum number of retries when a 5xx error code is encountered.",
 			},
 			"max_retries_ccc": {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("VAULT_MAX_RETRIES_CCC", DefaultMaxHTTPRetriesCCC),
+				Type:     schema.TypeInt,
+				Optional: true,
+				// DefaultFunc: schema.EnvDefaultFunc("VAULT_MAX_RETRIES_CCC", DefaultMaxHTTPRetriesCCC),
 				Description: "Maximum number of retries for Client Controlled Consistency related operations",
 			},
 			consts.FieldNamespace: {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("VAULT_NAMESPACE", ""),
+				Type:     schema.TypeString,
+				Optional: true,
+				// DefaultFunc: schema.EnvDefaultFunc("VAULT_NAMESPACE", ""),
 				Description: "The namespace to use. Available only for Vault Enterprise.",
 			},
 			consts.FieldSetNamespaceFromToken: {
@@ -186,27 +185,28 @@ func NewProvider(
 			"headers": {
 				Type:        schema.TypeList,
 				Optional:    true,
-				Sensitive:   true,
 				Description: "The headers to send with each Vault request.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
 							Type:        schema.TypeString,
 							Required:    true,
+							Sensitive:   true,
 							Description: "The header name",
 						},
 						"value": {
 							Type:        schema.TypeString,
 							Required:    true,
+							Sensitive:   true,
 							Description: "The header value",
 						},
 					},
 				},
 			},
 			consts.FieldSkipGetVaultVersion: {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     false,
+				Type:     schema.TypeBool,
+				Optional: true,
+				// Default:     false,
 				Description: "Skip the dynamic fetching of the Vault server version.",
 			},
 			consts.FieldVaultVersionOverride: {
@@ -223,6 +223,11 @@ func NewProvider(
 	}
 
 	MustAddAuthLoginSchema(r.Schema)
+
+	// Set the provider Meta (instance data) here.
+	// It will be overwritten by the result of the call to ConfigureFunc,
+	// but can be used pre-configuration by other (non-primary) provider servers.
+	r.SetMeta(&ProviderMeta{})
 
 	return r
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -138,14 +138,6 @@ func NewProvider(
 				Optional:    true,
 				Description: "The namespace to use. Available only for Vault Enterprise.",
 			},
-			consts.FieldSetNamespaceFromToken: {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-				Description: "In the case where the Vault token is for a specific namespace " +
-					"and the provider namespace is not configured, use the token namespace " +
-					"as the root namespace for all resources.",
-			},
 			"headers": {
 				Type:        schema.TypeList,
 				Optional:    true,

--- a/internal/provider/validators.go
+++ b/internal/provider/validators.go
@@ -22,7 +22,7 @@ import (
 var (
 	regexpPathLeading  = regexp.MustCompile(fmt.Sprintf(`^%s`, consts.PathDelim))
 	regexpPathTrailing = regexp.MustCompile(fmt.Sprintf(`%s$`, consts.PathDelim))
-	regexpPath         = regexp.MustCompile(fmt.Sprintf(`%s|%s`, regexpPathLeading, regexpPathTrailing))
+	RegexpPath         = regexp.MustCompile(fmt.Sprintf(`%s|%s`, regexpPathLeading, regexpPathTrailing))
 	regexpUUID         = regexp.MustCompile("^[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}$")
 )
 
@@ -63,7 +63,7 @@ func ValidateNoTrailingSlash(i interface{}, k string) ([]string, []error) {
 
 func ValidateNoLeadingTrailingSlashes(i interface{}, k string) ([]string, []error) {
 	var errs []error
-	if err := validatePath(regexpPath, i, k); err != nil {
+	if err := validatePath(RegexpPath, i, k); err != nil {
 		errs = append(errs, err)
 	}
 
@@ -71,7 +71,7 @@ func ValidateNoLeadingTrailingSlashes(i interface{}, k string) ([]string, []erro
 }
 
 func ValidateDiagPath(i interface{}, path cty.Path) diag.Diagnostics {
-	return validateDiagPath(regexpPath, i, path)
+	return validateDiagPath(RegexpPath, i, path)
 }
 
 func validateDiagPath(r *regexp.Regexp, i interface{}, path cty.Path) diag.Diagnostics {

--- a/internal/sys/password_policy.go
+++ b/internal/sys/password_policy.go
@@ -1,0 +1,256 @@
+package sys
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/framework/base"
+	"github.com/hashicorp/terraform-provider-vault/internal/framework/client"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+)
+
+// ensure we our interface implementation is correct
+var _ resource.ResourceWithConfigure = &PasswordPolicyResource{}
+
+func NewPasswordPolicyResource() resource.Resource {
+	return &PasswordPolicyResource{}
+}
+
+type PasswordPolicyResource struct {
+	meta *provider.ProviderMeta
+}
+
+func (r *PasswordPolicyResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_password_policy_fw"
+}
+
+// PasswordPolicyModel describes the Terraform resource data model to match the
+// resource schema.
+type PasswordPolicyModel struct {
+	Namespace types.String `tfsdk:"namespace"`
+
+	Name   types.String `tfsdk:"name"`
+	Policy types.String `tfsdk:"policy"`
+}
+
+// PasswordPolicyResourceAPIModel describes the Vault API data model.
+type PasswordPolicyResourceAPIModel struct {
+	Policy string `json:"policy" mapstructure:"policy"`
+}
+
+func (r *PasswordPolicyResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	meta, ok := req.ProviderData.(*provider.ProviderMeta)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *provider.ProviderMeta, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	r.meta = meta
+}
+
+func (r *PasswordPolicyResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
+				MarkdownDescription: "Name of the password policy.",
+				Required:            true,
+			},
+			"policy": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "The password policy document",
+			},
+		},
+		MarkdownDescription: "Provides a resource to manage Password Policies.",
+	}
+
+	base.MustAddBaseSchema(&resp.Schema)
+}
+
+func (r *PasswordPolicyResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan PasswordPolicyModel
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client, err := client.GetClient(ctx, r.meta, plan.Namespace.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Error Configuring Resource Client", err.Error())
+		return
+	}
+
+	data := map[string]interface{}{
+		"policy": plan.Policy.ValueString(),
+	}
+	path := r.path(plan.Name.ValueString())
+	// vault returns a nil response on success
+	_, err = client.Logical().Write(path, data)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Create Resource",
+			"An unexpected error occurred while attempting to create the resource. "+
+				"Please retry the operation or report this issue to the provider developers.\n\n"+
+				"HTTP Error: "+err.Error(),
+		)
+
+		return
+	}
+
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *PasswordPolicyResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state PasswordPolicyModel
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client, err := client.GetClient(ctx, r.meta, state.Namespace.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Error Configuring Resource Client", err.Error())
+		return
+	}
+
+	// TODO: refactor the following read, marshal and unmarshal into a helper?
+	path := r.path(state.Name.ValueString())
+	policyResp, err := client.Logical().Read(path)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Resource from Vault",
+			"An unexpected error occurred while attempting to read the resource. "+
+				"Please retry the operation or report this issue to the provider developers.\n\n"+
+				"HTTP Error: "+err.Error(),
+		)
+
+		return
+	}
+	if policyResp == nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Resource from Vault",
+			"An unexpected error occurred while attempting to read the resource. "+
+				"Please retry the operation or report this issue to the provider developers.\n\n"+
+				"Vault response was nil",
+		)
+
+		return
+	}
+
+	jsonData, err := json.Marshal(policyResp.Data)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to marshal Vault response",
+			"An unexpected error occurred while attempting to marshal the Vault response.\n\n"+
+				"Error: "+err.Error(),
+		)
+
+		return
+	}
+
+	var readResp *PasswordPolicyResourceAPIModel
+	err = json.Unmarshal(jsonData, &readResp)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to unmarshal data to API model",
+			"An unexpected error occurred while attempting to unmarshal the data.\n\n"+
+				"Error: "+err.Error(),
+		)
+
+		return
+	}
+
+	state.Policy = types.StringValue(readResp.Policy)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *PasswordPolicyResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan PasswordPolicyModel
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client, err := client.GetClient(ctx, r.meta, plan.Namespace.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Error Configuring Resource Client", err.Error())
+		return
+	}
+
+	data := map[string]interface{}{
+		"policy": plan.Policy.ValueString(),
+	}
+	path := r.path(plan.Name.ValueString())
+	// vault returns a nil response on success
+	_, err = client.Logical().Write(path, data)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Update Resource",
+			"An unexpected error occurred while attempting to update the resource. "+
+				"Please retry the operation or report this issue to the provider developers.\n\n"+
+				"HTTP Error: "+err.Error(),
+		)
+
+		return
+	}
+
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *PasswordPolicyResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var plan PasswordPolicyModel
+
+	// Read Terraform state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &plan)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	client, err := client.GetClient(ctx, r.meta, plan.Namespace.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Error Configuring Resource Client", err.Error())
+		return
+	}
+
+	path := r.path(plan.Name.ValueString())
+
+	_, err = client.Logical().Delete(path)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Delete Resource",
+			"An unexpected error occurred while attempting to delete the resource. "+
+				"Please retry the operation or report this issue to the provider developers.\n\n"+
+				"HTTP Error: "+err.Error(),
+		)
+
+		return
+	}
+
+	// If the logic reaches here, it implicitly succeeded and will remove
+	// the resource from state if there are no other errors.
+}
+
+func (r *PasswordPolicyResource) path(name string) string {
+	return fmt.Sprintf("/sys/policies/password/%s", name)
+}

--- a/main.go
+++ b/main.go
@@ -8,26 +8,12 @@ import (
 	"flag"
 	"log"
 
-	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server"
-	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
-	"github.com/hashicorp/terraform-provider-vault/internal/provider/fwprovider"
-	"github.com/hashicorp/terraform-provider-vault/schema"
 	"github.com/hashicorp/terraform-provider-vault/vault"
 )
 
 func main() {
-	ctx := context.Background()
-
-	sdkv2Provider := schema.NewProvider(vault.Provider())
-
-	providers := []func() tfprotov5.ProviderServer{
-		providerserver.NewProtocol5(fwprovider.New()), // terraform-plugin-framework provider
-		sdkv2Provider.GRPCProvider,
-	}
-
-	muxServer, err := tf5muxserver.NewMuxServer(ctx, providers...)
+	serverFactory, _, err := vault.ProtoV5ProviderServerFactory(context.Background())
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -47,7 +33,7 @@ func main() {
 
 	err = tf5server.Serve(
 		"registry.terraform.io/hashicorp/vault",
-		muxServer.ProviderServer,
+		serverFactory,
 		serveOpts...,
 	)
 

--- a/main.go
+++ b/main.go
@@ -8,9 +8,11 @@ import (
 	"flag"
 	"log"
 
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server"
 	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider/fwprovider"
 	"github.com/hashicorp/terraform-provider-vault/schema"
 	"github.com/hashicorp/terraform-provider-vault/vault"
 )
@@ -21,7 +23,7 @@ func main() {
 	sdkv2Provider := schema.NewProvider(vault.Provider())
 
 	providers := []func() tfprotov5.ProviderServer{
-		// providerserver.NewProtocol5(provider.New()), // Example terraform-plugin-framework provider
+		providerserver.NewProtocol5(fwprovider.New()), // terraform-plugin-framework provider
 		sdkv2Provider.GRPCProvider,
 	}
 

--- a/schema/provider.go
+++ b/schema/provider.go
@@ -33,3 +33,7 @@ func (p *Provider) SchemaProvider() *schema.Provider {
 func (p *Provider) GRPCProvider() tfprotov5.ProviderServer {
 	return p.provider.GRPCProvider()
 }
+
+func (p *Provider) Meta() interface{} {
+	return p.provider.Meta()
+}

--- a/vault/provider_factory.go
+++ b/vault/provider_factory.go
@@ -1,0 +1,29 @@
+package vault
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+	"github.com/hashicorp/terraform-plugin-mux/tf5muxserver"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider/fwprovider"
+	"github.com/hashicorp/terraform-provider-vault/schema"
+)
+
+// ProtoV5ProviderServerFactory returns a muxed terraform-plugin-go protocol v5 provider factory function.
+// This factory function is suitable for use with the terraform-plugin-go Serve function.
+// The primary (Plugin SDK) provider server is also returned (useful for testing).
+func ProtoV5ProviderServerFactory(ctx context.Context) (func() tfprotov5.ProviderServer, *schema.Provider, error) {
+	primary := schema.NewProvider(Provider())
+	servers := []func() tfprotov5.ProviderServer{
+		primary.GRPCProvider,
+		providerserver.NewProtocol5(fwprovider.New(primary)),
+	}
+
+	muxServer, err := tf5muxserver.NewMuxServer(ctx, servers...)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return muxServer.ProviderServer, primary, nil
+}

--- a/vault/provider_test.go
+++ b/vault/provider_test.go
@@ -4,6 +4,7 @@
 package vault
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -108,16 +110,72 @@ const tokenHelperScript = `#!/usr/bin/env bash
 echo "helper-token"
 `
 
-func TestAccAuthLoginProviderConfigure(t *testing.T) {
-	rootProvider := Provider()
-	rootProviderResource := &schema.Resource{
-		Schema: rootProvider.Schema,
+// testAccProtoV5ProviderFactories will return a map of provider servers
+// suitable for use as a resource.TestStep.ProtoV5ProviderFactories.
+//
+// When multiplexing providers, the schema and configuration handling must
+// exactly match between all underlying providers of the mux server. Mismatched
+// schemas will result in a runtime error.
+// see: https://developer.hashicorp.com/terraform/plugin/framework/migrating/mux
+//
+// Any tests that use this function will serve as a smoketest to verify the
+// provider schemas match 1-1 so that we may catch runtime errors.
+func testAccProtoV5ProviderFactories(ctx context.Context, t *testing.T, v **schema.Provider) map[string]func() (tfprotov5.ProviderServer, error) {
+	providerServerFactory, p, err := ProtoV5ProviderServerFactory(ctx)
+	if err != nil {
+		t.Fatal(err)
 	}
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() { testutil.TestAccPreCheck(t) },
-		Providers: map[string]*schema.Provider{
-			"vault": rootProvider,
+
+	providerServer := providerServerFactory()
+	*v = p.SchemaProvider()
+
+	return map[string]func() (tfprotov5.ProviderServer, error){
+		providerName: func() (tfprotov5.ProviderServer, error) {
+			return providerServer, nil
 		},
+	}
+}
+
+// TestAccMuxServer uses ExternalProviders (vault) to generate a state file
+// with a previous version of the provider and then verify that there are no
+// planned changes after migrating to the Framework.
+//
+// As of TFVP v3.23.0, the resources used in this test are not implemented with
+// the new Terraform Plugin Framework. However, this will act as a smoketest to
+// verify the provider schemas match 1-1.
+//
+// Additionally, when migrating a resource this test can be used as a pattern
+// to follow to verify that switching from SDKv2 to the Framework has not
+// affected your provider's behavior.
+func TestAccMuxServer(t *testing.T) {
+	var p *schema.Provider
+	resource.Test(t, resource.TestCase{
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"vault": {
+						// 3.23.0 is not multiplexed
+						VersionConstraint: "3.23.0",
+						Source:            "hashicorp/vault",
+					},
+				},
+				Config: testResourceApproleConfig_basic(),
+				Check:  testResourceApproleLoginCheckAttrs(t),
+			},
+			{
+				ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t, &p),
+				Config:                   testResourceApproleConfig_basic(),
+				PlanOnly:                 true,
+			},
+		},
+	})
+}
+
+func TestAccAuthLoginProviderConfigure(t *testing.T) {
+	var p *schema.Provider
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutil.TestAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t, &p),
 		Steps: []resource.TestStep{
 			{
 				Config: testResourceApproleConfig_basic(),
@@ -126,6 +184,9 @@ func TestAccAuthLoginProviderConfigure(t *testing.T) {
 		},
 	})
 
+	rootProviderResource := &schema.Resource{
+		Schema: p.Schema,
+	}
 	rootProviderData := rootProviderResource.TestResourceData()
 	if _, err := provider.NewProviderMeta(rootProviderData); err != nil {
 		t.Fatal(err)
@@ -133,14 +194,11 @@ func TestAccAuthLoginProviderConfigure(t *testing.T) {
 }
 
 func TestTokenReadProviderConfigureWithHeaders(t *testing.T) {
-	rootProvider := Provider()
+	var p *schema.Provider
 
-	rootProviderResource := &schema.Resource{
-		Schema: rootProvider.Schema,
-	}
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testutil.TestAccPreCheck(t) },
-		ProviderFactories: providerFactories,
+		PreCheck:                 func() { testutil.TestAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t, &p),
 		Steps: []resource.TestStep{
 			{
 				Config: testHeaderConfig("auth", "123"),
@@ -149,6 +207,9 @@ func TestTokenReadProviderConfigureWithHeaders(t *testing.T) {
 		},
 	})
 
+	rootProviderResource := &schema.Resource{
+		Schema: p.Schema,
+	}
 	rootProviderData := rootProviderResource.TestResourceData()
 	if _, err := provider.NewProviderMeta(rootProviderData); err != nil {
 		t.Fatal(err)
@@ -548,11 +609,12 @@ func TestAccTokenName(t *testing.T) {
 		},
 	}
 
+	var p *schema.Provider
 	for _, test := range tests {
 		t.Run(test.WantTokenName, func(t *testing.T) {
 			resource.Test(t, resource.TestCase{
-				ProviderFactories: providerFactories,
-				PreCheck:          func() { testutil.TestAccPreCheck(t) },
+				ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t, &p),
+				PreCheck:                 func() { testutil.TestAccPreCheck(t) },
 				Steps: []resource.TestStep{
 					{
 						PreConfig: func() {
@@ -611,11 +673,12 @@ func TestAccChildToken(t *testing.T) {
 		},
 	}
 
+	var p *schema.Provider
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			resource.Test(t, resource.TestCase{
-				ProviderFactories: providerFactories,
-				PreCheck:          func() { testutil.TestAccPreCheck(t) },
+				ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t, &p),
+				PreCheck:                 func() { testutil.TestAccPreCheck(t) },
 				Steps: []resource.TestStep{
 					{
 						Config: testProviderConfig(test.useChildTokenSchema,

--- a/vault/provider_test.go
+++ b/vault/provider_test.go
@@ -367,6 +367,7 @@ func TestAccProviderToken(t *testing.T) {
 		t.Fatal(err)
 	}
 	origTokenBytes, err := ioutil.ReadFile(tokenFilePath)
+
 	if err == nil {
 		// There is an existing token file. Ensure it is restored after this test.
 		info, err := os.Stat(tokenFilePath)
@@ -404,15 +405,12 @@ func TestAccProviderToken(t *testing.T) {
 		name          string
 		fileToken     bool
 		helperToken   bool
+		envToken      bool
 		schemaToken   bool
 		expectedToken string
 	}
 
 	tests := []testcase{
-		{
-			name:          "None",
-			expectedToken: "",
-		},
 		{
 			// The p will read the token file "~/.vault-token".
 			name:          "File",
@@ -428,10 +426,19 @@ func TestAccProviderToken(t *testing.T) {
 		},
 		{
 			// A VAULT_TOKEN env var or hardcoded token overrides all else.
+			name:          "Env",
+			fileToken:     true,
+			helperToken:   true,
+			envToken:      true,
+			expectedToken: os.Getenv("VAULT_TOKEN"),
+		},
+		{
+			// A VAULT_TOKEN env var or hardcoded token overrides all else.
 			name:          "Schema",
 			fileToken:     true,
 			helperToken:   true,
 			schemaToken:   true,
+			envToken:      true,
 			expectedToken: "schema-token",
 		},
 	}
@@ -459,6 +466,18 @@ func TestAccProviderToken(t *testing.T) {
 			}
 
 			d := providerResource.TestResourceData()
+			// Set up the env token.
+			if tc.envToken {
+				d.Set("token", os.Getenv("VAULT_TOKEN"))
+			} else {
+				// unset vault token env because it takes precedence over helper and file
+				resetConfigPathEnv, err := tempUnsetenv("VAULT_TOKEN")
+				defer failIfErr(t, resetConfigPathEnv)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
 			// Set up the schema token.
 			if tc.schemaToken {
 				d.Set("token", "schema-token")
@@ -559,8 +578,6 @@ func TestAccTokenName(t *testing.T) {
 }
 
 func TestAccChildToken(t *testing.T) {
-	defer os.Unsetenv(consts.EnvVarSkipChildToken)
-
 	checkTokenUsed := func(expectChildToken bool) resource.TestCheckFunc {
 		if expectChildToken {
 			// If the default child token was created, we expect the token
@@ -574,55 +591,23 @@ func TestAccChildToken(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		skipChildTokenEnv    string
-		useChildTokenEnv     bool
 		skipChildTokenSchema string
 		useChildTokenSchema  bool
 		expectChildToken     bool
 	}{
-		"tc1": {
+		"skip_child_token unset in config": {
 			useChildTokenSchema: false,
-			useChildTokenEnv:    false,
 			expectChildToken:    true,
 		},
-		"tc2": {
-			skipChildTokenEnv: "",
-			useChildTokenEnv:  true,
-			expectChildToken:  true,
-		},
-		"tc3": {
-			skipChildTokenEnv: "true",
-			useChildTokenEnv:  true,
-			expectChildToken:  false,
-		},
-		"tc4": {
-			skipChildTokenEnv: "false",
-			useChildTokenEnv:  true,
-			expectChildToken:  true,
-		},
-		"tc5": {
+		"skip_child_token true in config": {
 			skipChildTokenSchema: "true",
 			useChildTokenSchema:  true,
 			expectChildToken:     false,
 		},
-		"tc6": {
+		"skip_child_token false in config": {
 			skipChildTokenSchema: "false",
 			useChildTokenSchema:  true,
 			expectChildToken:     true,
-		},
-		"tc7": {
-			skipChildTokenEnv:    "true",
-			useChildTokenEnv:     true,
-			skipChildTokenSchema: "false",
-			useChildTokenSchema:  true,
-			expectChildToken:     true,
-		},
-		"tc8": {
-			skipChildTokenEnv:    "false",
-			useChildTokenEnv:     true,
-			skipChildTokenSchema: "true",
-			useChildTokenSchema:  true,
-			expectChildToken:     false,
 		},
 	}
 
@@ -633,19 +618,6 @@ func TestAccChildToken(t *testing.T) {
 				PreCheck:          func() { testutil.TestAccPreCheck(t) },
 				Steps: []resource.TestStep{
 					{
-						PreConfig: func() {
-							if test.useChildTokenEnv {
-								err := os.Setenv(consts.EnvVarSkipChildToken, test.skipChildTokenEnv)
-								if err != nil {
-									t.Fatal(err)
-								}
-							} else {
-								err := os.Unsetenv(consts.EnvVarSkipChildToken)
-								if err != nil {
-									t.Fatal(err)
-								}
-							}
-						},
 						Config: testProviderConfig(test.useChildTokenSchema,
 							consts.FieldSkipChildToken+` = `+test.skipChildTokenSchema,
 						),
@@ -780,6 +752,15 @@ func TestAccProviderVaultAddrEnv(t *testing.T) {
 			if tc.vaultAddrEnv != "" {
 				unset, err := tempSetenv(api.EnvVaultAddress, tc.vaultAddrEnv)
 				defer failIfErr(t, unset)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// unset vault token env because add_address_to_env will only
+				// be set if the token is unset in the config and the
+				// VAULT_ADDR env variable
+				reset, err := tempUnsetenv(api.EnvVaultToken)
+				defer failIfErr(t, reset)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # Vault Provider
 
 The Vault provider allows Terraform to read from, write to, and configure
-[HashiCorp Vault](https://vaultproject.io/).
+[HashiCorp Vault](https://developer.hashicorp.com/vault).
 
 ~> **Important** Interacting with Vault from Terraform causes any secrets
 that you read and write to be persisted in both Terraform's state file
@@ -160,12 +160,6 @@ variables in order to keep credential information out of the configuration.
   a limited child token using auth/token/create in order to enforce a short
   TTL and limit exposure. *[See usage details below.](#generic)*
 
-* `client_auth` - (Optional) A configuration block, described below, that
-  provides credentials used by Terraform to authenticate with the Vault
-  server. At present there is little reason to set this, because Terraform
-  does not support the TLS certificate authentication mechanism.
-  *Deprecated, use `auth_login_cert` instead.
-
 * `skip_tls_verify` - (Optional) Set this to `true` to disable verification
   of the Vault server's TLS certificate. This is strongly discouraged except
   in prototype or development environments, since it exposes the possibility
@@ -214,10 +208,6 @@ variables in order to keep credential information out of the configuration.
 
 * `use_root_namespace` - (Optional) Authenticate to the root Vault namespace. Conflicts with `namespace`.
 
-* `set_namespace_from_token` -(Optional) Defaults to `true`. In the case where the Vault token is
-  for a specific namespace and the provider namespace is not configured, use the token namespace
-  as the root namespace for all resources.
-
 * `skip_get_vault_version` - (Optional) Skip the dynamic fetching of the Vault server version. 
   Set to `true` when the */sys/seal-status* API endpoint is not available. See [vault_version_override](#vault_version_override)
   for related info
@@ -233,14 +223,6 @@ only ever use this option in the case where the server version cannot be dynamic
 * `headers` - (Optional) A configuration block, described below, that provides headers
 to be sent along with all requests to the Vault server.  This block can be specified
 multiple times.
-
-The `client_auth` configuration block accepts the following arguments:
-
-* `cert_file` - (Required) Path to a file on local disk that contains the
-  PEM-encoded certificate to present to the server.
-
-* `key_file` - (Required) Path to a file on local disk that contains the
-  PEM-encoded private key for which the authentication certificate was issued.
 
 The `headers` configuration block accepts the following arguments:
 
@@ -741,9 +723,9 @@ provider "vault" {
 The Vault provider supports managing [Namespaces][namespaces] (a feature of
 Vault Enterprise), as well as creating resources in those namespaces by
 utilizing [Provider Aliasing][aliasing]. The `namespace` option in the [provider
-block][provider-block] enables the management of  resources in the specified
-namespace. 
-In addition, all resources and data sources support specifying their own `namespace`. 
+block](#provider-arguments) enables the management of resources in the specified
+namespace.
+In addition, all resources and data sources support specifying their own `namespace`.
 All resource's `namespace` will be made relative to the `provider`'s configured namespace.
 
 ### Importing namespaced resources
@@ -966,11 +948,19 @@ default
 vault_team_policy
 ```
 
-## Tutorials 
+### Token namespaces
+
+In the case where the Vault token is for a specific namespace and the provider
+namespace is not configured, the provider will use the token namespace as the
+root namespace for all resources. This behavior can be disabled by setting the
+`VAULT_SET_NAMESPACE_FROM_TOKEN ` environment variable to "false". The only
+accepted values are "true" and "false".
+
+
+## Tutorials
 
 Refer to the [Codify Management of Vault Enterprise Using Terraform](https://learn.hashicorp.com/tutorials/vault/codify-mgmt-enterprise) tutorial for additional examples using Vault namespaces.
 
 
-[namespaces]: https://www.vaultproject.io/docs/enterprise/namespaces#vault-enterprise-namespaces
-[aliasing]: https://www.terraform.io/docs/configuration/providers.html#alias-multiple-provider-configurations
-[provider-block]: /docs#provider-arguments
+[namespaces]: https://developer.hashicorp.com/vault/docs/enterprise/namespaces#vault-enterprise-namespaces
+[aliasing]: https://developer.hashicorp.com/terraform/language/providers/configuration#alias-multiple-provider-configurations


### PR DESCRIPTION
# Description

We introduces a minimal first step for [combining](https://www.terraform.io/plugin/mux) (using [terraform-plugin-mux](https://github.com/hashicorp/terraform-plugin-mux)) into a single binary the current resource and data sources implemented using [Terraform Plugin SDK v2](https://github.com/hashicorp/terraform-plugin-sdk) with other future implementations (such as using [Terraform Plugin Framework](https://github.com/hashicorp/terraform-plugin-framework)).

## This PR
### Phase 1
- Introduces (in internal/provider/fwprovider) a minimal provider implementation that uses the TF Plugin Framework and muxes it with the current SDK v2-based provider's server. This new skeleton provider
- Implements 0 resources and data sources
- Is required to declare a provider schema that is identical to the schema(s) declared by all other providers in the muxed provider server
- Removes Default values from the SDK v2-based provider's schema declaration as the TF Framework-based provider does not have that facility. Defaults should be handled in the provider's ConfigureFunc


## Previous Phases
### Phase 0
- https://github.com/hashicorp/terraform-provider-vault/pull/2059
- Adds a multiplexer that combines the current Terraform Plugin SDK v2 Provider implementation with 0 additional providers
- Enables support for both SDKv2 and TF Plugin Framework

## Subsequent Phases

### Phase 2
- Completes the provider configuration setup
- Complete all auth login setup

### Phase 3
- Migrate a resource/data source to the TF Plugin Framework

