### PR TITLE
Workaround MSSQL CI failures with certificates containing negative serial numbers

### DIFF
--- a/testutil/mssqlhelper.go
+++ b/testutil/mssqlhelper.go
@@ -31,28 +31,51 @@ func PrepareMSSQLTestContainer(t *testing.T) (cleanup func(), retURL string) {
 		return func() {}, os.Getenv("MSSQL_URL")
 	}
 
-	var err error
-	for i := 0; i < mssqlNumRetries; i++ {
-		var svc *docker.Service
-		runner, err := docker.NewServiceRunner(docker.RunOptions{
-			ContainerName: "sqlserver",
-			ImageRepo:     "mcr.microsoft.com/mssql/server",
-			ImageTag:      "2017-latest-ubuntu",
-			Env:           []string{"ACCEPT_EULA=Y", "SA_PASSWORD=" + mssqlPassword},
-			Ports:         []string{"1433/tcp"},
-			LogConsumer: func(s string) {
-				if t.Failed() {
-					t.Logf("container logs: %s", s)
-				}
-			},
-		})
-		if err != nil {
-			t.Fatalf("Could not start docker MSSQL: %s", err)
-		}
+	// Workaround for https://github.com/microsoft/mssql-docker/issues/895 and us temporary seeing
+	// tls: failed to parse certificate from server: x509: negative serial number in test case failures.
+	containerfile := `
+FROM mcr.microsoft.com/mssql/server:2017-latest
+USER root
+ENV MSDIR=/var/opt/mssql
+RUN mkdir -p $MSDIR \
+    && openssl req -x509 -nodes -newkey rsa:2048 -subj '/CN=mssql' -addext "subjectAltName = DNS:mssql" -keyout $MSDIR/mssql.key -out $MSDIR/mssql.pem -days 1 \
+	&& chmod 400 $MSDIR/mssql.key \
+	&& chmod 400 $MSDIR/mssql.pem \
+    && chown -R mssql $MSDIR
+RUN echo "[network]" > $MSDIR/mssql.conf \
+	&& echo "tlscert = $MSDIR/mssql.pem" >> $MSDIR/mssql.conf \
+	&& echo "tlskey = $MSDIR/mssql.key" >> $MSDIR/mssql.conf \ 
+	&& echo "tlsprotocols = 1.2" >> $MSDIR/mssql.conf \ 
+	&& echo "forceencryption = 1" >> $MSDIR/mssql.conf 
+USER mssql
+`
+	bCtx := docker.NewBuildContext()
+	imageName := "mssql-workaround-895"
+	imageTag := "latest"
 
-		svc, err = runner.StartService(context.Background(), connectMSSQL)
+	runner, err := docker.NewServiceRunner(docker.RunOptions{
+		ContainerName: "sqlserver",
+		ImageRepo:     imageName,
+		ImageTag:      imageTag,
+		Env:           []string{"ACCEPT_EULA=Y", "SA_PASSWORD=" + mssqlPassword},
+		Ports:         []string{"1433/tcp"},
+	})
+	if err != nil {
+		t.Fatalf("Could not provision docker service runner: %s", err)
+	}
+
+	for i := 0; i < 3; i++ {
+		_, err = runner.BuildImage(context.Background(), containerfile, bCtx,
+			docker.BuildRemove(true),
+			docker.BuildForceRemove(true),
+			docker.BuildPullParent(true),
+			docker.BuildTags([]string{imageName + ":" + imageTag}))
 		if err == nil {
-			return svc.Cleanup, svc.Config.URL().String()
+			var svc *docker.Service
+			svc, err = runner.StartService(context.Background(), connectMSSQL)
+			if err == nil {
+				return svc.Cleanup, svc.Config.URL().String()
+			}
 		}
 	}
 


### PR DESCRIPTION
### Description

Attempt to workaround a known issue with the MSSQL docker container generating TLS certificates that contain negative serial numbers. Within Go 1.23 and higher these now cause TLS connection failures and are causing some CI runs to fail such as [this run](https://github.com/hashicorp/terraform-provider-vault/actions/runs/12681542223/job/35398749729?pr=2385#step:9:1431)

```
     resource_database_secrets_mount_test.go:46: Step 1/4 error: Error running apply: exit status 1
        
        Error: error configuring database connection "tf-test-db-6610745212182229063/config/db-5461545923627919509": Error making API request.
        
        URL: PUT http://localhost:8200/v1/tf-test-db-6610745212182229063/config/db-5461545923627919509
        Code: 400. Errors:
        
        * error creating database object: error verifying connection: ping failed: TLS Handshake failed: tls: failed to parse certificate from server: x509: negative serial number
```

Note no shippable code changes are being made within this PR.

### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

