### PR TITLE
Enhance secret by adding num_uses and ttl for vault_approle_auth_backend_role_secret_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ FEATURES:
 
 * Update `vault_database_secret_backend_connection` to support inline TLS config for PostgreSQL ([#2339](https://github.com/hashicorp/terraform-provider-vault/pull/2339))
 * Update `vault_database_secret_backend_connection` to support skip_verification config for Cassandra ([#2346](https://github.com/hashicorp/terraform-provider-vault/pull/2346))
+* Update `vault_approle_auth_backend_role_secret_id` to support `num_uses` and `ttl` fields ([#2345](https://github.com/hashicorp/terraform-provider-vault/pull/2345))
 
 ## 4.4.0 (Aug 7, 2024)
 

--- a/vault/resource_approle_auth_backend_role_secret_id.go
+++ b/vault/resource_approle_auth_backend_role_secret_id.go
@@ -71,6 +71,22 @@ func approleAuthBackendRoleSecretIDResource(name string) *schema.Resource {
 					return false
 				},
 			},
+			//Fadia u have added this
+			consts.FieldTTL: {
+				Type:        schema.TypeInt,
+				Required:    false,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The TTL duration of the SecretID.",
+			},
+			//fadia u have added this
+			consts.FieldNumUses: {
+				Type:        schema.TypeInt,
+				Required:    false,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "The number of uses for the secret-id.",
+			},
 
 			consts.FieldBackend: {
 				Type:        schema.TypeString,
@@ -161,6 +177,14 @@ func approleAuthBackendRoleSecretIDCreate(ctx context.Context, d *schema.Resourc
 		data["metadata"] = result
 	} else {
 		data["metadata"] = ""
+	}
+	//Fadia you just need to check weither the ttl was specified because it is optional.
+	if v, ok := d.GetOk(consts.FieldTTL); ok {
+		data["ttl"] = v
+	}
+	//Fadia you just need to check weither the num uses was specified because it is optional.
+	if v, ok := d.GetOk(consts.FieldNumUses); ok {
+		data["num_uses"] = v
 	}
 	withWrappedAccessor := d.Get(consts.FieldWithWrappedAccessor).(bool)
 
@@ -292,13 +316,17 @@ func approleAuthBackendRoleSecretIDRead(ctx context.Context, d *schema.ResourceD
 	if err != nil {
 		return diag.Errorf("error encoding metadata for SecretID %q to JSON: %s", id, err)
 	}
-
+	//fadia you have added this.
+	ttl := resp.Data["secret_id_ttl"]
+	numUses := resp.Data["secret_id_num_uses"]
 	fields := map[string]interface{}{
 		consts.FieldBackend:  backend,
 		consts.FieldRoleName: role,
 		consts.FieldCIDRList: cidrs,
 		consts.FieldMetadata: string(metadata),
 		consts.FieldAccessor: accessor,
+		consts.FieldTTL:      ttl,
+		consts.FieldNumUses:  numUses,
 	}
 
 	for k, v := range fields {

--- a/vault/resource_approle_auth_backend_role_secret_id.go
+++ b/vault/resource_approle_auth_backend_role_secret_id.go
@@ -71,7 +71,7 @@ func approleAuthBackendRoleSecretIDResource(name string) *schema.Resource {
 					return false
 				},
 			},
-			
+
 			consts.FieldTTL: {
 				Type:        schema.TypeInt,
 				Required:    false,
@@ -79,7 +79,7 @@ func approleAuthBackendRoleSecretIDResource(name string) *schema.Resource {
 				ForceNew:    true,
 				Description: "The TTL duration of the SecretID.",
 			},
-			
+
 			consts.FieldNumUses: {
 				Type:        schema.TypeInt,
 				Required:    false,
@@ -178,11 +178,11 @@ func approleAuthBackendRoleSecretIDCreate(ctx context.Context, d *schema.Resourc
 	} else {
 		data["metadata"] = ""
 	}
-	
+
 	if v, ok := d.GetOk(consts.FieldTTL); ok {
 		data["ttl"] = v
 	}
-	
+
 	if v, ok := d.GetOk(consts.FieldNumUses); ok {
 		data["num_uses"] = v
 	}
@@ -316,7 +316,7 @@ func approleAuthBackendRoleSecretIDRead(ctx context.Context, d *schema.ResourceD
 	if err != nil {
 		return diag.Errorf("error encoding metadata for SecretID %q to JSON: %s", id, err)
 	}
-	
+
 	ttl := resp.Data["secret_id_ttl"]
 	numUses := resp.Data["secret_id_num_uses"]
 	fields := map[string]interface{}{

--- a/vault/resource_approle_auth_backend_role_secret_id.go
+++ b/vault/resource_approle_auth_backend_role_secret_id.go
@@ -319,6 +319,7 @@ func approleAuthBackendRoleSecretIDRead(ctx context.Context, d *schema.ResourceD
 
 	ttl := resp.Data["secret_id_ttl"]
 	numUses := resp.Data["secret_id_num_uses"]
+
 	fields := map[string]interface{}{
 		consts.FieldBackend:  backend,
 		consts.FieldRoleName: role,

--- a/vault/resource_approle_auth_backend_role_secret_id.go
+++ b/vault/resource_approle_auth_backend_role_secret_id.go
@@ -71,7 +71,7 @@ func approleAuthBackendRoleSecretIDResource(name string) *schema.Resource {
 					return false
 				},
 			},
-			//Fadia u have added this
+			
 			consts.FieldTTL: {
 				Type:        schema.TypeInt,
 				Required:    false,
@@ -79,7 +79,7 @@ func approleAuthBackendRoleSecretIDResource(name string) *schema.Resource {
 				ForceNew:    true,
 				Description: "The TTL duration of the SecretID.",
 			},
-			//fadia u have added this
+			
 			consts.FieldNumUses: {
 				Type:        schema.TypeInt,
 				Required:    false,
@@ -178,11 +178,11 @@ func approleAuthBackendRoleSecretIDCreate(ctx context.Context, d *schema.Resourc
 	} else {
 		data["metadata"] = ""
 	}
-	//Fadia you just need to check weither the ttl was specified because it is optional.
+	
 	if v, ok := d.GetOk(consts.FieldTTL); ok {
 		data["ttl"] = v
 	}
-	//Fadia you just need to check weither the num uses was specified because it is optional.
+	
 	if v, ok := d.GetOk(consts.FieldNumUses); ok {
 		data["num_uses"] = v
 	}
@@ -316,7 +316,7 @@ func approleAuthBackendRoleSecretIDRead(ctx context.Context, d *schema.ResourceD
 	if err != nil {
 		return diag.Errorf("error encoding metadata for SecretID %q to JSON: %s", id, err)
 	}
-	//fadia you have added this.
+	
 	ttl := resp.Data["secret_id_ttl"]
 	numUses := resp.Data["secret_id_num_uses"]
 	fields := map[string]interface{}{

--- a/vault/resource_approle_auth_backend_role_secret_id_test.go
+++ b/vault/resource_approle_auth_backend_role_secret_id_test.go
@@ -190,6 +190,9 @@ func TestAccAppRoleAuthBackendRoleSecretID_full(t *testing.T) {
 					resource.TestCheckResourceAttrSet(secretIDResource, "accessor"),
 					resource.TestCheckResourceAttr(secretIDResource, "cidr_list.#", "2"),
 					resource.TestCheckResourceAttr(secretIDResource, consts.FieldMetadata, `{"hello":"world"}`),
+					//fadia
+					resource.TestCheckResourceAttr(secretIDResource, "ttl", "700"),
+					resource.TestCheckResourceAttr(secretIDResource, "num_uses", ""),
 				),
 			},
 		},
@@ -254,6 +257,8 @@ resource "vault_approle_auth_backend_role_secret_id" "secret_id" {
   role_name = vault_approle_auth_backend_role.role.role_name
   backend = vault_auth_backend.approle.path
   cidr_list = ["10.148.0.0/20", "10.150.0.0/20"]
+  ttl = 700
+  num_uses = 2
   metadata = <<EOF
 {
   "hello": "world"

--- a/vault/resource_approle_auth_backend_role_secret_id_test.go
+++ b/vault/resource_approle_auth_backend_role_secret_id_test.go
@@ -192,7 +192,7 @@ func TestAccAppRoleAuthBackendRoleSecretID_full(t *testing.T) {
 					resource.TestCheckResourceAttr(secretIDResource, consts.FieldMetadata, `{"hello":"world"}`),
 					//fadia
 					resource.TestCheckResourceAttr(secretIDResource, "ttl", "700"),
-					resource.TestCheckResourceAttr(secretIDResource, "num_uses", ""),
+					resource.TestCheckResourceAttr(secretIDResource, "num_uses", "2"),
 				),
 			},
 		},

--- a/vault/resource_approle_auth_backend_role_secret_id_test.go
+++ b/vault/resource_approle_auth_backend_role_secret_id_test.go
@@ -190,7 +190,6 @@ func TestAccAppRoleAuthBackendRoleSecretID_full(t *testing.T) {
 					resource.TestCheckResourceAttrSet(secretIDResource, "accessor"),
 					resource.TestCheckResourceAttr(secretIDResource, "cidr_list.#", "2"),
 					resource.TestCheckResourceAttr(secretIDResource, consts.FieldMetadata, `{"hello":"world"}`),
-					//fadia
 					resource.TestCheckResourceAttr(secretIDResource, "ttl", "700"),
 					resource.TestCheckResourceAttr(secretIDResource, "num_uses", "2"),
 				),


### PR DESCRIPTION



### Description

<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
Generating an AppRole secret_id in the vault API allows specifying the num_uses and ttl . these two parameters are not available for the vault_approle_auth_backend_role_secret_id resource, and so on can't be specified in the terraform code 

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
This PR adds the two attributes to the resources 
Closes #2236



### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAppRoleAuthBackendRoleSecretID_full'


?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/mfa     [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/pki      [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/sync     [no test files]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/codegen   0.933s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  1.471s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/internal/provider 1.948s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/testutil  1.775s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/util      2.091s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/util/mountutil    1.902s [no tests to run]
=== RUN   TestAccAppRoleAuthBackendRoleSecretID_full
--- PASS: TestAccAppRoleAuthBackendRoleSecretID_full (2.22s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     5.067s
...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

