### PR TITLE
kvv2: make path/mount regex lazy eval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+BUGS:
+* fix `vault_kv_secret_v2` drift when "data" is in secret name/path ([#2104](https://github.com/hashicorp/terraform-provider-vault/pull/2104))
+
 ## 3.23.0 (Nov 15, 2023)
 
 FEATURES:

--- a/vault/resource_kv_secret_v2.go
+++ b/vault/resource_kv_secret_v2.go
@@ -21,8 +21,8 @@ import (
 )
 
 var (
-	kvV2SecretMountFromPathRegex = regexp.MustCompile("^(.+)/data/.+$")
-	kvV2SecretNameFromPathRegex  = regexp.MustCompile("^.+/data/(.+)$")
+	kvV2SecretMountFromPathRegex = regexp.MustCompile("^(.+?)/data/.+$")
+	kvV2SecretNameFromPathRegex  = regexp.MustCompile("^.+?/data/(.+?)$")
 
 	kvMetadataFields = map[string]string{
 		consts.FieldMaxVersions:        consts.FieldMaxVersions,

--- a/vault/resource_kv_secret_v2_test.go
+++ b/vault/resource_kv_secret_v2_test.go
@@ -22,6 +22,49 @@ var testKVV2Data = map[string]interface{}{
 	"baz": "qux",
 }
 
+func TestAccKVSecretV2_pathRegex(t *testing.T) {
+	tests := map[string]struct {
+		path      string
+		wantMount string
+		wantName  string
+	}{
+		"no nesting": {
+			path:      "kvv2/data/a/b/c/d",
+			wantMount: "kvv2",
+			wantName:  "a/b/c/d",
+		},
+		"nested": {
+			path:      "kvv2/data/test/b/c/test/d",
+			wantMount: "kvv2",
+			wantName:  "test/b/c/test/d",
+		},
+		"nested-with-double-data": {
+			path:      "kvv2/data/a/b/c/data/d",
+			wantMount: "kvv2",
+			wantName:  "a/b/c/data/d",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			mount, err := getKVV2SecretMountFromPath(tc.path)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if mount != tc.wantMount {
+				t.Fatalf("expected mount %q, got %q", tc.wantMount, mount)
+			}
+
+			name, err := getKVV2SecretNameFromPath(tc.path)
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if name != tc.wantName {
+				t.Fatalf("expected name %q, got %q", tc.wantName, name)
+			}
+		})
+	}
+}
+
 func TestAccKVSecretV2(t *testing.T) {
 	t.Parallel()
 	resourceName := "vault_kv_secret_v2.test"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #2103


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

