### PR TITLE
db/cassandra: Add support for skip_verification config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 FEATURES:
 
 * Update `vault_database_secret_backend_connection` to support inline TLS config for PostgreSQL ([#2339](https://github.com/hashicorp/terraform-provider-vault/pull/2339))
+* Update `vault_database_secret_backend_connection` to support skip_verification config for Cassandra ([#2346](https://github.com/hashicorp/terraform-provider-vault/pull/2346))
 
 ## 4.4.0 (Aug 7, 2024)
 

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -2079,6 +2079,9 @@ func getConnectionDetailsCassandra(d *schema.ResourceData, prefix string, resp *
 			}
 			result["connect_timeout"] = timeout
 		}
+		if v, ok := data["skip_verification"]; ok {
+			result["skip_verification"] = v.(bool)
+		}
 		return result, nil
 	}
 	return nil, nil

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -335,6 +335,12 @@ func getDatabaseSchema(typ schema.ValueType) schemaMap {
 						Default:     5,
 						Description: "The number of seconds to use as a connection timeout.",
 					},
+					"skip_verification": {
+						Type:        schema.TypeBool,
+						Optional:    true,
+						Default:     false,
+						Description: "Skip permissions checks when a connection to Cassandra is first created. These checks ensure that Vault is able to create roles, but can be resource intensive in clusters with many roles.",
+					},
 				},
 			},
 			MaxItems:      1,
@@ -1040,6 +1046,9 @@ func setCassandraDatabaseConnectionData(d *schema.ResourceData, prefix string, d
 	}
 	if v, ok := d.GetOkExists(prefix + "connect_timeout"); ok {
 		data["connect_timeout"] = v.(int)
+	}
+	if v, ok := d.GetOkExists(prefix + "skip_verification"); ok {
+		data["skip_verification"] = v.(bool)
 	}
 }
 

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -116,6 +116,7 @@ func TestAccDatabaseSecretBackendConnection_cassandra(t *testing.T) {
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.pem_json", ""),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.protocol_version", "4"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.connect_timeout", "5"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.skip_verification", "false"),
 				),
 			},
 		},

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -160,6 +160,7 @@ func TestAccDatabaseSecretBackendConnection_cassandraProtocol(t *testing.T) {
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.pem_json", ""),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.protocol_version", "5"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.connect_timeout", "5"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.skip_verification", "false"),
 				),
 			},
 		},

--- a/website/docs/r/database_secret_backend_connection.md
+++ b/website/docs/r/database_secret_backend_connection.md
@@ -124,6 +124,9 @@ Exactly one of the nested blocks of configuration options must be supplied.
 * `connect_timeout` - (Optional) The number of seconds to use as a connection
   timeout.
 
+* `skip_verification` - (Optional) Skip permissions checks when a connection to Cassandra is first created. 
+  These checks ensure that Vault is able to create roles, but can be resource intensive in clusters with many roles.
+
 ### Couchbase Configuration Options
 
 * `hosts` - (Required) A set of Couchbase URIs to connect to. Must use `couchbases://` scheme if `tls` is `true`.


### PR DESCRIPTION
### Description
Adds [skip_verification](https://developer.hashicorp.com/vault/api-docs/secret/databases/cassandra#skip_verification) to Cassandra database plugin

### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -run=TestAccXXX -timeout 30m ./...
?   	github.com/hashicorp/terraform-provider-vault	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/generate	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/helper	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/consts	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/group	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/mfa	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/pki	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/sync	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/schema	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/codegen	0.007s [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/internal/identity/entity	0.013s [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/internal/provider	0.016s [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/testutil	0.007s [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/util	0.010s [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/util/mountutil	0.004s [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/vault	0.021s [no tests to run]
...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

