### PR TITLE
secret/ssh: handle state upgrade for key_type field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+BUGS:
+* fix `vault_ssh_secret_backend_ca` where a schema change forced the resource to be replaced ([#2308](https://github.com/hashicorp/terraform-provider-vault/pull/2308))
+* fix a bug where a read on non-existent auth or secret mount resulted in an error that prevented the provider from completing successfully ([#2289](https://github.com/hashicorp/terraform-provider-vault/pull/2289))
+
 ## 4.3.0 (Jun 17, 2024)
 
 FEATURES:

--- a/vault/resource_ssh_secret_backend_ca.go
+++ b/vault/resource_ssh_secret_backend_ca.go
@@ -15,6 +15,8 @@ import (
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
+const defaultKeyTypeSSH = "ssh-rsa"
+
 func sshSecretBackendCAResource() *schema.Resource {
 	return &schema.Resource{
 		Create: sshSecretBackendCACreate,
@@ -52,7 +54,7 @@ func sshSecretBackendCAResource() *schema.Resource {
 			},
 			"key_type": {
 				Type:        schema.TypeString,
-				Default:     "ssh-rsa",
+				Default:     defaultKeyTypeSSH,
 				Optional:    true,
 				ForceNew:    true,
 				Description: "Specifies the desired key type for the generated SSH CA key when `generate_signing_key` is set to `true`.",
@@ -177,7 +179,7 @@ func sshSecretBackendCAResourceV0() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"key_type": {
 				Type:        schema.TypeString,
-				Default:     "ssh-rsa",
+				Default:     defaultKeyTypeSSH,
 				Optional:    true,
 				ForceNew:    true,
 				Description: "Specifies the desired key type for the generated SSH CA key when `generate_signing_key` is set to `true`.",
@@ -196,7 +198,7 @@ func sshSecretBackendCAResourceV0() *schema.Resource {
 // See https://github.com/hashicorp/terraform-provider-vault/issues/2281
 func sshSecretBackendCAUpgradeV0(_ context.Context, rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
 	if rawState["key_type"] == nil {
-		rawState["key_type"] = "ssh-rsa"
+		rawState["key_type"] = defaultKeyTypeSSH
 	}
 
 	return rawState, nil


### PR DESCRIPTION
Fix a bug where Upgrading the Vault provider from 4.2.0 to 4.3.0 results in `vault_ssh_secret_backend_ca` being replaced although no other changes have been made.

The key_type attribute, introduced in https://github.com/hashicorp/terraform-provider-vault/pull/1454, gets added (implicit, using the default value) and forces the resource to be replaced.

Closes #2281 