### PR TITLE
Ensure all mount errors are covered

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,12 +63,12 @@ jobs:
       fail-fast: false
       matrix:
         image:
-        - "vault-enterprise:1.11.12-ent"
         - "vault-enterprise:1.12.11-ent"
         - "vault-enterprise:1.13.13-ent"
-        - "vault-enterprise:1.14.12-ent"
-        - "vault-enterprise:1.15.8-ent"
-        - "vault-enterprise:1.16.2-ent"
+        - "vault-enterprise:1.14.13-ent"
+        - "vault-enterprise:1.15.11-ent"
+        - "vault-enterprise:1.16.5-ent"
+        - "vault-enterprise:1.17.1-ent"
         - "vault:latest"
     services:
       vault:

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,20 @@ build: go-version-check fmtcheck
 test: go-version-check fmtcheck
 	TF_ACC= VAULT_TOKEN= go test $(TESTARGS) -timeout 10m $(TEST_PATH)
 
+testsum: go-version-check fmtcheck
+	TF_ACC= VAULT_TOKEN= gotestsum $(TEST_PATH) $(TESTARGS) -test.timeout 10m
+
 testacc: fmtcheck
 	TF_ACC=1 go test $(TESTARGS) -timeout 30m $(TEST_PATH)
 
+testaccsum: fmtcheck
+	TF_ACC=1 gotestsum $(TEST_PATH) $(TESTARGS) -timeout 30m
+
 testacc-ent:
 	make testacc TF_ACC_ENTERPRISE=1
+
+testaccsum-ent:
+	make testaccsum TF_ACC_ENTERPRISE=1
 
 dev: go-version-check fmtcheck
 	go build -o terraform-provider-vault
@@ -71,4 +80,4 @@ ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
 endif
 	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider-test PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
-.PHONY: build test testacc testacc-ent vet fmt fmtcheck errcheck test-compile website website-test go-version-check
+.PHONY: build test testacc testacc-ent vet fmt fmtcheck errcheck test-compile website website-test go-version-check testaccsum testaccsum-ent

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/jcmturner/gokrb5/v8 v8.4.4
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.5.0
+	github.com/stretchr/testify v1.9.0
 	golang.org/x/crypto v0.23.0
 	golang.org/x/net v0.25.0
 	golang.org/x/oauth2 v0.18.0
