### PR TITLE
JWT Auth method Role Creation - Set bound_claims values to be as per Vault format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+BUGS:
+* Fix `bound_claims` Set bound_claims values as per Vault format ([#2102](https://github.com/hashicorp/terraform-provider-vault/pull/2102))
+
 ## 3.23.0 (Nov 15, 2023)
 
 FEATURES:

--- a/vault/resource_jwt_auth_backend_role.go
+++ b/vault/resource_jwt_auth_backend_role.go
@@ -432,18 +432,18 @@ func jwtAuthBackendRoleDataToWrite(d *schema.ResourceData, create bool) map[stri
 		}
 
 		for key, val := range v.(map[string]interface{}) {
-			var claims []string
+			var claims string
 			if !disableParseClaims {
 				for _, v := range strings.Split(val.(string), ",") {
-					claims = append(claims, strings.TrimSpace(v))
+					claims = claims + strings.TrimSpace(v))
 				}
 			} else {
-				claims = append(claims, strings.TrimSpace(val.(string)))
+				claims = claims + strings.TrimSpace(val.(string))
 			}
 			boundClaims[key] = claims
 		}
 	}
-	data["bound_claims"] = boundClaims
+	data["bound_claims"] = 
 
 	if v, ok := d.GetOk("claim_mappings"); ok {
 		data["claim_mappings"] = v


### PR DESCRIPTION
### Description
Initially raised by(on behalf of) ent customer via Zendesk in an enterprise support engagement.

Update jwtAuthBackendRoleDataToWrite function to set the bound_claims values as a map of string:string instead of string:string[]

### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry 

### Output from acceptance testing:

```
resource "vault_jwt_auth_backend_role" "jwt-test-role" {
  role_name                     = "jwt-test-role"
  role_type                       = "jwt"
  token_explicit_max_ttl = "60"
  user_claim                     = "user_email"
  bound_claims_type      = "string"
  token_policies               = ["jwt-role-test-policy"]
  bound_claims                = {
       project_name = "jwt-role-test"
       branch = "jwt-role-test-branch"
  }
}
```

```
$ vault read auth/jwt/role/jwt-test-role
Key                        Value
---                        -----
allowed_redirect_uris      <nil>
bound_audiences            []
bound_claims               map[project_name:jwt-role-test branch:jwt-role-test-branch]
bound_claims_type          string
bound_subject              n/a
claim_mappings             <nil>
clock_skew_leeway          0
expiration_leeway          0
groups_claim               n/a
max_age                    0
not_before_leeway          0
oidc_scopes                <nil>
role_type                  jwt
token_bound_cidrs          []
token_explicit_max_ttl     1m
token_max_ttl              0s
token_no_default_policy    false
token_num_uses             0
token_period               0s
token_policies             [jwt-role-test-policy]
token_ttl                  0s
token_type                 default
user_claim                 user_email
user_claim_json_pointer    false
verbose_oidc_logging       false
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

