### PR TITLE
vault_database_secret_backend_connection: Add support for password_authentication on PostgreSQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+FEATURES: 
+
 * Update `vault_database_secret_backend_connection`to support `password_authentication` for PostgreSQL, allowing to encrypt password before being passed to PostgreSQL ([#2371](https://github.com/hashicorp/terraform-provider-vault/pull/2371))
 
 ## 4.5.0 (Nov 19, 2024)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Update `vault_database_secret_backend_connection`to support `password_authentication` for PostgreSQL, allowing to encrypt password before being passed to PostgreSQL ([#2371](https://github.com/hashicorp/terraform-provider-vault/pull/2371))
+
 ## 4.5.0 (Nov 19, 2024)
 
 FEATURES:

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -836,6 +836,12 @@ func postgresConnectionStringResource() *schema.Resource {
 		Optional:    true,
 		Description: "If set, allows onboarding static roles with a rootless connection configuration.",
 	}
+	r.Schema["password_authentication"] = &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    true,
+		Default:     "password",
+		Description: "When set to `scram-sha-256`, passwords will be hashed by Vault before being sent to PostgreSQL.",
+	}
 
 	return r
 }
@@ -1147,6 +1153,12 @@ func getPostgresConnectionDetailsFromResponse(d *schema.ResourceData, prefix str
 			if v, ok := data["service_account_json"]; ok {
 				result["service_account_json"] = v.(string)
 			}
+		}
+	}
+
+	if provider.IsAPISupported(meta, provider.VaultVersion114) {
+		if v, ok := data["password_authentication"]; ok {
+			result["password_authentication"] = v.(string)
 		}
 	}
 
@@ -1568,6 +1580,12 @@ func setPostgresDatabaseConnectionData(d *schema.ResourceData, prefix string, da
 		}
 		if v, ok := d.GetOk(prefix + "private_key"); ok {
 			data["private_key"] = v.(string)
+		}
+	}
+
+	if provider.IsAPISupported(meta, provider.VaultVersion114) {
+		if v, ok := d.GetOk(prefix + "password_authentication"); ok {
+			data["password_authentication"] = v.(string)
 		}
 	}
 

--- a/website/docs/r/database_secret_backend_connection.md
+++ b/website/docs/r/database_secret_backend_connection.md
@@ -340,7 +340,7 @@ See the [Vault
 
 * `password_authentication` - (Optional) When set to `scram-sha-256`, passwords will be
   hashed by Vault before being sent to PostgreSQL. See the [Vault docs](https://www.vaultproject.io/api-docs/secret/databases/postgresql.html#sample-payload)
-  for an example.
+  for an example. Requires Vault 1.14+.
 
 * `private_key` - (Optional) The secret key used for the x509 client
   certificate. Must be PEM encoded.

--- a/website/docs/r/database_secret_backend_connection.md
+++ b/website/docs/r/database_secret_backend_connection.md
@@ -124,7 +124,7 @@ Exactly one of the nested blocks of configuration options must be supplied.
 * `connect_timeout` - (Optional) The number of seconds to use as a connection
   timeout.
 
-* `skip_verification` - (Optional) Skip permissions checks when a connection to Cassandra is first created. 
+* `skip_verification` - (Optional) Skip permissions checks when a connection to Cassandra is first created.
   These checks ensure that Vault is able to create roles, but can be resource intensive in clusters with many roles.
 
 ### Couchbase Configuration Options
@@ -328,8 +328,8 @@ See the [Vault
 
 * `password` - (Optional) The root credential password used in the connection URL.
 
-* `self_managed` - (Optional)  If set, allows onboarding static roles with a rootless 
-  connection configuration. Mutually exclusive with `username` and `password`. 
+* `self_managed` - (Optional)  If set, allows onboarding static roles with a rootless
+  connection configuration. Mutually exclusive with `username` and `password`.
   If set, will force `verify_connection` to be false. Requires Vault 1.18+ Enterprise.
 
 * `tls_ca` - (Optional) The x509 CA file for validating the certificate
@@ -337,6 +337,10 @@ See the [Vault
 
 * `tls_certificate` - (Optional) The x509 client certificate for connecting to
   the database. Must be PEM encoded.
+
+* `password_authentication` - (Optional) When set to `scram-sha-256`, passwords will be
+  hashed by Vault before being sent to PostgreSQL. See the [Vault docs](https://www.vaultproject.io/api-docs/secret/databases/postgresql.html#sample-payload)
+  for an example.
 
 * `private_key` - (Optional) The secret key used for the x509 client
   certificate. Must be PEM encoded.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Permits to use SCRAM-SHA-256 to encrypt password before being sent to PosgreSQL.
The password_authentication parameter was implemented in Vault 1.14 (See https://github.com/hashicorp/vault/pull/19616)

Closes #2315


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [X] Acceptance tests were run against all supported Vault Versions


### Output from acceptance testing:

```
$ TESTARGS="--run DatabaseSecretBackendConnection -v" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test --run DatabaseSecretBackendConnection -v -timeout 30m ./...
?   	github.com/hashicorp/terraform-provider-vault	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/generate	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/helper	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/consts	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/group	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/mfa	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/pki	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/codegen	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/internal/identity/entity	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/internal/sync	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/schema	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/internal/provider	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/testutil	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/util	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/util/mountutil	(cached) [no tests to run]
=== RUN   TestAccDatabaseSecretBackendConnection_postgresql_import
--- PASS: TestAccDatabaseSecretBackendConnection_postgresql_import (1.30s)
=== RUN   TestAccDatabaseSecretBackendConnection_cassandra
    resource_database_secret_backend_connection_test.go:86: "CASSANDRA_HOST" must be set
--- SKIP: TestAccDatabaseSecretBackendConnection_cassandra (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_cassandraProtocol
    resource_database_secret_backend_connection_test.go:130: "CASSANDRA_HOST" must be set
--- SKIP: TestAccDatabaseSecretBackendConnection_cassandraProtocol (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_couchbase
    resource_database_secret_backend_connection_test.go:173: "COUCHBASE_HOST" must be set
--- SKIP: TestAccDatabaseSecretBackendConnection_couchbase (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_influxdb
    resource_database_secret_backend_connection_test.go:271: "INFLUXDB_HOST" must be set
--- SKIP: TestAccDatabaseSecretBackendConnection_influxdb (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_mongodbatlas
    resource_database_secret_backend_connection_test.go:314: "MONGODB_ATLAS_PUBLIC_KEY" must be set
--- SKIP: TestAccDatabaseSecretBackendConnection_mongodbatlas (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_mongodb
    resource_database_secret_backend_connection_test.go:351: "MONGODB_URL" must be set
--- SKIP: TestAccDatabaseSecretBackendConnection_mongodb (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_mssql
    mssqlhelper.go:27: Skipping, as this image is not supported on ARM architectures
--- SKIP: TestAccDatabaseSecretBackendConnection_mssql (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_mysql_cloud
    resource_database_secret_backend_connection_test.go:448: "MYSQL_CLOUD_CONNECTION_URL" must be set
--- SKIP: TestAccDatabaseSecretBackendConnection_mysql_cloud (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_mysql
    resource_database_secret_backend_connection_test.go:491: "MYSQL_CONNECTION_URL" must be set
--- SKIP: TestAccDatabaseSecretBackendConnection_mysql (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnectionUpdate_mysql
    resource_database_secret_backend_connection_test.go:585: "MYSQL_CONNECTION_URL" must be set
--- SKIP: TestAccDatabaseSecretBackendConnectionUpdate_mysql (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnectionTemplatedUpdateExcludePassword_mysql
    resource_database_secret_backend_connection_test.go:635: "MYSQL_CONNECTION_URL" must be set
--- SKIP: TestAccDatabaseSecretBackendConnectionTemplatedUpdateExcludePassword_mysql (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_mysql_tls
    resource_database_secret_backend_connection_test.go:726: "MYSQL_CA" must be set
--- SKIP: TestAccDatabaseSecretBackendConnection_mysql_tls (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_postgresql
--- PASS: TestAccDatabaseSecretBackendConnection_postgresql (2.27s)
=== RUN   TestAccDatabaseSecretBackendConnection_postgresql_tls
    resource_database_secret_backend_connection_test.go:857: Vault server version "1.18.1"
--- PASS: TestAccDatabaseSecretBackendConnection_postgresql_tls (1.15s)
=== RUN   TestAccDatabaseSecretBackendConnection_postgresql_rootlessConfig
    resource_database_secret_backend_connection_test.go:884: "TF_ACC_ENTERPRISE" must be set
--- SKIP: TestAccDatabaseSecretBackendConnection_postgresql_rootlessConfig (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_postgresql_cloud
    resource_database_secret_backend_connection_test.go:902: "POSTGRES_CLOUD_URL" must be set
--- SKIP: TestAccDatabaseSecretBackendConnection_postgresql_cloud (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_elasticsearch
    resource_database_secret_backend_connection_test.go:943: "ELASTIC_URL" must be set
--- SKIP: TestAccDatabaseSecretBackendConnection_elasticsearch (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_snowflake
    resource_database_secret_backend_connection_test.go:1022: "SNOWFLAKE_URL" must be set
--- SKIP: TestAccDatabaseSecretBackendConnection_snowflake (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_redis
    resource_database_secret_backend_connection_test.go:1058: "REDIS_HOST" must be set
--- SKIP: TestAccDatabaseSecretBackendConnection_redis (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_redisElastiCache
    resource_database_secret_backend_connection_test.go:1122: ELASTICACHE_URL not set
--- SKIP: TestAccDatabaseSecretBackendConnection_redisElastiCache (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_redshift
    resource_database_secret_backend_connection_test.go:1156: REDSHIFT_URL not set
--- SKIP: TestAccDatabaseSecretBackendConnection_redshift (0.00s)
=== RUN   TestAccDatabaseSecretBackendConnection_invalid_plugin
--- PASS: TestAccDatabaseSecretBackendConnection_invalid_plugin (0.18s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/vault	5.417s
...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

