### PR TITLE
fix Identity Group externally managed policies lost on update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+BUGS:
+
+* Fix `vault_identity_group` loses externally managed policies on updates when `external_policies = true`
+
 ## 3.22.0 (Nov 1, 2023)
 
 FEATURES:

--- a/vault/resource_identity_group.go
+++ b/vault/resource_identity_group.go
@@ -175,7 +175,7 @@ func identityGroupUpdateFields(d *schema.ResourceData, data map[string]interface
 			// should be configured on the entity.
 			data["external_policies"] = d.Get("external_policies").(bool)
 			if data["external_policies"].(bool) {
-				data["policies"] = nil
+				delete(data, "policies")
 			}
 		}
 	}

--- a/vault/resource_identity_group_policies_test.go
+++ b/vault/resource_identity_group_policies_test.go
@@ -253,7 +253,7 @@ func testAccIdentityGroupPoliciesConfigNonExclusiveUpdateGroup(group string) str
 resource "vault_identity_group" "group" {
   name = "%s"
   external_policies = true
-  metdata = {
+  metadata = {
 	version = "1"
   }
 }


### PR DESCRIPTION

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
Addresses losing externally managed policies on Vault Identity Group resources. Mirrored changes made in [1950](https://github.com/hashicorp/terraform-provider-vault/pull/1950) but for Identity Groups.

Like in 1950, I put tests in the `vault_identity_group_policies` resource as that seemed like the most appropriate place.

Note: I am using Windows for development and changed line returns from `CRLF` to `LF`. The `make fmt` reformatted all Go files in my local clone so I'm guessing line returns were automatically updated to `CRLF` when I cloned the repo. If this needs to be adjusted, please do so.

Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md):
Fix `vault_identity_group` loses externally managed policies on updates when `external_policies = true`


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #1956 


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-test.run TestAccIdentityGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -test.run TestAccIdentityGroup -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/codegen   (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/mfa     [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/pki      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/provider (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/testutil  (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/vault     128.122s
...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

