### PR TITLE
auth/mount: fetch single vault resource on read

### DIFF
--- a/website/docs/r/auth_backend.html.md
+++ b/website/docs/r/auth_backend.html.md
@@ -8,6 +8,7 @@ description: |-
 
 # vault\_auth\_backend
 
+This resource enables a new auth method at the given path.
 
 ## Example Usage
 

--- a/website/docs/r/mount.html.md
+++ b/website/docs/r/mount.html.md
@@ -8,6 +8,7 @@ description: |-
 
 # vault\_mount
 
+This resource enables a new secrets engine at the given path.
 
 ## Example Usage
 


### PR DESCRIPTION

### Description

This changes the READ operations in `vault_auth_backend` and `vault_mount` to use the [`GET /sys/auth/:path`](https://developer.hashicorp.com/vault/api-docs/system/auth#read-auth-method-configuration) and [`GET /sys/mounts/:path`](https://developer.hashicorp.com/vault/api-docs/system/mounts#get-the-configuration-of-a-secret-engine) APIs respectively. Previously, these resources were calling LIST which could result in a substantially higher CPU and memory footprint for the provider in cases where a given Vault server has a large number of secret/auth mounts.

At this time, there are no helpers for these API paths in the Vault `api` package so we handle the endpoints with raw requests via the Provider's Vault client.

### Details on the CPU performance improvements

As expected, the CPU profile shows the biggest improvements in the Provider's READ operations which were spending most of the CPU time listing and decoding mount data. The before snapshot shows 

#### pprof CPU profile flame graph
Before:
<img width="1330" alt="before-cpu" src="https://github.com/hashicorp/terraform-provider-vault/assets/10056608/4d2b4c10-5990-480a-b06d-fba716381a3f">


After:
<img width="1330" alt="after-cpu" src="https://github.com/hashicorp/terraform-provider-vault/assets/10056608/d4ea002f-68b0-4aec-8c61-5789e86b4000">

Additionally, from the CPU profile we can see a big difference in the time spent in the call to `mallocgc`:

Before:
```
      flat  flat%   sum%        cum   cum%
     2.33s  2.94% 49.05%      8.15s 10.29%  runtime.mallocgc
```

After:
```
      flat  flat%   sum%        cum   cum%
     0.07s  0.79% 88.25%      0.27s  3.05%  runtime.mallocgc
```

So let's take a look at the pprof memory profile...

### Details on the Memory performance improvements
Interestingly, the pprof memory profile does not shed any light on the performance improvements that we would predict based on the previous CPU profile analysis. However, both before and after point to the AWS SDK init functions as being very memory hungry.


#### pprof Memory profile
Before:
```
(pprof) top
Showing nodes accounting for 5680.34kB, 100% of 5680.34kB total
Showing top 10 nodes out of 33
      flat  flat%   sum%        cum   cum%
 1544.18kB 27.18% 27.18%  1544.18kB 27.18%  github.com/aws/aws-sdk-go/aws/endpoints.init
 1026.81kB 18.08% 45.26%  1026.81kB 18.08%  regexp.onePassCopy
  544.67kB  9.59% 54.85%   544.67kB  9.59%  regexp/syntax.(*compiler).inst (inline)
  516.01kB  9.08% 63.93%   516.01kB  9.08%  regexp/syntax.appendRange
  512.20kB  9.02% 72.95%   512.20kB  9.02%  runtime.malg
  512.16kB  9.02% 81.97%   512.16kB  9.02%  github.com/hashicorp/terraform-provider-vault/vault.approleAuthBackendLoginResource
  512.16kB  9.02% 90.98%   512.16kB  9.02%  github.com/hashicorp/terraform-provider-vault/vault.getCommonManagedKeysSchema
  512.16kB  9.02%   100%   512.16kB  9.02%  github.com/hashicorp/terraform-provider-vault/vault.identityOIDCOpenIDConfigDataSource
```



After:
```
(pprof) top
Showing nodes accounting for 8218.13kB, 84.25% of 9754.22kB total
Showing top 10 nodes out of 65
      flat  flat%   sum%        cum   cum%
 3075.29kB 31.53% 31.53%  3075.29kB 31.53%  github.com/aws/aws-sdk-go/aws/endpoints.init
 1028.88kB 10.55% 42.08%  1028.88kB 10.55%  regexp.onePassCopy
  520.04kB  5.33% 47.41%   520.04kB  5.33%  go.opencensus.io/stats/view.NewMeter
  517.33kB  5.30% 52.71%   517.33kB  5.30%  regexp/syntax.(*compiler).inst
  514.63kB  5.28% 57.99%   514.63kB  5.28%  cloud.google.com/go/monitoring/apiv3/v2/monitoringpb.init
  512.88kB  5.26% 63.24%   512.88kB  5.26%  unicode.map.init.0
  512.56kB  5.25% 68.50%   512.56kB  5.25%  encoding/json.typeFields
  512.20kB  5.25% 73.75%   512.20kB  5.25%  runtime.malg
  512.16kB  5.25% 79.00%   512.16kB  5.25%  github.com/hashicorp/terraform-provider-vault/vault.azureAuthBackendRoleResource
  512.16kB  5.25% 84.25%   512.16kB  5.25%  github.com/hashicorp/terraform-provider-vault/vault.tokenResource
```

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000


### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


