### PR TITLE
auth/k8s: update the description for token_reviewer_jwt

### DIFF
--- a/vault/resource_kubernetes_auth_backend_config.go
+++ b/vault/resource_kubernetes_auth_backend_config.go
@@ -43,7 +43,7 @@ func kubernetesAuthBackendConfigResource() *schema.Resource {
 		},
 		"token_reviewer_jwt": {
 			Type:        schema.TypeString,
-			Description: "A service account JWT used to access the TokenReview API to validate other JWTs during login. If not set the JWT used for login will be used to access the API.",
+			Description: "A service account JWT (or other token) used as a bearer token to access the TokenReview API to validate other JWTs during login. If not set the JWT used for login will be used to access the API.",
 			Default:     "",
 			Optional:    true,
 			Sensitive:   true,

--- a/website/docs/r/kubernetes_auth_backend_config.md
+++ b/website/docs/r/kubernetes_auth_backend_config.md
@@ -42,7 +42,7 @@ The following arguments are supported:
 
 * `kubernetes_ca_cert` - (Optional) PEM encoded CA cert for use by the TLS client used to talk with the Kubernetes API.
 
-* `token_reviewer_jwt` - (Optional) A service account JWT used to access the TokenReview API to validate other JWTs during login. If not set the JWT used for login will be used to access the API.
+* `token_reviewer_jwt` - (Optional) A service account JWT (or other token) used as a bearer token to access the TokenReview API to validate other JWTs during login. If not set the JWT used for login will be used to access the API.
 
 * `pem_keys` - (Optional) List of PEM-formatted public keys or certificates used to verify the signatures of Kubernetes service account JWTs. If a certificate is given, its public key will be extracted. Not every installation of Kubernetes exposes these keys.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->

Updates the description for `token_reviewer_jwt`, now that `token_reviewer_jwt` can be any type of token, not just JWT, as of [vault-plugin-auth-kubernetes@v0.17.1](https://github.com/hashicorp/vault-plugin-auth-kubernetes/blob/main/CHANGELOG.md#0171-sept-7-2023), which was included in Vault [1.15.0](https://github.com/hashicorp/vault/blob/main/CHANGELOG.md#1150).

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Relates to https://github.com/hashicorp/vault/pull/22857, https://github.com/hashicorp/vault-plugin-auth-kubernetes/pull/207

### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

