### PR TITLE
Vault 32530 add external id to aws auth backend sts role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+FEATURES:
+
+* Add support for `external_id` field for the `vault_aws_auth_backend_sts_role` resource ([#2370](https://github.com/hashicorp/terraform-provider-vault/pull/2370))
+
 ## 4.5.0 (Nov 19, 2024)
 
 FEATURES:
@@ -12,7 +16,6 @@ FEATURES:
 * Add support for `connection_timeout` field for the `vault_ldap_auth_backend` resource ([#2358](https://github.com/hashicorp/terraform-provider-vault/pull/2358))
 * Add support for Rootless Configuration for Static Roles to Postgres DB ([#2341](https://github.com/hashicorp/terraform-provider-vault/pull/2341))
 * Add support for `use_annotations_as_alias_metadata` field for the `vault_kubernetes_auth_backend_config` resource ([#2226](https://github.com/hashicorp/terraform-provider-vault/pull/2226))
-* Add support for `external_id` field for the `vault_aws_auth_backend_sts_role` resource ([#2370](https://github.com/hashicorp/terraform-provider-vault/pull/2370))
 
 BUGS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ FEATURES:
 * Add support for `connection_timeout` field for the `vault_ldap_auth_backend` resource ([#2358](https://github.com/hashicorp/terraform-provider-vault/pull/2358))
 * Add support for Rootless Configuration for Static Roles to Postgres DB ([#2341](https://github.com/hashicorp/terraform-provider-vault/pull/2341))
 * Add support for `use_annotations_as_alias_metadata` field for the `vault_kubernetes_auth_backend_config` resource ([#2226](https://github.com/hashicorp/terraform-provider-vault/pull/2226))
+* Add support for `external_id` field for the `vault_aws_auth_backend_sts_role` resource ([#2370](https://github.com/hashicorp/terraform-provider-vault/pull/2370))
 
 BUGS:
 

--- a/vault/resource_aws_auth_backend_sts_role.go
+++ b/vault/resource_aws_auth_backend_sts_role.go
@@ -133,7 +133,9 @@ func awsAuthBackendSTSRoleRead(d *schema.ResourceData, meta interface{}) error {
 
 	if provider.IsAPISupported(meta, provider.VaultVersion117) {
 		if v, ok := resp.Data[consts.FieldExternalID]; ok {
-			d.Set(consts.FieldExternalID, v)
+			if err := d.Set(consts.FieldExternalID, v); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/vault/resource_aws_auth_backend_sts_role.go
+++ b/vault/resource_aws_auth_backend_sts_role.go
@@ -76,8 +76,11 @@ func awsAuthBackendSTSRoleCreate(d *schema.ResourceData, meta interface{}) error
 	path := awsAuthBackendSTSRolePath(backend, accountID)
 
 	data := map[string]interface{}{
-		"sts_role":             stsRole,
-		consts.FieldExternalID: externalID,
+		"sts_role": stsRole,
+	}
+
+	if provider.IsAPISupported(meta, provider.VaultVersion117) {
+		data[consts.FieldExternalID] = externalID
 	}
 
 	log.Printf("[DEBUG] Writing STS role %q to AWS auth backend", path)
@@ -128,8 +131,10 @@ func awsAuthBackendSTSRoleRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("account_id", accountID)
 	d.Set("sts_role", resp.Data["sts_role"])
 
-	if v, ok := resp.Data[consts.FieldExternalID]; ok {
-		d.Set(consts.FieldExternalID, v)
+	if provider.IsAPISupported(meta, provider.VaultVersion117) {
+		if v, ok := resp.Data[consts.FieldExternalID]; ok {
+			d.Set(consts.FieldExternalID, v)
+		}
 	}
 
 	return nil
@@ -147,8 +152,11 @@ func awsAuthBackendSTSRoleUpdate(d *schema.ResourceData, meta interface{}) error
 	path := d.Id()
 
 	data := map[string]interface{}{
-		"sts_role":             stsRole,
-		consts.FieldExternalID: externalID,
+		"sts_role": stsRole,
+	}
+
+	if provider.IsAPISupported(meta, provider.VaultVersion117) {
+		data[consts.FieldExternalID] = externalID
 	}
 
 	log.Printf("[DEBUG] Updating STS role %q in AWS auth backend", path)

--- a/vault/resource_aws_auth_backend_sts_role_test.go
+++ b/vault/resource_aws_auth_backend_sts_role_test.go
@@ -35,7 +35,7 @@ func TestAccAWSAuthBackendSTSRole_withExternalID(t *testing.T) {
 		CheckDestroy:      testAccCheckAWSAuthBackendSTSRoleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSAuthBackendSTSRoleConfig_basic(backend, accountID, arn, externalID),
+				Config: testAccAWSAuthBackendSTSRoleConfig(backend, accountID, arn, externalID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "backend", backend),
 					resource.TestCheckResourceAttr(resourceName, "account_id", accountID),
@@ -45,7 +45,7 @@ func TestAccAWSAuthBackendSTSRole_withExternalID(t *testing.T) {
 			},
 			{
 				// Update external ID.
-				Config: testAccAWSAuthBackendSTSRoleConfig_basic(backend, accountID, arn, updatedExternalID),
+				Config: testAccAWSAuthBackendSTSRoleConfig(backend, accountID, arn, updatedExternalID),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "backend", backend),
 					resource.TestCheckResourceAttr(resourceName, "account_id", accountID),
@@ -73,12 +73,12 @@ func TestAccAWSAuthBackendSTSRole_basic(t *testing.T) {
 		CheckDestroy:      testAccCheckAWSAuthBackendSTSRoleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSAuthBackendSTSRoleConfig_basic(backend, accountID, arn, ""),
+				Config: testAccAWSAuthBackendSTSRoleConfig(backend, accountID, arn, ""),
 				Check:  testAccAWSAuthBackendSTSRoleCheck_attrs(backend, accountID, arn),
 			},
 			{
 				// Update ARN.
-				Config: testAccAWSAuthBackendSTSRoleConfig_basic(backend, accountID, updatedArn, ""),
+				Config: testAccAWSAuthBackendSTSRoleConfig(backend, accountID, updatedArn, ""),
 				Check:  testAccAWSAuthBackendSTSRoleCheck_attrs(backend, accountID, updatedArn),
 			},
 			{
@@ -159,7 +159,7 @@ func testAccAWSAuthBackendSTSRoleCheck_attrs(backend, accountID, stsRole string)
 	}
 }
 
-func testAccAWSAuthBackendSTSRoleConfig_basic(backend, accountID, stsRole, externalID string) string {
+func testAccAWSAuthBackendSTSRoleConfig(backend, accountID, stsRole, externalID string) string {
 	backendResource := fmt.Sprintf(`
 resource "vault_auth_backend" "aws" {
 	type = "aws"

--- a/website/docs/r/aws_auth_backend_sts_role.html.md
+++ b/website/docs/r/aws_auth_backend_sts_role.html.md
@@ -51,6 +51,8 @@ The following arguments are supported:
 * `backend` - (Optional) The path the AWS auth backend being configured was
    mounted at.  Defaults to `aws`.
 
+* `external_id` - (Optional) External ID expected by the STS role. The associated STS role must be configured to require the external ID.
+
 ## Attributes Reference
 
 No additional attributes are exported by this resource.

--- a/website/docs/r/aws_auth_backend_sts_role.html.md
+++ b/website/docs/r/aws_auth_backend_sts_role.html.md
@@ -51,7 +51,7 @@ The following arguments are supported:
 * `backend` - (Optional) The path the AWS auth backend being configured was
    mounted at.  Defaults to `aws`.
 
-* `external_id` - (Optional) External ID expected by the STS role. The associated STS role must be configured to require the external ID.
+* `external_id` - (Optional) External ID expected by the STS role. The associated STS role must be configured to require the external ID. Requires Vault 1.17+.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
This PR updates the `vault_aws_auth_backend_sts_role` resource to support the `external_id` field on Vault versions >= 1.17.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/vault/pull/26628.

### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests were run against all supported Vault Versions


### Output from acceptance testing:

<details><summary>On a Vault version < 1.17 (1.16.12)</summary>

```
$ TESTARGS="--run TestAccAWSAuthBackendSTSRole" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test --run TestAccAWSAuthBackendSTSRole -timeout 30m ./... -v
?   	github.com/hashicorp/terraform-provider-vault	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/generate	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/helper	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/consts	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/codegen	0.323s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/group	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/mfa	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/pki	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/sync	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/schema	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/internal/identity/entity	0.491s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/internal/provider	0.815s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/testutil	1.027s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/util	1.463s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/util/mountutil	1.126s [no tests to run]
=== RUN   TestAccAWSAuthBackendSTSRole_withExternalID
    resource_aws_auth_backend_sts_role_test.go:32: Vault server version "1.16.12+ent"
    resource_aws_auth_backend_sts_role_test.go:32: Vault version < "1.17.0"
--- SKIP: TestAccAWSAuthBackendSTSRole_withExternalID (0.00s)
=== RUN   TestAccAWSAuthBackendSTSRole_basic
--- PASS: TestAccAWSAuthBackendSTSRole_basic (2.81s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/vault	4.010s
```

</details>

<details><summary>On a Vault version >= 1.17 (1.17.8)</summary>

```
$ TESTARGS="--run TestAccAWSAuthBackendSTSRole" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test --run TestAccAWSAuthBackendSTSRole -timeout 30m ./... -v
?   	github.com/hashicorp/terraform-provider-vault	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/generate	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/helper	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/consts	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/group	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/mfa	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/pki	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/sync	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/schema	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/codegen	0.313s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/internal/identity/entity	0.584s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/internal/provider	0.956s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/testutil	0.861s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/util	1.043s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/util/mountutil	1.230s [no tests to run]
=== RUN   TestAccAWSAuthBackendSTSRole_withExternalID
    resource_aws_auth_backend_sts_role_test.go:32: Vault server version "1.17.8+ent"
--- PASS: TestAccAWSAuthBackendSTSRole_withExternalID (2.84s)
=== RUN   TestAccAWSAuthBackendSTSRole_basic
--- PASS: TestAccAWSAuthBackendSTSRole_basic (2.45s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/vault	6.183s
```

</details>


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

