### PR TITLE
Data json read update

### DIFF
--- a/vault/resource_kv_secret.go
+++ b/vault/resource_kv_secret.go
@@ -103,6 +103,14 @@ func kvSecretRead(_ context.Context, d *schema.ResourceData, meta interface{}) d
 	log.Printf("[DEBUG] secret: %#v", secret)
 
 	data := secret.Data
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return diag.Errorf("error marshaling JSON for %q: %s", path, err)
+	}
+
+	if err := d.Set(consts.FieldDataJSON, string(jsonData)); err != nil {
+		return diag.FromErr(err)
+	}
 
 	if err := d.Set(consts.FieldData, serializeDataMapToString(data)); err != nil {
 		return diag.FromErr(err)

--- a/vault/resource_kv_secret_v2.go
+++ b/vault/resource_kv_secret_v2.go
@@ -287,7 +287,14 @@ func kvSecretV2Read(_ context.Context, d *schema.ResourceData, meta interface{})
 		log.Printf("[DEBUG] secret: %#v", secret)
 
 		data := secret.Data["data"]
+		jsonData, err := json.Marshal(data)
+		if err != nil {
+			return diag.Errorf("error marshaling JSON for %q: %s", path, err)
+		}
 
+		if err := d.Set(consts.FieldDataJSON, string(jsonData)); err != nil {
+			return diag.FromErr(err)
+		}
 		if v, ok := data.(map[string]interface{}); ok {
 			if err := d.Set(consts.FieldData, serializeDataMapToString(v)); err != nil {
 				return diag.FromErr(err)

--- a/vault/resource_kv_secret_v2_test.go
+++ b/vault/resource_kv_secret_v2_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/vault/api"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
@@ -193,12 +192,14 @@ func TestAccKVSecretV2_UpdateOutsideTerraform(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "data.zip", "zap"),
 					resource.TestCheckResourceAttr(resourceName, "data.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "data.flag", "false"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.version", "1"),
 				),
 			},
 			{
 				PreConfig: func() {
 					client := testProvider.Meta().(*provider.ProviderMeta).MustGetClient()
 
+					// Simulate external change using Vault CLI
 					path := fmt.Sprintf("%s/data/%s", mount, name)
 					_, err := client.Logical().Write(path, map[string]interface{}{"data": map[string]interface{}{"testkey3": "testvalue3"}})
 					if err != nil {
@@ -210,45 +211,19 @@ func TestAccKVSecretV2_UpdateOutsideTerraform(t *testing.T) {
 				Config: testKVSecretV2Config_initial(mount, name),
 
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "data.flag", "false"),
 					resource.TestCheckResourceAttr(resourceName, "data.zip", "zap"),
 					resource.TestCheckResourceAttr(resourceName, "data.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "data.flag", "false"),
 					resource.TestCheckResourceAttr(resourceName, "data_json", "{\"flag\":false,\"foo\":\"bar\",\"zip\":\"zap\"}"),
+					//we check that the provider updated vault to match the the terraform config therefor creating a new version the secret.
 					resource.TestCheckResourceAttr(resourceName, "metadata.version", "3"),
 				),
-				//testRessourceKvSecretV2_check,
 			},
 		},
 	},
 	)
 }
 
-func testRessourceKvSecretV2_check(s *terraform.State) error {
-	resourceState := s.Modules[0].Resources["vault_kv_secret_v2.test"]
-	if resourceState == nil {
-		return fmt.Errorf("resource not found in state %v", s.Modules[0].Resources)
-	}
-
-	iState := resourceState.Primary
-	if iState == nil {
-		return fmt.Errorf("resource has no primary instance")
-	}
-
-	wantJson := `{"flag":false,"foo":"bar","zip":"zap"}`
-
-	if got, want := iState.Attributes["data_json"], wantJson; got != want {
-		return fmt.Errorf("data_json contains %s; want %s", got, want)
-	}
-
-	if got, want := iState.Attributes["data.zip"], "zap"; got != want {
-		return fmt.Errorf("data[\"zip\"] contains %s; want %s", got, want)
-	}
-
-	return nil
-}
-
-// Fadia end of what u have added
 func readKVData(t *testing.T, mount, name string) {
 	t.Helper()
 	client := testProvider.Meta().(*provider.ProviderMeta).MustGetClient()


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
The PR fixes the provider's behavior when resources (`kv secrets version 1 and version 2`) have been modified outside of terraform.
 before the modification, when you create` kv 2 secrets` using the provider, modify the resource outside of vault using `vault cli` for example with the command  `vault patch`, re-running` terraform apply` and checking the terraform state you would notice the `data` attribute correspond to what's in vault while `data_json` doesn't, and most importantly now the terraform state is different then what was specified in the terraform configuration  file which is not the expected behavior from the provider. 
The PR fixes this, so now if you re-run terraform apply, the provider deletes what's was modified outside of terraform and makes sure that vault state corresponds to what was specified in terraform configuration file. 
The modifications were both applied to `resource kv secret` and `resource kv secret V2`

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates to #1993





### Output from acceptance testing:

```
$ make testacc TESTARGS="--run TestAccKVSecretV2_UpdateOutsideTerraform"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test --run TestAccKVSecretV2_UpdateOutsideTerraform -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/mfa     [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/pki      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/codegen   (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/provider (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/testutil  (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/vault     2.742s



...
```
```
$make testacc TESTARGS="--run TestAccKVSecret_UpdateOutsideTerraform"

TF_ACC=1 go test --run TestAccKVSecret_UpdateOutsideTerraform -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
ok      github.com/hashicorp/terraform-provider-vault/codegen   0.223s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/mfa     [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/pki      [no test files]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  0.269s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/provider 0.455s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/testutil  0.588s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util      0.738s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/vault     2.661s
```


