### PR TITLE
Add `subscribe` to list of allowed capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ FEATURES:
 * Add new resource `vault_pki_secret_backend_acme_eab` to manage PKI ACME external account binding tokens. Requires Vault 1.14+. ([#2367](https://github.com/hashicorp/terraform-provider-vault/pull/2367))
 * Add new data source and resource `vault_pki_secret_backend_config_cmpv2`. Requires Vault 1.18+. *Available only for Vault Enterprise* ([#2330](https://github.com/hashicorp/terraform-provider-vault/pull/2330))
 
+IMPROVEMENTS:
+
+* Support the event `subscribe` policy capability for `vault_policy_document` data source ([#2293](https://github.com/hashicorp/terraform-provider-vault/pull/2293))
+
 ## 4.5.0 (Nov 19, 2024)
 
 FEATURES:

--- a/vault/data_source_policy_document.go
+++ b/vault/data_source_policy_document.go
@@ -41,6 +41,7 @@ var allowedCapabilities = []string{
 	"sudo",
 	"deny",
 	"patch",
+	"subscribe",
 }
 
 func policyDocumentDataSource() *schema.Resource {


### PR DESCRIPTION
For Vault Enterprise users, `subscribe` is a valid capability [(ref)](https://developer.hashicorp.com/vault/docs/concepts/events#policies) and should be included in the list of allowed capabilities.