### PR TITLE
[Phase 2] Include Auth Login blocks in multiplexed Provider configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework v1.4.1
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
 	github.com/hashicorp/terraform-plugin-go v0.19.0
+	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-mux v0.12.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.29.0
 	github.com/hashicorp/vault v1.11.3
@@ -134,7 +135,6 @@ require (
 	github.com/hashicorp/serf v0.9.7 // indirect
 	github.com/hashicorp/terraform-exec v0.19.0 // indirect
 	github.com/hashicorp/terraform-json v0.17.1 // indirect
-	github.com/hashicorp/terraform-plugin-log v0.9.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.2 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect

--- a/internal/framework/validators/README.md
+++ b/internal/framework/validators/README.md
@@ -1,0 +1,3 @@
+# Terraform Plugin Framework Validators
+
+This package contains custom Terraform Plugin Framework [validators](https://developer.hashicorp.com/terraform/plugin/framework/validation).

--- a/internal/framework/validators/gcp.go
+++ b/internal/framework/validators/gcp.go
@@ -1,0 +1,49 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validators
+
+import (
+	"context"
+	"os"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	googleoauth "golang.org/x/oauth2/google"
+)
+
+// Credentials Validator
+var _ validator.String = credentialsValidator{}
+
+// credentialsValidator validates that a string Attribute's is valid JSON credentials.
+type credentialsValidator struct{}
+
+// Description describes the validation in plain text formatting.
+func (v credentialsValidator) Description(_ context.Context) string {
+	return "value must be a path to valid JSON credentials or valid, raw, JSON credentials"
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (v credentialsValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// ValidateString performs the validation.
+func (v credentialsValidator) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	value := request.ConfigValue.ValueString()
+
+	// if this is a path and we can stat it, assume it's ok
+	if _, err := os.Stat(value); err == nil {
+		return
+	}
+	if _, err := googleoauth.CredentialsFromJSON(context.Background(), []byte(value)); err != nil {
+		response.Diagnostics.AddError("JSON credentials are not valid", err.Error())
+	}
+}
+
+func GCPCredentialsValidator() validator.String {
+	return credentialsValidator{}
+}

--- a/internal/framework/validators/gcp_test.go
+++ b/internal/framework/validators/gcp_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package validators
+
+import (
+	"context"
+	"io/ioutil"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+const testFakeCredentialsPath = "./test-fixtures/fake_account.json"
+
+func TestFrameworkProvider_CredentialsValidator(t *testing.T) {
+	cases := map[string]struct {
+		ConfigValue          func(t *testing.T) types.String
+		ExpectedWarningCount int
+		ExpectedErrorCount   int
+	}{
+		"configuring credentials as a path to a credentials JSON file is valid": {
+			ConfigValue: func(t *testing.T) types.String {
+				return types.StringValue(testFakeCredentialsPath) // Path to a test fixture
+			},
+		},
+		"configuring credentials as a path to a non-existant file is NOT valid": {
+			ConfigValue: func(t *testing.T) types.String {
+				return types.StringValue("./this/path/doesnt/exist.json") // Doesn't exist
+			},
+			ExpectedErrorCount: 1,
+		},
+		"configuring credentials as a credentials JSON string is valid": {
+			ConfigValue: func(t *testing.T) types.String {
+				contents, err := ioutil.ReadFile(testFakeCredentialsPath)
+				if err != nil {
+					t.Fatalf("Unexpected error: %s", err)
+				}
+				stringContents := string(contents)
+				return types.StringValue(stringContents)
+			},
+		},
+		"configuring credentials as an empty string is not valid": {
+			ConfigValue: func(t *testing.T) types.String {
+				return types.StringValue("")
+			},
+			ExpectedErrorCount: 1,
+		},
+		"leaving credentials unconfigured is valid": {
+			ConfigValue: func(t *testing.T) types.String {
+				return types.StringNull()
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			// Arrange
+			req := validator.StringRequest{
+				ConfigValue: tc.ConfigValue(t),
+			}
+
+			resp := validator.StringResponse{
+				Diagnostics: diag.Diagnostics{},
+			}
+
+			cv := GCPCredentialsValidator()
+
+			// Act
+			cv.ValidateString(context.Background(), req, &resp)
+
+			// Assert
+			if resp.Diagnostics.WarningsCount() > tc.ExpectedWarningCount {
+				t.Errorf("Expected %d warnings, got %d", tc.ExpectedWarningCount, resp.Diagnostics.WarningsCount())
+			}
+			if resp.Diagnostics.ErrorsCount() > tc.ExpectedErrorCount {
+				t.Errorf("Expected %d errors, got %d", tc.ExpectedErrorCount, resp.Diagnostics.ErrorsCount())
+			}
+		})
+	}
+}

--- a/internal/framework/validators/test-fixtures/fake_account.json
+++ b/internal/framework/validators/test-fixtures/fake_account.json
@@ -1,0 +1,7 @@
+{
+    "private_key_id": "foo",
+    "private_key": "bar",
+    "client_email": "foo@bar.com",
+    "client_id": "id@foo.com",
+    "type": "service_account"
+}

--- a/internal/provider/auth_aws.go
+++ b/internal/provider/auth_aws.go
@@ -15,6 +15,19 @@ import (
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 )
 
+const (
+	envVarAWSAccessKeyID           = "AWS_ACCESS_KEY_ID"
+	envVarAWSSecretAccessKey       = "AWS_SECRET_ACCESS_KEY"
+	envVarAWSSessionToken          = "AWS_SESSION_TOKEN"
+	envVarAWSProfile               = "AWS_PROFILE"
+	envVarAWSSharedCredentialsFile = "AWS_SHARED_CREDENTIALS_FILE"
+	envVarAWSWebIdentityTokenFile  = "AWS_WEB_IDENTITY_TOKEN_FILE"
+	envVarAWSRoleARN               = "AWS_ROLE_ARN"
+	envVarAWSRoleSessionName       = "AWS_ROLE_SESSION_NAME"
+	envVarAWSRegion                = "AWS_REGION"
+	envVarAWSDefaultRegion         = "AWS_DEFAULT_REGION"
+)
+
 func init() {
 	field := consts.FieldAuthLoginAWS
 	if err := globalAuthLoginRegistry.Register(field,
@@ -41,7 +54,7 @@ func GetAWSLoginSchemaResource(authField string) *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			consts.FieldRole: {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				Description: `The Vault role to use when logging into Vault.`,
 			},
 			// static credential fields
@@ -49,39 +62,33 @@ func GetAWSLoginSchemaResource(authField string) *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: `The AWS access key ID.`,
-				DefaultFunc: schema.EnvDefaultFunc("AWS_ACCESS_KEY_ID", nil),
 			},
 			consts.FieldAWSSecretAccessKey: {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Description:  `The AWS secret access key.`,
-				DefaultFunc:  schema.EnvDefaultFunc("AWS_SECRET_ACCESS_KEY", nil),
 				RequiredWith: []string{fmt.Sprintf("%s.0.%s", authField, consts.FieldAWSAccessKeyID)},
 			},
 			consts.FieldAWSSessionToken: {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: `The AWS session token.`,
-				DefaultFunc: schema.EnvDefaultFunc("AWS_SESSION_TOKEN", nil),
 			},
 			consts.FieldAWSProfile: {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: `The name of the AWS profile.`,
-				DefaultFunc: schema.EnvDefaultFunc("AWS_PROFILE", nil),
 			},
 			consts.FieldAWSSharedCredentialsFile: {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: `Path to the AWS shared credentials file.`,
-				DefaultFunc: schema.EnvDefaultFunc("AWS_SHARED_CREDENTIALS_FILE", nil),
 			},
 			consts.FieldAWSWebIdentityTokenFile: {
 				Type:     schema.TypeString,
 				Optional: true,
 				Description: `Path to the file containing an OAuth 2.0 access token or OpenID ` +
 					`Connect ID token.`,
-				DefaultFunc: schema.EnvDefaultFunc("AWS_WEB_IDENTITY_TOKEN_FILE", nil),
 			},
 			// STS assume role fields
 			consts.FieldAWSRoleARN: {
@@ -89,26 +96,17 @@ func GetAWSLoginSchemaResource(authField string) *schema.Resource {
 				Optional: true,
 				Description: `The ARN of the AWS Role to assume.` +
 					`Used during STS AssumeRole`,
-				DefaultFunc: schema.EnvDefaultFunc("AWS_ROLE_ARN", nil),
 			},
 			consts.FieldAWSRoleSessionName: {
 				Type:     schema.TypeString,
 				Optional: true,
 				Description: `Specifies the name to attach to the AWS role session. ` +
 					`Used during STS AssumeRole`,
-				DefaultFunc: schema.EnvDefaultFunc("AWS_ROLE_SESSION_NAME", nil),
 			},
 			consts.FieldAWSRegion: {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: `The AWS region.`,
-				DefaultFunc: schema.MultiEnvDefaultFunc(
-					[]string{
-						"AWS_REGION",
-						"AWS_DEFAULT_REGION",
-					},
-					nil,
-				),
 			},
 			consts.FieldAWSSTSEndpoint: {
 				Type:             schema.TypeString,
@@ -140,9 +138,13 @@ type AuthLoginAWS struct {
 }
 
 func (l *AuthLoginAWS) Init(d *schema.ResourceData, authField string) (AuthLogin, error) {
+	defaults := l.getDefaults()
 	if err := l.AuthLoginCommon.Init(d, authField,
-		func(data *schema.ResourceData) error {
-			return l.checkRequiredFields(d, consts.FieldRole)
+		func(data *schema.ResourceData, params map[string]interface{}) error {
+			return l.setDefaultFields(d, defaults, params)
+		},
+		func(data *schema.ResourceData, params map[string]interface{}) error {
+			return l.checkRequiredFields(d, params, consts.FieldRole)
 		},
 	); err != nil {
 		return nil, err
@@ -191,6 +193,68 @@ func (l *AuthLoginAWS) Login(client *api.Client) (*api.Secret, error) {
 	}
 
 	return l.login(client, l.LoginPath(), params)
+}
+
+func (l *AuthLoginAWS) getDefaults() authDefaults {
+	defaults := authDefaults{
+		{
+			field:      consts.FieldAWSAccessKeyID,
+			envVars:    []string{envVarAWSAccessKeyID},
+			defaultVal: "",
+		},
+		{
+			field:      consts.FieldAWSSecretAccessKey,
+			envVars:    []string{envVarAWSSecretAccessKey},
+			defaultVal: "",
+		},
+		{
+			field:      consts.FieldAWSSessionToken,
+			envVars:    []string{envVarAWSSessionToken},
+			defaultVal: "",
+		},
+		{
+			field:      consts.FieldAWSProfile,
+			envVars:    []string{envVarAWSProfile},
+			defaultVal: "",
+		},
+		{
+			field:      consts.FieldAWSProfile,
+			envVars:    []string{envVarAWSProfile},
+			defaultVal: "",
+		},
+		{
+			field:      consts.FieldAWSSharedCredentialsFile,
+			envVars:    []string{envVarAWSSharedCredentialsFile},
+			defaultVal: "",
+		},
+		{
+			field:      consts.FieldAWSWebIdentityTokenFile,
+			envVars:    []string{envVarAWSWebIdentityTokenFile},
+			defaultVal: "",
+		},
+		{
+			field:      consts.FieldAWSRoleARN,
+			envVars:    []string{envVarAWSRoleARN},
+			defaultVal: "",
+		},
+		{
+			field:      consts.FieldAWSRoleSessionName,
+			envVars:    []string{envVarAWSRoleSessionName},
+			defaultVal: "",
+		},
+		{
+			field:      consts.FieldAWSRoleSessionName,
+			envVars:    []string{envVarAWSRoleSessionName},
+			defaultVal: "",
+		},
+		{
+			field:      consts.FieldAWSRegion,
+			envVars:    []string{envVarAWSRegion, envVarAWSDefaultRegion},
+			defaultVal: "",
+		},
+	}
+
+	return defaults
 }
 
 func (l *AuthLoginAWS) getLoginData(logger hclog.Logger) (map[string]interface{}, error) {

--- a/internal/provider/auth_cert.go
+++ b/internal/provider/auth_cert.go
@@ -46,12 +46,12 @@ func GetCertLoginSchemaResource(authField string) *schema.Resource {
 			},
 			consts.FieldCertFile: {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				Description: "Path to a file containing the client certificate.",
 			},
 			consts.FieldKeyFile: {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				Description: "Path to a file containing the private key that the certificate was issued for.",
 			},
 		},
@@ -79,8 +79,8 @@ func (l *AuthLoginCert) LoginPath() string {
 
 func (l *AuthLoginCert) Init(d *schema.ResourceData, authField string) (AuthLogin, error) {
 	if err := l.AuthLoginCommon.Init(d, authField,
-		func(data *schema.ResourceData) error {
-			return l.checkRequiredFields(d, consts.FieldCertFile, consts.FieldKeyFile)
+		func(data *schema.ResourceData, params map[string]interface{}) error {
+			return l.checkRequiredFields(d, params, consts.FieldCertFile, consts.FieldKeyFile)
 		},
 	); err != nil {
 		return nil, err

--- a/internal/provider/auth_gcp.go
+++ b/internal/provider/auth_gcp.go
@@ -51,14 +51,13 @@ func GetGCPLoginSchemaResource(authField string) *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			consts.FieldRole: {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				Description: "Name of the login role.",
 			},
 			consts.FieldJWT: {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Description:   "A signed JSON Web Token.",
-				DefaultFunc:   schema.EnvDefaultFunc(consts.EnvVarGCPAuthJWT, nil),
 				ConflictsWith: []string{fmt.Sprintf("%s.0.%s", authField, consts.FieldCredentials)},
 			},
 			consts.FieldCredentials: {
@@ -66,7 +65,6 @@ func GetGCPLoginSchemaResource(authField string) *schema.Resource {
 				Optional:      true,
 				ValidateFunc:  validateCredentials,
 				Description:   "Path to the Google Cloud credentials file.",
-				DefaultFunc:   schema.EnvDefaultFunc(consts.EnvVarGoogleApplicationCreds, nil),
 				ConflictsWith: []string{fmt.Sprintf("%s.0.%s", authField, consts.FieldJWT)},
 			},
 			consts.FieldServiceAccount: {
@@ -89,7 +87,26 @@ type AuthLoginGCP struct {
 }
 
 func (l *AuthLoginGCP) Init(d *schema.ResourceData, authField string) (AuthLogin, error) {
-	if err := l.AuthLoginCommon.Init(d, authField); err != nil {
+	defaults := authDefaults{
+		{
+			field:      consts.FieldJWT,
+			envVars:    []string{consts.EnvVarGCPAuthJWT},
+			defaultVal: "",
+		},
+		{
+			field:      consts.FieldCredentials,
+			envVars:    []string{consts.EnvVarGoogleApplicationCreds},
+			defaultVal: "",
+		},
+	}
+	if err := l.AuthLoginCommon.Init(d, authField,
+		func(data *schema.ResourceData, params map[string]interface{}) error {
+			return l.setDefaultFields(d, defaults, params)
+		},
+		func(data *schema.ResourceData, params map[string]interface{}) error {
+			return l.checkRequiredFields(d, params, consts.FieldRole)
+		},
+	); err != nil {
 		return nil, err
 	}
 	return l, nil

--- a/internal/provider/auth_jwt.go
+++ b/internal/provider/auth_jwt.go
@@ -38,14 +38,13 @@ func GetJWTLoginSchemaResource(authField string) *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			consts.FieldRole: {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				Description: "Name of the login role.",
 			},
 			consts.FieldJWT: {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				Description: "A signed JSON Web Token.",
-				DefaultFunc: schema.EnvDefaultFunc(consts.EnvVarVaultAuthJWT, nil),
 			},
 		},
 	}, authField, consts.MountTypeJWT)
@@ -71,9 +70,20 @@ func (l *AuthLoginJWT) LoginPath() string {
 }
 
 func (l *AuthLoginJWT) Init(d *schema.ResourceData, authField string) (AuthLogin, error) {
+	defaults := authDefaults{
+		{
+			field:      consts.FieldJWT,
+			envVars:    []string{consts.EnvVarVaultAuthJWT},
+			defaultVal: "",
+		},
+	}
+
 	if err := l.AuthLoginCommon.Init(d, authField,
-		func(data *schema.ResourceData) error {
-			return l.checkRequiredFields(d, consts.FieldRole, consts.FieldJWT)
+		func(data *schema.ResourceData, params map[string]interface{}) error {
+			return l.setDefaultFields(d, defaults, params)
+		},
+		func(data *schema.ResourceData, params map[string]interface{}) error {
+			return l.checkRequiredFields(d, params, consts.FieldRole, consts.FieldJWT)
 		},
 	); err != nil {
 		return nil, err

--- a/internal/provider/auth_oci.go
+++ b/internal/provider/auth_oci.go
@@ -48,12 +48,12 @@ func GetOCILoginSchemaResource(authField string) *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			consts.FieldRole: {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				Description: "Name of the login role.",
 			},
 			consts.FieldAuthType: {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				Description: "Authentication type to use when getting OCI credentials.",
 				ValidateDiagFunc: GetValidateDiagChoices(
 					[]string{ociAuthTypeInstance, ociAuthTypeAPIKeys},
@@ -85,8 +85,8 @@ func (l *AuthLoginOCI) LoginPath() string {
 
 func (l *AuthLoginOCI) Init(d *schema.ResourceData, authField string) (AuthLogin, error) {
 	if err := l.AuthLoginCommon.Init(d, authField,
-		func(data *schema.ResourceData) error {
-			return l.checkRequiredFields(d, consts.FieldRole, consts.FieldAuthType)
+		func(data *schema.ResourceData, params map[string]interface{}) error {
+			return l.checkRequiredFields(d, params, consts.FieldRole, consts.FieldAuthType)
 		},
 	); err != nil {
 		return nil, err

--- a/internal/provider/auth_oidc.go
+++ b/internal/provider/auth_oidc.go
@@ -40,7 +40,7 @@ func GetOIDCLoginSchemaResource(authField string) *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			consts.FieldRole: {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				Description: "Name of the login role.",
 			},
 			consts.FieldCallbackListenerAddress: {
@@ -86,8 +86,8 @@ func (l *AuthLoginOIDC) LoginPath() string {
 
 func (l *AuthLoginOIDC) Init(d *schema.ResourceData, authField string) (AuthLogin, error) {
 	if err := l.AuthLoginCommon.Init(d, authField,
-		func(data *schema.ResourceData) error {
-			return l.checkRequiredFields(d, consts.FieldRole)
+		func(data *schema.ResourceData, params map[string]interface{}) error {
+			return l.checkRequiredFields(d, params, consts.FieldRole)
 		},
 	); err != nil {
 		return nil, err

--- a/internal/provider/auth_radius.go
+++ b/internal/provider/auth_radius.go
@@ -39,14 +39,12 @@ func GetRadiusLoginSchemaResource(authField string) *schema.Resource {
 			consts.FieldUsername: {
 				Type:        schema.TypeString,
 				Description: "The Radius username.",
-				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc(consts.EnvVarRadiusUsername, nil),
+				Optional:    true,
 			},
 			consts.FieldPassword: {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				Description: "The Radius password for username.",
-				DefaultFunc: schema.EnvDefaultFunc(consts.EnvVarRadiusPassword, nil),
 			},
 		},
 	}, authField, consts.MountTypeRadius)
@@ -72,9 +70,24 @@ func (l *AuthLoginRadius) LoginPath() string {
 }
 
 func (l *AuthLoginRadius) Init(d *schema.ResourceData, authField string) (AuthLogin, error) {
+	defaults := authDefaults{
+		{
+			field:      consts.FieldUsername,
+			envVars:    []string{consts.EnvVarRadiusUsername},
+			defaultVal: "",
+		},
+		{
+			field:      consts.FieldPassword,
+			envVars:    []string{consts.EnvVarRadiusPassword},
+			defaultVal: "",
+		},
+	}
 	if err := l.AuthLoginCommon.Init(d, authField,
-		func(data *schema.ResourceData) error {
-			return l.checkRequiredFields(d, consts.FieldUsername, consts.FieldPassword)
+		func(data *schema.ResourceData, params map[string]interface{}) error {
+			return l.setDefaultFields(d, defaults, params)
+		},
+		func(data *schema.ResourceData, params map[string]interface{}) error {
+			return l.checkRequiredFields(d, params, consts.FieldUsername, consts.FieldPassword)
 		},
 	); err != nil {
 		return nil, err

--- a/internal/provider/auth_token_file.go
+++ b/internal/provider/auth_token_file.go
@@ -74,16 +74,16 @@ func (l *AuthLoginTokenFile) Init(d *schema.ResourceData,
 	defaults := authDefaults{
 		{
 			field:      consts.FieldFilename,
-			envVar:     consts.EnvVarTokenFilename,
+			envVars:    []string{consts.EnvVarTokenFilename},
 			defaultVal: "",
 		},
 	}
 	if err := l.AuthLoginCommon.Init(d, authField,
-		func(data *schema.ResourceData) error {
-			return l.setDefaultFields(d, defaults)
+		func(data *schema.ResourceData, params map[string]interface{}) error {
+			return l.setDefaultFields(d, defaults, params)
 		},
-		func(data *schema.ResourceData) error {
-			return l.checkRequiredFields(d, consts.FieldFilename)
+		func(data *schema.ResourceData, params map[string]interface{}) error {
+			return l.checkRequiredFields(d, params, consts.FieldFilename)
 		},
 	); err != nil {
 		return nil, err

--- a/internal/provider/auth_token_file_test.go
+++ b/internal/provider/auth_token_file_test.go
@@ -49,9 +49,7 @@ func TestAuthLoginTokenFile_Init(t *testing.T) {
 				consts.EnvVarTokenFilename: "/tmp/vault-token",
 			},
 			expectParams: map[string]interface{}{
-				consts.FieldNamespace:        "",
-				consts.FieldUseRootNamespace: false,
-				consts.FieldFilename:         "/tmp/vault-token",
+				consts.FieldFilename: "/tmp/vault-token",
 			},
 			wantErr: false,
 		},

--- a/internal/provider/auth_userpass.go
+++ b/internal/provider/auth_userpass.go
@@ -41,21 +41,18 @@ func GetUserpassLoginSchemaResource(authField string) *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			consts.FieldUsername: {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				Description: "Login with username",
-				DefaultFunc: schema.EnvDefaultFunc(consts.EnvVarUsername, nil),
 			},
 			consts.FieldPassword: {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Login with password",
-				DefaultFunc: schema.EnvDefaultFunc(consts.EnvVarPassword, nil),
 			},
 			consts.FieldPasswordFile: {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Description: "Login with password from a file",
-				DefaultFunc: schema.EnvDefaultFunc(consts.EnvVarPasswordFile, nil),
 				// unfortunately the SDK does support conflicting relative fields
 				// within a list type. As long as the top level schema does not change
 				// we should be good to hard code fully qualified path like so.
@@ -77,9 +74,30 @@ type AuthLoginUserpass struct {
 }
 
 func (l *AuthLoginUserpass) Init(d *schema.ResourceData, authField string) (AuthLogin, error) {
+	defaults := authDefaults{
+		{
+			field:      consts.FieldUsername,
+			envVars:    []string{consts.EnvVarUsername},
+			defaultVal: "",
+		},
+		{
+			field:      consts.FieldPassword,
+			envVars:    []string{consts.EnvVarPassword},
+			defaultVal: "",
+		},
+		{
+			field:      consts.FieldPasswordFile,
+			envVars:    []string{consts.EnvVarPasswordFile},
+			defaultVal: "",
+		},
+	}
+
 	if err := l.AuthLoginCommon.Init(d, authField,
-		func(data *schema.ResourceData) error {
-			return l.checkRequiredFields(d, consts.FieldUsername)
+		func(data *schema.ResourceData, params map[string]interface{}) error {
+			return l.setDefaultFields(d, defaults, params)
+		},
+		func(data *schema.ResourceData, params map[string]interface{}) error {
+			return l.checkRequiredFields(d, params, consts.FieldUsername)
 		},
 	); err != nil {
 		return nil, err

--- a/internal/provider/fwprovider/auth_aws.go
+++ b/internal/provider/fwprovider/auth_aws.go
@@ -1,0 +1,78 @@
+package fwprovider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+)
+
+func AuthLoginAWSSchema() schema.Block {
+	return mustAddLoginSchema(&schema.ListNestedBlock{
+		Description: "Login to vault using the AWS method",
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				consts.FieldRole: schema.StringAttribute{
+					Optional:    true,
+					Description: `The Vault role to use when logging into Vault.`,
+				},
+				// static credential fields
+				consts.FieldAWSAccessKeyID: schema.StringAttribute{
+					Optional:    true,
+					Description: `The AWS access key ID.`,
+				},
+				consts.FieldAWSSecretAccessKey: schema.StringAttribute{
+					Optional:    true,
+					Description: `The AWS secret access key.`,
+				},
+				consts.FieldAWSSessionToken: schema.StringAttribute{
+					Optional:    true,
+					Description: `The AWS session token.`,
+				},
+				consts.FieldAWSProfile: schema.StringAttribute{
+					Optional:    true,
+					Description: `The name of the AWS profile.`,
+				},
+				consts.FieldAWSSharedCredentialsFile: schema.StringAttribute{
+					Optional:    true,
+					Description: `Path to the AWS shared credentials file.`,
+				},
+				consts.FieldAWSWebIdentityTokenFile: schema.StringAttribute{
+					Optional: true,
+					Description: `Path to the file containing an OAuth 2.0 access token or OpenID ` +
+						`Connect ID token.`,
+				},
+				// STS assume role fields
+				consts.FieldAWSRoleARN: schema.StringAttribute{
+					Optional: true,
+					Description: `The ARN of the AWS Role to assume.` +
+						`Used during STS AssumeRole`,
+				},
+				consts.FieldAWSRoleSessionName: schema.StringAttribute{
+					Optional: true,
+					Description: `Specifies the name to attach to the AWS role session. ` +
+						`Used during STS AssumeRole`,
+				},
+				consts.FieldAWSRegion: schema.StringAttribute{
+					Optional:    true,
+					Description: `The AWS region.`,
+				},
+				consts.FieldAWSSTSEndpoint: schema.StringAttribute{
+					Optional:    true,
+					Description: `The STS endpoint URL.`,
+					Validators:  []validator.String{},
+					// ValidateDiagFunc: GetValidateDiagURI([]string{"https", "http"}),
+				},
+				consts.FieldAWSIAMEndpoint: schema.StringAttribute{
+					Optional:    true,
+					Description: `The IAM endpoint URL.`,
+					// ValidateDiagFunc: GetValidateDiagURI([]string{"https", "http"}),
+				},
+				consts.FieldHeaderValue: schema.StringAttribute{
+					Optional:    true,
+					Description: `The Vault header value to include in the STS signing request.`,
+				},
+			},
+		},
+	}, consts.MountTypeAWS)
+}

--- a/internal/provider/fwprovider/auth_azure.go
+++ b/internal/provider/fwprovider/auth_azure.go
@@ -1,0 +1,82 @@
+package fwprovider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+)
+
+func AuthLoginAzureSchema() schema.Block {
+	return mustAddLoginSchema(&schema.ListNestedBlock{
+		Description: "Login to vault using the azure method",
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				consts.FieldJWT: schema.StringAttribute{
+					Optional: true,
+					Description: "A signed JSON Web Token. If not specified on will be " +
+						"created automatically",
+				},
+				consts.FieldRole: schema.StringAttribute{
+					Optional:    true,
+					Description: "Name of the login role.",
+				},
+				consts.FieldSubscriptionID: schema.StringAttribute{
+					Optional: true,
+					Description: "The subscription ID for the machine that generated the MSI token. " +
+						"This information can be obtained through instance metadata.",
+				},
+				consts.FieldResourceGroupName: schema.StringAttribute{
+					Optional: true,
+					Description: "The resource group for the machine that generated the MSI token. " +
+						"This information can be obtained through instance metadata.",
+				},
+				consts.FieldVMName: schema.StringAttribute{
+					Optional: true,
+					Description: "The virtual machine name for the machine that generated the MSI token. " +
+						"This information can be obtained through instance metadata.",
+				},
+				consts.FieldVMSSName: schema.StringAttribute{
+					Optional: true,
+					Description: "The virtual machine scale set name for the machine that generated " +
+						"the MSI token. This information can be obtained through instance metadata.",
+					Validators: []validator.String{
+						stringvalidator.ConflictsWith(
+							path.MatchRelative().AtName(consts.FieldVMName),
+						),
+					},
+				},
+				consts.FieldTenantID: schema.StringAttribute{
+					Optional: true,
+					Description: "Provides the tenant ID to use in a multi-tenant " +
+						"authentication scenario.",
+					Validators: []validator.String{
+						stringvalidator.ConflictsWith(
+							path.MatchRelative().AtName(consts.FieldJWT),
+						),
+					},
+				},
+				consts.FieldClientID: schema.StringAttribute{
+					Optional:    true,
+					Description: "The identity's client ID.",
+					Validators: []validator.String{
+						stringvalidator.ConflictsWith(
+							path.MatchRelative().AtName(consts.FieldJWT),
+						),
+					},
+				},
+				consts.FieldScope: schema.StringAttribute{
+					Optional:    true,
+					Description: "The scopes to include in the token request.",
+					Validators: []validator.String{
+						stringvalidator.ConflictsWith(
+							path.MatchRelative().AtName(consts.FieldJWT),
+						),
+					},
+				},
+			},
+		},
+	}, consts.MountTypeAzure)
+}

--- a/internal/provider/fwprovider/auth_cert.go
+++ b/internal/provider/fwprovider/auth_cert.go
@@ -1,0 +1,29 @@
+package fwprovider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+)
+
+func AuthLoginCertSchema() schema.Block {
+	return mustAddLoginSchema(&schema.ListNestedBlock{
+		Description: "Login to vault using the cert method",
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				consts.FieldName: schema.StringAttribute{
+					Optional:    true,
+					Description: "Name of the certificate's role",
+				},
+				consts.FieldCertFile: schema.StringAttribute{
+					Optional:    true,
+					Description: "Path to a file containing the client certificate.",
+				},
+				consts.FieldKeyFile: schema.StringAttribute{
+					Optional:    true,
+					Description: "Path to a file containing the private key that the certificate was issued for.",
+				},
+			},
+		},
+	}, consts.MountTypeCert)
+}

--- a/internal/provider/fwprovider/auth_gcp.go
+++ b/internal/provider/fwprovider/auth_gcp.go
@@ -1,0 +1,54 @@
+package fwprovider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/framework/validators"
+)
+
+func AuthLoginGCPSchema() schema.Block {
+	return mustAddLoginSchema(&schema.ListNestedBlock{
+		Description: "Login to vault using the gcp method",
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				consts.FieldRole: schema.StringAttribute{
+					Optional:    true,
+					Description: "Name of the login role.",
+				},
+				consts.FieldJWT: schema.StringAttribute{
+					Optional:    true,
+					Description: "A signed JSON Web Token.",
+					Validators: []validator.String{
+						stringvalidator.ConflictsWith(
+							path.MatchRelative().AtName(consts.FieldCredentials),
+						),
+					},
+				},
+				consts.FieldCredentials: schema.StringAttribute{
+					Optional:    true,
+					Description: "Path to the Google Cloud credentials file.",
+					Validators: []validator.String{
+						stringvalidator.ConflictsWith(
+							path.MatchRelative().AtName(consts.FieldJWT),
+						),
+						stringvalidator.LengthAtLeast(1),
+						validators.GCPCredentialsValidator(),
+					},
+				},
+				consts.FieldServiceAccount: schema.StringAttribute{
+					Optional:    true,
+					Description: "IAM service account.",
+					Validators: []validator.String{
+						stringvalidator.ConflictsWith(
+							path.MatchRelative().AtName(consts.FieldJWT),
+						),
+					},
+				},
+			},
+		},
+	}, consts.MountTypeGCP)
+}

--- a/internal/provider/fwprovider/auth_generic.go
+++ b/internal/provider/fwprovider/auth_generic.go
@@ -1,0 +1,29 @@
+package fwprovider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+)
+
+func AuthLoginGenericSchema() schema.Block {
+	return mustAddLoginSchema(&schema.ListNestedBlock{
+		Description: "Login to vault with an existing auth method using auth/<mount>/login",
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				consts.FieldPath: schema.StringAttribute{
+					Required: true,
+				},
+				consts.FieldParameters: schema.MapAttribute{
+					Optional:    true,
+					ElementType: types.StringType,
+					Sensitive:   true,
+				},
+				consts.FieldMethod: schema.StringAttribute{
+					Optional: true,
+				},
+			},
+		},
+	}, consts.MountTypeNone)
+}

--- a/internal/provider/fwprovider/auth_jwt.go
+++ b/internal/provider/fwprovider/auth_jwt.go
@@ -1,0 +1,25 @@
+package fwprovider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+)
+
+func AuthLoginJWTSchema() schema.Block {
+	return mustAddLoginSchema(&schema.ListNestedBlock{
+		Description: "Login to vault using the jwt method",
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				consts.FieldRole: schema.StringAttribute{
+					Optional:    true,
+					Description: "Name of the login role.",
+				},
+				consts.FieldJWT: schema.StringAttribute{
+					Optional:    true,
+					Description: "A signed JSON Web Token.",
+				},
+			},
+		},
+	}, consts.MountTypeJWT)
+}

--- a/internal/provider/fwprovider/auth_kerberos.go
+++ b/internal/provider/fwprovider/auth_kerberos.go
@@ -1,0 +1,91 @@
+package fwprovider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/boolvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+)
+
+func AuthLoginKerberosSchema() schema.Block {
+	return mustAddLoginSchema(&schema.ListNestedBlock{
+		Description: "Login to vault using the kerberos method",
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				consts.FieldToken: schema.StringAttribute{
+					Optional:    true,
+					Description: "Simple and Protected GSSAPI Negotiation Mechanism (SPNEGO) token",
+					// ValidateFunc: validateKRBNegToken,
+				},
+				consts.FieldUsername: schema.StringAttribute{
+					Optional:    true,
+					Description: "The username to login into Kerberos with.",
+					Validators: []validator.String{
+						stringvalidator.ConflictsWith(
+							path.MatchRelative().AtName(consts.FieldToken),
+						),
+					},
+				},
+				consts.FieldService: schema.StringAttribute{
+					Optional:    true,
+					Description: "The service principle name.",
+					Validators: []validator.String{
+						stringvalidator.ConflictsWith(
+							path.MatchRelative().AtName(consts.FieldToken),
+						),
+					},
+				},
+				consts.FieldRealm: schema.StringAttribute{
+					Optional:    true,
+					Description: "The Kerberos server's authoritative authentication domain",
+					Validators: []validator.String{
+						stringvalidator.ConflictsWith(
+							path.MatchRelative().AtName(consts.FieldToken),
+						),
+					},
+				},
+				consts.FieldKRB5ConfPath: schema.StringAttribute{
+					Optional:    true,
+					Description: "A valid Kerberos configuration file e.g. /etc/krb5.conf.",
+					// ValidateFunc:  validateFileExists,
+					Validators: []validator.String{
+						stringvalidator.ConflictsWith(
+							path.MatchRelative().AtName(consts.FieldToken),
+						),
+					},
+				},
+				consts.FieldKeytabPath: schema.StringAttribute{
+					Optional:    true,
+					Description: "The Kerberos keytab file containing the entry of the login entity.",
+					// ValidateFunc:  validateFileExists,
+					Validators: []validator.String{
+						stringvalidator.ConflictsWith(
+							path.MatchRelative().AtName(consts.FieldToken),
+						),
+					},
+				},
+				consts.FieldDisableFastNegotiation: schema.BoolAttribute{
+					Optional: true,
+					Validators: []validator.Bool{
+						boolvalidator.ConflictsWith(
+							path.MatchRelative().AtName(consts.FieldToken),
+						),
+					},
+					Description: "Disable the Kerberos FAST negotiation.",
+				},
+				consts.FieldRemoveInstanceName: schema.BoolAttribute{
+					Optional: true,
+					Validators: []validator.Bool{
+						boolvalidator.ConflictsWith(
+							path.MatchRelative().AtName(consts.FieldToken),
+						),
+					},
+					Description: "Strip the host from the username found in the keytab.",
+				},
+			},
+		},
+	}, consts.MountTypeGCP)
+}

--- a/internal/provider/fwprovider/auth_oci.go
+++ b/internal/provider/fwprovider/auth_oci.go
@@ -1,0 +1,35 @@
+package fwprovider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+)
+
+const (
+	ociAuthTypeInstance = "instance"
+	ociAuthTypeAPIKeys  = "apikey"
+)
+
+func AuthLoginOCISchema() schema.Block {
+	return mustAddLoginSchema(&schema.ListNestedBlock{
+		Description: "Login to vault using the OCI method",
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				consts.FieldRole: schema.StringAttribute{
+					Optional:    true,
+					Description: "Name of the login role.",
+				},
+				consts.FieldAuthType: schema.StringAttribute{
+					Optional:    true,
+					Description: "Authentication type to use when getting OCI credentials.",
+					Validators: []validator.String{
+						stringvalidator.OneOf([]string{ociAuthTypeInstance, ociAuthTypeAPIKeys}...),
+					},
+				},
+			},
+		},
+	}, consts.MountTypeGCP)
+}

--- a/internal/provider/fwprovider/auth_oidc.go
+++ b/internal/provider/fwprovider/auth_oidc.go
@@ -1,0 +1,32 @@
+package fwprovider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+)
+
+func AuthLoginOIDCSchema() schema.Block {
+	return mustAddLoginSchema(&schema.ListNestedBlock{
+		Description: "Login to vault using the oidc method",
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				consts.FieldRole: schema.StringAttribute{
+					Optional:    true,
+					Description: "Name of the login role.",
+				},
+
+				consts.FieldCallbackListenerAddress: schema.StringAttribute{
+					Optional:    true,
+					Description: "The callback listener's address. Must be a valid URI without the path.",
+					// ValidateDiagFunc: GetValidateDiagURI([]string{"tcp"}),
+				},
+				consts.FieldCallbackAddress: schema.StringAttribute{
+					Optional:    true,
+					Description: "The callback address. Must be a valid URI without the path.",
+					// ValidateDiagFunc: GetValidateDiagURI([]string{"http", "https"}),
+				},
+			},
+		},
+	}, consts.MountTypeGCP)
+}

--- a/internal/provider/fwprovider/auth_radius.go
+++ b/internal/provider/fwprovider/auth_radius.go
@@ -1,0 +1,25 @@
+package fwprovider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+)
+
+func AuthLoginRadiusSchema() schema.Block {
+	return mustAddLoginSchema(&schema.ListNestedBlock{
+		Description: "Login to vault using the radius method",
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				consts.FieldUsername: schema.StringAttribute{
+					Description: "The Radius username.",
+					Optional:    true,
+				},
+				consts.FieldPassword: schema.StringAttribute{
+					Optional:    true,
+					Description: "The Radius password for username.",
+				},
+			},
+		},
+	}, consts.MountTypeGCP)
+}

--- a/internal/provider/fwprovider/auth_userpass.go
+++ b/internal/provider/fwprovider/auth_userpass.go
@@ -1,21 +1,37 @@
 package fwprovider
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 )
 
 func AuthLoginUserpassSchema() schema.Block {
 	return mustAddLoginSchema(&schema.ListNestedBlock{
-		Description: "Login to vault using ",
+		Description: "Login to vault using the userpass method",
 		NestedObject: schema.NestedBlockObject{
 			Attributes: map[string]schema.Attribute{
-				"filename": schema.StringAttribute{
-					Required: true,
-					Description: "The name of a file containing a single " +
-						"line that is a valid Vault token",
+				consts.FieldUsername: schema.StringAttribute{
+					Optional:    true,
+					Description: "Login with username",
+				},
+				consts.FieldPassword: schema.StringAttribute{
+					Optional:    true,
+					Description: "Login with password",
+				},
+				consts.FieldPasswordFile: schema.StringAttribute{
+					Optional:    true,
+					Description: "Login with password from a file",
+					Validators: []validator.String{
+						stringvalidator.ConflictsWith(
+							path.MatchRelative().AtName(consts.FieldPassword),
+						),
+					},
 				},
 			},
 		},
-	}, consts.MountTypeNone)
+	}, consts.MountTypeUserpass)
 }

--- a/internal/provider/fwprovider/provider.go
+++ b/internal/provider/fwprovider/provider.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/sys"
 )
@@ -149,6 +150,17 @@ func (p *fwprovider) Schema(ctx context.Context, req provider.SchemaRequest, res
 					},
 				},
 			},
+			"auth_login":            AuthLoginGenericSchema(),
+			"auth_login_aws":        AuthLoginAWSSchema(),
+			"auth_login_azure":      AuthLoginAzureSchema(),
+			"auth_login_gcp":        AuthLoginGCPSchema(),
+			"auth_login_cert":       AuthLoginCertSchema(),
+			"auth_login_jwt":        AuthLoginJWTSchema(),
+			"auth_login_kerberos":   AuthLoginKerberosSchema(),
+			"auth_login_oci":        AuthLoginOCISchema(),
+			"auth_login_oidc":       AuthLoginOIDCSchema(),
+			"auth_login_radius":     AuthLoginRadiusSchema(),
+			"auth_login_userpass":   AuthLoginUserpassSchema(),
 			"auth_login_token_file": AuthLoginTokenFileSchema(),
 		},
 	}

