### PR TITLE
feat(data_source_kv_secret_v2): add the metadata version in returned values

### DIFF
--- a/vault/data_source_kv_secret_v2.go
+++ b/vault/data_source_kv_secret_v2.go
@@ -164,6 +164,12 @@ func kvSecretV2DataSourceRead(_ context.Context, d *schema.ResourceData, meta in
 			}
 		}
 
+		if v, ok := metadata["version"]; ok {
+			if err := d.Set("version", v); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+
 		if customMetadata, ok := metadata["custom_metadata"]; ok && customMetadata != nil {
 			if v, ok := customMetadata.(map[string]interface{}); ok {
 				if err := d.Set("custom_metadata", serializeDataMapToString(v)); err != nil {

--- a/website/docs/d/kv_secret_v2.html.md
+++ b/website/docs/d/kv_secret_v2.html.md
@@ -93,3 +93,5 @@ The following attributes are exported:
 * `deletion_time` - Deletion time for the secret.
 
 * `destroyed` - Indicates whether the secret has been destroyed.
+
+* `version` - Version of the secret.


### PR DESCRIPTION
### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->

This PR add the field "version" in the data source : vault_kv_secret_v2, which is useful when we don't specify the version in input. 

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2094 

### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
  - It's not directly modified the user api IMO, but I could change this.
- [x] Acceptance tests where run against all supported Vault Versions
  - I didn't modified the tests because Metadatas are not tested against this datasource.

### Output from acceptance testing:
I ran tests against the modified data source.

```
❯ m testacc TESTARGS="-run=TestDataSourceKVV2Secret"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -run=TestDataSourceKVV2Secret -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/mfa     [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/pki      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/codegen   (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/provider (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/testutil  (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/vault     24.516s
❯ m testacc TESTARGS="-run=TestDataSourceKVV2Secret_deletedSecret"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -run=TestDataSourceKVV2Secret_deletedSecret -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
ok      github.com/hashicorp/terraform-provider-vault/codegen   0.294s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/mfa     [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/pki      [no test files]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  0.858s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/provider 0.989s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/testutil  0.625s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util      0.649s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/vault     6.813s

```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

