### PR TITLE
Remove consul secret backend role from state if not found on vault

### DIFF
--- a/vault/resource_consul_secret_backend_role.go
+++ b/vault/resource_consul_secret_backend_role.go
@@ -231,7 +231,9 @@ func consulSecretBackendRoleRead(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	if secret == nil {
-		return diag.Errorf("resource not found")
+		log.Printf("[WARN] ConsulSecretBackendRole %q not found, removing from state", path)
+		d.SetId("")
+		return nil
 	}
 
 	data := secret.Data


### PR DESCRIPTION
### Description
When a consul secret beckend role disappears from Vault, the terraform provider returns an error during the refresh, because it fails reading the resource. This prevents Terraform from fixing what could be a configuration drift.

This merge request modifies the vault_consul_secret_backend_role resource so that the resource is removed from the state if it is no longer on Vault.

### Checklist
- [x ] Acceptance tests where run against the master version


### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request
