### PR TITLE
Update vault_aws_secret_backend_role to support setting session_tags and external_id

### DIFF
--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -436,6 +436,7 @@ const (
 	FieldPrivateKeyID                  = "private_key_id"
 	FieldTune                          = "tune"
 	FieldMaxRetries                    = "max_retries"
+	FieldSessionTags                   = "session_tags"
 
 	/*
 		common environment variables

--- a/vault/resource_aws_secret_backend_role_test.go
+++ b/vault/resource_aws_secret_backend_role_test.go
@@ -27,10 +27,6 @@ const (
 	testAccAWSSecretBackendRolePermissionsBoundaryArn_updated = "arn:aws:iam::123456789123:policy/boundary2"
 	testAccAWSSecretBackendRoleIamUserPath_basic              = "/path1/"
 	testAccAWSSecretBackendRoleIamUserPath_updated            = "/path2/"
-	testAccAWSSecretBackendRoleIamTag_key_basic               = "key1"
-	testAccAWSSecretBackendRoleIamTag_value_basic             = "value1"
-	testAccAWSSecretBackendRoleIamTag_key_updated             = "key2"
-	testAccAWSSecretBackendRoleIamTag_value_updated           = "value2"
 )
 
 func TestAccAWSSecretBackendRole_basic(t *testing.T) {
@@ -43,15 +39,15 @@ func TestAccAWSSecretBackendRole_basic(t *testing.T) {
 		CheckDestroy:      testAccAWSSecretBackendRoleCheckDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSecretBackendRoleConfig_basic(name, backend, accessKey, secretKey),
+				Config: testAccAWSSecretBackendRoleConfigBasic(name, backend, accessKey, secretKey),
 				Check:  testAccAWSSecretBackendRoleCheckBasicAttributes(name, backend),
 			},
 			{
-				Config: testAccAWSSecretBackendRoleConfig_updated(name, backend, accessKey, secretKey),
+				Config: testAccAWSSecretBackendRoleConfigUpdated(name, backend, accessKey, secretKey),
 				Check:  testAccAWSSecretBackendRoleCheckUpdatedAttributes(name, backend),
 			},
 			{
-				Config: testAccAWSSecretBackendRoleConfig_basic(name, backend, accessKey, secretKey),
+				Config: testAccAWSSecretBackendRoleConfigBasic(name, backend, accessKey, secretKey),
 				Check:  testAccAWSSecretBackendRoleCheckBasicAttributes(name, backend),
 			},
 		},
@@ -68,7 +64,7 @@ func TestAccAWSSecretBackendRole_import(t *testing.T) {
 		CheckDestroy:      testAccAWSSecretBackendRoleCheckDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSecretBackendRoleConfig_basic(name, backend, accessKey, secretKey),
+				Config: testAccAWSSecretBackendRoleConfigBasic(name, backend, accessKey, secretKey),
 				Check:  testAccAWSSecretBackendRoleCheckBasicAttributes(name, backend),
 			},
 			{
@@ -110,11 +106,11 @@ func TestAccAWSSecretBackendRole_nested(t *testing.T) {
 		CheckDestroy:      testAccAWSSecretBackendRoleCheckDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSecretBackendRoleConfig_basic(name, backend, accessKey, secretKey),
+				Config: testAccAWSSecretBackendRoleConfigBasic(name, backend, accessKey, secretKey),
 				Check:  testAccAWSSecretBackendRoleCheckBasicAttributes(name, backend),
 			},
 			{
-				Config: testAccAWSSecretBackendRoleConfig_updated(name, backend, accessKey, secretKey),
+				Config: testAccAWSSecretBackendRoleConfigUpdated(name, backend, accessKey, secretKey),
 				Check:  testAccAWSSecretBackendRoleCheckUpdatedAttributes(name, backend),
 			},
 		},
@@ -172,7 +168,14 @@ func testAccAWSSecretBackendRoleCheckBasicAttributes(name, backend string) resou
 		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_iam_user_type_optional_attributes", "permissions_boundary_arn", testAccAWSSecretBackendRolePermissionsBoundaryArn_basic),
 		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_iam_user_type_optional_attributes", "user_path", testAccAWSSecretBackendRoleIamUserPath_basic),
 		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_iam_user_type_optional_attributes", "iam_tags.%", "1"),
-		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_iam_user_type_optional_attributes", fmt.Sprintf("iam_tags.%s", testAccAWSSecretBackendRoleIamTag_key_basic), testAccAWSSecretBackendRoleIamTag_value_basic),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_iam_user_type_optional_attributes", "iam_tags.key1", "value1"),
+		// assume  role with session tags
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_assumed_role_session_tags", "name", fmt.Sprintf("%s-session-tags", name)),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_assumed_role_session_tags", "backend", backend),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_assumed_role_session_tags", "external_id", "ext1"),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_assumed_role_session_tags", "session_tags.%", "2"),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_assumed_role_session_tags", "session_tags.key1", "value1"),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_assumed_role_session_tags", "session_tags.key2", "value2"),
 	)
 }
 
@@ -212,11 +215,17 @@ func testAccAWSSecretBackendRoleCheckUpdatedAttributes(name, backend string) res
 		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_iam_user_type_optional_attributes", "permissions_boundary_arn", testAccAWSSecretBackendRolePermissionsBoundaryArn_updated),
 		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_iam_user_type_optional_attributes", "user_path", testAccAWSSecretBackendRoleIamUserPath_updated),
 		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_iam_user_type_optional_attributes", "iam_tags.%", "1"),
-		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_iam_user_type_optional_attributes", fmt.Sprintf("iam_tags.%s", testAccAWSSecretBackendRoleIamTag_key_updated), testAccAWSSecretBackendRoleIamTag_value_updated),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_iam_user_type_optional_attributes", "iam_tags.key2", "value2"),
+		// assume  role with session tags
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_assumed_role_session_tags", "name", fmt.Sprintf("%s-session-tags", name)),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_assumed_role_session_tags", "backend", backend),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_assumed_role_session_tags", "external_id", "ext2"),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_assumed_role_session_tags", "session_tags.%", "1"),
+		resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_assumed_role_session_tags", "session_tags.key1", "value1"),
 	)
 }
 
-func testAccAWSSecretBackendRoleConfig_basic(name, path, accessKey, secretKey string) string {
+func testAccAWSSecretBackendRoleConfigBasic(name, path, accessKey, secretKey string) string {
 	resources := []string{
 		fmt.Sprintf(`
 resource "vault_aws_secret_backend" "test" {
@@ -291,14 +300,28 @@ resource "vault_aws_secret_backend_role" "test_iam_user_type_optional_attributes
 			testAccAWSSecretBackendRolePolicyArn_basic,
 			testAccAWSSecretBackendRolePermissionsBoundaryArn_basic,
 			testAccAWSSecretBackendRoleIamUserPath_basic,
-			testAccAWSSecretBackendRoleIamTag_key_basic,
-			testAccAWSSecretBackendRoleIamTag_value_basic),
+			"key1",
+			"value1"),
+
+		fmt.Sprintf(`
+resource "vault_aws_secret_backend_role" "test_assumed_role_session_tags" {
+  name = "%s-session-tags"
+  role_arns = ["%s"]
+  credential_type = "assumed_role"
+  backend = vault_aws_secret_backend.test.path
+  external_id = "ext1"
+  session_tags = {
+	"key1" = "value1"
+	"key2" = "value2"
+  }
+}
+`, name, testAccAWSSecretBackendRoleRoleArn_basic),
 	}
 
 	return strings.Join(resources, "\n")
 }
 
-func testAccAWSSecretBackendRoleConfig_updated(name, path, accessKey, secretKey string) string {
+func testAccAWSSecretBackendRoleConfigUpdated(name, path, accessKey, secretKey string) string {
 	resources := []string{
 		fmt.Sprintf(`
 resource "vault_aws_secret_backend" "test" {
@@ -386,8 +409,20 @@ resource "vault_aws_secret_backend_role" "test_iam_user_type_optional_attributes
 			testAccAWSSecretBackendRolePolicyArn_updated,
 			testAccAWSSecretBackendRolePermissionsBoundaryArn_updated,
 			testAccAWSSecretBackendRoleIamUserPath_updated,
-			testAccAWSSecretBackendRoleIamTag_key_updated,
-			testAccAWSSecretBackendRoleIamTag_value_updated),
+			"key2",
+			"value2"),
+		fmt.Sprintf(`
+resource "vault_aws_secret_backend_role" "test_assumed_role_session_tags" {
+  name = "%s-session-tags"
+  role_arns = ["%s"]
+  credential_type = "assumed_role"
+  backend = vault_aws_secret_backend.test.path
+  external_id = "ext2"
+  session_tags = {
+	"key1" = "value1"
+  }
+}
+`, name, testAccAWSSecretBackendRoleRoleArn_basic),
 	}
 	return strings.Join(resources, "\n")
 }

--- a/website/docs/r/aws_secret_backend_role.html.md
+++ b/website/docs/r/aws_secret_backend_role.html.md
@@ -93,6 +93,13 @@ The following arguments are supported:
 * `iam_tags` (Optional) - A map of strings representing key/value pairs
   to be used as tags for any IAM user that is created by this role.
 
+* `session_tags` (Optional) - A map of strings representing key/value pairs to be set
+  during assume role creds creation. Valid only when `credential_type` is set to 
+  `assumed_role`.
+
+* `external_id` (Optional) - External ID to set for assume role creds. 
+  Valid only when `credential_type` is set to `assumed_role`.
+
 * `default_sts_ttl` - (Optional) The default TTL in seconds for STS credentials.
   When a TTL is not specified when STS credentials are requested,
   and a default TTL is specified on the role,


### PR DESCRIPTION
Updates vault_aws_secret_backend_role per: https://github.com/hashicorp/vault/pull/27620

Adds support for setting session_tags and external_id. Which will be
released in vault 1.17.2


### Output from acceptance testing:

```
go tool test2json -t /Users/bash/Library/Caches/JetBrains/IntelliJIdea2024.1/tmp/GoLand/___1TestAccAWSSecretBackendRole_basic_in_github_com_hashicorp_terraform_provider_vault_vault.test -test.v -test.paniconexit0 -test.run ^\QTestAccAWSSecretBackendRole_basic\E$
=== RUN   TestAccAWSSecretBackendRole_basic
--- PASS: TestAccAWSSecretBackendRole_basic (2.44s)
PASS
```
