### PR TITLE
(chore): add LICENSE file to terraform provider release archives

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,8 +3,8 @@
 
 archives:
   - files:
-      # Ensure only built binary is archived
-      - 'none*'
+      # Ensure only built binary and license file are archived
+      - 'LICENSE'
     format: zip
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 before:


### PR DESCRIPTION
This PR includes the relevant repository license file for release assets on releases.hashicorp.com. This is a minor adjustment to the release configuration.

It will be picked up for the next provider release. (there is no requirement for immediate release)