### PR TITLE
Fixes failing tests for `make test` run in build step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,10 @@
 
 FEATURES:
 * Add support for `ext_key_usage_oids` in `vault_pki_secret_backend_role` ([#2108](https://github.com/hashicorp/terraform-provider-vault/pull/2108))
+* Adds support to `vault_gcp_auth_backend` for common backend tune parameters ([#1997](https://github.com/terraform-providers/terraform-provider-vault/pull/1997)).
 
 BUGS:
 * fix `vault_kv_secret_v2` drift when "data" is in secret name/path ([#2104](https://github.com/hashicorp/terraform-provider-vault/pull/2104))
-
-FEATURES:
-* Adds support to `vault_gcp_auth_backend` for common backend tune parameters ([#1997](https://github.com/terraform-providers/terraform-provider-vault/pull/1997)).
 
 ## 3.23.0 (Nov 15, 2023)
 

--- a/vault/resource_auth_backend_test.go
+++ b/vault/resource_auth_backend_test.go
@@ -204,6 +204,8 @@ func testResourceAuth_initialCheck(expectedPath string) resource.TestCheckFunc {
 }
 
 func TestResourceAuthTune(t *testing.T) {
+	testutil.SkipTestAcc(t)
+
 	backend := acctest.RandomWithPrefix("github")
 	resName := "vault_auth_backend.test"
 	var resAuthFirst api.AuthMount

--- a/vault/resource_gcp_auth_backend_test.go
+++ b/vault/resource_gcp_auth_backend_test.go
@@ -32,7 +32,7 @@ const gcpJSONCredentials string = `
 `
 
 func TestGCPAuthBackend_basic(t *testing.T) {
-	testutil.SkipTestEnvSet(t, testutil.EnvVarSkipVaultNext)
+	testutil.SkipTestAcc(t)
 
 	var resAuthFirst api.AuthMount
 	path := resource.PrefixedUniqueId("gcp-basic-")

--- a/vault/resource_github_auth_backend_test.go
+++ b/vault/resource_github_auth_backend_test.go
@@ -224,6 +224,8 @@ func TestAccGithubAuthBackend_description(t *testing.T) {
 }
 
 func TestAccGithubAuthBackend_importTuning(t *testing.T) {
+	testutil.SkipTestAcc(t)
+
 	path := acctest.RandomWithPrefix("github")
 	resourceType := "vault_github_auth_backend"
 	resourceName := resourceType + ".test"
@@ -245,6 +247,8 @@ func TestAccGithubAuthBackend_importTuning(t *testing.T) {
 }
 
 func TestGithubAuthBackend_remount(t *testing.T) {
+	testutil.SkipTestAcc(t)
+
 	path := acctest.RandomWithPrefix("tf-test-gh")
 	updatedPath := acctest.RandomWithPrefix("tf-test-gh-updated")
 


### PR DESCRIPTION
This PR adds missing `testutil.SkipTestAcc(t)` to a few tests that were updated as a part of #1997. The build step was previously failing since these tests were not being skipped when running `make test` (these should be skipped and only run on `make testacc`). This fixes the build

