### PR TITLE
Fix vault_aws_auth_backend_cert typo in docs

### DIFF
--- a/website/docs/r/aws_auth_backend_cert.html.md
+++ b/website/docs/r/aws_auth_backend_cert.html.md
@@ -31,7 +31,7 @@ resource "vault_auth_backend" "aws" {
 }
 
 resource "vault_aws_auth_backend_cert" "cert" {
-  backend         = vault_auth_backend.aws.path}"
+  backend         = vault_auth_backend.aws.path
   cert_name       = "my-cert"
   aws_public_cert = file("${path.module}/aws_public_key.crt)"
   type            = "pkcs7"


### PR DESCRIPTION
This fixes a small interpolation typo in the docs.