### PR TITLE
Add field `set_namespace_from_token` to Provider configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 FEATURES:
 * Add support for `custom_metadata` on `vault_namespace`: ([#2033](https://github.com/hashicorp/terraform-provider-vault/pull/2033))
 * Add support for `OCSP*` role fields for the cert auth resource: ([#2056](https://github.com/hashicorp/terraform-provider-vault/pull/2056))
+* Add field `set_namespace_from_token` to Provider configuration ([#2070](https://github.com/hashicorp/terraform-provider-vault/pull/2070))
 
 BUGS:
 * Fix panic when readnig client_secret from a public oidc client ([#2048](https://github.com/hashicorp/terraform-provider-vault/pull/2048))

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -363,6 +363,7 @@ const (
 	FieldServiceAccountJWT             = "service_account_jwt"
 	FieldDisableISSValidation          = "disable_iss_validation"
 	FieldPEMKeys                       = "pem_keys"
+	FieldSetNamespaceFromToken         = "set_namespace_from_token"
 	/*
 		common environment variables
 	*/

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -314,8 +314,10 @@ func NewProviderMeta(d *schema.ResourceData) (interface{}, error) {
 		namespace = tokenNamespace
 		// set the namespace on the provider to ensure that all child
 		// namespace paths are properly honoured.
-		if err := d.Set(consts.FieldNamespace, namespace); err != nil {
-			return nil, err
+		if v, ok := d.Get(consts.FieldSetNamespaceFromToken).(bool); ok && v {
+			if err := d.Set(consts.FieldNamespace, namespace); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -175,6 +175,14 @@ func NewProvider(
 				DefaultFunc: schema.EnvDefaultFunc("VAULT_NAMESPACE", ""),
 				Description: "The namespace to use. Available only for Vault Enterprise.",
 			},
+			consts.FieldSetNamespaceFromToken: {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+				Description: "In the case where the Vault token is for a specific namespace " +
+					"and the provider namespace is not configured, use the token namespace " +
+					"as the root namespace for all resources.",
+			},
 			"headers": {
 				Type:        schema.TypeList,
 				Optional:    true,

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -214,6 +214,10 @@ variables in order to keep credential information out of the configuration.
 
 * `use_root_namespace` - (Optional) Authenticate to the root Vault namespace. Conflicts with `namespace`.
 
+* `set_namespace_from_token` -(Optional) Defaults to `true`. In the case where the Vault token is
+  for a specific namespace and the provider namespace is not configured, use the token namespace
+  as the root namespace for all resources.
+
 * `skip_get_vault_version` - (Optional) Skip the dynamic fetching of the Vault server version. 
   Set to `true` when the */sys/seal-status* API endpoint is not available. See [vault_version_override](#vault_version_override)
   for related info


### PR DESCRIPTION
### Description
This PR adds a field `set_namespace_from_token` to the Provider configuration block. This boolean parameter provides an initial escape-hatch to TFVP users who would like to avoid the default behavior in the Provider of setting the namespace from the Auth Login token whenever a Provider-level namespace is not set/specified.

### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestNewProviderMeta'
=== RUN   TestNewProviderMeta
--- PASS: TestNewProviderMeta (0.00s)
=== RUN   TestNewProviderMeta/invalid-nil-ResourceData
=== PAUSE TestNewProviderMeta/invalid-nil-ResourceData
=== CONT  TestNewProviderMeta/invalid-nil-ResourceData
    --- PASS: TestNewProviderMeta/invalid-nil-ResourceData (0.00s)
=== RUN   TestNewProviderMeta/with-provider-ns-only
=== PAUSE TestNewProviderMeta/with-provider-ns-only
=== CONT  TestNewProviderMeta/with-provider-ns-only
    --- PASS: TestNewProviderMeta/with-provider-ns-only (0.01s)
=== RUN   TestNewProviderMeta/with-token-ns-only
=== PAUSE TestNewProviderMeta/with-token-ns-only
=== CONT  TestNewProviderMeta/with-token-ns-only
    --- PASS: TestNewProviderMeta/with-token-ns-only (1.73s)
=== RUN   TestNewProviderMeta/with-provider-ns-and-token-ns
=== PAUSE TestNewProviderMeta/with-provider-ns-and-token-ns
=== CONT  TestNewProviderMeta/with-provider-ns-and-token-ns
    --- PASS: TestNewProviderMeta/with-provider-ns-and-token-ns (0.42s)
=== RUN   TestNewProviderMeta/with-auth-login-and-ns
=== PAUSE TestNewProviderMeta/with-auth-login-and-ns
=== CONT  TestNewProviderMeta/with-auth-login-and-ns
    --- PASS: TestNewProviderMeta/with-auth-login-and-ns (1.72s)
=== RUN   TestNewProviderMeta/with-provider-ns-and-auth-login-with-ns
=== PAUSE TestNewProviderMeta/with-provider-ns-and-auth-login-with-ns
=== CONT  TestNewProviderMeta/with-provider-ns-and-auth-login-with-ns
    --- PASS: TestNewProviderMeta/with-provider-ns-and-auth-login-with-ns (1.97s)
=== RUN   TestNewProviderMeta/set-namespace-from-token-false
=== PAUSE TestNewProviderMeta/set-namespace-from-token-false
=== CONT  TestNewProviderMeta/set-namespace-from-token-false
    --- PASS: TestNewProviderMeta/set-namespace-from-token-false (1.98s)
=== RUN   TestNewProviderMeta/set-namespace-from-token-true
=== PAUSE TestNewProviderMeta/set-namespace-from-token-true
=== CONT  TestNewProviderMeta/set-namespace-from-token-true
    --- PASS: TestNewProviderMeta/set-namespace-from-token-true (2.03s)
PASS
```
