### PR TITLE
docs: fix upgrade guide and add add policy guide

### DIFF
--- a/website/docs/d/ad_access_credentials.html.md
+++ b/website/docs/d/ad_access_credentials.html.md
@@ -53,7 +53,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace of the target resource.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `backend` - (Required) The path to the AD secret backend to

--- a/website/docs/d/auth_backend.html.md
+++ b/website/docs/d/auth_backend.html.md
@@ -22,7 +22,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace of the target resource.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `path` - (Required) The auth backend mount point.

--- a/website/docs/d/auth_backends.html.md
+++ b/website/docs/d/auth_backends.html.md
@@ -25,7 +25,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace of the target resource.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `type` - (Optional) The name of the auth method type. Allows filtering of backends returned by type.

--- a/website/docs/d/aws_access_credentials.html.md
+++ b/website/docs/d/aws_access_credentials.html.md
@@ -68,7 +68,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace of the target resource.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `backend` - (Required) The path to the AWS secret backend to

--- a/website/docs/d/aws_static_credentials.md
+++ b/website/docs/d/aws_static_credentials.md
@@ -58,7 +58,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `backend` - (Required) The path to the AWS secret backend to

--- a/website/docs/d/azure_access_credentials.html.md
+++ b/website/docs/d/azure_access_credentials.html.md
@@ -66,7 +66,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace of the target resource.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `backend` - (Required) The path to the Azure secret backend to

--- a/website/docs/d/generic_secret.html.md
+++ b/website/docs/d/generic_secret.html.md
@@ -66,7 +66,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace of the target resource.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `path` - (Required) The full logical path from which to request data.

--- a/website/docs/d/identity_entity.html.md
+++ b/website/docs/d/identity_entity.html.md
@@ -32,7 +32,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace of the target resource.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `entity_name` - (Optional) Name of the entity.

--- a/website/docs/d/identity_group.html.md
+++ b/website/docs/d/identity_group.html.md
@@ -32,7 +32,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace of the target resource.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `group_name` - (Optional) Name of the group.

--- a/website/docs/d/identity_oidc_client_creds.html.md
+++ b/website/docs/d/identity_oidc_client_creds.html.md
@@ -43,7 +43,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace of the target resource.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `name` - (Required) The name of the OIDC Client in Vault.

--- a/website/docs/d/identity_oidc_openid_config.html.md
+++ b/website/docs/d/identity_oidc_openid_config.html.md
@@ -58,7 +58,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace of the target resource.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `name` - (Required) The name of the OIDC Provider in Vault.

--- a/website/docs/d/identity_oidc_public_keys.html.md
+++ b/website/docs/d/identity_oidc_public_keys.html.md
@@ -58,7 +58,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace of the target resource.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `name` - (Required) The name of the OIDC Provider in Vault.

--- a/website/docs/d/kubernetes_credentials.html.md
+++ b/website/docs/d/kubernetes_credentials.html.md
@@ -63,7 +63,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace of the target resource.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `backend` - (Required) The Kubernetes secret backend to generate service account 

--- a/website/docs/d/kv_secret.html.md
+++ b/website/docs/d/kv_secret.html.md
@@ -52,7 +52,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace of the target resource.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `path` - (Required) Full path of the KV-V1 secret.

--- a/website/docs/d/kv_secret_v2.html.md
+++ b/website/docs/d/kv_secret_v2.html.md
@@ -56,7 +56,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace of the target resource.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `mount` - (Required) Path where KV-V2 engine is mounted.

--- a/website/docs/d/kv_secrets_list.html.md
+++ b/website/docs/d/kv_secrets_list.html.md
@@ -61,7 +61,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace of the target resource.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `path` - (Required) Full KV-V1 path where secrets will be listed.

--- a/website/docs/d/kv_secrets_list_v2.html.md
+++ b/website/docs/d/kv_secrets_list_v2.html.md
@@ -79,7 +79,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace of the target resource.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `mount` - (Required) Path where KV-V2 engine is mounted.

--- a/website/docs/d/kv_subkeys_v2.html.md
+++ b/website/docs/d/kv_subkeys_v2.html.md
@@ -55,7 +55,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace of the target resource.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `mount` - (Required) Path where KV-V2 engine is mounted.

--- a/website/docs/d/ldap_dynamic_role_credentials.html.md
+++ b/website/docs/d/ldap_dynamic_role_credentials.html.md
@@ -63,7 +63,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace of the target resource.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `mount` - (Required) The path to the LDAP secret backend to

--- a/website/docs/d/ldap_static_role_credentials.html.md
+++ b/website/docs/d/ldap_static_role_credentials.html.md
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace of the target resource.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `mount` - (Required) The path to the LDAP secret backend to

--- a/website/docs/d/nomad_access_token.html.md
+++ b/website/docs/d/nomad_access_token.html.md
@@ -50,7 +50,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace of the target resource.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `backend` - (Required) The path to the Nomad secret backend to

--- a/website/docs/d/pki_secret_backend_issuer.html.md
+++ b/website/docs/d/pki_secret_backend_issuer.html.md
@@ -47,7 +47,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace of the target resource.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `backend` - (Required) The path to the PKI secret backend to

--- a/website/docs/d/pki_secret_backend_issuers.html.md
+++ b/website/docs/d/pki_secret_backend_issuers.html.md
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace of the target resource.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `backend` - (Required) The path to the PKI secret backend to

--- a/website/docs/d/pki_secret_backend_key.html.md
+++ b/website/docs/d/pki_secret_backend_key.html.md
@@ -47,7 +47,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace of the target resource.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `backend` - (Required) The path to the PKI secret backend to

