### PR TITLE
kvv2: handle data_json not being set on ignored lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ FEATURES:
 BUGS:
 * fix `vault_approle_auth_backend_role_secret_id` regression to handle 404 errors ([#2204](https://github.com/hashicorp/terraform-provider-vault/pull/2204))
 * fix `vault_kv_secret` and `vault_kv_secret_v2` failure to update secret data modified outside terraform ([#1933](https://github.com/hashicorp/terraform-provider-vault/pull/1933))
-* fix `vault_kv_secret_v2` failing on imported resource when data_json should be ignored ([#xx](https://github.com/hashicorp/terraform-provider-vault/pull/xx))
+* fix `vault_kv_secret_v2` failing on imported resource when data_json should be ignored ([#2209](https://github.com/hashicorp/terraform-provider-vault/pull/2209))
 
 ## 4.1.0 (Mar 20, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ FEATURES:
 BUGS:
 * fix `vault_approle_auth_backend_role_secret_id` regression to handle 404 errors ([#2204](https://github.com/hashicorp/terraform-provider-vault/pull/2204))
 * fix `vault_kv_secret` and `vault_kv_secret_v2` failure to update secret data modified outside terraform ([#1933](https://github.com/hashicorp/terraform-provider-vault/pull/1933))
+* fix `vault_kv_secret_v2` failing on imported resource when data_json should be ignored ([#xx](https://github.com/hashicorp/terraform-provider-vault/pull/xx))
 
 ## 4.1.0 (Mar 20, 2024)
 

--- a/vault/resource_kv_secret_v2.go
+++ b/vault/resource_kv_secret_v2.go
@@ -201,14 +201,15 @@ func kvSecretV2Write(ctx context.Context, d *schema.ResourceData, meta interface
 
 	path := getKVV2Path(mount, name, consts.FieldData)
 
-	var secretData map[string]interface{}
-	err := json.Unmarshal([]byte(d.Get(consts.FieldDataJSON).(string)), &secretData)
-	if err != nil {
-		return diag.Errorf("data_json %#v syntax error: %s", d.Get(consts.FieldDataJSON), err)
-	}
+	data := map[string]interface{}{}
+	if dataJSON, ok := d.GetOk(consts.FieldDataJSON); ok {
+		var secretData map[string]interface{}
+		err := json.Unmarshal([]byte(dataJSON.(string)), &secretData)
+		if err != nil {
+			return diag.Errorf("data_json %#v syntax error: %s", dataJSON, err)
+		}
 
-	data := map[string]interface{}{
-		"data": secretData,
+		data["data"] = secretData
 	}
 
 	kvFields := []string{"cas", "options"}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
Handle the scenario where `ignore_changes` is true for `data_json` after import

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2205 


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


