### PR TITLE
allow syncing with out-of-band changes for kv v1 and v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ FEATURES:
 
 BUGS:
 * fix `vault_approle_auth_backend_role_secret_id` regression to handle 404 errors ([#2204](https://github.com/hashicorp/terraform-provider-vault/pull/2204))
+* fix `vault_kv_secret` and `vault_kv_secret_v2` failure to update secret data modified outside terraform ([#1933](https://github.com/hashicorp/terraform-provider-vault/pull/1933))
 
 ## 4.1.0 (Mar 20, 2024)
 

--- a/vault/resource_kv_secret.go
+++ b/vault/resource_kv_secret.go
@@ -103,6 +103,14 @@ func kvSecretRead(_ context.Context, d *schema.ResourceData, meta interface{}) d
 	log.Printf("[DEBUG] secret: %#v", secret)
 
 	data := secret.Data
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return diag.Errorf("error marshaling JSON for %q: %s", path, err)
+	}
+
+	if err := d.Set(consts.FieldDataJSON, string(jsonData)); err != nil {
+		return diag.FromErr(err)
+	}
 
 	if err := d.Set(consts.FieldData, serializeDataMapToString(data)); err != nil {
 		return diag.FromErr(err)

--- a/vault/resource_kv_secret_v2.go
+++ b/vault/resource_kv_secret_v2.go
@@ -287,7 +287,14 @@ func kvSecretV2Read(_ context.Context, d *schema.ResourceData, meta interface{})
 		log.Printf("[DEBUG] secret: %#v", secret)
 
 		data := secret.Data["data"]
+		jsonData, err := json.Marshal(data)
+		if err != nil {
+			return diag.Errorf("error marshaling JSON for %q: %s", path, err)
+		}
 
+		if err := d.Set(consts.FieldDataJSON, string(jsonData)); err != nil {
+			return diag.FromErr(err)
+		}
 		if v, ok := data.(map[string]interface{}); ok {
 			if err := d.Set(consts.FieldData, serializeDataMapToString(v)); err != nil {
 				return diag.FromErr(err)

--- a/vault/resource_kv_secret_v2_test.go
+++ b/vault/resource_kv_secret_v2_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/vault/api"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
@@ -215,6 +216,82 @@ func TestAccKVSecretV2_DisableRead(t *testing.T) {
 	})
 }
 
+// Fadia u have added this
+func TestAccKVSecretV2_UpdateOutsideTerraform(t *testing.T) {
+	resourceName := "vault_kv_secret_v2.test"
+	mount := acctest.RandomWithPrefix("tf-kv")
+	name := acctest.RandomWithPrefix("foo")
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		PreCheck:          func() { testutil.TestAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testKVSecretV2Config_initial(mount, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldMount, mount),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldName, name),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, fmt.Sprintf("%s/data/%s", mount, name)),
+					resource.TestCheckResourceAttr(resourceName, "delete_all_versions", "true"),
+					resource.TestCheckResourceAttr(resourceName, "data.zip", "zap"),
+					resource.TestCheckResourceAttr(resourceName, "data.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "data.flag", "false"),
+				),
+			},
+			{
+				PreConfig: func() {
+					client := testProvider.Meta().(*provider.ProviderMeta).MustGetClient()
+
+					path := fmt.Sprintf("%s/data/%s", mount, name)
+					_, err := client.Logical().Write(path, map[string]interface{}{"data": map[string]interface{}{"testkey3": "testvalue3"}})
+					if err != nil {
+						t.Fatalf(fmt.Sprintf("error simulating external change; err=%s", err))
+					}
+
+				},
+
+				Config: testKVSecretV2Config_initial(mount, name),
+
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "data.flag", "false"),
+					resource.TestCheckResourceAttr(resourceName, "data.zip", "zap"),
+					resource.TestCheckResourceAttr(resourceName, "data.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "data.flag", "false"),
+					resource.TestCheckResourceAttr(resourceName, "data_json", "{\"flag\":false,\"foo\":\"bar\",\"zip\":\"zap\"}"),
+					resource.TestCheckResourceAttr(resourceName, "metadata.version", "3"),
+				),
+				//testRessourceKvSecretV2_check,
+			},
+		},
+	},
+	)
+}
+
+func testRessourceKvSecretV2_check(s *terraform.State) error {
+	resourceState := s.Modules[0].Resources["vault_kv_secret_v2.test"]
+	if resourceState == nil {
+		return fmt.Errorf("resource not found in state %v", s.Modules[0].Resources)
+	}
+
+	iState := resourceState.Primary
+	if iState == nil {
+		return fmt.Errorf("resource has no primary instance")
+	}
+
+	wantJson := `{"flag":false,"foo":"bar","zip":"zap"}`
+
+	if got, want := iState.Attributes["data_json"], wantJson; got != want {
+		return fmt.Errorf("data_json contains %s; want %s", got, want)
+	}
+
+	if got, want := iState.Attributes["data.zip"], "zap"; got != want {
+		return fmt.Errorf("data[\"zip\"] contains %s; want %s", got, want)
+	}
+
+	return nil
+}
+
+// Fadia end of what u have added
 func readKVData(t *testing.T, mount, name string) {
 	t.Helper()
 	client := testProvider.Meta().(*provider.ProviderMeta).MustGetClient()
@@ -235,6 +312,7 @@ func readKVData(t *testing.T, mount, name string) {
 	if !reflect.DeepEqual(resp.Data["data"], testKVV2Data) {
 		t.Fatalf("kvv2 secret data does not match got: %#+v, want: %#+v", resp.Data["data"], testKVV2Data)
 	}
+
 }
 
 func writeKVData(t *testing.T, mount, name string) {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
Piggy backs on https://github.com/hashicorp/terraform-provider-vault/pull/2099 from @NightOwl998 to allow TFVP to sync out-of-band changes to kv secrets for v1 and v2.


Closes #2099
Closes #1993
Relates https://github.com/hashicorp/terraform-provider-vault/issues/1993


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


