### PR TITLE
feat: support default_extensions_template in SSH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ FEATURES:
 * Update `vault_database_secret_backend_connection` to support skip_verification config for Cassandra ([#2346](https://github.com/hashicorp/terraform-provider-vault/pull/2346))
 * Update `vault_approle_auth_backend_role_secret_id` to support `num_uses` and `ttl` fields ([#2345](https://github.com/hashicorp/terraform-provider-vault/pull/2345))
 * Add support for `use_annotations_as_alias_metadata` field for the `vault_kubernetes_auth_backend_config` resource ([#2206](https://github.com/hashicorp/terraform-provider-vault/pull/2206))
+* Add support for `default_extensions_template` field for the `vault_ssh_secret_backend_role` resource.
 
 ## 4.4.0 (Aug 7, 2024)
 

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -507,6 +507,7 @@ const (
 	/*
 		Vault version constants
 	*/
+	VaultVersion180 = "1.8.0"
 	VaultVersion190 = "1.9.0"
 	VaultVersion110 = "1.10.0"
 	VaultVersion111 = "1.11.0"

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -35,6 +35,8 @@ const (
 var (
 	MaxHTTPRetriesCCC int
 
+	VaultVersion180 = version.Must(version.NewSemver(consts.VaultVersion110))
+	VaultVersion190 = version.Must(version.NewSemver(consts.VaultVersion190))
 	VaultVersion110 = version.Must(version.NewSemver(consts.VaultVersion110))
 	VaultVersion111 = version.Must(version.NewSemver(consts.VaultVersion111))
 	VaultVersion112 = version.Must(version.NewSemver(consts.VaultVersion112))

--- a/vault/resource_ssh_secret_backend_role.go
+++ b/vault/resource_ssh_secret_backend_role.go
@@ -91,6 +91,11 @@ func sshSecretBackendRoleResource() *schema.Resource {
 			Type:     schema.TypeMap,
 			Optional: true,
 		},
+		"default_extensions_template": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
 		"default_critical_options": {
 			Type:     schema.TypeMap,
 			Optional: true,
@@ -238,6 +243,12 @@ func sshSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) error {
 		data["default_extensions"] = v
 	}
 
+	if provider.IsAPISupported(meta, provider.VaultVersion180) {
+		if v, ok := d.GetOk("default_extensions_template"); ok {
+			data["default_extensions_template"] = v.(bool)
+		}
+	}
+
 	if v, ok := d.GetOk("default_critical_options"); ok {
 		data["default_critical_options"] = v
 	}
@@ -354,6 +365,10 @@ func sshSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 		"default_critical_options", "allowed_users_template",
 		"allowed_users", "default_user", "key_id_format",
 		"max_ttl", "ttl", "algorithm_signer", "not_before_duration",
+	}
+
+	if provider.IsAPISupported(meta, provider.VaultVersion180) {
+		fields = append(fields, []string{"default_extensions_template"}...)
 	}
 
 	if provider.IsAPISupported(meta, provider.VaultVersion112) {

--- a/website/docs/r/ssh_secret_backend_role.html.md
+++ b/website/docs/r/ssh_secret_backend_role.html.md
@@ -73,6 +73,8 @@ The following arguments are supported:
 
 * `default_extensions` - (Optional) Specifies a map of extensions that certificates have when signed.
 
+* `default_extensions_template` - (Optional) If set, `default_extensions` can be specified using identity template values. A non-templated user is also permitted.
+
 * `default_critical_options` - (Optional) Specifies a map of critical options that certificates have when signed.
 
 * `allowed_users_template` - (Optional) Specifies if `allowed_users` can be declared using identity template policies. Non-templated users are also permitted.


### PR DESCRIPTION


<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
Support the `default_extensions_template` parameter in SSH backend role resource.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000


### Checklist
- [X] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [X] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='--run SSHSecretBackendRole'
...
=== RUN   TestAccSSHSecretBackendRole_extensionsTemplate
--- PASS: TestAccSSHSecretBackendRole_extensionsTemplate (4.19s)
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

