### PR TITLE
Azure Creds: Honors the documented default behavior (again)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+BUGS:
+* fix `vault_azure_access_credentials` to default to Azure Public Cloud ([#2190](https://github.com/hashicorp/terraform-provider-vault/pull/2190))
+
 ## 4.0.0 (Mar 13, 2024)
 
 **Important**: This release requires read policies to be set at the path level for mount metadata.

--- a/vault/data_source_azure_access_credentials.go
+++ b/vault/data_source_azure_access_credentials.go
@@ -125,7 +125,7 @@ func azureAccessCredentialsDataSource() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Description: `The Azure environment to use during credential validation.
-Defaults to the environment configured in the Vault backend.
+Defaults to the Azure Public Cloud.
 Some possible values: AzurePublicCloud, AzureUSGovernmentCloud`,
 			},
 		},
@@ -313,6 +313,9 @@ func azureAccessCredentialsDataSourceRead(ctx context.Context, d *schema.Resourc
 }
 
 func getAzureCloudConfigFromName(name string) (cloud.Configuration, error) {
+	if name == "" {
+		return cloud.AzurePublic, nil
+	}
 	if c, ok := azureCloudConfigMap[strings.ToUpper(name)]; !ok {
 		return c, fmt.Errorf("unsupported Azure cloud name %q", name)
 	} else {

--- a/vault/data_source_azure_access_credentials_test.go
+++ b/vault/data_source_azure_access_credentials_test.go
@@ -173,6 +173,12 @@ func Test_getAzureCloudConfigFromName(t *testing.T) {
 			cloudName: "unknown",
 			wantErr:   true,
 		},
+		{
+			name:      "empty",
+			cloudName: "",
+			want:      cloud.AzurePublic,
+			wantErr:   false,
+		},
 	}
 	for k, v := range azureCloudConfigMap {
 		tests = append(tests, test{


### PR DESCRIPTION
If no environment is specified, will show up as an empty string and (currently) throw an error that "" is an unknown cloud provider. After this change it allows the `environment` attribute on the datasource to be optional again.

Ideally this would fetch the value from Vault, but for most cases we may want the default to be Azure Public Cloud, which is the default on the Vault backend if nothing is specified.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
Documented behavior of the azure credentials data source is that `environment` is optional. In reality, not providing it (only in v4.0.0) results in an error message saying "" is an unknown cloud provider.


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2189


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccDataSourceAzureAccessCredentials'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -run=TestAccDataSourceAzureAccessCredentials -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
ok      github.com/hashicorp/terraform-provider-vault/codegen   0.319s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/mfa     [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/pki      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/sync     [no test files]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
?       github.com/hashicorp/terraform-provider-vault/util/mountutil    [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/provider (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/testutil  (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/vault     0.654s
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

