### PR TITLE
secret/ssh: add support for allow_empty_principals on roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ FEATURES:
 * Update `vault_database_secret_backend_connection` to support skip_verification config for Cassandra ([#2346](https://github.com/hashicorp/terraform-provider-vault/pull/2346))
 * Update `vault_approle_auth_backend_role_secret_id` to support `num_uses` and `ttl` fields ([#2345](https://github.com/hashicorp/terraform-provider-vault/pull/2345))
 * Add support for `use_annotations_as_alias_metadata` field for the `vault_kubernetes_auth_backend_config` resource ([#2206](https://github.com/hashicorp/terraform-provider-vault/pull/2206))
+* Add support for `allow_empty_principals` field for the `vault_ssh_secret_backend_role` resource ([#2354](https://github.com/hashicorp/terraform-provider-vault/pull/2354))
 
 ## 4.4.0 (Aug 7, 2024)
 

--- a/vault/resource_ssh_secret_backend_role_test.go
+++ b/vault/resource_ssh_secret_backend_role_test.go
@@ -86,10 +86,6 @@ func TestAccSSHSecretBackendRole(t *testing.T) {
 				checks = append(checks, initialCheckFuncs...)
 			}
 
-			// can append version-dependent checks here:
-			// meta := testProvider.Meta().(*provider.ProviderMeta)
-			// isVaultVersion117 := meta.IsAPISupported(provider.VaultVersion117)
-
 			return resource.ComposeAggregateTestCheckFunc(checks...)(state)
 		}
 	}

--- a/vault/resource_ssh_secret_backend_role_test.go
+++ b/vault/resource_ssh_secret_backend_role_test.go
@@ -122,11 +122,7 @@ func TestAccSSHSecretBackendRole(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "allowed_user_key_config.1.lengths.0", "256"),
 				),
 			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
+			testutil.GetImportTestStep(resourceName, false, nil, "allow_empty_principals"),
 		}
 	}
 
@@ -134,7 +130,6 @@ func TestAccSSHSecretBackendRole(t *testing.T) {
 		ProviderFactories: providerFactories,
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion117)
 		},
 		CheckDestroy: testAccSSHSecretBackendRoleCheckDestroy,
 		Steps:        getSteps(""),
@@ -185,7 +180,7 @@ func TestAccSSHSecretBackendRole_template(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "default_user_template", "true"),
 				),
 			},
-			testutil.GetImportTestStep(resourceName, false, nil),
+			testutil.GetImportTestStep(resourceName, false, nil, "allow_empty_principals"),
 		},
 	})
 }


### PR DESCRIPTION
https://github.com/hashicorp/vault/pull/28466 introduced a breaking change (Vault 1.18, backported to 1.17) for the SSH Backend by disallowing empty roles by default. This PR allows configuring that via TFVP.


Closes https://github.com/hashicorp/terraform-provider-vault/issues/2340