### PR TITLE
secrets/kube: normalize json field

### DIFF
--- a/vault/resource_kubernetes_secret_backend_role.go
+++ b/vault/resource_kubernetes_secret_backend_role.go
@@ -34,6 +34,7 @@ const (
 )
 
 func kubernetesSecretBackendRoleResource() *schema.Resource {
+	name := "vault_kubernetes_secret_backend_role"
 	return &schema.Resource{
 		CreateContext: provider.MountCreateContextWrapper(kubernetesSecretBackendRoleCreateUpdate, provider.VaultVersion111),
 		ReadContext:   provider.ReadContextWrapper(kubernetesSecretBackendRoleRead),
@@ -70,6 +71,11 @@ func kubernetesSecretBackendRoleResource() *schema.Resource {
 			},
 			fieldAllowedKubernetesNamespaceSelector: {
 				Type: schema.TypeString,
+				// We rebuild the attached JSON string to a simple singleline
+				// string. This makes terraform not want to change when an extra
+				// space is included in the JSON string.
+				StateFunc:    NormalizeDataJSONFunc(name),
+				ValidateFunc: ValidateDataJSONFunc(name),
 				Description: "A label selector for Kubernetes namespaces in which credentials can be" +
 					"generated. Accepts either a JSON or YAML object. The value should be of type" +
 					"LabelSelector. If set with `allowed_kubernetes_namespace`, the conditions are `OR`ed.",


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
Follow-up to https://github.com/hashicorp/terraform-provider-vault/pull/2180 to normalize the json field to prevent unwanted drift.

No changelog entry because this is unreleased


### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


