### PR TITLE
Fix unhandled error in d/azure_access_creds

### DIFF
--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -133,6 +133,8 @@ type AzureTestConf struct {
 }
 
 func GetTestAzureConf(t *testing.T) *AzureTestConf {
+	t.Helper()
+
 	v := SkipTestEnvUnset(t,
 		"AZURE_SUBSCRIPTION_ID",
 		"AZURE_TENANT_ID",

--- a/vault/data_source_azure_access_credentials.go
+++ b/vault/data_source_azure_access_credentials.go
@@ -33,7 +33,7 @@ const (
 	azureUSGovCloudEnvName  = "AZUREUSGOVERNMENTCLOUD"
 )
 
-var configs = map[string]cloud.Configuration{
+var azureCloudConfigMap = map[string]cloud.Configuration{
 	azureChinaCloudEnvName:  cloud.AzureChina,
 	azurePublicCloudEnvName: cloud.AzurePublic,
 	azureUSGovCloudEnvName:  cloud.AzureGovernment,
@@ -313,7 +313,7 @@ func azureAccessCredentialsDataSourceRead(ctx context.Context, d *schema.Resourc
 }
 
 func getAzureCloudConfigFromName(name string) (cloud.Configuration, error) {
-	if c, ok := configs[strings.ToUpper(name)]; !ok {
+	if c, ok := azureCloudConfigMap[strings.ToUpper(name)]; !ok {
 		return c, fmt.Errorf("unsupported Azure cloud name %q", name)
 	} else {
 		return c, nil

--- a/vault/data_source_azure_access_credentials.go
+++ b/vault/data_source_azure_access_credentials.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
@@ -24,6 +25,19 @@ import (
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
+
+// https://learn.microsoft.com/en-us/graph/sdks/national-clouds
+const (
+	azurePublicCloudEnvName = "AZUREPUBLICCLOUD"
+	azureChinaCloudEnvName  = "AZURECHINACLOUD"
+	azureUSGovCloudEnvName  = "AZUREUSGOVERNMENTCLOUD"
+)
+
+var configs = map[string]cloud.Configuration{
+	azureChinaCloudEnvName:  cloud.AzureChina,
+	azurePublicCloudEnvName: cloud.AzurePublic,
+	azureUSGovCloudEnvName:  cloud.AzureGovernment,
+}
 
 func azureAccessCredentialsDataSource() *schema.Resource {
 	return &schema.Resource{
@@ -216,7 +230,6 @@ func azureAccessCredentialsDataSourceRead(ctx context.Context, d *schema.Resourc
 		return diag.FromErr(e)
 	}
 
-	clientOptions := &arm.ClientOptions{}
 	var environment string
 	if v, ok := d.GetOk("environment"); ok {
 		environment = v.(string)
@@ -230,10 +243,17 @@ func azureAccessCredentialsDataSourceRead(ctx context.Context, d *schema.Resourc
 		}
 	}
 
-	cloudConfig, err := cloudConfigFromName(environment)
-	clientOptions.Cloud = cloudConfig
+	cloudConfig, err := getAzureCloudConfigFromName(environment)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
-	providerClient, err := armresources.NewProvidersClient(subscriptionID, creds, clientOptions)
+	providerClient, err := armresources.NewProvidersClient(subscriptionID, creds,
+		&arm.ClientOptions{
+			ClientOptions: policy.ClientOptions{
+				Cloud: cloudConfig,
+			},
+		})
 	if err != nil {
 		return diag.Errorf("failed to create providers client: %s", err)
 	}
@@ -292,25 +312,10 @@ func azureAccessCredentialsDataSourceRead(ctx context.Context, d *schema.Resourc
 	return nil
 }
 
-// https://learn.microsoft.com/en-us/graph/sdks/national-clouds
-const (
-	azurePublicCloudEnvName = "AZUREPUBLICCLOUD"
-	azureChinaCloudEnvName  = "AZURECHINACLOUD"
-	azureUSGovCloudEnvName  = "AZUREUSGOVERNMENTCLOUD"
-)
-
-func cloudConfigFromName(name string) (cloud.Configuration, error) {
-	configs := map[string]cloud.Configuration{
-		azureChinaCloudEnvName:  cloud.AzureChina,
-		azurePublicCloudEnvName: cloud.AzurePublic,
-		azureUSGovCloudEnvName:  cloud.AzureGovernment,
+func getAzureCloudConfigFromName(name string) (cloud.Configuration, error) {
+	if c, ok := configs[strings.ToUpper(name)]; !ok {
+		return c, fmt.Errorf("unsupported Azure cloud name %q", name)
+	} else {
+		return c, nil
 	}
-
-	name = strings.ToUpper(name)
-	c, ok := configs[name]
-	if !ok {
-		return c, fmt.Errorf("err: no cloud configuration matching the name %q", name)
-	}
-
-	return c, nil
 }

--- a/vault/data_source_azure_access_credentials_test.go
+++ b/vault/data_source_azure_access_credentials_test.go
@@ -174,7 +174,7 @@ func Test_getAzureCloudConfigFromName(t *testing.T) {
 			wantErr:   true,
 		},
 	}
-	for k, v := range configs {
+	for k, v := range azureCloudConfigMap {
 		tests = append(tests, test{
 			name:      "mixed-" + k,
 			cloudName: mixedCap(k),

--- a/vault/data_source_azure_access_credentials_test.go
+++ b/vault/data_source_azure_access_credentials_test.go
@@ -4,10 +4,13 @@
 package vault
 
 import (
+	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
@@ -139,4 +142,68 @@ data "vault_azure_access_credentials" "test" {
 	parsed = strings.Replace(parsed, "{{scope}}", conf.Scope, -1)
 	parsed = strings.Replace(parsed, "{{maxCredValidationSeconds}}", strconv.Itoa(maxSecs), -1)
 	return parsed
+}
+
+func Test_getAzureCloudConfigFromName(t *testing.T) {
+	t.Parallel()
+
+	mixedCap := func(s string) string {
+		var r string
+		s = strings.ToUpper(s)
+		for i := 0; i < len(s); i++ {
+			l := fmt.Sprintf("%c", s[i])
+			if i%2 == 0 {
+				r += strings.ToLower(l)
+			} else {
+				r += l
+			}
+		}
+		return r
+	}
+
+	type test struct {
+		name      string
+		cloudName string
+		want      cloud.Configuration
+		wantErr   bool
+	}
+	tests := []test{
+		{
+			name:      "invalid",
+			cloudName: "unknown",
+			wantErr:   true,
+		},
+	}
+	for k, v := range configs {
+		tests = append(tests, test{
+			name:      "mixed-" + k,
+			cloudName: mixedCap(k),
+			want:      v,
+			wantErr:   false,
+		})
+		tests = append(tests, test{
+			name:      "default-" + k,
+			cloudName: k,
+			want:      v,
+			wantErr:   false,
+		})
+		tests = append(tests, test{
+			name:      "lower-" + strings.ToLower(k),
+			cloudName: strings.ToLower(k),
+			want:      v,
+			wantErr:   false,
+		})
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getAzureCloudConfigFromName(tt.cloudName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getAzureCloudConfigFromName() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getAzureCloudConfigFromName() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
We were not handling the error from `cloudConfigFromName()` when reading azure access credentials.

Refactor some of the code, and add tests for `getAzureCloudConfigFromName()` which was renamed from `cloudConfigFromName()`

