### PR TITLE
approle: handle 404 on state refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Unreleased
 
+FEATURES:
 * Add support for `allowed_kubernetes_namespace_selector` in `vault_kubernetes_secret_backend_role` ([#2180](https://github.com/hashicorp/terraform-provider-vault/pull/2180)).
+
+BUGS:
+* fix `vault_approle_auth_backend_role_secret_id` regression to handle 404 errors ([#2204](https://github.com/hashicorp/terraform-provider-vault/pull/2204))
 
 ## 4.1.0 (Mar 20, 2024)
 

--- a/vault/resource_approle_auth_backend_role_secret_id.go
+++ b/vault/resource_approle_auth_backend_role_secret_id.go
@@ -417,5 +417,5 @@ func approleAuthBackendRoleSecretIDParseID(id string) (backend, role, accessor s
 }
 
 func isAppRoleDoesNotExistError(err error, role string) bool {
-	return util.Is500(err) && strings.Contains(err.Error(), fmt.Sprintf("role \"%s\" does not exist", role))
+	return util.Is404(err) || (util.Is500(err) && strings.Contains(err.Error(), fmt.Sprintf("role \"%s\" does not exist", role)))
 }

--- a/vault/resource_approle_auth_backend_role_secret_id.go
+++ b/vault/resource_approle_auth_backend_role_secret_id.go
@@ -250,7 +250,9 @@ func approleAuthBackendRoleSecretIDRead(ctx context.Context, d *schema.ResourceD
 	})
 	if err != nil {
 		// We need to check if the secret_id has expired
-		if util.IsExpiredTokenErr(err) {
+		if util.IsExpiredTokenErr(err) || util.Is404(err) {
+			log.Printf("[WARN] AppRole auth backend role SecretID %q from %q not found, removing from state", id, path)
+			d.SetId("")
 			return nil
 		}
 		if isAppRoleDoesNotExistError(err, role) {
@@ -417,5 +419,5 @@ func approleAuthBackendRoleSecretIDParseID(id string) (backend, role, accessor s
 }
 
 func isAppRoleDoesNotExistError(err error, role string) bool {
-	return util.Is404(err) || (util.Is500(err) && strings.Contains(err.Error(), fmt.Sprintf("role \"%s\" does not exist", role)))
+	return util.Is500(err) && strings.Contains(err.Error(), fmt.Sprintf("role \"%s\" does not exist", role))
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
This should tell TF to remove the entry from state and prevent an error when the approle secret ID has expired.



### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

