### PR TITLE
Handle missing GitHub resources

### DIFF
--- a/vault/resource_github_auth_backend.go
+++ b/vault/resource_github_auth_backend.go
@@ -179,13 +179,6 @@ func githubAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 	path := "auth/" + d.Id()
 	configPath := path + "/config"
 
-	log.Printf("[DEBUG] Reading github auth mount from '%q'", path)
-	mount, err := authMountInfoGet(client, d.Id())
-	if err != nil {
-		return fmt.Errorf("error reading github auth mount from '%q': %w", path, err)
-	}
-	log.Printf("[INFO] Read github auth mount from '%q'", path)
-
 	log.Printf("[DEBUG] Reading github auth config from '%q'", configPath)
 	resp, err := client.Logical().Read(configPath)
 	if err != nil {
@@ -198,6 +191,13 @@ func githubAuthBackendRead(d *schema.ResourceData, meta interface{}) error {
 		d.SetId("")
 		return nil
 	}
+
+	log.Printf("[DEBUG] Reading github auth mount from '%q'", path)
+	mount, err := authMountInfoGet(client, d.Id())
+	if err != nil {
+		return fmt.Errorf("error reading github auth mount from '%q': %w", path, err)
+	}
+	log.Printf("[INFO] Read github auth mount from '%q'", path)
 
 	log.Printf("[DEBUG] Reading github auth tune from '%q/tune'", path)
 	rawTune, err := authMountTuneGet(client, path)

--- a/vault/resource_github_team.go
+++ b/vault/resource_github_team.go
@@ -4,7 +4,6 @@
 package vault
 
 import (
-	"fmt"
 	"log"
 	"strings"
 
@@ -101,10 +100,20 @@ func githubTeamRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	// If the auth method is not enabled, dt is nil
+	if dt == nil {
+		log.Printf("[WARN] Github team mapping from '%q' is null, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if v, ok := dt.Data["key"]; ok {
 		d.Set("team", v.(string))
 	} else {
-		return fmt.Errorf("github team information not found at path: '%v'", d.Id())
+		// If the method is enabled but the team is not mapped, the API responds 200 with an empty Data object
+		log.Printf("[WARN] Github team information from '%q' not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
 	}
 
 	if v, ok := dt.Data["value"]; ok {

--- a/vault/resource_github_user.go
+++ b/vault/resource_github_user.go
@@ -4,7 +4,6 @@
 package vault
 
 import (
-	"fmt"
 	"log"
 	"strings"
 
@@ -100,10 +99,20 @@ func githubUserRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	// If the auth method is not enabled, dt is nil
+	if dt == nil {
+		log.Printf("[WARN] Github user mapping from '%q' is null, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if v, ok := dt.Data["key"]; ok {
 		d.Set("user", v.(string))
 	} else {
-		return fmt.Errorf("github user information not found at path: '%v'", d.Id())
+		// If the method is enabled but the user is not mapped, the API responds 200 with an empty Data object
+		log.Printf("[WARN] Github user information from '%q' not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
 	}
 
 	if v, ok := dt.Data["value"]; ok {


### PR DESCRIPTION
### Description
Updates `resource_github_auth_backend`, `resource_github_team`, and `resource_github_user` to handle resources present in state but missing from Vault configuration.

For `resource_github_auth_backend`, `authMountInfoGet` was simply relocated to occur after checking for the existence of the mount. Comments inline for the other two changes.

Closes #2123 

### Output from acceptance testing:
=== RUN   TestAccGithubTeam_basic
--- PASS: TestAccGithubTeam_basic (1.85s)
=== RUN   TestAccGithubTeam_teamConfigError
--- PASS: TestAccGithubTeam_teamConfigError (0.12s)
=== RUN   TestAccGithubTeam_importBasic
--- PASS: TestAccGithubTeam_importBasic (1.30s)
PASS

=== RUN   TestAccGithubUser_basic
--- PASS: TestAccGithubUser_basic (1.70s)
=== RUN   TestAccGithubUser_importBasic
--- PASS: TestAccGithubUser_importBasic (1.16s)
PASS


### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request