--- a/internal/sys/password_policy.go
+++ b/internal/sys/password_policy.go
@@ -2,14 +2,16 @@ package sys
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func NewPasswordPolicyResource() resource.Resource {
@@ -21,7 +23,7 @@ type PasswordPolicyResource struct {
 }
 
 func (r *PasswordPolicyResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + "_password_policy"
+	resp.TypeName = req.ProviderTypeName + "_password_policy_fw"
 }
 
 // PasswordPolicyModel describes the Terraform resource data model to match the
@@ -91,7 +93,7 @@ func (r *PasswordPolicyResource) Create(ctx context.Context, req resource.Create
 		"policy": plan.Policy.ValueString(),
 	}
 	tflog.Error(ctx, "data", data)
-	path := fmt.Sprintf("/sys/policies/password/%s", plan.Name.ValueString())
+	path := passwordPolicyResourcePath(plan.Name.ValueString())
 	// vault returns a nil response on success
 	_, err := r.client.Logical().Write(path, data)
 	if err != nil {
@@ -111,13 +113,116 @@ func (r *PasswordPolicyResource) Create(ctx context.Context, req resource.Create
 
 func (r *PasswordPolicyResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	tflog.Error(ctx, "JMF READ a password policy resource")
-	return
+
+	var policyModel *PasswordPolicyModel
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &policyModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	path := passwordPolicyResourcePath(policyModel.Name.ValueString())
+	policyResp, err := r.client.Logical().Read(path)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Resource from Vault",
+			"An unexpected error occurred while attempting to read the resource. "+
+				"Please retry the operation or report this issue to the provider developers.\n\n"+
+				"HTTP Error: "+err.Error(),
+		)
+
+		return
+	}
+
+	var readResp *PasswordPolicyResourceAPIModel
+	jsonData, err := json.Marshal(policyResp.Data)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to marshal Vault response",
+			"An unexpected error occurred while attempting to marshal the Vault response.\n\n"+
+				"Error: "+err.Error(),
+		)
+
+		return
+	}
+
+	err = json.Unmarshal(jsonData, &readResp)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to unmarshal data to API model",
+			"An unexpected error occurred while attempting to unmarshal the data.\n\n"+
+				"Error: "+err.Error(),
+		)
+
+		return
+	}
+
+	policyModel.Policy = types.StringValue(readResp.Policy)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &policyModel)...)
 }
 
 func (r *PasswordPolicyResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	return
+	tflog.Error(ctx, "Update a password policy resource")
+	var plan *PasswordPolicyModel
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data := map[string]interface{}{
+		"policy": plan.Policy.ValueString(),
+	}
+	tflog.Error(ctx, "data", data)
+	path := passwordPolicyResourcePath(plan.Name.ValueString())
+	// vault returns a nil response on success
+	_, err := r.client.Logical().Write(path, data)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Update Resource",
+			"An unexpected error occurred while attempting to update the resource. "+
+				"Please retry the operation or report this issue to the provider developers.\n\n"+
+				"HTTP Error: "+err.Error(),
+		)
+
+		return
+	}
+
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
 func (r *PasswordPolicyResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var plan *PasswordPolicyModel
+
+	// Read Terraform state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &plan)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	path := passwordPolicyResourcePath(plan.Name.ValueString())
+
+	_, err := r.client.Logical().Delete(path)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Delete Resource",
+			"An unexpected error occurred while attempting to delete the resource. "+
+				"Please retry the operation or report this issue to the provider developers.\n\n"+
+				"HTTP Error: "+err.Error(),
+		)
+
+		return
+	}
+
 	return
