### PR TITLE
secrets/ldap: return error on read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 BUGS:
 * Handle graceful destruction of resources when approle is deleted out-of-band ([#2142](https://github.com/hashicorp/terraform-provider-vault/pull/2142)).
+* Ensure errors are returned on read operations for `vault_ldap_secret_backend_static_role`, `vault_ldap_secret_backend_library_set`, and `vault_ldap_secret_backend_static_role` ([#2156](https://github.com/hashicorp/terraform-provider-vault/pull/2156)).
 
 FEATURES:
 * Add support for PKI Secrets Engine cluster configuration with the `vault_pki_secret_backend_config_cluster` resource. Requires Vault 1.13+ ([#1949](https://github.com/hashicorp/terraform-provider-vault/pull/1949)).

--- a/vault/resource_identity_entity_test.go
+++ b/vault/resource_identity_entity_test.go
@@ -305,7 +305,7 @@ func TestReadEntity(t *testing.T) {
 			expectedRetries: 5,
 			wantError: fmt.Errorf(`failed reading %q`,
 				entity.JoinEntityID("retry-exhausted-custom-max-412")),
-			retryWait: time.Millisecond,
+			retryWait: 500 * time.Millisecond,
 		},
 	}
 

--- a/vault/resource_ldap_secret_backend_dynamic_role.go
+++ b/vault/resource_ldap_secret_backend_dynamic_role.go
@@ -119,12 +119,15 @@ func readLDAPDynamicRoleResource(ctx context.Context, d *schema.ResourceData, me
 	log.Printf("[DEBUG] Reading %q", rolePath)
 
 	resp, err := client.Logical().ReadWithContext(ctx, rolePath)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	if resp == nil {
 		log.Printf("[WARN] %q not found, removing from state", rolePath)
 		d.SetId("")
 		return nil
 	}
-
 	for _, field := range ldapSecretBackendDynamicRoleFields {
 		if val, ok := resp.Data[field]; ok {
 			if err := d.Set(field, val); err != nil {

--- a/vault/resource_ldap_secret_backend_library_set.go
+++ b/vault/resource_ldap_secret_backend_library_set.go
@@ -114,12 +114,15 @@ func readLDAPLibrarySetResource(ctx context.Context, d *schema.ResourceData, met
 	log.Printf("[DEBUG] Reading %q", libraryPath)
 
 	resp, err := client.Logical().ReadWithContext(ctx, libraryPath)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	if resp == nil {
 		log.Printf("[WARN] %q not found, removing from state", libraryPath)
 		d.SetId("")
 		return nil
 	}
-
 	for _, field := range ldapSecretBackendLibrarySetFields {
 		if val, ok := resp.Data[field]; ok {
 			if err := d.Set(field, val); err != nil {

--- a/vault/resource_ldap_secret_backend_static_role.go
+++ b/vault/resource_ldap_secret_backend_static_role.go
@@ -113,12 +113,15 @@ func readLDAPStaticRoleResource(ctx context.Context, d *schema.ResourceData, met
 	log.Printf("[DEBUG] Reading %q", rolePath)
 
 	resp, err := client.Logical().ReadWithContext(ctx, rolePath)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	if resp == nil {
 		log.Printf("[WARN] %q not found, removing from state", rolePath)
 		d.SetId("")
 		return nil
 	}
-
 	for _, field := range ldapSecretBackendStaticRoleFields {
 		if field == consts.FieldSkipImportRotation && !provider.IsAPISupported(meta, provider.VaultVersion116) {
 			continue


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
We are swallowing errors which results in incorrect and confusing behavior when Vault returns an error on Read.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #2155 


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions




