### PR TITLE
Fix typo in documentation for JWT Auth Role

### DIFF
--- a/vault/resource_jwt_auth_backend_role.go
+++ b/vault/resource_jwt_auth_backend_role.go
@@ -60,7 +60,7 @@ func jwtAuthBackendRoleResource() *schema.Resource {
 			Type:        schema.TypeInt,
 			Optional:    true,
 			Default:     0,
-			Description: "The amount of leeway to add to expiration (exp) claims to account for clock skew, in seconds. Defaults to 60 seconds if set to 0 and can be disabled if set to -1. Only applicable with 'jwt' roles.",
+			Description: "The amount of leeway to add to expiration (exp) claims to account for clock skew, in seconds. Defaults to 150 seconds if set to 0 and can be disabled if set to -1. Only applicable with 'jwt' roles.",
 		},
 		"not_before_leeway": {
 			Type:        schema.TypeInt,

--- a/website/docs/r/jwt_auth_backend_role.html.md
+++ b/website/docs/r/jwt_auth_backend_role.html.md
@@ -113,11 +113,11 @@ The following arguments are supported:
   Only applicable with "jwt" roles.
 
 * `expiration_leeway` - (Optional) The amount of leeway to add to expiration (`exp`) claims to account for
-  clock skew, in seconds. Defaults to `60` seconds if set to `0` and can be disabled if set to `-1`.
+  clock skew, in seconds. Defaults to `150` seconds if set to `0` and can be disabled if set to `-1`.
   Only applicable with "jwt" roles.
 
 * `not_before_leeway` - (Optional) The amount of leeway to add to not before (`nbf`) claims to account for
-  clock skew, in seconds. Defaults to `60` seconds if set to `0` and can be disabled if set to `-1`.
+  clock skew, in seconds. Defaults to `150` seconds if set to `0` and can be disabled if set to `-1`.
   Only applicable with "jwt" roles.
 
 * `verbose_oidc_logging` - (Optional) Log received OIDC tokens and claims when debug-level


### PR DESCRIPTION
### Description
The documentation for `not_before_leeway` and `expiration_leeway` contained typos. If set to 0, [Vault will enforce a default](https://developer.hashicorp.com/vault/api-docs/auth/jwt#not_before_leeway) of `150s`, not `60s` as the documentation currently states.

Reported by customer.