### PR TITLE
Fix PKI Issuer overwrites on updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ BUGS:
 * Handle graceful destruction of resources when approle is deleted out-of-band ([#2142](https://github.com/hashicorp/terraform-provider-vault/pull/2142)).
 * Ensure errors are returned on read operations for `vault_ldap_secret_backend_static_role`, `vault_ldap_secret_backend_library_set`, and `vault_ldap_secret_backend_static_role` ([#2156](https://github.com/hashicorp/terraform-provider-vault/pull/2156)).
 * Ensure proper use of issuer endpoints for root sign intermediate resource: ([#2160](https://github.com/hashicorp/terraform-provider-vault/pull/2160))
+* Fix issuer data overwrites on updates: ([#2186](https://github.com/hashicorp/terraform-provider-vault/pull/2186))
 
 FEATURES:
 * Add support for PKI Secrets Engine cluster configuration with the `vault_pki_secret_backend_config_cluster` resource. Requires Vault 1.13+ ([#1949](https://github.com/hashicorp/terraform-provider-vault/pull/1949)).

--- a/vault/resource_pki_secret_backend_issuer.go
+++ b/vault/resource_pki_secret_backend_issuer.go
@@ -175,9 +175,16 @@ func pkiSecretBackendIssuerUpdate(ctx context.Context, d *schema.ResourceData, m
 
 	// only write to Vault if a patch is required
 	if patchRequired {
-		_, err := client.Logical().WriteWithContext(ctx, path, data)
-		if err != nil {
-			return diag.Errorf("error writing data to %q, err=%s", path, err)
+		if d.IsNewResource() {
+			_, err := client.Logical().WriteWithContext(ctx, path, data)
+			if err != nil {
+				return diag.Errorf("error writing issuer data to %q, err=%s", path, err)
+			}
+		} else {
+			_, err := client.Logical().JSONMergePatch(ctx, path, data)
+			if err != nil {
+				return diag.Errorf("error updating issuer data at %q, err=%s", path, err)
+			}
 		}
 	}
 

--- a/vault/resource_pki_secret_backend_issuer_test.go
+++ b/vault/resource_pki_secret_backend_issuer_test.go
@@ -5,6 +5,7 @@ package vault
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -51,6 +52,13 @@ func TestAccPKISecretBackendIssuer_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, consts.FieldIssuerRef),
 					resource.TestCheckResourceAttrSet(resourceName, consts.FieldIssuerID),
 				),
+			},
+			// confirm error case when updating issuer by sending invalid option
+			{
+				Config: testAccPKISecretBackendIssuer_basic(backend,
+					fmt.Sprintf(`issuer_name = "%s"
+										leaf_not_after_behavior = "invalid"`, issuerName)),
+				ExpectError: regexp.MustCompile("error updating issuer data"),
 			},
 			// ensure JSON merge patch functions as expected. No overwrites
 			{

--- a/vault/resource_pki_secret_backend_issuer_test.go
+++ b/vault/resource_pki_secret_backend_issuer_test.go
@@ -43,12 +43,11 @@ func TestAccPKISecretBackendIssuer_basic(t *testing.T) {
 			},
 			{
 				Config: testAccPKISecretBackendIssuer_basic(backend,
-					fmt.Sprintf(`issuer_name = "%s"
-										leaf_not_after_behavior = "truncate"`, issuerName)),
+					fmt.Sprintf(`issuer_name = "%s"`, issuerName)),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, consts.FieldBackend, backend),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldIssuerName, issuerName),
-					resource.TestCheckResourceAttr(resourceName, consts.FieldLeafNotAfterBehavior, "truncate"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldLeafNotAfterBehavior, "err"),
 					resource.TestCheckResourceAttrSet(resourceName, consts.FieldIssuerRef),
 					resource.TestCheckResourceAttrSet(resourceName, consts.FieldIssuerID),
 				),
@@ -64,14 +63,11 @@ func TestAccPKISecretBackendIssuer_basic(t *testing.T) {
 			{
 				Config: testAccPKISecretBackendIssuer_basic(backend,
 					fmt.Sprintf(`issuer_name = "%s"
-										leaf_not_after_behavior = "truncate"
-										crl_distribution_points = ["http://example.com/crl.crl"]`, issuerName)),
+										leaf_not_after_behavior = "truncate"`, issuerName)),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, consts.FieldBackend, backend),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldIssuerName, issuerName),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldLeafNotAfterBehavior, "truncate"),
-					resource.TestCheckResourceAttr(resourceName, fmt.Sprintf("%s.#", consts.FieldCRLDistributionPoints), "1"),
-					resource.TestCheckResourceAttr(resourceName, fmt.Sprintf("%s.0", consts.FieldCRLDistributionPoints), "http://example.com/crl.crl"),
 					resource.TestCheckResourceAttrSet(resourceName, consts.FieldIssuerRef),
 					resource.TestCheckResourceAttrSet(resourceName, consts.FieldIssuerID),
 				),

--- a/vault/resource_pki_secret_backend_issuer_test.go
+++ b/vault/resource_pki_secret_backend_issuer_test.go
@@ -52,6 +52,22 @@ func TestAccPKISecretBackendIssuer_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, consts.FieldIssuerID),
 				),
 			},
+			// ensure JSON merge patch functions as expected. No overwrites
+			{
+				Config: testAccPKISecretBackendIssuer_basic(backend,
+					fmt.Sprintf(`issuer_name = "%s"
+										leaf_not_after_behavior = "truncate"
+										crl_distribution_points = ["http://example.com/crl.crl"]`, issuerName)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldBackend, backend),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldIssuerName, issuerName),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldLeafNotAfterBehavior, "truncate"),
+					resource.TestCheckResourceAttr(resourceName, fmt.Sprintf("%s.#", consts.FieldCRLDistributionPoints), "1"),
+					resource.TestCheckResourceAttr(resourceName, fmt.Sprintf("%s.0", consts.FieldCRLDistributionPoints), "http://example.com/crl.crl"),
+					resource.TestCheckResourceAttrSet(resourceName, consts.FieldIssuerRef),
+					resource.TestCheckResourceAttrSet(resourceName, consts.FieldIssuerID),
+				),
+			},
 			// ignore changes in 'usage' field since it can be returned in any order
 			// example, error in attribute equivalence in following
 			// Import returns "crl-signing,read-only,issuing-certificates"


### PR DESCRIPTION
### Description
Previously, the resource was not employing a JSON Merge Patch when making update requests to the Vault server. This was causing all data to be overwritten for the issuer. This fix follows the Vault documentation and makes a `PATCH` request to the issuer API when sending update info. [Vault docs](https://developer.hashicorp.com/vault/api-docs/secret/pki#update-issuer)


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #1990 #2061 


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccPKISecretBackendIssuer_basic'
=== RUN   TestAccPKISecretBackendIssuer_basic
    resource_pki_secret_backend_issuer_test.go:29: Vault server version "1.17.0-beta1+ent"
--- PASS: TestAccPKISecretBackendIssuer_basic (3.82s)
PASS
```