### PR TITLE
auth/kubernetes: add support for use_annotations_as_alias_metadata field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ FEATURES:
 * Update `vault_database_secret_backend_connection` to support inline TLS config for PostgreSQL ([#2339](https://github.com/hashicorp/terraform-provider-vault/pull/2339))
 * Update `vault_database_secret_backend_connection` to support skip_verification config for Cassandra ([#2346](https://github.com/hashicorp/terraform-provider-vault/pull/2346))
 * Update `vault_approle_auth_backend_role_secret_id` to support `num_uses` and `ttl` fields ([#2345](https://github.com/hashicorp/terraform-provider-vault/pull/2345))
+* Add support for `use_annotations_as_alias_metadata` field for the `vault_kubernetes_auth_backend_config` resource ([#2206](https://github.com/hashicorp/terraform-provider-vault/pull/2206))
 
 ## 4.4.0 (Aug 7, 2024)
 

--- a/vault/data_source_kubernetes_auth_backend_config.go
+++ b/vault/data_source_kubernetes_auth_backend_config.go
@@ -66,6 +66,12 @@ func kubernetesAuthBackendConfigDataSource() *schema.Resource {
 				Optional:    true,
 				Description: "Optional disable defaulting to the local CA cert and service account JWT when running in a Kubernetes pod.",
 			},
+			fieldUseAnnotationsAsAliasMetadata: {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Optional:    true,
+				Description: "Use annotations from the client token's associated service account as alias metadata for the Vault entity.",
+			},
 		},
 	}
 }
@@ -104,6 +110,10 @@ func kubernetesAuthBackendConfigDataSourceRead(d *schema.ResourceData, meta inte
 	d.Set(consts.FieldIssuer, resp.Data[consts.FieldIssuer])
 	d.Set(consts.FieldDisableISSValidation, resp.Data[consts.FieldDisableISSValidation])
 	d.Set(consts.FieldDisableLocalCAJWT, resp.Data[consts.FieldDisableLocalCAJWT])
+
+	if provider.IsAPISupported(meta, provider.VaultVersion116) {
+		d.Set(fieldUseAnnotationsAsAliasMetadata, resp.Data[fieldUseAnnotationsAsAliasMetadata])
+	}
 
 	return nil
 }

--- a/vault/data_source_kubernetes_auth_backend_config.go
+++ b/vault/data_source_kubernetes_auth_backend_config.go
@@ -112,7 +112,10 @@ func kubernetesAuthBackendConfigDataSourceRead(d *schema.ResourceData, meta inte
 	d.Set(consts.FieldDisableLocalCAJWT, resp.Data[consts.FieldDisableLocalCAJWT])
 
 	if provider.IsAPISupported(meta, provider.VaultVersion116) {
-		d.Set(fieldUseAnnotationsAsAliasMetadata, resp.Data[fieldUseAnnotationsAsAliasMetadata])
+		err := d.Set(fieldUseAnnotationsAsAliasMetadata, resp.Data[fieldUseAnnotationsAsAliasMetadata])
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/vault/data_source_kubernetes_auth_backend_config_test.go
+++ b/vault/data_source_kubernetes_auth_backend_config_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -91,8 +92,6 @@ func TestAccKubernetesAuthBackendConfigDataSource_full(t *testing.T) {
 						consts.FieldDisableISSValidation, strconv.FormatBool(disableIssValidation)),
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						consts.FieldDisableLocalCAJWT, strconv.FormatBool(disableLocalCaJwt)),
-					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
-						fieldUseAnnotationsAsAliasMetadata, strconv.FormatBool(useAnnotationsAsAliasMetadata)),
 				),
 			},
 			{
@@ -116,6 +115,15 @@ func TestAccKubernetesAuthBackendConfigDataSource_full(t *testing.T) {
 						consts.FieldDisableISSValidation, strconv.FormatBool(disableIssValidation)),
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						consts.FieldDisableLocalCAJWT, strconv.FormatBool(disableLocalCaJwt)),
+				),
+			},
+			{
+				SkipFunc: func() (bool, error) {
+					meta := testProvider.Meta().(*provider.ProviderMeta)
+					return !meta.IsAPISupported(provider.VaultVersion116), nil
+				},
+				Config: testAccKubernetesAuthBackendConfig_useAnnotations(backend, jwt),
+				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						fieldUseAnnotationsAsAliasMetadata, strconv.FormatBool(useAnnotationsAsAliasMetadata)),
 				),

--- a/vault/data_source_kubernetes_auth_backend_config_test.go
+++ b/vault/data_source_kubernetes_auth_backend_config_test.go
@@ -62,6 +62,7 @@ func TestAccKubernetesAuthBackendConfigDataSource_full(t *testing.T) {
 	issuer := "kubernetes/serviceaccount"
 	disableIssValidation := true
 	disableLocalCaJwt := true
+	useAnnotationsAsAliasMetadata := true
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testutil.TestAccPreCheck(t) },
@@ -90,6 +91,8 @@ func TestAccKubernetesAuthBackendConfigDataSource_full(t *testing.T) {
 						consts.FieldDisableISSValidation, strconv.FormatBool(disableIssValidation)),
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						consts.FieldDisableLocalCAJWT, strconv.FormatBool(disableLocalCaJwt)),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						fieldUseAnnotationsAsAliasMetadata, strconv.FormatBool(useAnnotationsAsAliasMetadata)),
 				),
 			},
 			{
@@ -113,6 +116,8 @@ func TestAccKubernetesAuthBackendConfigDataSource_full(t *testing.T) {
 						consts.FieldDisableISSValidation, strconv.FormatBool(disableIssValidation)),
 					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
 						consts.FieldDisableLocalCAJWT, strconv.FormatBool(disableLocalCaJwt)),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						fieldUseAnnotationsAsAliasMetadata, strconv.FormatBool(useAnnotationsAsAliasMetadata)),
 				),
 			},
 		},

