### PR TITLE
Support inheritable resource quotas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 FEATURES:
 * Add support for `iam_tags` in `vault_aws_secret_backend_role` ([#2231](https://github.com/hashicorp/terraform-provider-vault/pull/2231)).
+* Add support for `inheritable` on `vault_quota_rate_limit` and `vault_quota_lease_count`. Requires Vault 1.15+.: ([#2133](https://github.com/hashicorp/terraform-provider-vault/pull/2133)).
 
 IMPROVEMENTS:
 * return a useful error when delete fails for the `vault_jwt_auth_backend_role` resource: ([#2232](https://github.com/hashicorp/terraform-provider-vault/pull/2232))

--- a/vault/resource_quota_lease_count.go
+++ b/vault/resource_quota_lease_count.go
@@ -54,6 +54,12 @@ func quotaLeaseCountResource() *schema.Resource {
 				Optional:    true,
 				Description: "If set on a quota where path is set to an auth mount with a concept of roles (such as /auth/approle/), this will make the quota restrict login requests to that mount that are made with the specified role.",
 			},
+			"inheritable": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+				Description: "If set to true on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to true if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default.",
+			},
 		},
 	}
 }
@@ -73,6 +79,12 @@ func quotaLeaseCountCreate(d *schema.ResourceData, meta interface{}) error {
 	data := map[string]interface{}{}
 	data["path"] = d.Get("path").(string)
 	data["max_leases"] = d.Get("max_leases").(int)
+
+	if data["path"] == "" && d.Get("inheritable") == nil {
+		data["inheritable"] = true
+	} else if v, ok := d.GetOkExists("inheritable"); ok {
+		data["inheritable"] = v.(bool)
+	}
 
 	if provider.IsAPISupported(meta, provider.VaultVersion112) {
 		if v, ok := d.GetOk(consts.FieldRole); ok {
@@ -111,7 +123,7 @@ func quotaLeaseCountRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	fields := []string{"path", "max_leases", "name"}
+	fields := []string{"path", "max_leases", "name", "inheritable"}
 	if provider.IsAPISupported(meta, provider.VaultVersion112) {
 		fields = append(fields, consts.FieldRole)
 	}
@@ -142,6 +154,12 @@ func quotaLeaseCountUpdate(d *schema.ResourceData, meta interface{}) error {
 	data := map[string]interface{}{}
 	data["path"] = d.Get(consts.FieldPath).(string)
 	data["max_leases"] = d.Get("max_leases").(int)
+
+	if data["path"] == "" && d.Get("inheritable") == nil {
+		data["inheritable"] = true
+	} else if v, ok := d.GetOkExists("inheritable"); ok {
+		data["inheritable"] = v.(bool)
+	}
 
 	if provider.IsAPISupported(meta, provider.VaultVersion112) {
 		if v, ok := d.GetOk(consts.FieldRole); ok {

--- a/vault/resource_quota_lease_count.go
+++ b/vault/resource_quota_lease_count.go
@@ -57,7 +57,6 @@ func quotaLeaseCountResource() *schema.Resource {
 			"inheritable": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Computed:    true,
 				Description: "If set to true on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to true if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default.",
 			},
 		},
@@ -80,10 +79,10 @@ func quotaLeaseCountCreate(d *schema.ResourceData, meta interface{}) error {
 	data["path"] = d.Get("path").(string)
 	data["max_leases"] = d.Get("max_leases").(int)
 
-	if data["path"] == "" && d.Get("inheritable") == nil {
-		data["inheritable"] = true
-	} else if v, ok := d.GetOkExists("inheritable"); ok {
-		data["inheritable"] = v.(bool)
+	if provider.IsAPISupported(meta, provider.VaultVersion115) {
+		if v, ok := d.GetOkExists("inheritable"); ok {
+			data["inheritable"] = v.(bool)
+		}
 	}
 
 	if provider.IsAPISupported(meta, provider.VaultVersion112) {
@@ -123,9 +122,15 @@ func quotaLeaseCountRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	fields := []string{"path", "max_leases", "name", "inheritable"}
+	fields := []string{"path", "max_leases", "name"}
 	if provider.IsAPISupported(meta, provider.VaultVersion112) {
 		fields = append(fields, consts.FieldRole)
+	}
+
+	if provider.IsAPISupported(meta, provider.VaultVersion115) {
+		if _, ok := d.GetOkExists("inheritable"); ok {
+			fields = append(fields, "inheritable")
+		}
 	}
 
 	for _, k := range fields {
@@ -155,15 +160,15 @@ func quotaLeaseCountUpdate(d *schema.ResourceData, meta interface{}) error {
 	data["path"] = d.Get(consts.FieldPath).(string)
 	data["max_leases"] = d.Get("max_leases").(int)
 
-	if data["path"] == "" && d.Get("inheritable") == nil {
-		data["inheritable"] = true
-	} else if v, ok := d.GetOkExists("inheritable"); ok {
-		data["inheritable"] = v.(bool)
-	}
-
 	if provider.IsAPISupported(meta, provider.VaultVersion112) {
 		if v, ok := d.GetOk(consts.FieldRole); ok {
 			data[consts.FieldRole] = v
+		}
+	}
+
+	if provider.IsAPISupported(meta, provider.VaultVersion115) {
+		if d.HasChange("inheritable") {
+			data["inheritable"] = d.Get("inheritable")
 		}
 	}
 

--- a/vault/resource_quota_lease_count.go
+++ b/vault/resource_quota_lease_count.go
@@ -167,8 +167,8 @@ func quotaLeaseCountUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if provider.IsAPISupported(meta, provider.VaultVersion115) {
-		if d.HasChange("inheritable") {
-			data["inheritable"] = d.Get("inheritable")
+		if v, ok := d.GetOkExists("inheritable"); ok {
+			data["inheritable"] = v.(bool)
 		}
 	}
 

--- a/vault/resource_quota_lease_count_test.go
+++ b/vault/resource_quota_lease_count_test.go
@@ -52,6 +52,24 @@ func TestQuotaLeaseCount(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "max_leases", newLeaseCount),
 				),
 			},
+		},
+	})
+}
+
+func TestQuotaLeaseCountRoot(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-test")
+	leaseCount := "1001"
+	newLeaseCount := "2001"
+	resourceName := "vault_quota_lease_count.foobar"
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		PreCheck: func() {
+			testutil.TestEntPreCheck(t)
+			SkipIfAPIVersionGTE(t, testProvider.Meta(), provider.VaultVersion116)
+		},
+		CheckDestroy: testQuotaLeaseCountCheckDestroy([]string{leaseCount, newLeaseCount}),
+		Steps: []resource.TestStep{
 			{
 				Config: testQuotaLeaseCountConfigRootPath(name, "", newLeaseCount),
 				Check: resource.ComposeTestCheckFunc(

--- a/vault/resource_quota_lease_count_test.go
+++ b/vault/resource_quota_lease_count_test.go
@@ -21,7 +21,6 @@ func TestQuotaLeaseCount(t *testing.T) {
 	ns := "ns-" + name
 	leaseCount := "1001"
 	newLeaseCount := "2001"
-	inheritable := false
 	resourceName := "vault_quota_lease_count.foobar"
 
 	resource.Test(t, resource.TestCase{
@@ -30,39 +29,35 @@ func TestQuotaLeaseCount(t *testing.T) {
 		CheckDestroy:      testQuotaLeaseCountCheckDestroy([]string{leaseCount, newLeaseCount}),
 		Steps: []resource.TestStep{
 			{
-				Config: testQuotaLeaseCountConfig(ns, name, "", leaseCount, inheritable),
+				Config: testQuotaLeaseCountConfig(ns, name, "", leaseCount),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, ns+"/"),
 					resource.TestCheckResourceAttr(resourceName, "max_leases", leaseCount),
-					resource.TestCheckResourceAttr(resourceName, "inheritable", fmt.Sprintf("%t", inheritable)),
 				),
 			},
 			{
-				Config: testQuotaLeaseCountConfig(ns, name, "", newLeaseCount, inheritable),
+				Config: testQuotaLeaseCountConfig(ns, name, "", newLeaseCount),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, ns+"/"),
 					resource.TestCheckResourceAttr(resourceName, "max_leases", newLeaseCount),
-					resource.TestCheckResourceAttr(resourceName, "inheritable", fmt.Sprintf("%t", inheritable)),
 				),
 			},
 			{
-				Config: testQuotaLeaseCountConfig(ns, name, "sys/", newLeaseCount, inheritable),
+				Config: testQuotaLeaseCountConfig(ns, name, "sys/", newLeaseCount),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, ns+"/sys/"),
 					resource.TestCheckResourceAttr(resourceName, "max_leases", newLeaseCount),
-					resource.TestCheckResourceAttr(resourceName, "inheritable", fmt.Sprintf("%t", inheritable)),
 				),
 			},
 			{
-				Config: testQuotaLeaseCountConfig(ns, name, "", newLeaseCount, true),
+				Config: testQuotaLeaseCountConfigRootPath(name, "", newLeaseCount),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
-					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, ns+"/"),
+					resource.TestCheckResourceAttr(resourceName, "path", ""),
 					resource.TestCheckResourceAttr(resourceName, "max_leases", newLeaseCount),
-					resource.TestCheckResourceAttr(resourceName, "inheritable", "true"),
 				),
 			},
 		},
@@ -76,7 +71,6 @@ func TestQuotaLeaseCountWithRole(t *testing.T) {
 	role := acctest.RandomWithPrefix("test-role")
 	leaseCount := "1001"
 	newLeaseCount := "2001"
-	inheritable := false
 	resourceName := "vault_quota_lease_count.foobar"
 
 	resource.Test(t, resource.TestCase{
@@ -91,7 +85,107 @@ func TestQuotaLeaseCountWithRole(t *testing.T) {
 		),
 		Steps: []resource.TestStep{
 			{
-				Config: testQuotaLeaseCountWithRoleConfig(ns, backend, role, name, leaseCount, inheritable),
+				Config: testQuotaLeaseCountWithRoleConfig(ns, backend, role, name, leaseCount),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, fmt.Sprintf("%s/auth/%s/", ns, backend)),
+					resource.TestCheckResourceAttr(resourceName, "max_leases", leaseCount),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldRole, role),
+				),
+			},
+			{
+				Config: testQuotaLeaseCountWithRoleConfig(ns, backend, role, name, newLeaseCount),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, fmt.Sprintf("%s/auth/%s/", ns, backend)),
+					resource.TestCheckResourceAttr(resourceName, "max_leases", newLeaseCount),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldRole, role),
+				),
+			},
+			testutil.GetImportTestStep(resourceName, false, nil),
+		},
+	})
+}
+
+func TestQuotaLeaseCountInheritable(t *testing.T) {
+	name := acctest.RandomWithPrefix("tf-test")
+	ns := "ns-" + name
+	leaseCount := "1001"
+	newLeaseCount := "2001"
+	inheritable := false
+	resourceName := "vault_quota_lease_count.foobar"
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		PreCheck: func() {
+			testutil.TestEntPreCheck(t)
+			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion115)
+		},
+		CheckDestroy: testQuotaLeaseCountCheckDestroy([]string{leaseCount, newLeaseCount}),
+		Steps: []resource.TestStep{
+			{
+				Config: testQuotaLeaseCountConfigInheritable(ns, name, "", leaseCount, inheritable),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, ns+"/"),
+					resource.TestCheckResourceAttr(resourceName, "max_leases", leaseCount),
+					resource.TestCheckResourceAttr(resourceName, "inheritable", fmt.Sprintf("%t", inheritable)),
+				),
+			},
+			{
+				Config: testQuotaLeaseCountConfigInheritable(ns, name, "", newLeaseCount, inheritable),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, ns+"/"),
+					resource.TestCheckResourceAttr(resourceName, "max_leases", newLeaseCount),
+					resource.TestCheckResourceAttr(resourceName, "inheritable", fmt.Sprintf("%t", inheritable)),
+				),
+			},
+			{
+				Config: testQuotaLeaseCountConfigInheritable(ns, name, "sys/", newLeaseCount, inheritable),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, ns+"/sys/"),
+					resource.TestCheckResourceAttr(resourceName, "max_leases", newLeaseCount),
+					resource.TestCheckResourceAttr(resourceName, "inheritable", fmt.Sprintf("%t", inheritable)),
+				),
+			},
+			{
+				Config: testQuotaLeaseCountConfigInheritable(ns, name, "", newLeaseCount, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, ns+"/"),
+					resource.TestCheckResourceAttr(resourceName, "max_leases", newLeaseCount),
+					resource.TestCheckResourceAttr(resourceName, "inheritable", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestQuotaLeaseCountWithRoleInheritable(t *testing.T) {
+	name := acctest.RandomWithPrefix("lease-count")
+	ns := "ns-" + name
+	backend := acctest.RandomWithPrefix("approle")
+	role := acctest.RandomWithPrefix("test-role")
+	leaseCount := "1001"
+	newLeaseCount := "2001"
+	inheritable := false
+	resourceName := "vault_quota_lease_count.foobar"
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		PreCheck: func() {
+			testutil.TestEntPreCheck(t)
+			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion115)
+		},
+		CheckDestroy: resource.ComposeTestCheckFunc(
+			testQuotaLeaseCountCheckDestroy([]string{leaseCount, newLeaseCount}),
+			testAccCheckAppRoleAuthBackendRoleDestroy,
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: testQuotaLeaseCountWithRoleConfigInheritable(ns, backend, role, name, leaseCount, inheritable),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, fmt.Sprintf("%s/auth/%s/", ns, backend)),
@@ -101,7 +195,7 @@ func TestQuotaLeaseCountWithRole(t *testing.T) {
 				),
 			},
 			{
-				Config: testQuotaLeaseCountWithRoleConfig(ns, backend, role, name, newLeaseCount, inheritable),
+				Config: testQuotaLeaseCountWithRoleConfigInheritable(ns, backend, role, name, newLeaseCount, inheritable),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, fmt.Sprintf("%s/auth/%s/", ns, backend)),
@@ -110,7 +204,12 @@ func TestQuotaLeaseCountWithRole(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "inheritable", fmt.Sprintf("%t", inheritable)),
 				),
 			},
