### PR TITLE
Update max db conn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 FEATURES:
 * Add support for `ext_key_usage_oids` in `vault_pki_secret_backend_role` ([#2108](https://github.com/hashicorp/terraform-provider-vault/pull/2108))
 * Adds support to `vault_gcp_auth_backend` for common backend tune parameters ([#1997](https://github.com/terraform-providers/terraform-provider-vault/pull/1997)).
+* Modified `resource_database_secret_backend_connection`'s `max_open_connections` to match 4 as defined elsewhere, including our [documentation](https://developer.hashicorp.com/vault/api-docs/secret/databases/mysql-maria#max_open_connections) ([#](https://github.com/terraform-providers/terraform-provider-vault/pull/)).
 
 BUGS:
 * fix `vault_kv_secret_v2` drift when "data" is in secret name/path ([#2104](https://github.com/hashicorp/terraform-provider-vault/pull/2104))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 FEATURES:
 * Add support for `ext_key_usage_oids` in `vault_pki_secret_backend_role` ([#2108](https://github.com/hashicorp/terraform-provider-vault/pull/2108))
 * Adds support to `vault_gcp_auth_backend` for common backend tune parameters ([#1997](https://github.com/terraform-providers/terraform-provider-vault/pull/1997)).
-* Modified `resource_database_secret_backend_connection`'s `max_open_connections` to match 4 as defined elsewhere, including our [documentation](https://developer.hashicorp.com/vault/api-docs/secret/databases/mysql-maria#max_open_connections) ([#](https://github.com/terraform-providers/terraform-provider-vault/pull/)).
+* Modified `resource_database_secret_backend_connection`'s `max_open_connections` to match 4 as defined elsewhere, including our [documentation](https://developer.hashicorp.com/vault/api-docs/secret/databases/mysql-maria#max_open_connections) ([#2119]([https://github.com/terraform-providers/terraform-provider-vault/pull/](https://github.com/hashicorp/terraform-provider-vault/pull/2119))).
 
 BUGS:
 * fix `vault_kv_secret_v2` drift when "data" is in secret name/path ([#2104](https://github.com/hashicorp/terraform-provider-vault/pull/2104))

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -739,7 +739,7 @@ func connectionStringResource(config *connectionStringConfig) *schema.Resource {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Description: "Maximum number of open connections to the database.",
-				Default:     2,
+				Default:     4,
 			},
 			"max_idle_connections": {
 				Type:        schema.TypeInt,


### PR DESCRIPTION
### Description
The default value in our docs is 4, I'm not sure if there is a good reason to keep the providers default as 2. In my mind it makes sense to keep the same limit across different implementation techniques, unless there's a justification for this being lower in the provider.

### Checklist
- [ X] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:
```
ok  	github.com/hashicorp/terraform-provider-vault/vault	1.862s
```
- Full output is attached to VAULT-22953, cut it here as it was pretty long.

This is a pretty basic change so I haven't done super extensive testing. Let me know if this needs more stringent tests performed, happy to resubmit.


### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

