### PR TITLE
add UUID at INFO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ BUGS:
 
 FEATURES:
 * Add support for `skip_import_rotation` and `skip_static_role_import_rotation` in `ldap_secret_backend_static_role` and `ldap_secret_backend` respectively. Requires Vault 1.16+ ([#2128](https://github.com/hashicorp/terraform-provider-vault/pull/2128)).
+* Improve logging to track full API exchanges between the provider and Vault ([#2139](https://github.com/hashicorp/terraform-provider-vault/pull/2139))
 
 ## 3.25.0 (Feb 14, 2024)
 
@@ -12,7 +13,6 @@ FEATURES:
 * Add destination and association resources to support Secrets Sync. Requires Vault 1.16+ ([#2098](https://github.com/hashicorp/terraform-provider-vault/pull/2098)).
 * Add support for configuration of plugin WIF to the AWS Secret Backend. Requires Vault 1.16+ ([#2138](https://github.com/hashicorp/terraform-provider-vault/pull/2138)).
 * Add support for Oracle database plugin configuration options `split_statements` and `disconnect_sessions`: ([#2085](https://github.com/hashicorp/terraform-provider-vault/pull/2085))
-* Improve logging to track full API exchanges between the provider and Vault ([#2139](https://github.com/hashicorp/terraform-provider-vault/pull/2139))
 
 IMPROVEMENTS:
 * Add an API client lock to the `vault_identity_group_alias` resource: ([#2140](https://github.com/hashicorp/terraform-provider-vault/pull/2140))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ FEATURES:
 * Add destination and association resources to support Secrets Sync. Requires Vault 1.16+ ([#2098](https://github.com/hashicorp/terraform-provider-vault/pull/2098)).
 * Add support for configuration of plugin WIF to the AWS Secret Backend. Requires Vault 1.16+ ([#2138](https://github.com/hashicorp/terraform-provider-vault/pull/2138)).
 * Add support for Oracle database plugin configuration options `split_statements` and `disconnect_sessions`: ([#2085](https://github.com/hashicorp/terraform-provider-vault/pull/2085))
+* Improve logging to track full API exchanges between the provider and Vault ([#2139](https://github.com/hashicorp/terraform-provider-vault/pull/2139))
 
 IMPROVEMENTS:
 * Add an API client lock to the `vault_identity_group_alias` resource: ([#2140](https://github.com/hashicorp/terraform-provider-vault/pull/2140))

--- a/helper/transport.go
+++ b/helper/transport.go
@@ -113,7 +113,6 @@ func (t *TransportWrapper) RoundTrip(req *http.Request) (*http.Response, error) 
 				}
 			}
 		}
-		log.Printf("       \n")
 
 		reqData, err := httputil.DumpRequestOut(req, t.options.LogRequestBody)
 		if err == nil {
@@ -141,6 +140,7 @@ func (t *TransportWrapper) RoundTrip(req *http.Request) (*http.Response, error) 
 			log.Printf("[ERROR] %s API Response error: %#v", t.name, err)
 		}
 	}
+
 	return resp, nil
 }
 

--- a/helper/transport.go
+++ b/helper/transport.go
@@ -92,7 +92,6 @@ func (t *TransportWrapper) SetTLSConfig(c *tls.Config) error {
 
 func (t *TransportWrapper) RoundTrip(req *http.Request) (*http.Response, error) {
 	transportID := uuid.New().String()
-
 	if logging.IsDebugOrHigher() {
 
 		var origHeaders http.Header

--- a/helper/transport.go
+++ b/helper/transport.go
@@ -93,7 +93,6 @@ func (t *TransportWrapper) SetTLSConfig(c *tls.Config) error {
 func (t *TransportWrapper) RoundTrip(req *http.Request) (*http.Response, error) {
 	transportID := uuid.New().String()
 	if logging.IsDebugOrHigher() {
-
 		var origHeaders http.Header
 		if len(t.options.HMACRequestHeaders) > 0 && len(req.Header) > 0 {
 			origHeaders = req.Header.Clone()


### PR DESCRIPTION
### Description
Adding UUID at INFO level to help track request/responses within the transport wrapper, as well as the times these get sent out and are received.

This will help when debugging complex environments where hundreds/thousands of requests are sent within milliseconds of each other, as well as facilitate troubleshooting issues where apply timing mismatches are suspected, among other things.

### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### KV mount creating with `TF_LOG=info`:
```
vault_mount.kv-v2: Creating...
2024-02-11T11:49:04.765+1100 [INFO]  Starting apply for vault_mount.kv-v2
vault_mount.transit: Creating...
2024-02-11T11:49:04.765+1100 [INFO]  Starting apply for vault_mount.transit
2024-02-11T11:49:04.766+1100 [INFO]  provider.terraform-provider-vault: Request for UUID 40d007be-964d-4356-b51c-21bf0bfa19c2 sent: timestamp=2024-02-11T11:49:04.766+1100
2024-02-11T11:49:04.769+1100 [INFO]  provider.terraform-provider-vault: Response for UUID 40d007be-964d-4356-b51c-21bf0bfa19c2 received: timestamp=2024-02-11T11:49:04.769+1100
2024-02-11T11:49:04.769+1100 [INFO]  provider.terraform-provider-vault: Request for UUID dae66dd8-c611-4cee-b7c1-bb5abaf8167d sent: timestamp=2024-02-11T11:49:04.769+1100
2024-02-11T11:49:04.770+1100 [INFO]  provider.terraform-provider-vault: Response for UUID dae66dd8-c611-4cee-b7c1-bb5abaf8167d received: timestamp=2024-02-11T11:49:04.770+1100
2024-02-11T11:49:04.770+1100 [INFO]  provider.terraform-provider-vault: Using Vault token with the following policies: root: timestamp=2024-02-11T11:49:04.770+1100
2024-02-11T11:49:04.770+1100 [INFO]  provider.terraform-provider-vault: Request for UUID 89166ad5-8d27-4a5d-a4b6-6e48d9ce2339 sent: timestamp=2024-02-11T11:49:04.770+1100
2024-02-11T11:49:04.770+1100 [INFO]  provider.terraform-provider-vault: Request for UUID 73f74557-7c83-416a-9d16-8afd56acf7c7 sent: timestamp=2024-02-11T11:49:04.770+1100
2024-02-11T11:49:04.771+1100 [INFO]  provider.terraform-provider-vault: Response for UUID 89166ad5-8d27-4a5d-a4b6-6e48d9ce2339 received: timestamp=2024-02-11T11:49:04.771+1100
2024-02-11T11:49:04.771+1100 [INFO]  provider.terraform-provider-vault: Request for UUID dde9e0f6-d3cc-4a6e-8e0f-a3c02284b520 sent: timestamp=2024-02-11T11:49:04.771+1100
2024-02-11T11:49:04.771+1100 [INFO]  provider.terraform-provider-vault: Response for UUID 73f74557-7c83-416a-9d16-8afd56acf7c7 received: timestamp=2024-02-11T11:49:04.771+1100
2024-02-11T11:49:04.771+1100 [INFO]  provider.terraform-provider-vault: Request for UUID f40dee42-f1c8-42b0-971c-589307506d0c sent: timestamp=2024-02-11T11:49:04.771+1100
2024-02-11T11:49:04.771+1100 [INFO]  provider.terraform-provider-vault: Response for UUID dde9e0f6-d3cc-4a6e-8e0f-a3c02284b520 received: timestamp=2024-02-11T11:49:04.771+1100
2024-02-11T11:49:04.772+1100 [INFO]  provider.terraform-provider-vault: Response for UUID f40dee42-f1c8-42b0-971c-589307506d0c received: timestamp=2024-02-11T11:49:04.772+1100
2024-02-11T11:49:04.772+1100 [WARN]  Provider "provider[\"registry.terraform.io/hashicorp/vault\"]" produced an unexpected new value for vault_mount.kv-v2, but we are tolerating it because it is using the legacy plugin SDK.
    The following problems may be the cause of any confusing errors from downstream operations:
      - .description: was null, but now cty.StringVal("")
      - .local: was null, but now cty.False
vault_mount.kv-v2: Creation complete after 0s [id=kv-v2]
```

The above adds utility to the INFO level logs, however the benefit here largely  comes from debug & logging the Vault API body exchanges, which is too long to paste here conveniently.


### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

