### PR TITLE
docs: fix database_secret_backend_role formatting

### DIFF
--- a/website/docs/r/database_secret_backend_role.md
+++ b/website/docs/r/database_secret_backend_role.md
@@ -88,29 +88,29 @@ The following arguments are supported:
   The following options are available for each `credential_type` value:
 
   * `password`
-    * `password_policy` (Optional) - The [policy](/vault/docs/concepts/password-policies)
-      used for password generation. If not provided, defaults to the password policy of the
-      database [configuration](/vault/api-docs/secret/databases#password_policy).
+      * `password_policy` (Optional) - The [policy](/vault/docs/concepts/password-policies)
+        used for password generation. If not provided, defaults to the password policy of the
+        database [configuration](/vault/api-docs/secret/databases#password_policy).
 
   * `rsa_private_key`
-    * `key_bits` (Optional) - The bit size of the RSA key to generate. Options include:
-      `2048`, `3072`, `4096`.
-    * `format` (Optional) - The output format of the generated private key
-      credential. The private key will be returned from the API in PEM encoding. Options
-      include: `pkcs8`.
+      * `key_bits` (Optional) - The bit size of the RSA key to generate. Options include:
+        `2048`, `3072`, `4096`.
+      * `format` (Optional) - The output format of the generated private key
+        credential. The private key will be returned from the API in PEM encoding. Options
+        include: `pkcs8`.
 
   * `client_certificate`
-    * `common_name_template` (Optional) - A [username template](/vault/docs/concepts/username-templating)
-      to be used for the client certificate common name.
-    * `ca_cert` (Optional) - The PEM-encoded CA certificate.
-    * `ca_private_key` (Optional) - The PEM-encoded private key for the given `ca_cert`.
-    * `key_type` (Required) - Specifies the desired key type. Options include:
-      `rsa`, `ed25519`, `ec`.
-    * `key_bits` (Optional) - Number of bits to use for the generated keys. Options include:
-      `2048` (default), `3072`, `4096`; with `key_type=ec`, allowed values are: `224`, `256` (default),
-      `384`, `521`; ignored with `key_type=ed25519`.
-    * `signature_bits` (Optional) - The number of bits to use in the signature algorithm. Options include:
-      `256` (default), `384`, `512`.
+      * `common_name_template` (Optional) - A [username template](/vault/docs/concepts/username-templating)
+        to be used for the client certificate common name.
+      * `ca_cert` (Optional) - The PEM-encoded CA certificate.
+      * `ca_private_key` (Optional) - The PEM-encoded private key for the given `ca_cert`.
+      * `key_type` (Required) - Specifies the desired key type. Options include:
+        `rsa`, `ed25519`, `ec`.
+      * `key_bits` (Optional) - Number of bits to use for the generated keys. Options include:
+        `2048` (default), `3072`, `4096`; with `key_type=ec`, allowed values are: `224`, `256` (default),
+        `384`, `521`; ignored with `key_type=ed25519`.
+      * `signature_bits` (Optional) - The number of bits to use in the signature algorithm. Options include:
+        `256` (default), `384`, `512`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
Fix the formatting for https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/database_secret_backend_role#credential_config bulleted list



### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