--- a/website/docs/d/pki_secret_backend_keys.html.md
+++ b/website/docs/d/pki_secret_backend_keys.html.md
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace of the target resource.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `backend` - (Required) The path to the PKI secret backend to

--- a/website/docs/d/raft_autopilot_state.html.md
+++ b/website/docs/d/raft_autopilot_state.html.md
@@ -30,7 +30,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace of the target resource.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 ## Attributes Reference

--- a/website/docs/d/transform_decode.html.md
+++ b/website/docs/d/transform_decode.html.md
@@ -45,7 +45,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace of the target resource.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `path` - (Required) Path to where the back-end is mounted within Vault.

--- a/website/docs/d/transform_encode.html.md
+++ b/website/docs/d/transform_encode.html.md
@@ -45,7 +45,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace of the target resource.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `path` - (Required) Path to where the back-end is mounted within Vault.

--- a/website/docs/guides/policies.html.markdown
+++ b/website/docs/guides/policies.html.markdown
@@ -1,0 +1,62 @@
+---
+layout: "vault"
+page_title: "Vault Policies and the Terraform Vault Provider"
+sidebar_current: "docs-vault-policies-and-tfvp"
+description: |-
+  Vault Policies and the Terraform Vault Provider
+
+---
+
+# Vault Policies and the Terraform Vault Provider
+
+Vault uses policies to govern the behavior of clients and instrument Role-Based
+Access Control (RBAC) by specifying access privileges (authorization).
+
+Vault's [root](https://developer.hashicorp.com/vault/docs/concepts/policies#root-policy)
+policy is capable of performing every operation for all paths. Root tokens are
+tokens that have the `root` policy attached to them. Root tokens are useful in
+development but should be carefully guarded in production.
+
+In environments where permissions are least privilege, the Terraform Vault
+Provider should not be given a token that has the root policy assigned to it.
+Instead, the Vault provider should be given a token that limits its actions to only
+the operations that it needs to provision Vault's resources.
+
+For example, the following policy would limit the Vault provider to enabling and
+configuring the Google Cloud secrets engine via the `vault_gcp_secret_backend`
+resource:
+
+```hcl
+# Permit creating a new token that is a child of the one given
+path "auth/token/create"
+{
+  capabilities = ["update"]
+}
+
+# Permit managing the lifecycle of the gcp secrets engine mount
+path "sys/mounts/gcp"
+{
+  capabilities = ["read", "create", "update", "delete", "sudo"]
+}
+
+# Permit reading tune metadata of the gcp secrets engine
+path "sys/mounts/gcp/tune"
+{
+  capabilities = ["read"]
+}
+
+# Permit managing the lifecycle of the gcp secrets engine configuration
+path "gcp/config"
+{
+  capabilities = ["create", "update", "read"]
+}
+```
+
+# Vault Policy Resources
+
+For more details on Vault policies see:
+
+- [Vault Policies Documentation](https://developer.hashicorp.com/vault/docs/concepts/policies)
+- [Vault Policies Tutorial](https://developer.hashicorp.com/vault/tutorials/policies/policies)
+
+

--- a/website/docs/guides/policies.html.markdown
+++ b/website/docs/guides/policies.html.markdown
@@ -22,8 +22,8 @@ Provider should not be given a token that has the root policy assigned to it.
 Instead, the Vault provider should be given a token that limits its actions to only
 the operations that it needs to provision Vault's resources.
 
-For example, the following policy would limit the Vault provider to enabling and
-configuring the Google Cloud secrets engine via the `vault_gcp_secret_backend`
+For example, the following policy would limit the Vault provider to managing
+the lifecycle of the Google Cloud secrets engine via the `vault_gcp_secret_backend`
 resource:
 
 ```hcl

--- a/website/docs/guides/version_4_upgrade.html.markdown
+++ b/website/docs/guides/version_4_upgrade.html.markdown
@@ -80,8 +80,8 @@ when many mounts are enabled in Vault:
 
 ## What Vault server versions are supported in version 4.X?
 
-The Vault provider will be dropping Vault version support for Vault <= v1.10.0.
-This means that only Vault server version 1.11.x and greater will be supported.
+The Vault provider will be dropping Vault version support for Vault <= `1.10.x`.
+This means that only Vault server version `1.11.x` and greater will be supported.
 
 ## What is the impact of these changes?
 

--- a/website/docs/guides/version_4_upgrade.html.markdown
+++ b/website/docs/guides/version_4_upgrade.html.markdown
@@ -54,23 +54,29 @@ The following is the list of resources that should see performance improvements
 when many mounts are enabled in Vault:
 
 #### Data sources
-- `vault_auth_backend`
+* `vault_auth_backend`
 
 #### Resources
-- `vault_auth_backend`
-- `vault_aws_secret_backend`
-- `vault_azure_secret_backend`
-- `vault_consul_secret_backend`
-- `vault_gcp_auth_backend`
-- `vault_gcp_secret_backend`
-- `vault_github_auth_backend`
-- `vault_jwt_auth_backend`
-- `vault_ldap_auth_backend`
-- `vault_mount`
-- `vault_okta_auth_backend`
-- `vault_pki_secret_backend_cert`
-- `vault_rabbitmq_secret_backend`
-- `vault_terraform_cloud_secret_backend`
+* `vault_auth_backend`
+* `vault_aws_secret_backend`
+* `vault_azure_secret_backend`
+* `vault_consul_secret_backend`
+* `vault_database_secrets_mount`
+* `vault_gcp_auth_backend`
+* `vault_gcp_secret_backend`
+* `vault_github_auth_backend`
+* `vault_jwt_auth_backend`
+* `vault_kubernetes_secret_backend`
+* `vault_ldap_auth_backend`
+* `vault_ldap_secret_backend`
+* `vault_mount`
+* `vault_okta_auth_backend`
+* `vault_pki_secret_backend_cert`
+* `vault_pki_secret_backend_intermediate_set_signed`
+* `vault_pki_secret_backend_root_cert`
+* `vault_pki_secret_backend_sign`
+* `vault_rabbitmq_secret_backend`
+* `vault_terraform_cloud_secret_backend`
 
 ## What Vault server versions are supported in version 4.X?
 
@@ -257,14 +263,20 @@ The below table specifies what changed between version 3.X and 4.X for the
 following resources:
 
 #### Resources
-  - `vault_aws_secret_backend`
-  - `vault_azure_secret_backend`
-  - `vault_consul_secret_backend`
-  - `vault_gcp_secret_backend`
-  - `vault_mount`
-  - `vault_pki_secret_backend_cert`
-  - `vault_rabbitmq_secret_backend`
-  - `vault_terraform_cloud_secret_backend`
+- `vault_aws_secret_backend`
+- `vault_azure_secret_backend`
+- `vault_consul_secret_backend`
+- `vault_database_secrets_mount`
+- `vault_gcp_secret_backend`
+- `vault_kubernetes_secret_backend`
+- `vault_ldap_secret_backend`
+- `vault_mount`
+- `vault_pki_secret_backend_cert`
+- `vault_pki_secret_backend_intermediate_set_signed`
+- `vault_pki_secret_backend_root_cert`
+- `vault_pki_secret_backend_sign`
+- `vault_rabbitmq_secret_backend`
+- `vault_terraform_cloud_secret_backend`
 
 -> Note that the table below does not include any additional policies the
 individual resources might require.

--- a/website/docs/guides/version_4_upgrade.html.markdown
+++ b/website/docs/guides/version_4_upgrade.html.markdown
@@ -54,29 +54,29 @@ The following is the list of resources that should see performance improvements
 when many mounts are enabled in Vault:
 
 #### Data sources
-* `vault_auth_backend`
+- `vault_auth_backend`
 
 #### Resources
-* `vault_auth_backend`
-* `vault_aws_secret_backend`
-* `vault_azure_secret_backend`
-* `vault_consul_secret_backend`
-* `vault_database_secrets_mount`
-* `vault_gcp_auth_backend`
-* `vault_gcp_secret_backend`
-* `vault_github_auth_backend`
-* `vault_jwt_auth_backend`
-* `vault_kubernetes_secret_backend`
-* `vault_ldap_auth_backend`
-* `vault_ldap_secret_backend`
-* `vault_mount`
-* `vault_okta_auth_backend`
-* `vault_pki_secret_backend_cert`
-* `vault_pki_secret_backend_intermediate_set_signed`
-* `vault_pki_secret_backend_root_cert`
-* `vault_pki_secret_backend_sign`
-* `vault_rabbitmq_secret_backend`
-* `vault_terraform_cloud_secret_backend`
+- `vault_auth_backend`
+- `vault_aws_secret_backend`
+- `vault_azure_secret_backend`
+- `vault_consul_secret_backend`
+- `vault_database_secrets_mount`
+- `vault_gcp_auth_backend`
+- `vault_gcp_secret_backend`
+- `vault_github_auth_backend`
+- `vault_jwt_auth_backend`
+- `vault_kubernetes_secret_backend`
+- `vault_ldap_auth_backend`
+- `vault_ldap_secret_backend`
+- `vault_mount`
+- `vault_okta_auth_backend`
+- `vault_pki_secret_backend_cert`
+- `vault_pki_secret_backend_intermediate_set_signed`
+- `vault_pki_secret_backend_root_cert`
+- `vault_pki_secret_backend_sign`
+- `vault_rabbitmq_secret_backend`
+- `vault_terraform_cloud_secret_backend`
 
 ## What Vault server versions are supported in version 4.X?
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -48,10 +48,8 @@ on each resource's documentation page about how any secrets are persisted
 to the state and consider carefully whether such usage is compatible with
 their security policies.
 
-Except as otherwise noted, the resources that write secrets into Vault are
-designed such that they require only the *create* and *update* capabilities
-on the relevant resources, so that distinct tokens can be used for reading
-vs. writing and thus limit the exposure of a compromised token.
+Please see the [Vault Policies and the Terraform Vault Provider](/docs/providers/vault/guides/policies.html)
+guide for details on token capabilites.
 
 ## Using Vault credentials in Terraform configuration
 

--- a/website/docs/r/ad_secret_backend.html.md
+++ b/website/docs/r/ad_secret_backend.html.md
@@ -40,7 +40,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `backend` - (Optional) The unique path this backend should be mounted at. Must

--- a/website/docs/r/ad_secret_backend_library.html.md
+++ b/website/docs/r/ad_secret_backend_library.html.md
@@ -50,7 +50,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `backend` - (Required) The path the AD secret backend is mounted at,

--- a/website/docs/r/ad_secret_role.html.md
+++ b/website/docs/r/ad_secret_role.html.md
@@ -47,7 +47,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `backend` - (Required) The path the AD secret backend is mounted at,

--- a/website/docs/r/approle_auth_backend_login.html.md
+++ b/website/docs/r/approle_auth_backend_login.html.md
@@ -43,7 +43,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `role_id` - (Required) The ID of the role to log in with.

--- a/website/docs/r/approle_auth_backend_role.html.md
+++ b/website/docs/r/approle_auth_backend_role.html.md
@@ -32,7 +32,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `role_name` - (Required) The name of the role.

--- a/website/docs/r/approle_auth_backend_role_secret_id.html.md
+++ b/website/docs/r/approle_auth_backend_role_secret_id.html.md
@@ -43,7 +43,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `role_name` - (Required) The name of the role to create the SecretID for.

--- a/website/docs/r/audit.html.md
+++ b/website/docs/r/audit.html.md
@@ -42,7 +42,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `type` - (Required) Type of the audit device, such as 'file'.

--- a/website/docs/r/auth_backend.html.md
+++ b/website/docs/r/auth_backend.html.md
@@ -29,7 +29,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `type` - (Required) The name of the auth method type.

--- a/website/docs/r/aws_auth_backend_cert.html.md
+++ b/website/docs/r/aws_auth_backend_cert.html.md
@@ -44,7 +44,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `cert_name` - (Required) The name of the certificate.

--- a/website/docs/r/aws_auth_backend_client.html.md
+++ b/website/docs/r/aws_auth_backend_client.html.md
@@ -44,7 +44,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `backend` - (Optional) The path the AWS auth backend being configured was

--- a/website/docs/r/aws_auth_backend_config_identity.html.md
+++ b/website/docs/r/aws_auth_backend_config_identity.html.md
@@ -32,7 +32,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `iam_alias` - (Optional) How to generate the identity alias when using the iam auth method. Valid choices are

--- a/website/docs/r/aws_auth_backend_identity_whitelist.html.md
+++ b/website/docs/r/aws_auth_backend_identity_whitelist.html.md
@@ -32,7 +32,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `backend` - (Optional) The path of the AWS backend being configured.

--- a/website/docs/r/aws_auth_backend_login.html.md
+++ b/website/docs/r/aws_auth_backend_login.html.md
@@ -57,7 +57,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `backend` - (Optional) The unique name of the AWS auth backend. Defaults to

--- a/website/docs/r/aws_auth_backend_role.html.md
+++ b/website/docs/r/aws_auth_backend_role.html.md
@@ -45,7 +45,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `role` - (Required) The name of the role.

--- a/website/docs/r/aws_auth_backend_role_tag.html.md
+++ b/website/docs/r/aws_auth_backend_role_tag.html.md
@@ -42,7 +42,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `role` - (Required) The name of the AWS auth backend role to read

--- a/website/docs/r/aws_auth_backend_roletag_blacklist.html.md
+++ b/website/docs/r/aws_auth_backend_roletag_blacklist.html.md
@@ -29,7 +29,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `backend` - (Required) The path the AWS auth backend being configured was

--- a/website/docs/r/aws_auth_backend_sts_role.html.md
+++ b/website/docs/r/aws_auth_backend_sts_role.html.md
@@ -40,7 +40,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `account_id` - (Optional) The AWS account ID to configure the STS role for.

--- a/website/docs/r/aws_secret_backend.html.md
+++ b/website/docs/r/aws_secret_backend.html.md
@@ -41,7 +41,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `access_key` - (Optional) The AWS Access Key ID this backend should use to

--- a/website/docs/r/aws_secret_backend_role.html.md
+++ b/website/docs/r/aws_secret_backend_role.html.md
@@ -52,7 +52,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `backend` - (Required) The path the AWS secret backend is mounted at,

--- a/website/docs/r/aws_secret_backend_static_role.md
+++ b/website/docs/r/aws_secret_backend_static_role.md
@@ -40,7 +40,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `backend` - (Optional) The unique path this backend should be mounted at. Must

--- a/website/docs/r/azure_auth_backend_config.html.md
+++ b/website/docs/r/azure_auth_backend_config.html.md
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `tenant_id` - (Required) The tenant id for the Azure Active Directory

--- a/website/docs/r/azure_auth_backend_role.html.md
+++ b/website/docs/r/azure_auth_backend_role.html.md
@@ -38,7 +38,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `role` - (Required) The name of the role.

--- a/website/docs/r/azure_secret_backend.html.md
+++ b/website/docs/r/azure_secret_backend.html.md
@@ -55,7 +55,7 @@ The following arguments are supported:
 
 - `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 - `subscription_id` (`string: <required>`) - The subscription id for the Azure Active Directory.

--- a/website/docs/r/azure_secret_backend_role.html.md
+++ b/website/docs/r/azure_secret_backend_role.html.md
@@ -58,7 +58,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `role` - (Required) Name of the Azure role

--- a/website/docs/r/cert_auth_backend_role.html.md
+++ b/website/docs/r/cert_auth_backend_role.html.md
@@ -35,7 +35,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `backend` - (Optional string: "cert") Path to the mounted Cert auth backend

--- a/website/docs/r/consul_secret_backend.html.md
+++ b/website/docs/r/consul_secret_backend.html.md
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `token` - (Optional) The Consul management token this backend should use to issue new tokens. This field is required

--- a/website/docs/r/consul_secret_backend_role.html.md
+++ b/website/docs/r/consul_secret_backend_role.html.md
@@ -37,7 +37,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `backend` - (Optional) The unique name of an existing Consul secrets backend mount. Must not begin or end with a `/`. One of `path` or `backend` is required.

--- a/website/docs/r/egp_policy.html.md
+++ b/website/docs/r/egp_policy.html.md
@@ -35,7 +35,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `name` - (Required) The name of the policy

--- a/website/docs/r/gcp_auth_backend.html.md
+++ b/website/docs/r/gcp_auth_backend.html.md
@@ -31,7 +31,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `credentials` - A JSON string containing the contents of a GCP credentials file. If this value is empty, Vault will try to use Application Default Credentials from the machine on which the Vault server is running.

--- a/website/docs/r/gcp_auth_backend_role.html.md
+++ b/website/docs/r/gcp_auth_backend_role.html.md
@@ -37,7 +37,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `role` - (Required) Name of the GCP role

--- a/website/docs/r/gcp_secret_backend.html.md
+++ b/website/docs/r/gcp_secret_backend.html.md
@@ -32,7 +32,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `credentials` - (Optional) The GCP service account credentials in JSON format.

--- a/website/docs/r/gcp_secret_roleset.html.md
+++ b/website/docs/r/gcp_secret_roleset.html.md
@@ -47,7 +47,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `backend` - (Required, Forces new resource) Path where the GCP Secrets Engine is mounted

--- a/website/docs/r/gcp_secret_static_account.html.md
+++ b/website/docs/r/gcp_secret_static_account.html.md
@@ -50,7 +50,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `backend` - (Required, Forces new resource) Path where the GCP Secrets Engine is mounted

--- a/website/docs/r/generic_endpoint.html.md
+++ b/website/docs/r/generic_endpoint.html.md
@@ -87,7 +87,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `path` - (Required) The full logical path at which to write the given

--- a/website/docs/r/generic_secret.html.md
+++ b/website/docs/r/generic_secret.html.md
@@ -47,7 +47,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `path` - (Required) The full logical path at which to write the given data.

--- a/website/docs/r/github_auth_backend.html.md
+++ b/website/docs/r/github_auth_backend.html.md
@@ -26,7 +26,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `path` - (Optional) Path where the auth backend is mounted. Defaults to `auth/github`

--- a/website/docs/r/github_team.html.md
+++ b/website/docs/r/github_team.html.md
@@ -32,7 +32,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `backend` - (Required) Path where the github auth backend is mounted. Defaults to `github`

--- a/website/docs/r/github_user.html.md
+++ b/website/docs/r/github_user.html.md
@@ -32,7 +32,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `backend` - (Required) Path where the github auth backend is mounted. Defaults to `github`

--- a/website/docs/r/identity_entity.html.md
+++ b/website/docs/r/identity_entity.html.md
@@ -35,7 +35,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `name` - (Required) Name of the identity entity to create.

--- a/website/docs/r/identity_entity_alias.html.md
+++ b/website/docs/r/identity_entity_alias.html.md
@@ -33,7 +33,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `name` - (Required) Name of the alias. Name should be the identifier of the client in the authentication source. For example, if the alias belongs to userpass backend, the name should be a valid username within userpass backend. If alias belongs to GitHub, it should be the GitHub username.

--- a/website/docs/r/identity_entity_policies.html.md
+++ b/website/docs/r/identity_entity_policies.html.md
@@ -68,7 +68,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `policies` - (Required) List of policies to assign to the entity

--- a/website/docs/r/identity_group.html.md
+++ b/website/docs/r/identity_group.html.md
@@ -79,7 +79,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `name` - (Required, Forces new resource) Name of the identity group to create.

--- a/website/docs/r/identity_group_alias.html.md
+++ b/website/docs/r/identity_group_alias.html.md
@@ -39,7 +39,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `name` - (Required, Forces new resource) Name of the group alias to create.

--- a/website/docs/r/identity_group_member_entity_ids.html.md
+++ b/website/docs/r/identity_group_member_entity_ids.html.md
@@ -86,7 +86,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `member_entity_ids` - (Required) List of member entities that belong to the group

--- a/website/docs/r/identity_group_member_group_ids.html.md
+++ b/website/docs/r/identity_group_member_group_ids.html.md
@@ -76,7 +76,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `member_group_ids` - (Required) List of member groups that belong to the group

--- a/website/docs/r/identity_group_policies.html.md
+++ b/website/docs/r/identity_group_policies.html.md
@@ -80,7 +80,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `policies` - (Required) List of policies to assign to the group

--- a/website/docs/r/identity_oidc.html.md
+++ b/website/docs/r/identity_oidc.html.md
@@ -29,7 +29,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `issuer` - (Optional) Issuer URL to be used in the iss claim of the token. If not set, Vault's

--- a/website/docs/r/identity_oidc_assignment.html.md
+++ b/website/docs/r/identity_oidc_assignment.html.md
@@ -42,7 +42,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `name` - (Required) The name of the assignment.

--- a/website/docs/r/identity_oidc_client.html.md
+++ b/website/docs/r/identity_oidc_client.html.md
@@ -42,7 +42,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `name` - (Required) The name of the client.

--- a/website/docs/r/identity_oidc_key.html.md
+++ b/website/docs/r/identity_oidc_key.html.md
@@ -51,7 +51,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `name` - (Required; Forces new resource) Name of the OIDC Key to create.

--- a/website/docs/r/identity_oidc_key_allowed_client_id.html.md
+++ b/website/docs/r/identity_oidc_key_allowed_client_id.html.md
@@ -50,7 +50,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `key_name` - (Required; Forces new resource) Name of the OIDC Key allow the Client ID.

--- a/website/docs/r/identity_oidc_provider.html.md
+++ b/website/docs/r/identity_oidc_provider.html.md
@@ -71,7 +71,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `name` - (Required) The name of the provider.

--- a/website/docs/r/identity_oidc_role.html.md
+++ b/website/docs/r/identity_oidc_role.html.md
@@ -80,7 +80,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `name` - (Required; Forces new resource) Name of the OIDC Role to create.

--- a/website/docs/r/identity_oidc_scope.html.md
+++ b/website/docs/r/identity_oidc_scope.html.md
@@ -27,7 +27,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `name` - (Required) The name of the scope. The `openid` scope name is reserved.

--- a/website/docs/r/jwt_auth_backend.html.md
+++ b/website/docs/r/jwt_auth_backend.html.md
@@ -65,7 +65,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `path` - (Required) Path to mount the JWT/OIDC auth backend

--- a/website/docs/r/jwt_auth_backend_role.html.md
+++ b/website/docs/r/jwt_auth_backend_role.html.md
@@ -60,7 +60,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `role_name` - (Required) The name of the role.

--- a/website/docs/r/kmip_secret_backend.html.md
+++ b/website/docs/r/kmip_secret_backend.html.md
@@ -33,7 +33,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `path` - (Required) The unique path this backend should be mounted at. Must

--- a/website/docs/r/kmip_secret_role.html.md
+++ b/website/docs/r/kmip_secret_role.html.md
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `path` - (Required) The unique path this backend should be mounted at. Must

--- a/website/docs/r/kmip_secret_scope.html.md
+++ b/website/docs/r/kmip_secret_scope.html.md
@@ -33,7 +33,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `path` - (Required) The unique path this backend should be mounted at. Must

--- a/website/docs/r/kubernetes_auth_backend_role.html.md
+++ b/website/docs/r/kubernetes_auth_backend_role.html.md
@@ -36,7 +36,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `role_name` - (Required) Name of the role.

--- a/website/docs/r/kubernetes_secret_backend.html.md
+++ b/website/docs/r/kubernetes_secret_backend.html.md
@@ -43,7 +43,7 @@ Additionally, the following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `kubernetes_host` - (Optional) The Kubernetes API URL to connect to. Required if the 

--- a/website/docs/r/kubernetes_secret_backend_role.html.md
+++ b/website/docs/r/kubernetes_secret_backend_role.html.md
@@ -131,7 +131,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `name` - (Required) The name of the role.

--- a/website/docs/r/kv_secret.html.md
+++ b/website/docs/r/kv_secret.html.md
@@ -40,7 +40,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `path` - (Required) Full path of the KV-V1 secret.

--- a/website/docs/r/kv_secret_backend_v2.html.md
+++ b/website/docs/r/kv_secret_backend_v2.html.md
@@ -39,7 +39,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `mount` - (Required) Path where KV-V2 engine is mounted.

--- a/website/docs/r/kv_secret_v2.html.md
+++ b/website/docs/r/kv_secret_v2.html.md
@@ -50,7 +50,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `mount` - (Required) Path where KV-V2 engine is mounted.

--- a/website/docs/r/ldap_auth_backend.html.md
+++ b/website/docs/r/ldap_auth_backend.html.md
@@ -31,7 +31,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `url` - (Required) The URL of the LDAP server

--- a/website/docs/r/ldap_auth_backend_group.html.md
+++ b/website/docs/r/ldap_auth_backend_group.html.md
@@ -37,7 +37,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `groupname` - (Required) The LDAP groupname

--- a/website/docs/r/ldap_auth_backend_user.html.md
+++ b/website/docs/r/ldap_auth_backend_user.html.md
@@ -37,7 +37,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `username` - (Required) The LDAP username

--- a/website/docs/r/ldap_secret_backend.html.md
+++ b/website/docs/r/ldap_secret_backend.html.md
@@ -37,7 +37,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `path` - (Optional) The unique path this backend should be mounted at. Must

--- a/website/docs/r/ldap_secret_backend_dynamic_role.html.md
+++ b/website/docs/r/ldap_secret_backend_dynamic_role.html.md
@@ -57,7 +57,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `mount` - (Optional) The unique path this backend should be mounted at. Must

--- a/website/docs/r/ldap_secret_backend_library_set.html.md
+++ b/website/docs/r/ldap_secret_backend_library_set.html.md
@@ -47,7 +47,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `path` - (Required) The path the LDAP secret backend is mounted at,

--- a/website/docs/r/ldap_secret_backend_static_role.html.md
+++ b/website/docs/r/ldap_secret_backend_static_role.html.md
@@ -45,7 +45,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `mount` - (Optional) The unique path this backend should be mounted at. Must

--- a/website/docs/r/mfa_duo.html.md
+++ b/website/docs/r/mfa_duo.html.md
@@ -35,7 +35,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 - `name` `(string: <required>)` – Name of the MFA method.

--- a/website/docs/r/mfa_okta.html.md
+++ b/website/docs/r/mfa_okta.html.md
@@ -35,7 +35,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 - `name` `(string: <required>)` – Name of the MFA method.

--- a/website/docs/r/mfa_pingid.html.md
+++ b/website/docs/r/mfa_pingid.html.md
@@ -36,7 +36,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 - `name` `(string: <required>)` – Name of the MFA method.

--- a/website/docs/r/mfa_totp.html.md
+++ b/website/docs/r/mfa_totp.html.md
@@ -31,7 +31,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 - `name` `(string: <required>)` – Name of the MFA method.

--- a/website/docs/r/mongodbatlas_secret_backend.html.md
+++ b/website/docs/r/mongodbatlas_secret_backend.html.md
@@ -39,7 +39,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `mount` - (Required) Path where the MongoDB Atlas Secrets Engine is mounted.

--- a/website/docs/r/mongodbatlas_secret_role.html.md
+++ b/website/docs/r/mongodbatlas_secret_role.html.md
@@ -52,7 +52,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `mount` - (Required) Path where the MongoDB Atlas Secrets Engine is mounted.

--- a/website/docs/r/mount.html.md
+++ b/website/docs/r/mount.html.md
@@ -61,7 +61,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `path` - (Required) Where the secret backend will be mounted

--- a/website/docs/r/namespace.html.md
+++ b/website/docs/r/namespace.html.md
@@ -74,7 +74,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `path` - (Required) The path of the namespace. Must not have a trailing `/`.

--- a/website/docs/r/nomad_secret_backend.html.md
+++ b/website/docs/r/nomad_secret_backend.html.md
@@ -39,7 +39,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `backend` - (Optional) The unique path this backend should be mounted at. Must

--- a/website/docs/r/nomad_secret_role.html.md
+++ b/website/docs/r/nomad_secret_role.html.md
@@ -44,7 +44,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `backend` - (Required) The unique path this backend should be mounted at.

--- a/website/docs/r/okta_auth_backend.html.md
+++ b/website/docs/r/okta_auth_backend.html.md
@@ -37,7 +37,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `path` - (Optional) Path to mount the Okta auth backend. Default to path `okta`.

--- a/website/docs/r/okta_auth_backend_group.html.md
+++ b/website/docs/r/okta_auth_backend_group.html.md
@@ -32,7 +32,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `path` - (Required) The path where the Okta auth backend is mounted

--- a/website/docs/r/okta_auth_backend_user.html.md
+++ b/website/docs/r/okta_auth_backend_user.html.md
@@ -32,7 +32,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `path` - (Required) The path where the Okta auth backend is mounted

--- a/website/docs/r/password_policy.html.md
+++ b/website/docs/r/password_policy.html.md
@@ -33,7 +33,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `name` - (Required) The name of the password policy.

--- a/website/docs/r/pki_secret_backend_cert.html.md
+++ b/website/docs/r/pki_secret_backend_cert.html.md
@@ -36,7 +36,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `backend` - (Required) The PKI secret backend the resource belongs to.

--- a/website/docs/r/pki_secret_backend_config_ca.html.md
+++ b/website/docs/r/pki_secret_backend_config_ca.html.md
@@ -84,7 +84,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `backend` - (Required) The PKI secret backend the resource belongs to.

--- a/website/docs/r/pki_secret_backend_config_cluster.html.md
+++ b/website/docs/r/pki_secret_backend_config_cluster.html.md
@@ -34,7 +34,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `backend` - (Required) The path the PKI secret backend is mounted at, with no leading or trailing `/`s.

--- a/website/docs/r/pki_secret_backend_config_issuers.html.md
+++ b/website/docs/r/pki_secret_backend_config_issuers.html.md
@@ -47,7 +47,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `backend` - (Required) The path the PKI secret backend is mounted at, with no

--- a/website/docs/r/pki_secret_backend_config_urls.html.md
+++ b/website/docs/r/pki_secret_backend_config_urls.html.md
@@ -35,7 +35,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `backend` - (Required) The path the PKI secret backend is mounted at, with no leading or trailing `/`s.

--- a/website/docs/r/pki_secret_backend_crl_config.html.md
+++ b/website/docs/r/pki_secret_backend_crl_config.html.md
@@ -33,7 +33,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `backend` - (Required) The path the PKI secret backend is mounted at, with no leading or trailing `/`s.

--- a/website/docs/r/pki_secret_backend_intermediate_cert_request.html.md
+++ b/website/docs/r/pki_secret_backend_intermediate_cert_request.html.md
@@ -38,7 +38,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `backend` - (Required) The PKI secret backend the resource belongs to.

--- a/website/docs/r/pki_secret_backend_intermediate_set_signed.html.md
+++ b/website/docs/r/pki_secret_backend_intermediate_set_signed.html.md
@@ -88,7 +88,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `backend` - (Required) The PKI secret backend the resource belongs to.

--- a/website/docs/r/pki_secret_backend_issuer.html.md
+++ b/website/docs/r/pki_secret_backend_issuer.html.md
@@ -43,7 +43,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `backend` - (Required) The path the PKI secret backend is mounted at, with no

--- a/website/docs/r/pki_secret_backend_key.html.md
+++ b/website/docs/r/pki_secret_backend_key.html.md
@@ -35,7 +35,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `backend` - (Required) The path the PKI secret backend is mounted at, with no leading or trailing `/`s.

--- a/website/docs/r/pki_secret_backend_role.html.md
+++ b/website/docs/r/pki_secret_backend_role.html.md
@@ -38,7 +38,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `backend` - (Required) The path the PKI secret backend is mounted at, with no leading or trailing `/`s.

--- a/website/docs/r/pki_secret_backend_root_cert.html.md
+++ b/website/docs/r/pki_secret_backend_root_cert.html.md
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `backend` - (Required) The PKI secret backend the resource belongs to.

--- a/website/docs/r/pki_secret_backend_root_sign_intermediate.html.md
+++ b/website/docs/r/pki_secret_backend_root_sign_intermediate.html.md
@@ -30,7 +30,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `backend` - (Required) The PKI secret backend the resource belongs to.

--- a/website/docs/r/pki_secret_backend_sign.html.md
+++ b/website/docs/r/pki_secret_backend_sign.html.md
@@ -63,7 +63,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `backend` - (Required) The PKI secret backend the resource belongs to.

--- a/website/docs/r/policy.html.md
+++ b/website/docs/r/policy.html.md
@@ -29,7 +29,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `name` - (Required) The name of the policy

--- a/website/docs/r/rabbitmq_secret_backend.html.md
+++ b/website/docs/r/rabbitmq_secret_backend.html.md
@@ -34,7 +34,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `connection_uri` - (Required)  Specifies the RabbitMQ connection URI.

--- a/website/docs/r/rabbitmq_secret_backend_role.html.md
+++ b/website/docs/r/rabbitmq_secret_backend_role.html.md
@@ -58,7 +58,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `backend` - (Required) The path the RabbitMQ secret backend is mounted at,

--- a/website/docs/r/raft_autopilot.html.md
+++ b/website/docs/r/raft_autopilot.html.md
@@ -32,7 +32,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 - `cleanup_dead_servers` – (Optional) Specifies whether to remove dead server nodes

--- a/website/docs/r/raft_snapshot_agent_config.html.md
+++ b/website/docs/r/raft_snapshot_agent_config.html.md
@@ -86,7 +86,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 - `name` `<required>` – Name of the configuration to modify.

--- a/website/docs/r/rgp_policy.html.md
+++ b/website/docs/r/rgp_policy.html.md
@@ -33,7 +33,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `name` - (Required) The name of the policy

--- a/website/docs/r/saml_auth_backend.html.md
+++ b/website/docs/r/saml_auth_backend.html.md
@@ -30,7 +30,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `path` - (Optional) Path where the auth backend will be mounted. Defaults to `auth/saml`

--- a/website/docs/r/saml_auth_backend_role.html.md
+++ b/website/docs/r/saml_auth_backend_role.html.md
@@ -42,7 +42,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
   *Available only for Vault Enterprise*.
 
 * `path` - (Required) Path where the auth backend is mounted.

--- a/website/docs/r/secrets_sync_association.html.md
+++ b/website/docs/r/secrets_sync_association.html.md
@@ -64,7 +64,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
 
 * `name` - (Required) Specifies the name of the destination.
 

--- a/website/docs/r/secrets_sync_aws_destination.html.md
+++ b/website/docs/r/secrets_sync_aws_destination.html.md
@@ -44,7 +44,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
 
 * `name` - (Required) Unique name of the AWS destination.
 

--- a/website/docs/r/secrets_sync_azure_destination.html.md
+++ b/website/docs/r/secrets_sync_azure_destination.html.md
@@ -43,7 +43,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
 
 * `name` - (Required) Unique name of the Azure destination.
 

--- a/website/docs/r/secrets_sync_gcp_destination.html.md
+++ b/website/docs/r/secrets_sync_gcp_destination.html.md
@@ -41,7 +41,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
 
 * `name` - (Required) Unique name of the GCP destination.
 

--- a/website/docs/r/secrets_sync_gh_destination.html.md
+++ b/website/docs/r/secrets_sync_gh_destination.html.md
@@ -39,7 +39,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
 
 * `name` - (Required) Unique name of the GitHub destination.
 

--- a/website/docs/r/secrets_sync_github_apps.html.md
+++ b/website/docs/r/secrets_sync_github_apps.html.md
@@ -37,7 +37,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
 
 * `name` - (Required) The user-defined name of the GitHub App configuration.
 

--- a/website/docs/r/secrets_sync_vercel_destination.html.md
+++ b/website/docs/r/secrets_sync_vercel_destination.html.md
@@ -39,7 +39,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
 
 * `name` - (Required) Unique name of the GitHub destination.
 

--- a/website/docs/r/ssh_secret_backend_ca.html.md
+++ b/website/docs/r/ssh_secret_backend_ca.html.md
@@ -29,7 +29,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `backend` - (Optional) The path where the SSH secret backend is mounted. Defaults to 'ssh'

--- a/website/docs/r/ssh_secret_backend_role.html.md
+++ b/website/docs/r/ssh_secret_backend_role.html.md
@@ -41,7 +41,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `name` - (Required) Specifies the name of the role to create.

--- a/website/docs/r/terraform_cloud_secret_creds.html.md
+++ b/website/docs/r/terraform_cloud_secret_creds.html.md
@@ -47,7 +47,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `backend` - (Required) The path to the Terraform Cloud secret backend to

--- a/website/docs/r/terraform_cloud_secret_role.html.md
+++ b/website/docs/r/terraform_cloud_secret_role.html.md
@@ -34,7 +34,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `backend` - (Optional) The unique name of an existing Terraform Cloud secrets backend mount. Must not begin or end with a `/`.

--- a/website/docs/r/token.html.md
+++ b/website/docs/r/token.html.md
@@ -51,7 +51,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `role_name` - (Optional) The token role name

--- a/website/docs/r/token_auth_backend_role.html.md
+++ b/website/docs/r/token_auth_backend_role.html.md
@@ -34,7 +34,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `role_name` - (Required) The name of the role.

--- a/website/docs/r/transform_alphabet.html.md
+++ b/website/docs/r/transform_alphabet.html.md
@@ -33,7 +33,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `path` - (Required) Path to where the back-end is mounted within Vault.

--- a/website/docs/r/transform_role.html.md
+++ b/website/docs/r/transform_role.html.md
@@ -33,7 +33,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `path` - (Required) Path to where the back-end is mounted within Vault.

--- a/website/docs/r/transform_template.html.md
+++ b/website/docs/r/transform_template.html.md
@@ -56,7 +56,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `path` - (Required) Path to where the back-end is mounted within Vault.

--- a/website/docs/r/transform_transformation.html.md
+++ b/website/docs/r/transform_transformation.html.md
@@ -37,7 +37,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `path` - (Required) Path to where the back-end is mounted within Vault.

--- a/website/docs/r/transit_secret_backend_cache_config.html.md
+++ b/website/docs/r/transit_secret_backend_cache_config.html.md
@@ -33,7 +33,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `backend` - (Required) The path the transit secret backend is mounted at, with no leading or trailing `/`s.

--- a/website/docs/r/transit_secret_backend_key.html.md
+++ b/website/docs/r/transit_secret_backend_key.html.md
@@ -33,7 +33,7 @@ The following arguments are supported:
 
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
-  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
    *Available only for Vault Enterprise*.
 
 * `backend` - (Required) The path the transit secret backend is mounted at, with no leading or trailing `/`s.

--- a/website/vault.erb
+++ b/website/vault.erb
@@ -26,6 +26,10 @@
                     <a href="/docs/providers/vault/guides/pki_multi_issuer_upgrade.html">PKI Multi-Issuer Upgrade Guide</a>
                 </li>
 
+                <li<%= sidebar_current("docs-vault-policies-and-tfvp") %>>
+                    <a href="/docs/providers/vault/guides/policies.html">Vault Policies and the Terraform Vault Provider</a>
+                </li>
+
                 <li<%= sidebar_current("docs-vault-datasource") %>>
                 <a href="#">Data Sources</a>
                     <ul class="nav nav-visible">


### PR DESCRIPTION
This PR proposes the following changes:
- add missing resources to the v4.0.0 Upgrade Guide
- add a new guide on Vault Policies
- fix namespace broken links across many resource doc pages