### PR TITLE
Fix required go version in README.md to match .go-version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Requirements
 ------------
 
 - [Terraform](https://www.terraform.io/downloads.html) 0.12.x and above, we recommend using the latest stable release whenever possible.
-- [Go](https://golang.org/doc/install) 1.20 (to build the provider plugin)
+- [Go](https://golang.org/doc/install) 1.22.3 (to build the provider plugin)
 
 Building The Provider
 ---------------------
@@ -45,7 +45,7 @@ $ make build
 Developing the Provider
 ---------------------------
 
-If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.20+ is *required*). You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.
+If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.22.3+ is *required*). You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.
 
 To compile the provider, run `make build`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
 


### PR DESCRIPTION
### Description
This PR updates README.md to reflect the Go version actually required to build the provider.
