### PR TITLE
fix: 2107: Add missing schema fields and tests for ext_key_usage_oids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 BUGS:
+* fix `vault_pki_secret_backend_role` missing `ext_key_usage_oids` in schema ([#2107](https://github.com/hashicorp/terraform-provider-vault/pull/2108))_
 * fix `vault_kv_secret_v2` drift when "data" is in secret name/path ([#2104](https://github.com/hashicorp/terraform-provider-vault/pull/2104))
 
 ## 3.23.0 (Nov 15, 2023)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## Unreleased
 
-BUGS:
-* fix `vault_kv_secret_v2` drift when "data" is in secret name/path ([#2104](https://github.com/hashicorp/terraform-provider-vault/pull/2104))
-
 FEATURES:
 * Add support for `ext_key_usage_oids` in `vault_pki_secret_backend_role` ([#2108](https://github.com/hashicorp/terraform-provider-vault/pull/2108))
+
+BUGS:
+* fix `vault_kv_secret_v2` drift when "data" is in secret name/path ([#2104](https://github.com/hashicorp/terraform-provider-vault/pull/2104))
 
 ## 3.23.0 (Nov 15, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## Unreleased
 
 BUGS:
-* fix `vault_pki_secret_backend_role` missing `ext_key_usage_oids` in schema ([#2107](https://github.com/hashicorp/terraform-provider-vault/pull/2108))_
 * fix `vault_kv_secret_v2` drift when "data" is in secret name/path ([#2104](https://github.com/hashicorp/terraform-provider-vault/pull/2104))
+
+FEATURES:
+* Add support for `ext_key_usage_oids` in `vault_pki_secret_backend_role` ([#2108](https://github.com/hashicorp/terraform-provider-vault/pull/2108))
 
 ## 3.23.0 (Nov 15, 2023)
 

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -280,6 +280,7 @@ const (
 	FieldEmailProtectionFlag           = "email_protection_flag"
 	FieldKeyUsage                      = "key_usage"
 	FieldExtKeyUsage                   = "ext_key_usage"
+	FieldExtKeyUsageOIDs               = "ext_key_usage_oids"
 	FieldUseCSRCommonName              = "use_csr_common_name"
 	FieldUseCSRSans                    = "use_csr_sans"
 	FieldOU                            = "ou"

--- a/vault/resource_pki_secret_backend_role.go
+++ b/vault/resource_pki_secret_backend_role.go
@@ -49,6 +49,7 @@ var pkiSecretListFields = []string{
 	consts.FieldAllowedDomains,
 	consts.FieldAllowedSerialNumbers,
 	consts.FieldExtKeyUsage,
+	consts.FieldExtKeyUsageOIDs,
 }
 
 var pkiSecretBooleanFields = []string{
@@ -267,6 +268,15 @@ func pkiSecretBackendRoleResource() *schema.Resource {
 				Required:    false,
 				Optional:    true,
 				Description: "Specify the allowed extended key usage constraint on issued certificates.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			consts.FieldExtKeyUsageOIDs: {
+				Type:        schema.TypeList,
+				Required:    false,
+				Optional:    true,
+				Description: "A list of extended key usage OIDs.",
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},

--- a/vault/resource_pki_secret_backend_role_test.go
+++ b/vault/resource_pki_secret_backend_role_test.go
@@ -303,7 +303,7 @@ func TestPkiSecretBackendRole_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "key_usage.0", "DigitalSignature"),
 					resource.TestCheckResourceAttr(resourceName, "ext_key_usage.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "ext_key_usage_oids.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "ext_key_usage_oids.0", "1.3.6.1.4.1.311.4"),					
+					resource.TestCheckResourceAttr(resourceName, "ext_key_usage_oids.0", "1.3.6.1.4.1.311.4"),
 					resource.TestCheckResourceAttr(resourceName, "use_csr_common_name", "true"),
 					resource.TestCheckResourceAttr(resourceName, "use_csr_sans", "true"),
 					resource.TestCheckResourceAttr(resourceName, "ou.0", "test"),

--- a/vault/resource_pki_secret_backend_role_test.go
+++ b/vault/resource_pki_secret_backend_role_test.go
@@ -61,6 +61,8 @@ func TestPkiSecretBackendRole_policy_identifier(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceName, "key_usage.1", "KeyAgreement"),
 		resource.TestCheckResourceAttr(resourceName, "key_usage.2", "KeyEncipherment"),
 		resource.TestCheckResourceAttr(resourceName, "ext_key_usage.#", "0"),
+		resource.TestCheckResourceAttr(resourceName, "ext_key_usage_oids.#", "1"),
+		resource.TestCheckResourceAttr(resourceName, "ext_key_usage_oids.0", "1.3.6.1.4.1.311.4"),
 		resource.TestCheckResourceAttr(resourceName, "use_csr_common_name", "true"),
 		resource.TestCheckResourceAttr(resourceName, "use_csr_sans", "true"),
 		resource.TestCheckResourceAttr(resourceName, "ou.0", "test"),
@@ -160,6 +162,8 @@ func TestPkiSecretBackendRole_basic(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceName, "key_usage.1", "KeyAgreement"),
 		resource.TestCheckResourceAttr(resourceName, "key_usage.2", "KeyEncipherment"),
 		resource.TestCheckResourceAttr(resourceName, "ext_key_usage.#", "0"),
+		resource.TestCheckResourceAttr(resourceName, "ext_key_usage_oids.#", "1"),
+		resource.TestCheckResourceAttr(resourceName, "ext_key_usage_oids.0", "1.3.6.1.4.1.311.4"),
 		resource.TestCheckResourceAttr(resourceName, "use_csr_common_name", "true"),
 		resource.TestCheckResourceAttr(resourceName, "use_csr_sans", "true"),
 		resource.TestCheckResourceAttr(resourceName, "ou.0", "test"),
@@ -298,6 +302,8 @@ func TestPkiSecretBackendRole_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "key_usage.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "key_usage.0", "DigitalSignature"),
 					resource.TestCheckResourceAttr(resourceName, "ext_key_usage.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "ext_key_usage_oids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ext_key_usage_oids.0", "1.3.6.1.4.1.311.4"),					
 					resource.TestCheckResourceAttr(resourceName, "use_csr_common_name", "true"),
 					resource.TestCheckResourceAttr(resourceName, "use_csr_sans", "true"),
 					resource.TestCheckResourceAttr(resourceName, "ou.0", "test"),
@@ -368,6 +374,7 @@ resource "vault_pki_secret_backend_role" "test" {
   key_type                           = "rsa"
   key_bits                           = 2048
   ext_key_usage                      = []
+  ext_key_usage_oids                 = ["1.3.6.1.4.1.311.4"]
   use_csr_common_name                = true
   use_csr_sans                       = true
   ou                                 = ["test"]
@@ -422,6 +429,7 @@ resource "vault_pki_secret_backend_role" "test" {
   key_bits = 2048
   key_usage = ["DigitalSignature"]
   ext_key_usage = []
+  ext_key_usage_oids = ["1.3.6.1.4.1.311.4"]
   use_csr_common_name = true
   use_csr_sans = true
   ou = ["test"]

--- a/website/docs/r/pki_secret_backend_role.html.md
+++ b/website/docs/r/pki_secret_backend_role.html.md
@@ -101,6 +101,8 @@ The following arguments are supported:
 
 * `ext_key_usage` - (Optional) Specify the allowed extended key usage constraint on issued certificates
 
+* `ext_key_usage_oids` - (Optional) Specify the allowed extended key usage OIDs constraint on issued certificates
+
 * `use_csr_common_name` - (Optional) Flag to use the CN in the CSR
 
 * `use_csr_sans` - (Optional) Flag to use the SANs in the CSR


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #2107 


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ terraform-provider-vault % VAULT_TOKEN="TEST" VAULT_ADDR='http://127.0.0.1:8200' make testacc TESTARGS='-run=TestPkiSecretBackendRole'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -run=TestPkiSecretBackendRole -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/mfa     [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/pki      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/codegen   (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/provider (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/testutil  (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/vault     16.497s
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