@@ -148,7 +149,6 @@ require (
 	github.com/sasha-s/go-deadlock v0.2.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/sony/gobreaker v0.5.0 // indirect
-	github.com/stretchr/testify v1.9.0 // indirect
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect

--- a/util/mountutil/mountutil_test.go
+++ b/util/mountutil/mountutil_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package mountutil
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/vault/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsMountNotFoundError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "with-err-mount-not-found",
+			err:  ErrMountNotFound,
+			want: true,
+		},
+		{
+			name: "with-response-error-no-secret-engine-mount",
+			err: &api.ResponseError{
+				StatusCode: http.StatusBadRequest,
+				Errors: []string{
+					"No secret engine mount at auth/operator/",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "with-response-error-no-auth-engine-mount",
+			err: &api.ResponseError{
+				StatusCode: http.StatusBadRequest,
+				Errors: []string{
+					"No auth engine at auth/operator/",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "with-response-error-both",
+			err: &api.ResponseError{
+				StatusCode: http.StatusBadRequest,
+				Errors: []string{
+					"No secret engine mount at auth/operator/",
+					"No auth engine at auth/operator/",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "with-response-error-others",
+			err: &api.ResponseError{
+				StatusCode: http.StatusBadRequest,
+				Errors: []string{
+					"Some other error",
+					"No auth engine at auth/operator/",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "with-not-found-status-code",
+			err: &api.ResponseError{
+				StatusCode: http.StatusNotFound,
+				Errors: []string{
+					"some error",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "with-response-error-canary",
+			err: &api.ResponseError{
+				StatusCode: http.StatusBadRequest,
+				Errors: []string{
+					"secret engine mount",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "with-nil-error",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, IsMountNotFoundError(tt.err), "IsMountNotFoundError(%v)", tt.err)
+		})
+	}
+}

--- a/vault/resource_ad_secret_backend.go
+++ b/vault/resource_ad_secret_backend.go
@@ -5,7 +5,6 @@ package vault
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -344,14 +343,14 @@ func readConfigResource(d *schema.ResourceData, meta interface{}) error {
 	path := d.Id()
 	log.Printf("[DEBUG] Reading %q", path)
 
-	mount, err := mountutil.GetMount(context.Background(), client, path)
-	if errors.Is(err, mountutil.ErrMountNotFound) {
-		log.Printf("[WARN] Mount %q not found, removing from state.", path)
-		d.SetId("")
-		return nil
-	}
-
+	ctx := context.Background()
+	mount, err := mountutil.GetMount(ctx, client, path)
 	if err != nil {
+		if mountutil.IsMountNotFoundError(err) {
+			log.Printf("[WARN] Mount %q not found, removing from state.", path)
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 

--- a/vault/resource_aws_secret_backend.go
+++ b/vault/resource_aws_secret_backend.go
@@ -5,7 +5,6 @@ package vault
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -256,13 +255,12 @@ func awsSecretBackendRead(ctx context.Context, d *schema.ResourceData, meta inte
 	log.Printf("[DEBUG] Reading AWS backend mount %q from Vault", path)
 
 	mount, err := mountutil.GetMount(ctx, client, path)
-	if errors.Is(err, mountutil.ErrMountNotFound) {
-		log.Printf("[WARN] Mount %q not found, removing from state.", path)
-		d.SetId("")
-		return nil
-	}
-
 	if err != nil {
+		if mountutil.IsMountNotFoundError(err) {
+			log.Printf("[WARN] Mount %q not found, removing from state.", path)
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 

--- a/vault/resource_azure_secret_backend.go
+++ b/vault/resource_azure_secret_backend.go
@@ -5,7 +5,6 @@ package vault
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -166,13 +165,12 @@ func azureSecretBackendRead(ctx context.Context, d *schema.ResourceData, meta in
 	log.Printf("[DEBUG] Reading Azure backend mount %q from Vault", path)
 
 	mount, err := mountutil.GetMount(ctx, client, path)
-	if errors.Is(err, mountutil.ErrMountNotFound) {
-		log.Printf("[WARN] Mount %q not found, removing from state.", path)
-		d.SetId("")
-		return nil
-	}
-
 	if err != nil {
+		if mountutil.IsMountNotFoundError(err) {
+			log.Printf("[WARN] Mount %q not found, removing from state.", path)
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 

--- a/vault/resource_consul_secret_backend.go
+++ b/vault/resource_consul_secret_backend.go
@@ -5,7 +5,6 @@ package vault
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -201,13 +200,12 @@ func consulSecretBackendRead(ctx context.Context, d *schema.ResourceData, meta i
 	log.Printf("[DEBUG] Reading Consul backend mount %q from Vault", path)
 
 	mount, err := mountutil.GetMount(ctx, client, path)
-	if errors.Is(err, mountutil.ErrMountNotFound) {
-		log.Printf("[WARN] Mount %q not found, removing from state.", path)
-		d.SetId("")
-		return nil
-	}
-
 	if err != nil {
+		if mountutil.IsMountNotFoundError(err) {
+			log.Printf("[WARN] Mount %q not found, removing from state.", path)
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 

--- a/vault/resource_gcp_auth_backend.go
+++ b/vault/resource_gcp_auth_backend.go
@@ -6,7 +6,6 @@ package vault
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -383,13 +382,12 @@ func gcpAuthBackendRead(ctx context.Context, d *schema.ResourceData, meta interf
 	}
 
 	mount, err := mountutil.GetAuthMount(ctx, client, gcpPath)
-	if errors.Is(err, mountutil.ErrMountNotFound) {
-		log.Printf("[WARN] Mount %q not found, removing from state.", gcpPath)
-		d.SetId("")
-		return nil
-	}
-
 	if err != nil {
+		if mountutil.IsMountNotFoundError(err) {
+			log.Printf("[WARN] Mount %q not found, removing from state.", gcpPath)
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 

--- a/vault/resource_gcp_secret_backend.go
+++ b/vault/resource_gcp_secret_backend.go
@@ -5,7 +5,6 @@ package vault
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -197,13 +196,12 @@ func gcpSecretBackendRead(ctx context.Context, d *schema.ResourceData, meta inte
 	log.Printf("[DEBUG] Reading GCP backend mount %q from Vault", path)
 
 	mount, err := mountutil.GetMount(ctx, client, path)
-	if errors.Is(err, mountutil.ErrMountNotFound) {
-		log.Printf("[WARN] Mount %q not found, removing from state.", path)
-		d.SetId("")
-		return nil
-	}
-
 	if err != nil {
+		if mountutil.IsMountNotFoundError(err) {
+			log.Printf("[WARN] Mount %q not found, removing from state.", path)
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 

--- a/vault/resource_github_auth_backend.go
+++ b/vault/resource_github_auth_backend.go
@@ -5,18 +5,17 @@ package vault
 
 import (
 	"context"
-	"errors"
-
 	"log"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/vault/api"
+
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/terraform-provider-vault/util/mountutil"
-	"github.com/hashicorp/vault/api"
 )
 
 func githubAuthBackendResource() *schema.Resource {
@@ -183,14 +182,13 @@ func githubAuthBackendRead(ctx context.Context, d *schema.ResourceData, meta int
 	configPath := path + "/config"
 
 	log.Printf("[DEBUG] Reading github auth mount from '%q'", path)
-	mount, err := mountutil.GetAuthMount(context.Background(), client, d.Id())
-	if errors.Is(err, mountutil.ErrMountNotFound) {
-		log.Printf("[WARN] Mount %q not found, removing from state.", path)
-		d.SetId("")
-		return nil
-	}
-
+	mount, err := mountutil.GetAuthMount(ctx, client, d.Id())
 	if err != nil {
+		if mountutil.IsMountNotFoundError(err) {
+			log.Printf("[WARN] Mount %q not found, removing from state.", path)
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 

--- a/vault/resource_kmip_secret_backend.go
+++ b/vault/resource_kmip_secret_backend.go
@@ -4,6 +4,7 @@
 package vault
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -157,6 +158,7 @@ func kmipSecretBackendUpdate(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("error remounting in Vault: %s", err)
 		}
 
+		ctx := context.Background()
 		// There is something similar in resource_mount.go, but in the call to TuneMount().
 		var tries int
 		for {
@@ -165,7 +167,7 @@ func kmipSecretBackendUpdate(d *schema.ResourceData, meta interface{}) error {
 					"mount %q did did not become available after %d tries, interval=1s", dest, tries)
 			}
 
-			enabled, err := mountutil.CheckMountEnabled(client, dest)
+			enabled, err := mountutil.CheckMountEnabled(ctx, client, dest)
 			if err != nil {
 				return err
 			}

--- a/vault/resource_nomad_secret_backend.go
+++ b/vault/resource_nomad_secret_backend.go
@@ -5,7 +5,6 @@ package vault
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -201,14 +200,14 @@ func readNomadAccessConfigResource(d *schema.ResourceData, meta interface{}) err
 	path := d.Id()
 	log.Printf("[DEBUG] Reading %q", path)
 
-	mount, err := mountutil.GetMount(context.Background(), client, path)
-	if errors.Is(err, mountutil.ErrMountNotFound) {
-		log.Printf("[WARN] Mount %q not found, removing from state.", path)
-		d.SetId("")
-		return nil
-	}
-
+	ctx := context.Background()
+	mount, err := mountutil.GetMount(ctx, client, path)
 	if err != nil {
+		if mountutil.IsMountNotFoundError(err) {
+			log.Printf("[WARN] Mount %q not found, removing from state.", path)
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 

--- a/vault/resource_okta_auth_backend.go
+++ b/vault/resource_okta_auth_backend.go
@@ -315,13 +315,12 @@ func oktaAuthBackendRead(ctx context.Context, d *schema.ResourceData, meta inter
 	log.Printf("[DEBUG] Reading auth %s from Vault", path)
 
 	mount, err := mountutil.GetAuthMount(ctx, client, path)
-	if errors.Is(err, mountutil.ErrMountNotFound) {
-		log.Printf("[WARN] Mount %q not found, removing from state.", path)
-		d.SetId("")
-		return nil
-	}
-
 	if err != nil {
+		if mountutil.IsMountNotFoundError(err) {
+			log.Printf("[WARN] Mount %q not found, removing from state.", path)
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 

--- a/vault/resource_pki_secret_backend_cert.go
+++ b/vault/resource_pki_secret_backend_cert.go
@@ -5,7 +5,6 @@ package vault
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -336,13 +335,12 @@ func pkiSecretBackendCertRead(ctx context.Context, d *schema.ResourceData, meta 
 	path := d.Get(consts.FieldBackend).(string)
 
 	_, err := mountutil.GetMount(ctx, client, path)
-	if errors.Is(err, mountutil.ErrMountNotFound) {
-		log.Printf("[WARN] Mount %q not found, removing from state.", path)
-		d.SetId("")
-		return nil
-	}
-
 	if err != nil {
+		if mountutil.IsMountNotFoundError(err) {
+			log.Printf("[WARN] Mount %q not found, removing from state.", path)
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 

--- a/vault/resource_secrets_sync_association.go
+++ b/vault/resource_secrets_sync_association.go
@@ -6,7 +6,6 @@ package vault
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"regexp"
@@ -251,11 +250,10 @@ func getMountAccessor(ctx context.Context, d *schema.ResourceData, meta interfac
 	log.Printf("[DEBUG] Reading mount %s from Vault", mount)
 
 	m, err := mountutil.GetMount(ctx, client, mount)
-	if errors.Is(err, mountutil.ErrMountNotFound) {
-		return "", fmt.Errorf("expected mount at %s; no mount found", mount)
-	}
-
 	if err != nil {
+		if mountutil.IsMountNotFoundError(err) {
+			return "", fmt.Errorf("expected mount at %s; no mount found: %w", mount, err)
+		}
 		return "", err
 	}
 


### PR DESCRIPTION
While working on VSO, we discovered an issue where a read on non-existent mount resulted in an error that prevented the provider from completing successfully.

This PR reworks the error handling for both auth and secret engines.

Additional fixes:
- CI: test against vault enterprise 1.17.1; drop 1.11.x

See sample error below for
https://github.com/hashicorp/vault-secrets-operator/blob/8ee1ba05f08ea1c74a3cdcc76653908a8ae7f46f/demo/infra/app/auth.tf#L5 :
```
╷
│ Error: error reading from Vault: Error making API request.
│
│ URL: GET http://127.0.0.1:8200/v1/sys/mounts/auth/demo-auth-mount
│ Code: 400. Errors:
│
│ * No secret engine mount at auth/demo-auth-mount/
│
│   with vault_auth_backend.default,
│   on auth.tf line 5, in resource "vault_auth_backend" "default":
│    5: resource "vault_auth_backend" "default" {
│
```

The issue seems to also lead to the https://github.com/hashicorp/vault-secrets-operator/actions/runs/9810145898/job/27089804738#step:3:6485