### PR TITLE
Do not panic on Vault PKI roles without the cn_validations field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+BUGS:
+
+* Do not panic on Vault PKI roles without the cn_validations field: ([#2398](https://github.com/hashicorp/terraform-provider-vault/pull/2398))
+
+
 ## 4.6.0 (Jan 15, 2025)
 
 FEATURES:

--- a/vault/resource_pki_secret_backend_role.go
+++ b/vault/resource_pki_secret_backend_role.go
@@ -14,10 +14,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/pki"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
 var (
@@ -575,10 +575,10 @@ func pkiSecretBackendRoleRead(_ context.Context, d *schema.ResourceData, meta in
 	listFields := append(pkiSecretListFields, consts.FieldKeyUsage)
 	// handle TypeList
 	for _, k := range listFields {
-		list := expandStringSlice(secret.Data[k].([]interface{}))
-
-		if len(list) > 0 {
-			d.Set(k, list)
+		if list, ok := util.GetStringSliceFromSecret(secret, k); ok {
+			if len(list) > 0 {
+				d.Set(k, list)
+			}
 		}
 	}
 


### PR DESCRIPTION
### Description

 - When we added support for the cn_validations field within #1820 the code was tested against Vault versions 1.12 and higher.
 - If Vault is an earlier version than 1.12 TFVP will panic as we attempt to cast the missing field to an []interface{} value.
 - This fix hardens the parsing path for slice values within the PKI role parsing to properly extract out a []string value

Fixes #2397

### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

