### PR TITLE
add password_policy to vault_database_secret_backend_connection

### DIFF
--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -1749,6 +1749,10 @@ func writeDatabaseSecretConfig(d *schema.ResourceData, client *api.Client,
 		data["root_rotation_statements"] = v
 	}
 
+	if v, ok := d.GetOk("password_policy"); ok {
+		data["password_policy"] = v
+	}
+
 	if m, ok := d.GetOkExists(prefix + "data"); ok {
 		for k, v := range m.(map[string]interface{}) {
 			// Vault does not return the password in the API. If the root credentials have been rotated, sending
@@ -1885,6 +1889,7 @@ func getDBCommonConfig(d *schema.ResourceData, resp *api.Secret,
 		"data":              d.Get(prefix + "data"),
 		"verify_connection": d.Get(prefix + "verify_connection"),
 		"plugin_name":       resp.Data["plugin_name"],
+		"password_policy":   resp.Data["password_policy"],
 	}
 
 	//"root_rotation_statements": resp.Data["root_credentials_rotate_statements"],

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -62,6 +62,7 @@ func TestAccDatabaseSecretBackendConnection_postgresql_import(t *testing.T) {
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "allowed_roles.1", "prod"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "root_rotation_statements.#", "1"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "password_policy", "foo-pol"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "verify_connection", "true"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "postgresql.0.connection_url", connURL),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "postgresql.0.max_open_connections", "2"),
@@ -506,6 +507,7 @@ func TestAccDatabaseSecretBackendConnection_mysql(t *testing.T) {
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "allowed_roles.1", "prod"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "root_rotation_statements.#", "1"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "password_policy", "foo-pol"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "verify_connection", "true"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "mysql.0.connection_url", connURL),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "mysql.0.username", username),
@@ -522,6 +524,7 @@ func TestAccDatabaseSecretBackendConnection_mysql(t *testing.T) {
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "allowed_roles.1", "prod"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "root_rotation_statements.#", "1"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "password_policy", "foo-pol"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "verify_connection", "true"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "mysql_rds.0.connection_url", connURL),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "mysql_rds.0.username", username),
@@ -538,6 +541,7 @@ func TestAccDatabaseSecretBackendConnection_mysql(t *testing.T) {
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "allowed_roles.1", "prod"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "root_rotation_statements.#", "1"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "password_policy", "foo-pol"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "verify_connection", "true"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "mysql_aurora.0.connection_url", connURL),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "mysql_aurora.0.username", username),
@@ -554,6 +558,7 @@ func TestAccDatabaseSecretBackendConnection_mysql(t *testing.T) {
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "allowed_roles.1", "prod"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "root_rotation_statements.#", "1"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "password_policy", "foo-pol"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "verify_connection", "true"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "mysql_legacy.0.connection_url", connURL),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "mysql_legacy.0.username", username),
@@ -809,6 +814,7 @@ func TestAccDatabaseSecretBackendConnection_postgresql(t *testing.T) {
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "allowed_roles.1", "prod"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "root_rotation_statements.#", "1"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "root_rotation_statements.0", "FOOBAR"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "password_policy", "foo-pol"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "verify_connection", "true"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "postgresql.0.connection_url", connURL),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "postgresql.0.max_open_connections", maxOpenConnections),
@@ -1253,6 +1259,7 @@ resource "vault_database_secret_backend_connection" "test" {
   name = "%s"
   allowed_roles = ["dev", "prod"]
   root_rotation_statements = ["FOOBAR"]
+  password_policy = "foo-pol"
 
   postgresql {
 	  connection_url = "%s"
@@ -1463,6 +1470,7 @@ resource "vault_database_secret_backend_connection" "test" {
   name = "%s"
   allowed_roles = ["dev", "prod"]
   root_rotation_statements = ["FOOBAR"]
+  password_policy = "foo-pol"
 
   mysql {
 	  connection_url = "%s"
@@ -1594,6 +1602,7 @@ resource "vault_database_secret_backend_connection" "test" {
   name = "%s"
   allowed_roles = ["dev", "prod"]
   root_rotation_statements = ["FOOBAR"]
+  password_policy = "foo-pol"
 
   mysql_rds {
 	  connection_url = "%s"
@@ -1616,6 +1625,7 @@ resource "vault_database_secret_backend_connection" "test" {
   name = "%s"
   allowed_roles = ["dev", "prod"]
   root_rotation_statements = ["FOOBAR"]
+  password_policy = "foo-pol"
 
   mysql_aurora {
 	  connection_url = "%s"
@@ -1638,6 +1648,7 @@ resource "vault_database_secret_backend_connection" "test" {
   name = "%s"
   allowed_roles = ["dev", "prod"]
   root_rotation_statements = ["FOOBAR"]
+  password_policy = "foo-pol"
 
   mysql_legacy {
 	  connection_url = "%s"
@@ -1682,6 +1693,7 @@ resource "vault_database_secret_backend_connection" "test" {
   name = "%s"
   allowed_roles = ["dev", "prod"]
   root_rotation_statements = ["FOOBAR"]
+  password_policy = "foo-pol"
 
   postgresql {
       connection_url          = "%s"
@@ -1709,6 +1721,7 @@ resource "vault_database_secret_backend_connection" "test" {
   name = "%s"
   allowed_roles = ["dev", "prod"]
   root_rotation_statements = ["FOOBAR"]
+  password_policy = "foo-pol"
 
   postgresql {
 	  connection_url    = "%s"

--- a/vault/resource_database_secrets_mount.go
+++ b/vault/resource_database_secrets_mount.go
@@ -197,6 +197,11 @@ func getCommonDatabaseSchema() schemaMap {
 				Type: schema.TypeString,
 			},
 		},
+		"password_policy": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "The name of the password policy to use when generating passwords for this database.",
+		},
 		"data": {
 			Type:        schema.TypeMap,
 			Optional:    true,

--- a/website/docs/r/database_secret_backend_connection.md
+++ b/website/docs/r/database_secret_backend_connection.md
@@ -60,6 +60,8 @@ The following arguments are supported:
 
 * `root_rotation_statements` - (Optional) A list of database statements to be executed to rotate the root user's credentials.
 
+* `password_policy` - (Optional) The name of the password policy to use when generating passwords for this database.
+
 * `data` - (Optional) A map of sensitive data to pass to the endpoint. Useful for templated connection strings.
 
 * `cassandra` - (Optional) A nested block containing configuration options for Cassandra connections.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
This PR updates `vault_database_secret_backend_connection` resource so that we can specify a `password_policy`.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
<!-- Relates OR Closes #0000 -->

\
One observation I would like to bubble up - there's potential for drift to be introduced if a password policy is set and applied, then subsequently removed from the configuration. In that scenario, the resource will not actually reconcile the engine's configuration to a defined default. The next plan or apply will show drift that can only be resolved by the resource if a new password policy is specified.

I modeled the existing behavior defined for other resource arguments, but I would be interested in feedback on the use of `d.Get` in place of `d.GetOk`.

### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:
Only a subset of databases have been updated as part of the PR. I passed in the verbose argument to highlight which tests were updated. Only the tests that passed have been updated; tests that are skipped have not been changed.
 
```sh
$ make testacc TESTARGS='-run=^TestAccDatabaseSecretBackendConnection_\(postgresql\|mysql\)' | grep -v -E "testing: warning: no tests to run|^PASS$" 

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -v -count 1 -run=^TestAccDatabaseSecretBackendConnection_\(postgresql\|mysql\) -timeout 30m ./...
?   	github.com/hashicorp/terraform-provider-vault	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/generate	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/helper	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/consts	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/codegen	0.298s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/group	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/mfa	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/pki	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/sync	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/schema	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/util/mountutil	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/internal/identity/entity	0.422s [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/internal/provider	0.742s [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/testutil	0.979s [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/util	0.832s [no tests to run]
=== RUN   TestAccDatabaseSecretBackendConnection_postgresql_import
--- PASS: TestAccDatabaseSecretBackendConnection_postgresql_import (1.15s)
=== RUN   TestAccDatabaseSecretBackendConnection_mysql_cloud
    resource_database_secret_backend_connection_test.go:448: "MYSQL_CLOUD_CONNECTION_URL" must be set
--- SKIP: TestAccDatabaseSecretBackendConnection_mysql_cloud (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_mysql
--- PASS: TestAccDatabaseSecretBackendConnection_mysql (2.61s)
=== RUN   TestAccDatabaseSecretBackendConnection_mysql_tls
    resource_database_secret_backend_connection_test.go:730: "MYSQL_CA" must be set
--- SKIP: TestAccDatabaseSecretBackendConnection_mysql_tls (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_postgresql
--- PASS: TestAccDatabaseSecretBackendConnection_postgresql (1.48s)
=== RUN   TestAccDatabaseSecretBackendConnection_postgresql_cloud
    resource_database_secret_backend_connection_test.go:847: "POSTGRES_CLOUD_URL" must be set
--- SKIP: TestAccDatabaseSecretBackendConnection_postgresql_cloud (0.00s)
ok  	github.com/hashicorp/terraform-provider-vault/vault	5.918s
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

