### PR TITLE
feat(pki): Add support to enable_templating in vault_pki_secret_backend_config_urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 BUGS:
 * Handle graceful destruction of resources when approle is deleted out-of-band ([#2142](https://github.com/hashicorp/terraform-provider-vault/pull/2142)).
+* Add support to `enable_templating` in `vault_pki_secret_backend_config_urls` ([#2147](https://github.com/hashicorp/terraform-provider-vault/pull/2147)).
 
 FEATURES:
 * Add support for PKI Secrets Engine cluster configuration. Requires Vault 1.13+ ([#1949](https://github.com/hashicorp/terraform-provider-vault/pull/1949)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,9 @@
 BUGS:
 * Handle graceful destruction of resources when approle is deleted out-of-band ([#2142](https://github.com/hashicorp/terraform-provider-vault/pull/2142)).
 
-IMPROVEMENTS:
-* Add support to `enable_templating` in `vault_pki_secret_backend_config_urls` ([#2147](https://github.com/hashicorp/terraform-provider-vault/pull/2147)).
-
 FEATURES:
-* Add support for PKI Secrets Engine cluster configuration. Requires Vault 1.13+ ([#1949](https://github.com/hashicorp/terraform-provider-vault/pull/1949)).
+* Add support for PKI Secrets Engine cluster configuration with the `vault_pki_secret_backend_config_cluster` resource. Requires Vault 1.13+ ([#1949](https://github.com/hashicorp/terraform-provider-vault/pull/1949)).
+* Add support to `enable_templating` in `vault_pki_secret_backend_config_urls` ([#2147](https://github.com/hashicorp/terraform-provider-vault/pull/2147)).
 * Add support for `skip_import_rotation` and `skip_static_role_import_rotation` in `ldap_secret_backend_static_role` and `ldap_secret_backend` respectively. Requires Vault 1.16+ ([#2128](https://github.com/hashicorp/terraform-provider-vault/pull/2128)).
 * Improve logging to track full API exchanges between the provider and Vault ([#2139](https://github.com/hashicorp/terraform-provider-vault/pull/2139))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 BUGS:
 * Handle graceful destruction of resources when approle is deleted out-of-band ([#2142](https://github.com/hashicorp/terraform-provider-vault/pull/2142)).
+
+IMPROVEMENTS:
 * Add support to `enable_templating` in `vault_pki_secret_backend_config_urls` ([#2147](https://github.com/hashicorp/terraform-provider-vault/pull/2147)).
 
 FEATURES:

--- a/vault/resource_pki_secret_backend_config_urls.go
+++ b/vault/resource_pki_secret_backend_config_urls.go
@@ -91,7 +91,7 @@ func pkiSecretBackendConfigUrlsCreateUpdate(d *schema.ResourceData, meta interfa
 		"ocsp_servers":            d.Get("ocsp_servers"),
 	}
 
-	if provider.IsAPISupported(meta, provider.VaultVersion114) {
+	if provider.IsAPISupported(meta, provider.VaultVersion113) {
 		if enableTemplating, ok := d.GetOkExists("enable_templating"); ok {
 			data["enable_templating"] = enableTemplating
 		}
@@ -146,7 +146,7 @@ func pkiSecretBackendConfigUrlsRead(d *schema.ResourceData, meta interface{}) er
 		}
 	}
 
-	if provider.IsAPISupported(meta, provider.VaultVersion114) {
+	if provider.IsAPISupported(meta, provider.VaultVersion113) {
 		if err := d.Set("enable_templating", config.Data["enable_templating"]); err != nil {
 			return err
 		}

--- a/vault/resource_pki_secret_backend_config_urls.go
+++ b/vault/resource_pki_secret_backend_config_urls.go
@@ -61,6 +61,11 @@ func pkiSecretBackendConfigUrlsResource() *schema.Resource {
 				Description: "Specifies the URL values for the OCSP Servers field.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
+			"enable_templating": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Specifies that templating of AIA fields is allowed.",
+			},
 		},
 	}
 }
@@ -84,6 +89,7 @@ func pkiSecretBackendConfigUrlsCreateUpdate(d *schema.ResourceData, meta interfa
 		"issuing_certificates":    d.Get("issuing_certificates"),
 		"crl_distribution_points": d.Get("crl_distribution_points"),
 		"ocsp_servers":            d.Get("ocsp_servers"),
+		"enable_templating":       d.Get("enable_templating"),
 	}
 
 	log.Printf("[DEBUG] %s URL config on PKI secret backend %q", action, backend)
@@ -128,6 +134,7 @@ func pkiSecretBackendConfigUrlsRead(d *schema.ResourceData, meta interface{}) er
 		"issuing_certificates",
 		"crl_distribution_points",
 		"ocsp_servers",
+		"enable_templating",
 	}
 	for _, k := range fields {
 		if err := d.Set(k, config.Data[k]); err != nil {

--- a/vault/resource_pki_secret_backend_config_urls.go
+++ b/vault/resource_pki_secret_backend_config_urls.go
@@ -92,9 +92,7 @@ func pkiSecretBackendConfigUrlsCreateUpdate(d *schema.ResourceData, meta interfa
 	}
 
 	if provider.IsAPISupported(meta, provider.VaultVersion113) {
-		if enableTemplating, ok := d.GetOkExists("enable_templating"); ok {
-			data["enable_templating"] = enableTemplating
-		}
+		data["enable_templating"] = d.Get("enable_templating")
 	}
 
 	log.Printf("[DEBUG] %s URL config on PKI secret backend %q", action, backend)

--- a/vault/resource_pki_secret_backend_config_urls_test.go
+++ b/vault/resource_pki_secret_backend_config_urls_test.go
@@ -80,7 +80,7 @@ func TestPkiSecretBackendConfigUrls_basic(t *testing.T) {
 			{
 				SkipFunc: func() (bool, error) {
 					meta := testProvider.Meta().(*provider.ProviderMeta)
-					return provider.IsAPISupported(meta, provider.VaultVersion113), nil
+					return !provider.IsAPISupported(meta, provider.VaultVersion113), nil
 				},
 				Config: testPkiSecretBackendCertConfigUrlsConfig(
 					rootPath, issuingCertificates, crlDistributionPoints, ocspServers),

--- a/vault/resource_pki_secret_backend_config_urls_test.go
+++ b/vault/resource_pki_secret_backend_config_urls_test.go
@@ -44,7 +44,7 @@ func TestPkiSecretBackendConfigUrls_basic(t *testing.T) {
 			resource.TestCheckResourceAttr(
 				resourceName, "ocsp_servers.0", o),
 		}
-		v114Checks := []resource.TestCheckFunc{
+		v113Checks := []resource.TestCheckFunc{
 			resource.TestCheckResourceAttr(
 				resourceName, "enable_templating", strconv.FormatBool(e)),
 		}
@@ -53,8 +53,8 @@ func TestPkiSecretBackendConfigUrls_basic(t *testing.T) {
 			var checks []resource.TestCheckFunc
 			meta := testProvider.Meta().(*provider.ProviderMeta)
 			checks = append(checks, baseChecks...)
-			if provider.IsAPISupported(meta, provider.VaultVersion114) {
-				checks = append(checks, v114Checks...)
+			if provider.IsAPISupported(meta, provider.VaultVersion113) {
+				checks = append(checks, v113Checks...)
 			}
 
 			return resource.ComposeTestCheckFunc(checks...)(state)
@@ -80,7 +80,7 @@ func TestPkiSecretBackendConfigUrls_basic(t *testing.T) {
 			{
 				SkipFunc: func() (bool, error) {
 					meta := testProvider.Meta().(*provider.ProviderMeta)
-					return provider.IsAPISupported(meta, provider.VaultVersion114), nil
+					return provider.IsAPISupported(meta, provider.VaultVersion113), nil
 				},
 				Config: testPkiSecretBackendCertConfigUrlsConfig(
 					rootPath, issuingCertificates, crlDistributionPoints, ocspServers),
@@ -91,16 +91,16 @@ func TestPkiSecretBackendConfigUrls_basic(t *testing.T) {
 			{
 				SkipFunc: func() (bool, error) {
 					meta := testProvider.Meta().(*provider.ProviderMeta)
-					return !provider.IsAPISupported(meta, provider.VaultVersion114), nil
+					return !provider.IsAPISupported(meta, provider.VaultVersion113), nil
 				},
-				Config: testPkiSecretBackendCertConfigUrlsConfig114(
+				Config: testPkiSecretBackendCertConfigUrlsConfig113(
 					rootPath, issuingCertificates, crlDistributionPoints, ocspServers, enableTemplating),
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
-				Config: testPkiSecretBackendCertConfigUrlsConfig114(
+				Config: testPkiSecretBackendCertConfigUrlsConfig113(
 					rootPath, issuingCertificates+"/new", crlDistributionPoints+"/new", ocspServers+"/new", !enableTemplating),
 				Check: getChecks(
 					issuingCertificates+"/new", crlDistributionPoints+"/new", ocspServers+"/new", !enableTemplating),
@@ -177,7 +177,7 @@ resource "vault_pki_secret_backend_config_urls" "test" {
 		issuingCertificates, crlDistributionPoints, ocspServers)
 }
 
-func testPkiSecretBackendCertConfigUrlsConfig114(rootPath string, issuingCertificates string, crlDistributionPoints string, ocspServers string, enableTemplating bool) string {
+func testPkiSecretBackendCertConfigUrlsConfig113(rootPath string, issuingCertificates string, crlDistributionPoints string, ocspServers string, enableTemplating bool) string {
 	return fmt.Sprintf(`
 %s
 

--- a/website/docs/r/pki_secret_backend_config_urls.html.md
+++ b/website/docs/r/pki_secret_backend_config_urls.html.md
@@ -46,6 +46,8 @@ The following arguments are supported:
 
 * `ocsp_servers` - (Optional) Specifies the URL values for the OCSP Servers field.
 
+* `enable_templating` - (Optional) Specifies that templating of AIA fields is allowed.
+
 ## Attributes Reference
 
 No additional attributes are exported by this resource.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
This PR adds a new option to allow configuration of the templating on the global URLs (vault_pki_secret_backend_config_urls)

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates [#1947](https://github.com/hashicorp/terraform-provider-vault/issues/1947#issuecomment-1719908124)
Closes #1983


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
# Vault 1.13
$ VAULT_ADDR=http://172.20.0.1:8213 TESTARGS="--run TestPkiSecretBackendConfigUrls_basic" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test --run TestPkiSecretBackendConfigUrls_basic -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
ok      github.com/hashicorp/terraform-provider-vault/codegen   0.006s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/mfa     [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/pki      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  0.022s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/sync     [no test files]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/provider 0.023s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/testutil  0.007s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util      0.005s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/vault     3.885s


# Vault 1.14
$ VAULT_ADDR=http://172.20.0.1:8214 TESTARGS="--run TestPkiSecretBackendConfigUrls_basic" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test --run TestPkiSecretBackendConfigUrls_basic -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
ok      github.com/hashicorp/terraform-provider-vault/codegen   0.008s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/mfa     [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/pki      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  0.027s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/sync     [no test files]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/provider 0.023s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/testutil  0.005s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util      0.005s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/vault     3.125s


# Vault 1.15
$ VAULT_ADDR=http://172.20.0.1:8215 TESTARGS="--run TestPkiSecretBackendConfigUrls_basic" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test --run TestPkiSecretBackendConfigUrls_basic -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
ok      github.com/hashicorp/terraform-provider-vault/codegen   0.007s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/mfa     [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/pki      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  0.042s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/sync     [no test files]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/provider 0.030s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/testutil  0.006s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util      0.004s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/vault     3.411s

```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