--- a/vault/resource_kubernetes_auth_backend_config_test.go
+++ b/vault/resource_kubernetes_auth_backend_config_test.go
@@ -227,6 +227,7 @@ func TestAccKubernetesAuthBackendConfig_full(t *testing.T) {
 	backend := acctest.RandomWithPrefix("kubernetes")
 	jwt := kubernetesJWT
 	issuer := "api"
+	testResource := "vault_kubernetes_auth_backend_config.config"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testutil.TestAccPreCheck(t) },
@@ -237,24 +238,16 @@ func TestAccKubernetesAuthBackendConfig_full(t *testing.T) {
 				Config: testAccKubernetesAuthBackendConfigConfig_full(backend, kubernetesCAcert, jwt, issuer,
 					true, true, false),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
-						"backend", backend),
-					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
-						consts.FieldKubernetesHost, "http://example.com:443"),
-					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
-						consts.FieldKubernetesCACert, kubernetesCAcert),
-					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
-						"token_reviewer_jwt", jwt),
-					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
-						"pem_keys.#", "1"),
-					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
-						"pem_keys.0", kubernetesPEMfile),
-					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
-						consts.FieldIssuer, "api"),
-					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
-						consts.FieldDisableISSValidation, strconv.FormatBool(true)),
-					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
-						consts.FieldDisableLocalCAJWT, strconv.FormatBool(true)),
+					resource.TestCheckResourceAttr(testResource, "backend", backend),
+					resource.TestCheckResourceAttr(testResource, consts.FieldKubernetesHost, "http://example.com:443"),
+					resource.TestCheckResourceAttr(testResource, consts.FieldKubernetesCACert, kubernetesCAcert),
+					resource.TestCheckResourceAttr(testResource, "token_reviewer_jwt", jwt),
+					resource.TestCheckResourceAttr(testResource, "pem_keys.#", "1"),
+					resource.TestCheckResourceAttr(testResource, "pem_keys.0", kubernetesPEMfile),
+					resource.TestCheckResourceAttr(testResource, consts.FieldIssuer, "api"),
+					resource.TestCheckResourceAttr(testResource, consts.FieldDisableISSValidation, strconv.FormatBool(true)),
+					resource.TestCheckResourceAttr(testResource, consts.FieldDisableLocalCAJWT, strconv.FormatBool(true)),
+					resource.TestCheckResourceAttr(testResource, fieldUseAnnotationsAsAliasMetadata, strconv.FormatBool(true)),
 				),
 			},
 		},
@@ -451,6 +444,7 @@ resource "vault_kubernetes_auth_backend_config" "config" {
   issuer = %q
   disable_iss_validation = %t
   disable_local_ca_jwt = %t
+  use_annotations_as_alias_metadata = true
 }`, backend, caConfig, jwt, kubernetesPEMfile, issuer, disableIssValidation, disableLocalCaJwt)
 
 	return config

--- a/website/docs/d/kubernetes_auth_backend_config.md
+++ b/website/docs/d/kubernetes_auth_backend_config.md
@@ -47,3 +47,9 @@ In addition to the above arguments, the following attributes are exported:
 * `pem_keys` - Optional list of PEM-formatted public keys or certificates used to verify the signatures of Kubernetes service account JWTs. If a certificate is given, its public key will be extracted. Not every installation of Kubernetes exposes these keys.
 
 * `issuer` - Optional JWT issuer. If no issuer is specified, `kubernetes.io/serviceaccount` will be used as the default issuer.
+
+* `disable_iss_validation` - (Optional) Disable JWT issuer validation. Allows to skip ISS validation. Requires Vault `v1.5.4+` or Vault auth kubernetes plugin `v0.7.1+`
+
+* `disable_local_ca_jwt` - (Optional) Disable defaulting to the local CA cert and service account JWT when running in a Kubernetes pod. Requires Vault `v1.5.4+` or Vault auth kubernetes plugin `v0.7.1+`
+
+* `use_annotations_as_alias_metadata` - (Optional) Use annotations from the client token's associated service account as alias metadata for the Vault entity. Requires Vault `v1.16+` or Vault auth kubernetes plugin `v0.18.0+`

--- a/website/docs/r/kubernetes_auth_backend_config.md
+++ b/website/docs/r/kubernetes_auth_backend_config.md
@@ -52,6 +52,8 @@ The following arguments are supported:
 
 * `disable_local_ca_jwt` - (Optional) Disable defaulting to the local CA cert and service account JWT when running in a Kubernetes pod. Requires Vault `v1.5.4+` or Vault auth kubernetes plugin `v0.7.1+`
 
+* `use_annotations_as_alias_metadata` - (Optional) Use annotations from the client token's associated service account as alias metadata for the Vault entity. Requires Vault `v1.16+` or Vault auth kubernetes plugin `v0.18.0+`
+
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2224
Closes #2213 

### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


