### PR TITLE
tests: make postgres rootless tests run in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,7 +205,14 @@ jobs:
           MYSQL_CONNECTION_PASSWORD: "mysql"
           MONGODB_URL: "mongodb://root:mongodb@mongo:27017/admin?ssl=false"
           MSSQL_URL: "sqlserver://sa:${{ secrets.MSSQL_SA_PASSWORD }}@mssql:1433"
+          # POSTGRES_URL is the standard root conn URL for Vault
           POSTGRES_URL: "postgres://postgres:secret@postgres:5432/database?sslmode=disable"
+          # POSTGRES_URL_TEST is used by the TFVP test to connect directly to
+          # the postgres container. Note: the host is "localhost" because the
+          # TFVP tests do not run in the same docker network.
+          POSTGRES_URL_TEST: "postgres://postgres:secret@localhost:5432/database?sslmode=disable"
+          # POSTGRES_URL_ROOTLESS is used by Vault to connect to the postgres container.
+          POSTGRES_URL_ROOTLESS: "postgres://{{username}}:{{password}}@postgres:5432/database?sslmode=disable"
           COUCHBASE_HOST: couchbase
           COUCHBASE_USERNAME: Administrator
           COUCHBASE_PASSWORD: password

--- a/testutil/postgresqlhelper.go
+++ b/testutil/postgresqlhelper.go
@@ -6,41 +6,12 @@ package testutil
 import (
 	"context"
 	"database/sql"
-	"fmt"
-	"github.com/hashicorp/vault/sdk/helper/dbtxn"
-	"github.com/hashicorp/vault/sdk/helper/docker"
-	"net/url"
-	"os"
 	"testing"
+
+	"github.com/hashicorp/vault/sdk/helper/dbtxn"
 
 	_ "github.com/jackc/pgx/v4/stdlib"
 )
-
-const (
-	defaultPGImage   = "docker.mirror.hashicorp.services/postgres"
-	defaultPGVersion = "13.4-buster"
-	defaultPGPass    = "secret"
-)
-
-func defaultRunOpts(t *testing.T) docker.RunOptions {
-	return docker.RunOptions{
-		ContainerName: "postgres",
-		ImageRepo:     defaultPGImage,
-		ImageTag:      defaultPGVersion,
-		Env: []string{
-			"POSTGRES_PASSWORD=" + defaultPGPass,
-			"POSTGRES_DB=database",
-		},
-		Ports:             []string{"5432/tcp"},
-		DoNotAutoRemove:   false,
-		OmitLogTimestamps: true,
-		LogConsumer: func(s string) {
-			if t.Failed() {
-				t.Logf("container logs: %s", s)
-			}
-		},
-	}
-}
 
 func CreateTestPGUser(t *testing.T, connURL string, username, password, query string) {
 	t.Helper()
@@ -72,56 +43,5 @@ func CreateTestPGUser(t *testing.T, connURL string, username, password, query st
 	// Commit the transaction
 	if err := tx.Commit(); err != nil {
 		t.Fatal(err)
-	}
-}
-
-func PrepareTestContainerSelfManaged(t *testing.T) (func(), *url.URL) {
-	return prepareTestContainerSelfManaged(t, defaultRunOpts(t), defaultPGPass, true, false, false)
-}
-
-func prepareTestContainerSelfManaged(t *testing.T, runOpts docker.RunOptions, password string, addSuffix, forceLocalAddr, useFallback bool,
-) (func(), *url.URL) {
-	if os.Getenv("PG_URL") != "" {
-		return func() {}, nil
-	}
-
-	runner, err := docker.NewServiceRunner(runOpts)
-	if err != nil {
-		t.Fatalf("Could not start docker Postgres: %s", err)
-	}
-
-	svc, _, err := runner.StartNewService(context.Background(), addSuffix, forceLocalAddr, connectPostgres(password, runOpts.ImageRepo, useFallback))
-	if err != nil {
-		t.Fatalf("Could not start docker Postgres: %s", err)
-	}
-
-	return svc.Cleanup, svc.Config.URL()
-}
-
-func connectPostgres(password, repo string, useFallback bool) docker.ServiceAdapter {
-	return func(ctx context.Context, host string, port int) (docker.ServiceConfig, error) {
-		hostAddr := fmt.Sprintf("%s:%d", host, port)
-		if useFallback {
-			// set the first host to a bad address so we can test the fallback logic
-			hostAddr = "localhost:55," + hostAddr
-		}
-		u := url.URL{
-			Scheme:   "postgres",
-			User:     url.UserPassword("postgres", password),
-			Host:     hostAddr,
-			Path:     "postgres",
-			RawQuery: "sslmode=disable",
-		}
-
-		db, err := sql.Open("pgx", u.String())
-		if err != nil {
-			return nil, err
-		}
-		defer db.Close()
-
-		if err = db.Ping(); err != nil {
-			return nil, err
-		}
-		return docker.NewServiceURL(u), nil
 	}
 }


### PR DESCRIPTION
This PR has no effect on the end user. This changes makes the postgres rootless test run in CI.