-			testutil.GetImportTestStep(resourceName, false, nil),
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"inheritable"},
+			},
 		},
 	})
 }
@@ -135,7 +234,60 @@ func testQuotaLeaseCountCheckDestroy(leaseCounts []string) resource.TestCheckFun
 }
 
 // Caution: Don't set test max_leases values too low or other tests running concurrently might fail
-func testQuotaLeaseCountConfig(ns, name, path, maxLeases string, inheritable bool) string {
+func testQuotaLeaseCountConfig(ns, name, path, maxLeases string) string {
+	return fmt.Sprintf(`
+resource "vault_namespace" "test" {
+  path = "%s"
+}
+
+resource "vault_quota_lease_count" "foobar" {
+  name       = "%s"
+  path       = "${vault_namespace.test.path}/%s"
+  max_leases = %s
+}
+`, ns, name, path, maxLeases)
+}
+
+func testQuotaLeaseCountConfigRootPath(name, path, maxLeases string) string {
+	return fmt.Sprintf(`
+resource "vault_quota_lease_count" "foobar" {
+  name       = "%s"
+  path       = "%s"
+  max_leases = %s
+}
+`, name, path, maxLeases)
+}
+
+func testQuotaLeaseCountWithRoleConfig(ns, backend, role, name, maxLeases string) string {
+	return fmt.Sprintf(`
+resource "vault_namespace" "test" {
+	path = "%s"
+	}
+
+resource "vault_auth_backend" "approle" {
+  namespace      = vault_namespace.test.path
+  type = "approle"
+  path = "%s"
+}
+
+resource "vault_approle_auth_backend_role" "role" {
+  namespace      = vault_namespace.test.path
+  backend = vault_auth_backend.approle.path
+  role_name = "%s"
+  token_policies = ["default", "dev", "prod"]
+}
+
+resource "vault_quota_lease_count" "foobar" {
+  name = "%s"
+  path = "${vault_namespace.test.path}/auth/${vault_auth_backend.approle.path}/"
+  role = vault_approle_auth_backend_role.role.role_name
+  max_leases = %s
+}
+`, ns, backend, role, name, maxLeases)
+}
+
+// Caution: Don't set test max_leases values too low or other tests running concurrently might fail
+func testQuotaLeaseCountConfigInheritable(ns, name, path, maxLeases string, inheritable bool) string {
 	return fmt.Sprintf(`
 resource "vault_namespace" "test" {
   path = "%s"
@@ -150,7 +302,7 @@ resource "vault_quota_lease_count" "foobar" {
 `, ns, name, path, maxLeases, inheritable)
 }
 
-func testQuotaLeaseCountWithRoleConfig(ns, backend, role, name, maxLeases string, inheritable bool) string {
+func testQuotaLeaseCountWithRoleConfigInheritable(ns, backend, role, name, maxLeases string, inheritable bool) string {
 	return fmt.Sprintf(`
 resource "vault_namespace" "test" {
   path = "%s"

--- a/vault/resource_quota_rate_limit.go
+++ b/vault/resource_quota_rate_limit.go
@@ -69,7 +69,6 @@ func quotaRateLimitResource() *schema.Resource {
 			"inheritable": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Computed:    true,
 				Description: "If set to true on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to true if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default.",
 			},
 		},
@@ -100,10 +99,10 @@ func quotaRateLimitCreate(d *schema.ResourceData, meta interface{}) error {
 		data["block_interval"] = v
 	}
 
-	if data["path"] == "" && d.Get("inheritable") == nil {
-		data["inheritable"] = true
-	} else if v, ok := d.GetOkExists("inheritable"); ok {
-		data["inheritable"] = v.(bool)
+	if provider.IsAPISupported(meta, provider.VaultVersion115) {
+		if v, ok := d.GetOkExists("inheritable"); ok {
+			data["inheritable"] = v.(bool)
+		}
 	}
 
 	if provider.IsAPISupported(meta, provider.VaultVersion112) {
@@ -143,9 +142,15 @@ func quotaRateLimitRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	fields := []string{"path", "rate", "interval", "block_interval", "name", "inheritable"}
+	fields := []string{"path", "rate", "interval", "block_interval", "name"}
 	if provider.IsAPISupported(meta, provider.VaultVersion112) {
 		fields = append(fields, consts.FieldRole)
+	}
+
+	if provider.IsAPISupported(meta, provider.VaultVersion115) {
+		if _, ok := d.GetOkExists("inheritable"); ok {
+			fields = append(fields, "inheritable")
+		}
 	}
 
 	for _, k := range fields {
@@ -183,10 +188,10 @@ func quotaRateLimitUpdate(d *schema.ResourceData, meta interface{}) error {
 		data["block_interval"] = v
 	}
 
-	if data["path"] == "" && d.Get("inheritable") == nil {
-		data["inheritable"] = true
-	} else if v, ok := d.GetOkExists("inheritable"); ok {
-		data["inheritable"] = v.(bool)
+	if provider.IsAPISupported(meta, provider.VaultVersion115) {
+		if v, ok := d.GetOkExists("inheritable"); ok {
+			data["inheritable"] = v.(bool)
+		}
 	}
 
 	if provider.IsAPISupported(meta, provider.VaultVersion112) {

--- a/vault/resource_quota_rate_limit_test.go
+++ b/vault/resource_quota_rate_limit_test.go
@@ -118,7 +118,7 @@ func TestQuotaRateLimitWithNamespace(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
-		PreCheck:          func() { testutil.TestAccPreCheck(t) },
+		PreCheck:          func() { testutil.TestEntPreCheck(t) },
 		CheckDestroy:      testQuotaRateLimitCheckDestroy([]string{rateLimit, newRateLimit}),
 		Steps: []resource.TestStep{
 			{

--- a/website/docs/r/quota_lease_count.md
+++ b/website/docs/r/quota_lease_count.md
@@ -50,7 +50,7 @@ The following arguments are supported:
 
 * `role` - (Optional) If set on a quota where `path` is set to an auth mount with a concept of roles (such as /auth/approle/), this will make the quota restrict login requests to that mount that are made with the specified role.
 
-* `inheritable` - (Optional) If set to `true` on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to `true` if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default.
+* `inheritable` - (Optional) If set to `true` on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to `true` if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default. Requires Vault 1.15+.
 
 ## Attributes Reference
 

--- a/website/docs/r/quota_lease_count.md
+++ b/website/docs/r/quota_lease_count.md
@@ -50,6 +50,8 @@ The following arguments are supported:
 
 * `role` - (Optional) If set on a quota where `path` is set to an auth mount with a concept of roles (such as /auth/approle/), this will make the quota restrict login requests to that mount that are made with the specified role.
 
+* `inheritable` - (Optional) If set to `true` on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to `true` if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default.
+
 ## Attributes Reference
 
 No additional attributes are exported by this resource.

--- a/website/docs/r/quota_rate_limit.md
+++ b/website/docs/r/quota_rate_limit.md
@@ -53,7 +53,7 @@ The following arguments are supported:
 
 * `role` - (Optional) If set on a quota where `path` is set to an auth mount with a concept of roles (such as /auth/approle/), this will make the quota restrict login requests to that mount that are made with the specified role.
 
-* `inheritable` - (Optional) If set to `true` on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to `true` if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default.
+* `inheritable` - (Optional) If set to `true` on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to `true` if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default. Requires Vault 1.15+.
 
 ## Attributes Reference
 

--- a/website/docs/r/quota_rate_limit.md
+++ b/website/docs/r/quota_rate_limit.md
@@ -53,6 +53,8 @@ The following arguments are supported:
 
 * `role` - (Optional) If set on a quota where `path` is set to an auth mount with a concept of roles (such as /auth/approle/), this will make the quota restrict login requests to that mount that are made with the specified role.
 
+* `inheritable` - (Optional) If set to `true` on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to `true` if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default.
+
 ## Attributes Reference
 
 No additional attributes are exported by this resource.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
Support `inheritable` parameter for the `vault_quota_rate_limit` and `vault_quota_lease_count` resources.

<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->



### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
=== RUN   TestQuotaRateLimit
--- PASS: TestQuotaRateLimit (2.62s)
=== RUN   TestQuotaRateLimitWithRole
    resource_quota_rate_limit_test.go:88: Vault server version "1.15.4+ent"
--- PASS: TestQuotaRateLimitWithRole (1.91s)
=== RUN   TestQuotaRateLimitWithNamespace
--- PASS: TestQuotaRateLimitWithNamespace (4.68s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault
```
```
=== RUN   TestQuotaLeaseCount
--- PASS: TestQuotaLeaseCount (5.02s)
=== RUN   TestQuotaLeaseCountWithRole
    resource_quota_lease_count_test.go:86: Vault server version "1.15.4+ent"
--- PASS: TestQuotaLeaseCountWithRole (4.09s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault

```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

