### PR TITLE
Add new WIF fields for GCP Secrets (Vault Enterprise only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 FEATURES:
 * Add support for `iam_tags` in `vault_aws_secret_backend_role` ([#2231](https://github.com/hashicorp/terraform-provider-vault/pull/2231)).
 * Add support for `inheritable` on `vault_quota_rate_limit` and `vault_quota_lease_count`. Requires Vault 1.15+.: ([#2133](https://github.com/hashicorp/terraform-provider-vault/pull/2133)).
+* Add support for new WIF fields in `vault_gcp_secret_backend` ([#2249](https://github.com/hashicorp/terraform-provider-vault/pull/2249))
 
 IMPROVEMENTS:
 * return a useful error when delete fails for the `vault_jwt_auth_backend_role` resource: ([#2232](https://github.com/hashicorp/terraform-provider-vault/pull/2232))

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -485,14 +485,17 @@ const (
 	/*
 		Vault version constants
 	*/
-	VaultVersion190 = "1.9.0"
-	VaultVersion110 = "1.10.0"
-	VaultVersion111 = "1.11.0"
-	VaultVersion112 = "1.12.0"
-	VaultVersion113 = "1.13.0"
-	VaultVersion114 = "1.14.0"
-	VaultVersion115 = "1.15.0"
-	VaultVersion116 = "1.16.0"
+	VaultVersion190    = "1.9.0"
+	VaultVersion110    = "1.10.0"
+	VaultVersion111    = "1.11.0"
+	VaultVersion112    = "1.12.0"
+	VaultVersion113    = "1.13.0"
+	VaultVersion114    = "1.14.0"
+	VaultVersion115    = "1.15.0"
+	VaultVersion116    = "1.16.0"
+	VaultVersion116Ent = "1.16.0+ent"
+	VaultVersion117    = "1.17.0"
+	VaultVersion117Ent = "1.17.0+ent"
 
 	/*
 		Vault auth methods

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -35,13 +35,16 @@ const (
 var (
 	MaxHTTPRetriesCCC int
 
-	VaultVersion110 = version.Must(version.NewSemver(consts.VaultVersion110))
-	VaultVersion111 = version.Must(version.NewSemver(consts.VaultVersion111))
-	VaultVersion112 = version.Must(version.NewSemver(consts.VaultVersion112))
-	VaultVersion113 = version.Must(version.NewSemver(consts.VaultVersion113))
-	VaultVersion114 = version.Must(version.NewSemver(consts.VaultVersion114))
-	VaultVersion115 = version.Must(version.NewSemver(consts.VaultVersion115))
-	VaultVersion116 = version.Must(version.NewSemver(consts.VaultVersion116))
+	VaultVersion110    = version.Must(version.NewSemver(consts.VaultVersion110))
+	VaultVersion111    = version.Must(version.NewSemver(consts.VaultVersion111))
+	VaultVersion112    = version.Must(version.NewSemver(consts.VaultVersion112))
+	VaultVersion113    = version.Must(version.NewSemver(consts.VaultVersion113))
+	VaultVersion114    = version.Must(version.NewSemver(consts.VaultVersion114))
+	VaultVersion115    = version.Must(version.NewSemver(consts.VaultVersion115))
+	VaultVersion116    = version.Must(version.NewSemver(consts.VaultVersion116))
+	VaultVersion116Ent = version.Must(version.NewSemver(consts.VaultVersion116Ent))
+	VaultVersion117    = version.Must(version.NewSemver(consts.VaultVersion117))
+	VaultVersion117Ent = version.Must(version.NewSemver(consts.VaultVersion117Ent))
 
 	TokenTTLMinRecommended = time.Minute * 15
 )

--- a/vault/resource_gcp_secret_backend.go
+++ b/vault/resource_gcp_secret_backend.go
@@ -231,7 +231,7 @@ func gcpSecretBackendRead(ctx context.Context, d *schema.ResourceData, meta inte
 
 	// read and set config if needed
 	if provider.IsAPISupported(meta, provider.VaultVersion117Ent) {
-		resp, err := client.Logical().Read(gcpSecretBackendConfigPath(path))
+		resp, err := client.Logical().ReadWithContext(ctx, gcpSecretBackendConfigPath(path))
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -269,7 +269,7 @@ func gcpSecretBackendUpdate(ctx context.Context, d *schema.ResourceData, meta in
 
 	useAPIVer117Ent := provider.IsAPISupported(meta, provider.VaultVersion117Ent)
 
-	if d.HasChange(consts.FieldDefaultLeaseTTL) || d.HasChange(consts.FieldMaxLeaseTTL) || d.HasChange(consts.FieldIdentityTokenKey) {
+	if d.HasChanges(consts.FieldDefaultLeaseTTL, consts.FieldMaxLeaseTTL, consts.FieldIdentityTokenKey) {
 		config := api.MountConfigInput{
 			DefaultLeaseTTL: fmt.Sprintf("%ds", d.Get(consts.FieldDefaultLeaseTTL)),
 			MaxLeaseTTL:     fmt.Sprintf("%ds", d.Get(consts.FieldMaxLeaseTTL)),

--- a/vault/resource_gcp_secret_backend_test.go
+++ b/vault/resource_gcp_secret_backend_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -47,6 +48,20 @@ func TestGCPSecretBackend(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "local", "true"),
 				),
 			},
+			{
+				SkipFunc: func() (bool, error) {
+					meta := testProvider.Meta().(*provider.ProviderMeta)
+					return !meta.IsAPISupported(provider.VaultVersion117Ent), nil
+				},
+				Config: testGCPSecretBackend_WIFConfig(path),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "path", path),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldIdentityTokenAudience, "test"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldIdentityTokenTTL, "30"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldServiceAccountEmail, "test"),
+				),
+			},
+			testutil.GetImportTestStep(resourceName, false, nil, consts.FieldDisableRemount),
 		},
 	})
 }
@@ -101,6 +116,16 @@ resource "vault_gcp_secret_backend" "test" {
 EOF
   description = "test description"
   default_lease_ttl_seconds = 3600
+}`, path)
+}
+
+func testGCPSecretBackend_WIFConfig(path string) string {
+	return fmt.Sprintf(`
+resource "vault_gcp_secret_backend" "test" {
+  path                    = "%s"
+  service_account_email   = "test"
+  identity_token_audience = "test"
+  identity_token_ttl      = 30
 }`, path)
 }
 

--- a/vault/resource_gcp_secret_backend_test.go
+++ b/vault/resource_gcp_secret_backend_test.go
@@ -61,7 +61,10 @@ func TestGCPSecretBackend(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, consts.FieldServiceAccountEmail, "test"),
 				),
 			},
-			testutil.GetImportTestStep(resourceName, false, nil, consts.FieldDisableRemount),
+			testutil.GetImportTestStep(resourceName, false, nil,
+				consts.FieldDisableRemount,
+				consts.FieldCredentials,
+			),
 		},
 	})
 }

--- a/website/docs/r/gcp_secret_backend.html.md
+++ b/website/docs/r/gcp_secret_backend.html.md
@@ -58,6 +58,22 @@ for credentials issued by this backend. Defaults to '0'.
 
 * `local` - (Optional) Boolean flag that can be explicitly set to true to enforce local mount in HA environment
 
+* `service_account_email` – (Optional) Service Account to impersonate for plugin workload identity federation.
+  Required with `identity_token_audience`. Requires Vault 1.17+. *Available only for Vault Enterprise*.
+
+* `identity_token_audience` - (Optional) The audience claim value for plugin identity
+  tokens. Must match an allowed audience configured for the target [Workload Identity Pool](https://cloud.google.com/iam/docs/workload-identity-federation-with-other-providers#prepare).
+  Mutually exclusive with `credentials`.  Requires Vault 1.17+. *Available only for Vault Enterprise*.
+
+* `identity_token_ttl` - (Optional) The TTL of generated tokens. Defaults to
+  1 hour. Uses [duration format strings](https://developer.hashicorp.com/vault/docs/concepts/duration-format).
+  Requires Vault 1.17+. *Available only for Vault Enterprise*.
+
+* `identity_token_key` - (Optional) The key to use for signing plugin identity
+  tokens. Requires Vault 1.17+. *Available only for Vault Enterprise*.
+
 ## Attributes Reference
 
-No additional attributes are exported by this resource.
+In addition to the arguments above, the following attributes are exported:
+
+* `accessor` - The accessor of the created GCP mount.


### PR DESCRIPTION
### Description
Adds the following new fields to the GCP Secrets Backend resource to enable the WIF workflow:
- `identity_token_audience`
- `identity_token_ttl`
- `identity_token_key`
- `service_account_email`
- `accessor`

### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestGCPSecretBackend'
=== RUN   TestGCPSecretBackend
--- PASS: TestGCPSecretBackend (3.79s)
PASS
```