### PR TITLE
identity/group-alias: add api client lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ FEATURES:
 * Add support for configuration of plugin WIF to the AWS Secret Backend. Requires Vault 1.16+ ([#2138](https://github.com/hashicorp/terraform-provider-vault/pull/2138)).
 * Add support for Oracle database plugin configuration options `split_statements` and `disconnect_sessions`: ([#2085](https://github.com/hashicorp/terraform-provider-vault/pull/2085))
 
+IMPROVEMENTS:
+* Add an API client lock to the `vault_identity_group_alias` resource: ([#2140](https://github.com/hashicorp/terraform-provider-vault/pull/2140))
+
 ## 3.24.0 (Jan 17, 2024)
 
 FEATURES:

--- a/vault/data_identity_entity.go
+++ b/vault/data_identity_entity.go
@@ -201,6 +201,7 @@ func identityEntityDataSource() *schema.Resource {
 
 func identityEntityLookup(client *api.Client, data map[string]interface{}) (*api.Secret, error) {
 	log.Print("[DEBUG] Looking up IdentityEntity")
+
 	resp, err := client.Logical().Write(entity.LookupPath, data)
 	if err != nil {
 		return nil, fmt.Errorf("Error reading Identity Entity '%v': %w", data, err)

--- a/vault/resource_identity_entity_alias.go
+++ b/vault/resource_identity_entity_alias.go
@@ -26,7 +26,7 @@ func identityEntityAliasResource() *schema.Resource {
 		ReadContext:   provider.ReadContextWrapper(identityEntityAliasRead),
 		DeleteContext: identityEntityAliasDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/vault/resource_identity_group_alias.go
+++ b/vault/resource_identity_group_alias.go
@@ -60,6 +60,9 @@ func identityGroupAliasCreate(d *schema.ResourceData, meta interface{}) error {
 
 	path := identityGroupAliasPath
 
+	provider.VaultMutexKV.Lock(path)
+	defer provider.VaultMutexKV.Unlock(path)
+
 	data := map[string]interface{}{
 		"name":                    name,
 		consts.FieldMountAccessor: mountAccessor,
@@ -86,6 +89,9 @@ func identityGroupAliasUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Updating IdentityGroupAlias %q", id)
 	path := identityGroupAliasIDPath(id)
+
+	provider.VaultMutexKV.Lock(path)
+	defer provider.VaultMutexKV.Unlock(path)
 
 	resp, err := client.Logical().Read(path)
 	if err != nil {
@@ -128,6 +134,9 @@ func identityGroupAliasRead(d *schema.ResourceData, meta interface{}) error {
 
 	path := identityGroupAliasIDPath(id)
 
+	provider.VaultMutexKV.Lock(path)
+	defer provider.VaultMutexKV.Unlock(path)
+
 	log.Printf("[DEBUG] Reading IdentityGroupAlias %s from %q", id, path)
 	resp, err := client.Logical().Read(path)
 	if err != nil {
@@ -158,6 +167,9 @@ func identityGroupAliasDelete(d *schema.ResourceData, meta interface{}) error {
 	id := d.Id()
 
 	path := identityGroupAliasIDPath(id)
+
+	provider.VaultMutexKV.Lock(path)
+	defer provider.VaultMutexKV.Unlock(path)
 
 	log.Printf("[DEBUG] Deleting IdentityGroupAlias %q", id)
 	_, err := client.Logical().Delete(path)

--- a/vault/resource_identity_group_alias.go
+++ b/vault/resource_identity_group_alias.go
@@ -216,5 +216,5 @@ func identityGroupAliasNamePath(name string) string {
 }
 
 func getIdentityGroupAliasIDPath(id string) string {
-	return fmt.Sprintf("%s/%s", identityGroupAliasPath, id)
+	return fmt.Sprintf("%s/%s", identityGroupAliasIDPath, id)
 }

--- a/vault/resource_identity_group_alias.go
+++ b/vault/resource_identity_group_alias.go
@@ -4,9 +4,11 @@
 package vault
 
 import (
+	"context"
 	"fmt"
 	"log"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
@@ -20,11 +22,10 @@ const (
 
 func identityGroupAliasResource() *schema.Resource {
 	return &schema.Resource{
-		Create: identityGroupAliasCreate,
-		Update: identityGroupAliasUpdate,
-		Read:   provider.ReadWrapper(identityGroupAliasRead),
-		Delete: identityGroupAliasDelete,
-		Exists: identityGroupAliasExists,
+		CreateContext: identityGroupAliasCreate,
+		UpdateContext: identityGroupAliasUpdate,
+		ReadContext:   provider.ReadContextWrapper(identityGroupAliasRead),
+		DeleteContext: identityGroupAliasDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -51,14 +52,14 @@ func identityGroupAliasResource() *schema.Resource {
 	}
 }
 
-func identityGroupAliasCreate(d *schema.ResourceData, meta interface{}) error {
+func identityGroupAliasCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	lock, unlock := getEntityLockFuncs(d, identityGroupAliasIDPath)
 	lock()
 	defer unlock()
 
 	client, e := provider.GetClient(d, meta)
 	if e != nil {
-		return e
+		return diag.FromErr(e)
 	}
 
 	name := d.Get("name").(string)
@@ -73,24 +74,24 @@ func identityGroupAliasCreate(d *schema.ResourceData, meta interface{}) error {
 		"canonical_id":            canonicalID,
 	}
 
-	resp, err := client.Logical().Write(path, data)
+	resp, err := client.Logical().WriteWithContext(ctx, path, data)
 	if err != nil {
-		return fmt.Errorf("error writing IdentityGroupAlias to %q: %s", name, err)
+		return diag.FromErr(fmt.Errorf("error writing IdentityGroupAlias to %q: %s", name, err))
 	}
 	log.Printf("[DEBUG] Wrote IdentityGroupAlias %q", name)
 	d.SetId(resp.Data["id"].(string))
 
-	return identityGroupAliasRead(d, meta)
+	return identityGroupAliasRead(ctx, d, meta)
 }
 
-func identityGroupAliasUpdate(d *schema.ResourceData, meta interface{}) error {
+func identityGroupAliasUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	lock, unlock := getEntityLockFuncs(d, identityGroupAliasIDPath)
 	lock()
 	defer unlock()
 
 	client, e := provider.GetClient(d, meta)
 	if e != nil {
-		return e
+		return diag.FromErr(e)
 	}
 
 	id := d.Id()
@@ -98,9 +99,9 @@ func identityGroupAliasUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Updating IdentityGroupAlias %q", id)
 	path := getIdentityGroupAliasIDPath(id)
 
-	resp, err := client.Logical().Read(path)
+	resp, err := client.Logical().ReadWithContext(ctx, path)
 	if err != nil {
-		return fmt.Errorf("error updating IdentityGroupAlias %q: %s", id, err)
+		return diag.FromErr(fmt.Errorf("error updating IdentityGroupAlias %q: %s", id, err))
 	}
 
 	data := map[string]interface{}{
@@ -119,20 +120,20 @@ func identityGroupAliasUpdate(d *schema.ResourceData, meta interface{}) error {
 		data["canonical_id"] = canonicalID
 	}
 
-	_, err = client.Logical().Write(path, data)
+	_, err = client.Logical().WriteWithContext(ctx, path, data)
 
 	if err != nil {
-		return fmt.Errorf("error updating IdentityGroupAlias %q: %s", id, err)
+		return diag.FromErr(fmt.Errorf("error updating IdentityGroupAlias %q: %s", id, err))
 	}
 	log.Printf("[DEBUG] Updated IdentityGroupAlias %q", id)
 
-	return identityGroupAliasRead(d, meta)
+	return identityGroupAliasRead(ctx, d, meta)
 }
 
-func identityGroupAliasRead(d *schema.ResourceData, meta interface{}) error {
+func identityGroupAliasRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client, e := provider.GetClient(d, meta)
 	if e != nil {
-		return e
+		return diag.FromErr(e)
 	}
 
 	id := d.Id()
@@ -140,9 +141,9 @@ func identityGroupAliasRead(d *schema.ResourceData, meta interface{}) error {
 	path := getIdentityGroupAliasIDPath(id)
 
 	log.Printf("[DEBUG] Reading IdentityGroupAlias %s from %q", id, path)
-	resp, err := client.Logical().Read(path)
+	resp, err := client.Logical().ReadWithContext(ctx, path)
 	if err != nil {
-		return fmt.Errorf("error reading IdentityGroupAlias %q: %s", id, err)
+		return diag.FromErr(fmt.Errorf("error reading IdentityGroupAlias %q: %s", id, err))
 	}
 	log.Printf("[DEBUG] Read IdentityGroupAlias %s", id)
 	if resp == nil {
@@ -154,20 +155,20 @@ func identityGroupAliasRead(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(resp.Data["id"].(string))
 	for _, k := range []string{"name", consts.FieldMountAccessor, "canonical_id"} {
 		if err := d.Set(k, resp.Data[k]); err != nil {
-			return fmt.Errorf("error setting state key \"%s\" on IdentityGroupAlias %q: %s", k, id, err)
+			return diag.FromErr(fmt.Errorf("error setting state key \"%s\" on IdentityGroupAlias %q: %s", k, id, err))
 		}
 	}
 	return nil
 }
 
-func identityGroupAliasDelete(d *schema.ResourceData, meta interface{}) error {
+func identityGroupAliasDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	lock, unlock := getEntityLockFuncs(d, identityGroupAliasIDPath)
 	lock()
 	defer unlock()
 
 	client, e := provider.GetClient(d, meta)
 	if e != nil {
-		return e
+		return diag.FromErr(e)
 	}
 
 	id := d.Id()
@@ -175,40 +176,13 @@ func identityGroupAliasDelete(d *schema.ResourceData, meta interface{}) error {
 	path := getIdentityGroupAliasIDPath(id)
 
 	log.Printf("[DEBUG] Deleting IdentityGroupAlias %q", id)
-	_, err := client.Logical().Delete(path)
+	_, err := client.Logical().DeleteWithContext(ctx, path)
 	if err != nil {
-		return fmt.Errorf("error IdentityGroupAlias %q", id)
+		return diag.FromErr(fmt.Errorf("error IdentityGroupAlias %q", id))
 	}
 	log.Printf("[DEBUG] Deleted IdentityGroupAlias %q", id)
 
 	return nil
-}
-
-func identityGroupAliasExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	client, e := provider.GetClient(d, meta)
-	if e != nil {
-		return false, e
-	}
-
-	id := d.Id()
-
-	path := getIdentityGroupAliasIDPath(id)
-	key := id
-
-	// use the name if no ID is set
-	if len(id) == 0 {
-		key = d.Get("name").(string)
-		path = identityGroupAliasNamePath(key)
-	}
-
-	log.Printf("[DEBUG] Checking if IdentityGroupAlias %q exists", key)
-	resp, err := client.Logical().Read(path)
-	if err != nil {
-		return true, fmt.Errorf("error checking if IdentityGroupAlias %q exists: %s", key, err)
-	}
-	log.Printf("[DEBUG] Checked if IdentityGroupAlias %q exists", key)
-
-	return resp != nil, nil
 }
 
 func identityGroupAliasNamePath(name string) string {

--- a/vault/resource_identity_group_alias_test.go
+++ b/vault/resource_identity_group_alias_test.go
@@ -87,7 +87,7 @@ func testAccCheckIdentityGroupAliasDestroy(s *terraform.State) error {
 			return e
 		}
 
-		secret, err := client.Logical().Read(identityGroupAliasIDPath(rs.Primary.ID))
+		secret, err := client.Logical().Read(getIdentityGroupAliasIDPath(rs.Primary.ID))
 		if err != nil {
 			return fmt.Errorf("error checking for identity group %q: %s", rs.Primary.ID, err)
 		}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #1695 

I haven't been able to reproduce the issue from #1695 yet, but the lack of locking here is quite suspicious.


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


