### PR TITLE
add use_annotations_as_alias_metadata field to auth_kubernetes_config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ FEATURES:
 * Add support for `allowed_kubernetes_namespace_selector` in `vault_kubernetes_secret_backend_role` ([#2180](https://github.com/hashicorp/terraform-provider-vault/pull/2180)).
 * Add new data source `vault_namespace`. Requires Vault Enterprise: ([#2208](https://github.com/hashicorp/terraform-provider-vault/pull/2208)).
 * Add new data source `vault_namespaces`. Requires Vault Enterprise: ([#2212](https://github.com/hashicorp/terraform-provider-vault/pull/2212)).
+* Add `use_annotations_as_alias_metadata` to `vault_kubernetes_auth_backend_config`. Requires Vault 1.16+. ([#2213](https://github.com/hashicorp/terraform-provider-vault/pull/2213)).
 
 IMPROVEMENTS:
 * Enable Secrets Sync Association resource to track sync status across all subkeys of a secret. Requires Vault 1.16+ Enterprise. ([#2202](https://github.com/hashicorp/terraform-provider-vault/pull/2202))

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -399,6 +399,7 @@ const (
 	FieldTLSMaxVersion                 = "tls_max_version"
 	FieldCaseSensitiveNames            = "case_sensitive_names"
 	FieldMaxPageSize                   = "max_page_size"
+	FieldUseAnnotationsAsAliasMetadata = "use_annotations_as_alias_metadata"
 	FieldUserFilter                    = "userfilter"
 	FieldDiscoverDN                    = "discoverdn"
 	FieldDenyNullBind                  = "deny_null_bind"

--- a/vault/data_source_kubernetes_auth_backend_config.go
+++ b/vault/data_source_kubernetes_auth_backend_config.go
@@ -66,6 +66,12 @@ func kubernetesAuthBackendConfigDataSource() *schema.Resource {
 				Optional:    true,
 				Description: "Optional disable defaulting to the local CA cert and service account JWT when running in a Kubernetes pod.",
 			},
+			consts.FieldUseAnnotationsAsAliasMetadata: {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Optional:    true,
+				Description: "Optional use annotations from the client token's associated service account as alias metadata for the Vault entity.",
+			},
 		},
 	}
 }
@@ -104,6 +110,9 @@ func kubernetesAuthBackendConfigDataSourceRead(d *schema.ResourceData, meta inte
 	d.Set(consts.FieldIssuer, resp.Data[consts.FieldIssuer])
 	d.Set(consts.FieldDisableISSValidation, resp.Data[consts.FieldDisableISSValidation])
 	d.Set(consts.FieldDisableLocalCAJWT, resp.Data[consts.FieldDisableLocalCAJWT])
+	if v, ok := resp.Data[consts.FieldUseAnnotationsAsAliasMetadata]; ok {
+		d.Set(consts.FieldUseAnnotationsAsAliasMetadata, v)
+	}
 
 	return nil
 }

--- a/vault/data_source_kubernetes_auth_backend_config_test.go
+++ b/vault/data_source_kubernetes_auth_backend_config_test.go
@@ -62,6 +62,7 @@ func TestAccKubernetesAuthBackendConfigDataSource_full(t *testing.T) {
 	issuer := "kubernetes/serviceaccount"
 	disableIssValidation := true
 	disableLocalCaJwt := true
+	useAnnotationsAsAliasMetadata := true
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testutil.TestAccPreCheck(t) },
@@ -70,7 +71,7 @@ func TestAccKubernetesAuthBackendConfigDataSource_full(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, kubernetesCAcert, jwt, issuer,
-					disableIssValidation, disableLocalCaJwt, false),
+					disableIssValidation, disableLocalCaJwt, false, useAnnotationsAsAliasMetadata),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						"backend", backend),
@@ -90,10 +91,12 @@ func TestAccKubernetesAuthBackendConfigDataSource_full(t *testing.T) {
 						consts.FieldDisableISSValidation, strconv.FormatBool(disableIssValidation)),
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						consts.FieldDisableLocalCAJWT, strconv.FormatBool(disableLocalCaJwt)),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						consts.FieldUseAnnotationsAsAliasMetadata, strconv.FormatBool(useAnnotationsAsAliasMetadata)),
 				),
 			},
 			{
-				Config: testAccKubernetesAuthBackendConfigDataSourceConfig_full(backend, jwt, issuer, disableIssValidation, disableLocalCaJwt),
+				Config: testAccKubernetesAuthBackendConfigDataSourceConfig_full(backend, jwt, issuer, disableIssValidation, disableLocalCaJwt, useAnnotationsAsAliasMetadata),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.vault_kubernetes_auth_backend_config.config",
 						"backend", backend),
@@ -113,6 +116,8 @@ func TestAccKubernetesAuthBackendConfigDataSource_full(t *testing.T) {
 						consts.FieldDisableISSValidation, strconv.FormatBool(disableIssValidation)),
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						consts.FieldDisableLocalCAJWT, strconv.FormatBool(disableLocalCaJwt)),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						consts.FieldUseAnnotationsAsAliasMetadata, strconv.FormatBool(useAnnotationsAsAliasMetadata)),
 				),
 			},
 		},
@@ -128,12 +133,12 @@ data "vault_kubernetes_auth_backend_config" "config" {
 }`, testAccKubernetesAuthBackendConfigConfig_basic(backend, jwt, kubernetesCAcert), backend)
 }
 
-func testAccKubernetesAuthBackendConfigDataSourceConfig_full(backend, jwt string, issuer string, disableIssValidation bool, disableLocalCaJwt bool) string {
+func testAccKubernetesAuthBackendConfigDataSourceConfig_full(backend, jwt string, issuer string, disableIssValidation bool, disableLocalCaJwt bool, useAnnotationsAsAliasMetadata bool) string {
 	return fmt.Sprintf(`
 %s
 
 data "vault_kubernetes_auth_backend_config" "config" {
   backend = "%s"
 }`, testAccKubernetesAuthBackendConfigConfig_full(backend, kubernetesCAcert, jwt, issuer,
-		disableIssValidation, disableLocalCaJwt, false), backend)
+		disableIssValidation, disableLocalCaJwt, false, useAnnotationsAsAliasMetadata), backend)
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->

This PR adds the field [use_annotations_as_alias_metadata](https://developer.hashicorp.com/vault/api-docs/v1.16.x/auth/kubernetes#use_annotations_as_alias_metadata) to the `vault_kubernetes_auth_backend_config` resource. The field is missing in older versions of Vault (<1.16) so it's made optional in the code.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2224


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions

**^ I'm not sure how to run the acceptance tests locally, kind of hoping they run on CI?**

I have tested the binary generated with `make build` locally against Vault 1.16.1.

### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

