### PR TITLE
Add credential_type and credential_config to static roles for DBs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ FEATURES:
 * Add support for signature_bits field to `vault_pki_secret_backend_role`, `vault_pki_secret_backend_root_cert`, `vault_pki_secret_backend_root_sign_intermediate` and `vault_pki_secret_backend_intermediate_cert_request` ([#2401])(https://github.com/hashicorp/terraform-provider-vault/pull/2401)
 * Add support for key_usage and serial_number to `vault_pki_secret_backend_intermediate_cert_request` ([#2404])(https://github.com/hashicorp/terraform-provider-vault/pull/2404)
 * Add support for `skip_import_rotation` in `vault_database_secret_backend_static_role`. Requires Vault Enterprise 1.18.5+ ([#2386](https://github.com/hashicorp/terraform-provider-vault/pull/2386)).
+* Add `credential_type` and `credential_config` to `database_secret_backend_static_role` to support features like rsa keys for Snowflake DB engines with static roles
 
 BUGS:
 

--- a/vault/resource_database_secret_backend_static_role.go
+++ b/vault/resource_database_secret_backend_static_role.go
@@ -27,6 +27,8 @@ var staticRoleFields = []string{
 	consts.FieldRotationPeriod,
 	consts.FieldRotationStatements,
 	consts.FieldDBName,
+	consts.FieldCredentialType,
+	consts.FieldCredentialConfig,
 }
 
 func databaseSecretBackendStaticRoleResource() *schema.Resource {
@@ -105,6 +107,20 @@ func databaseSecretBackendStaticRoleResource() *schema.Resource {
 				Optional:    true,
 				Description: "Skip rotation of the password on import.",
 			},
+			consts.FieldCredentialType: {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				Description: "The credential type for the user, can be one of \"password\", \"rsa_private_key\" or \"client_certificate\"." +
+					"The configuration can be done in `credential_config`.",
+			},
+			consts.FieldCredentialConfig: {
+				Type:     schema.TypeMap,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+				Description: "The configuration for the credential type." +
+					"Full documentation for the allowed values can be found under \"https://developer.hashicorp.com/vault/api-docs/secret/databases#credential_config\".",
+			},
 		},
 	}
 }
@@ -142,6 +158,14 @@ func databaseSecretBackendStaticRoleWrite(ctx context.Context, d *schema.Resourc
 
 	if v, ok := d.GetOk(consts.FieldRotationPeriod); ok && v != "" {
 		data[consts.FieldRotationPeriod] = v
+	}
+
+	if v, ok := d.GetOk(consts.FieldCredentialType); ok && v != "" {
+		data[consts.FieldCredentialType] = v
+	}
+
+	if v, ok := d.GetOk(consts.FieldCredentialConfig); ok && v != "" {
+		data[consts.FieldCredentialConfig] = v
 	}
 
 	if provider.IsAPISupported(meta, provider.VaultVersion118) && provider.IsEnterpriseSupported(meta) {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
An attempt to add `credential_type` and `credential_config` as fields to the static roles in database engines. 

This is to enable support for using `rsa_public_key` on Snowflake secret engines which is currently not possible on static roles.

Closes https://github.com/hashicorp/terraform-provider-vault/issues/1585.
Closes https://github.com/hashicorp/terraform-provider-vault/pull/1992

### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
pboeschen@LL16KDB44 terraform-provider-vault main> RUNS_IN_CONTAINER=true make testacc TESTARGS='-run=TestAccDatabaseSecretBackendStaticRole.* -v'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -run=TestAccDatabaseSecretBackendStaticRole.* -v -timeout 30m ./...
?   	github.com/hashicorp/terraform-provider-vault	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/generate	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/helper	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/consts	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/group	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/mfa	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/pki	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/codegen	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/internal/identity/entity	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/internal/sync	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/schema	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/internal/provider	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/testutil	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/util	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/util/mountutil	(cached) [no tests to run]
=== RUN   TestAccDatabaseSecretBackendStaticRole_import
--- PASS: TestAccDatabaseSecretBackendStaticRole_import (1.76s)
=== RUN   TestAccDatabaseSecretBackendStaticRole_credentialType
--- PASS: TestAccDatabaseSecretBackendStaticRole_credentialType (1.43s)
=== RUN   TestAccDatabaseSecretBackendStaticRole_credentialConfig
--- PASS: TestAccDatabaseSecretBackendStaticRole_credentialConfig (2.46s)
=== RUN   TestAccDatabaseSecretBackendStaticRole_rotationPeriod
--- PASS: TestAccDatabaseSecretBackendStaticRole_rotationPeriod (2.45s)
=== RUN   TestAccDatabaseSecretBackendStaticRole_rotationSchedule
    resource_database_secret_backend_static_role_test.go:197: Vault server version "1.18.2"
--- PASS: TestAccDatabaseSecretBackendStaticRole_rotationSchedule (2.47s)
=== RUN   TestAccDatabaseSecretBackendStaticRole_Rootless
    resource_database_secret_backend_static_role_test.go:234: "POSTGRES_URL_TEST" must be set
--- SKIP: TestAccDatabaseSecretBackendStaticRole_Rootless (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/vault	10.614s
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

