### PR TITLE
chore: Use consistent LICENSE.txt naming in release archives

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,8 @@
 archives:
   - files:
       # Ensure only built binary and license file are archived
-      - 'LICENSE'
+      - src: 'LICENSE'
+        dst: 'LICENSE.txt'
     format: zip
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 before:


### PR DESCRIPTION
Reference: https://go.hashi.co/memo/ips-002