+}
+
+func passwordPolicyResourcePath(name string) string {
+	return fmt.Sprintf("/sys/policies/password/%s", name)
 }

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -553,10 +553,10 @@ var (
 			Resource:      UpdateSchemaResource(rabbitMQSecretBackendRoleResource()),
 			PathInventory: []string{"/rabbitmq/roles/{name}"},
 		},
-		// "vault_password_policy": {
-		// 	Resource:      UpdateSchemaResource(passwordPolicyResource()),
-		// 	PathInventory: []string{"/sys/policy/password/{name}"},
-		// },
+		"vault_password_policy": {
+			Resource:      UpdateSchemaResource(passwordPolicyResource()),
+			PathInventory: []string{"/sys/policy/password/{name}"},
+		},
 		"vault_pki_secret_backend_cert": {
 			Resource:      UpdateSchemaResource(pkiSecretBackendCertResource()),
 			PathInventory: []string{"/pki/issue/{role}"},


### PR DESCRIPTION
Branches off of #2090 to complete updates to all auth login blocks so that they:
- Do not make use of environment default funcs to set values
- Do not have fields marked as `Required` (validation is handled internally)
- Do not set defaults in the schema

Ensures that the build is stable and the provider configurations match up

Completes the PoC for a TF Framework resource with `vault_password_policy`/`vault_password_policy_fw`