### PR TITLE
feat(ssh): add support for `key_type` parameter

### DIFF
--- a/vault/resource_ssh_secret_backend_ca.go
+++ b/vault/resource_ssh_secret_backend_ca.go
@@ -41,6 +41,13 @@ func sshSecretBackendCAResource() *schema.Resource {
 				ForceNew:    true,
 				Description: "Whether Vault should generate the signing key pair internally.",
 			},
+			"key_type": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "ssh-rsa",
+				ForceNew:    true,
+				Description: "Specifies the desired key type for the generated SSH CA key when generate_signing_key is set to true.",
+			},
 			"private_key": {
 				Type:        schema.TypeString,
 				Optional:    true,

--- a/vault/resource_ssh_secret_backend_ca_test.go
+++ b/vault/resource_ssh_secret_backend_ca_test.go
@@ -101,6 +101,7 @@ resource "vault_mount" "test" {
 resource "vault_ssh_secret_backend_ca" "test" {
   backend              = vault_mount.test.path
   generate_signing_key = true
+  key_type             = "ssh-ed25519"
 }`, backend)
 }
 

--- a/website/docs/r/ssh_secret_backend_ca.html.md
+++ b/website/docs/r/ssh_secret_backend_ca.html.md
@@ -36,6 +36,8 @@ The following arguments are supported:
 
 * `generate_signing_key` - (Optional) Whether Vault should generate the signing key pair internally. Defaults to true
 
+* `key_type` - (Optional) Specifies the desired key type for the generated SSH CA key when generate_signing_key is set to true. Defaults to 'ssh-rsa'.
+
 * `public_key` - (Optional) The public key part the SSH CA key pair; required if generate_signing_key is false.
 
 * `private_key` - (Optional) The private key part the SSH CA key pair; required if generate_signing_key is false.


### PR DESCRIPTION


<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
Add support for `key_type` parameter in SSH Secret Engine, so we can specify types other than the default `ssh-rsa`.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000


### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests were run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

