### PR TITLE
Use single runner label for custom-linux-large runner

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -4,5 +4,4 @@
 self-hosted-runner:
   # Labels of custom runners in array of string
   labels:
-    - custom
     - custom-linux-large

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
           make test
   acceptance:
     needs: [go-version, build]
-    runs-on: [custom, linux, custom-linux-large]
+    runs-on: custom-linux-large
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
👋 Greetings! 

To align with Github’s removal of [custom labels on larger runners](https://github.blog/changelog/2023-02-15-github-actions-removal-of-additional-label-option-for-github-hosted-larger-runners/), this PR is removing extra custom labels defined in your Github Actions. Moving forward, only one label (the github runner name)  will be needed to ensure the appropriate larger runner is used for your GHA job.

Please review for accuracy and merge before May 27, 2024. Thank you!


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->


### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

