### PR TITLE
Add new PKI issuer verification config  fields to issuer resources.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ FEATURES:
 
 * Update `vault_pki_secret_backend_root_cert` and `vault_pki_secret_backend_root_sign_intermediate` to support the new fields for the name constraints extension. Requires Vault 1.19+ ([#2396](https://github.com/hashicorp/terraform-provider-vault/pull/2396)).
 * Update `vault_pki_secret_backend_issuer` resource with the new issuer configuration fields to control certificate verification. Requires Vault Enterprise 1.19+ ([#2400](https://github.com/hashicorp/terraform-provider-vault/pull/2400)).
+* Add support for certificate revocation with `revoke_with_key` in `vault_pki_secret_backend_cert` ([#2242](https://github.com/hashicorp/terraform-provider-vault/pull/2242))
 
 BUGS:
 
@@ -19,7 +20,7 @@ FEATURES:
 * Update `vault_pki_secret_backend_role` to support the `cn_validations` role field ([#1820](https://github.com/hashicorp/terraform-provider-vault/pull/1820)).
 * Add new resource `vault_pki_secret_backend_acme_eab` to manage PKI ACME external account binding tokens. Requires Vault 1.14+. ([#2367](https://github.com/hashicorp/terraform-provider-vault/pull/2367))
 * Add new data source and resource `vault_pki_secret_backend_config_cmpv2`. Requires Vault 1.18+. *Available only for Vault Enterprise* ([#2330](https://github.com/hashicorp/terraform-provider-vault/pull/2330))
-* Add support for certificate revocation with `revoke_with_key` in `vault_pki_secret_backend_cert` ([#2242](https://github.com/hashicorp/terraform-provider-vault/pull/2242))
+
 IMPROVEMENTS:
 
 * Support the event `subscribe` policy capability for `vault_policy_document` data source ([#2293](https://github.com/hashicorp/terraform-provider-vault/pull/2293))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 FEATURES:
 
 * Update `vault_pki_secret_backend_root_cert` and `vault_pki_secret_backend_root_sign_intermediate` to support the new fields for the name constraints extension. Requires Vault 1.19+ ([#2396](https://github.com/hashicorp/terraform-provider-vault/pull/2396)).
+* Update `vault_pki_secret_backend_issuer` resource with the new issuer configuration fields to control certificate verification. Requires Vault Enterprise 1.19+ ([#2400](https://github.com/hashicorp/terraform-provider-vault/pull/2400)).
 
 BUGS:
 

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -459,6 +459,12 @@ const (
 	FieldEabKey                        = "key"
 	FieldAcmeDirectory                 = "acme_directory"
 	FieldEabId                         = "eab_id"
+
+	FieldDisableCriticalExtensionChecks = "disable_critical_extension_checks"
+	FieldDisablePathLengthChecks        = "disable_path_length_checks"
+	FieldDisableNameChecks              = "disable_name_checks"
+	FieldDisableNameConstraintChecks    = "disable_name_constraint_checks"
+
 	/*
 		common environment variables
 	*/

--- a/vault/data_source_pki_secret_backend_issuer.go
+++ b/vault/data_source_pki_secret_backend_issuer.go
@@ -133,13 +133,7 @@ func readPKISecretBackendIssuer(ctx context.Context, d *schema.ResourceData, met
 		consts.FieldManualChain,
 		consts.FieldUsage,
 	}
-	if supportPkiCertVerifyDisableChecksFields(meta) {
-		issuerComputedFields = append(issuerComputedFields,
-			consts.FieldDisableCriticalExtensionChecks,
-			consts.FieldDisablePathLengthChecks,
-			consts.FieldDisableNameChecks,
-			consts.FieldDisableNameConstraintChecks)
-	}
+	issuerComputedFields = appendPkiCertVerifyDisableChecksFields(meta, issuerComputedFields)
 
 	for _, k := range issuerComputedFields {
 		if err := d.Set(k, resp.Data[k]); err != nil {
@@ -150,6 +144,14 @@ func readPKISecretBackendIssuer(ctx context.Context, d *schema.ResourceData, met
 	return nil
 }
 
-func supportPkiCertVerifyDisableChecksFields(meta interface{}) bool {
-	return provider.IsAPISupported(meta, provider.VaultVersion119) && provider.IsEnterpriseSupported(meta)
+func appendPkiCertVerifyDisableChecksFields(meta interface{}, fields []string) []string {
+	if !provider.IsAPISupported(meta, provider.VaultVersion119) && provider.IsEnterpriseSupported(meta) {
+		return fields
+	}
+	return append(fields,
+		consts.FieldDisableCriticalExtensionChecks,
+		consts.FieldDisablePathLengthChecks,
+		consts.FieldDisableNameChecks,
+		consts.FieldDisableNameConstraintChecks,
+	)
 }

--- a/vault/data_source_pki_secret_backend_issuer_test.go
+++ b/vault/data_source_pki_secret_backend_issuer_test.go
@@ -5,13 +5,13 @@ package vault
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
-	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -40,6 +40,67 @@ func TestAccDataSourcePKISecretIssuer(t *testing.T) {
 	})
 }
 
+func TestAccDataSourcePKISecretIssuer_verify_disable_fields(t *testing.T) {
+	backend := acctest.RandomWithPrefix("tf-test-pki-backend")
+	issuerName := acctest.RandomWithPrefix("tf-test-pki-issuer")
+	dataName := "data.vault_pki_secret_backend_issuer.test"
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		PreCheck: func() {
+			testutil.TestEntPreCheck(t)
+			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion119)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testPKISecretIssuerDataSource(backend, issuerName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataName, consts.FieldBackend, backend),
+					resource.TestCheckResourceAttr(dataName, consts.FieldIssuerName, issuerName),
+					resource.TestCheckResourceAttrSet(dataName, consts.FieldIssuerID),
+					resource.TestCheckResourceAttrSet(dataName, consts.FieldKeyID),
+					resource.TestCheckResourceAttrSet(dataName, consts.FieldCertificate),
+
+					resource.TestCheckResourceAttr(dataName, consts.FieldDisableCriticalExtensionChecks, "false"),
+					resource.TestCheckResourceAttr(dataName, consts.FieldDisablePathLengthChecks, "false"),
+					resource.TestCheckResourceAttr(dataName, consts.FieldDisableNameChecks, "false"),
+					resource.TestCheckResourceAttr(dataName, consts.FieldDisableNameConstraintChecks, "false"),
+				),
+			},
+			{
+				Config: testPKISecretIssuerDataSource_verify_disable_fields(backend, issuerName, "true"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataName, consts.FieldBackend, backend),
+					resource.TestCheckResourceAttr(dataName, consts.FieldIssuerName, issuerName),
+					resource.TestCheckResourceAttrSet(dataName, consts.FieldIssuerID),
+					resource.TestCheckResourceAttrSet(dataName, consts.FieldKeyID),
+					resource.TestCheckResourceAttrSet(dataName, consts.FieldCertificate),
+
+					resource.TestCheckResourceAttr(dataName, consts.FieldDisableCriticalExtensionChecks, "true"),
+					resource.TestCheckResourceAttr(dataName, consts.FieldDisablePathLengthChecks, "true"),
+					resource.TestCheckResourceAttr(dataName, consts.FieldDisableNameChecks, "true"),
+					resource.TestCheckResourceAttr(dataName, consts.FieldDisableNameConstraintChecks, "true"),
+				),
+			},
+			// As above, but leave FieldDisableNameChecks false as a spot check
+			{
+				Config: testPKISecretIssuerDataSource_verify_disable_fields(backend, issuerName, "false"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataName, consts.FieldBackend, backend),
+					resource.TestCheckResourceAttr(dataName, consts.FieldIssuerName, issuerName),
+					resource.TestCheckResourceAttrSet(dataName, consts.FieldIssuerID),
+					resource.TestCheckResourceAttrSet(dataName, consts.FieldKeyID),
+					resource.TestCheckResourceAttrSet(dataName, consts.FieldCertificate),
+
+					resource.TestCheckResourceAttr(dataName, consts.FieldDisableCriticalExtensionChecks, "true"),
+					resource.TestCheckResourceAttr(dataName, consts.FieldDisablePathLengthChecks, "true"),
+					resource.TestCheckResourceAttr(dataName, consts.FieldDisableNameChecks, "false"),
+					resource.TestCheckResourceAttr(dataName, consts.FieldDisableNameConstraintChecks, "true"),
+				),
+			},
+		},
+	})
+}
+
 func testPKISecretIssuerDataSource(path, issuerName string) string {
 	return fmt.Sprintf(`
 resource "vault_mount" "test" {
@@ -60,4 +121,41 @@ data "vault_pki_secret_backend_issuer" "test" {
   backend     = vault_mount.test.path
   issuer_ref  = vault_pki_secret_backend_root_cert.test.issuer_id
 }`, path, issuerName)
+}
+
+func testPKISecretIssuerDataSource_verify_disable_fields(path, issuerName, disableNameChecks string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "test" {
+	path        = "%s"
+	type        = "pki"
+    description = "PKI secret engine mount"
+}
+
+resource "vault_pki_secret_backend_root_cert" "test" {
+  backend     = vault_mount.test.path
+  type        = "internal"
+  common_name = "test"
+  ttl         = "86400"
+  issuer_name = "%s"
+}
+
+resource "vault_pki_secret_backend_issuer" "test" {
+  backend     = vault_mount.test.path
+  issuer_ref  = vault_pki_secret_backend_root_cert.test.issuer_id
+  issuer_name = "%s"
+
+  disable_critical_extension_checks = "true"
+  disable_path_length_checks        = "true"
+  disable_name_checks               = "%s"
+  disable_name_constraint_checks    = "true"
+}
+
+data "vault_pki_secret_backend_issuer" "test" {
+  backend     = vault_mount.test.path
+  issuer_ref  = vault_pki_secret_backend_root_cert.test.issuer_id
+
+  # Depend on vault_pki_secret_backend_issuer.test so that the data
+  # is gathered after the issuer is updated.
+  depends_on  = [vault_pki_secret_backend_issuer.test]
+}`, path, issuerName, issuerName, disableNameChecks)
 }

--- a/vault/resource_pki_secret_backend_issuer.go
+++ b/vault/resource_pki_secret_backend_issuer.go
@@ -183,15 +183,7 @@ func pkiSecretBackendIssuerUpdate(ctx context.Context, d *schema.ResourceData, m
 		consts.FieldOCSPServers,
 		consts.FieldEnableAIAURLTemplating,
 	}
-
-	if supportPkiCertVerifyDisableChecksFields(meta) {
-		configurableFields = append(configurableFields,
-			consts.FieldDisableCriticalExtensionChecks,
-			consts.FieldDisablePathLengthChecks,
-			consts.FieldDisableNameChecks,
-			consts.FieldDisableNameConstraintChecks,
-		)
-	}
+	configurableFields = appendPkiCertVerifyDisableChecksFields(meta, configurableFields)
 
 	var patchRequired bool
 	data := map[string]interface{}{}
@@ -271,15 +263,7 @@ func pkiSecretBackendIssuerRead(ctx context.Context, d *schema.ResourceData, met
 		consts.FieldEnableAIAURLTemplating,
 		consts.FieldIssuerID,
 	}
-
-	if supportPkiCertVerifyDisableChecksFields(meta) {
-		fields = append(fields,
-			consts.FieldDisableCriticalExtensionChecks,
-			consts.FieldDisablePathLengthChecks,
-			consts.FieldDisableNameChecks,
-			consts.FieldDisableNameConstraintChecks,
-		)
-	}
+	fields = appendPkiCertVerifyDisableChecksFields(meta, fields)
 
 	for _, k := range fields {
 		if v, ok := resp.Data[k]; ok {

--- a/vault/resource_pki_secret_backend_issuer.go
+++ b/vault/resource_pki_secret_backend_issuer.go
@@ -105,6 +105,26 @@ func pkiSecretBackendIssuerResource() *schema.Resource {
 				Optional:    true,
 				Description: "Specifies that the AIA URL values should be templated.",
 			},
+			consts.FieldDisableCriticalExtensionChecks: {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "This determines whether this issuer is able to issue certificates where the chain of trust (including the issued certificate) contain critical extensions not processed by Vault.",
+			},
+			consts.FieldDisablePathLengthChecks: {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "This determines whether this issuer is able to issue certificates where the chain of trust (including the final issued certificate) is longer than allowed by a certificate authority in that chain.",
+			},
+			consts.FieldDisableNameChecks: {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "This determines whether this issuer is able to issue certificates where the chain of trust (including the final issued certificate) contains a link in which the subject of the issuing certificate does not match the named issuer of the certificate it signed.",
+			},
+			consts.FieldDisableNameConstraintChecks: {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "This determines whether this issuer is able to issue certificates where the chain of trust (including the final issued certificate) violates the name constraints critical extension of one of the issuer certificates in the chain",
+			},
 			consts.FieldIssuerID: {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -162,6 +182,15 @@ func pkiSecretBackendIssuerUpdate(ctx context.Context, d *schema.ResourceData, m
 		consts.FieldCRLDistributionPoints,
 		consts.FieldOCSPServers,
 		consts.FieldEnableAIAURLTemplating,
+	}
+
+	if supportPkiCertVerifyDisableChecksFields(meta) {
+		configurableFields = append(configurableFields,
+			consts.FieldDisableCriticalExtensionChecks,
+			consts.FieldDisablePathLengthChecks,
+			consts.FieldDisableNameChecks,
+			consts.FieldDisableNameConstraintChecks,
+		)
 	}
 
 	var patchRequired bool
@@ -241,6 +270,15 @@ func pkiSecretBackendIssuerRead(ctx context.Context, d *schema.ResourceData, met
 		consts.FieldOCSPServers,
 		consts.FieldEnableAIAURLTemplating,
 		consts.FieldIssuerID,
+	}
+
+	if supportPkiCertVerifyDisableChecksFields(meta) {
+		fields = append(fields,
+			consts.FieldDisableCriticalExtensionChecks,
+			consts.FieldDisablePathLengthChecks,
+			consts.FieldDisableNameChecks,
+			consts.FieldDisableNameConstraintChecks,
+		)
 	}
 
 	for _, k := range fields {

--- a/vault/resource_pki_secret_backend_issuer_test.go
+++ b/vault/resource_pki_secret_backend_issuer_test.go
@@ -81,6 +81,120 @@ func TestAccPKISecretBackendIssuer_basic(t *testing.T) {
 	})
 }
 
+func TestAccPKISecretBackendIssuer_verify_disable_fields(t *testing.T) {
+	backend := acctest.RandomWithPrefix("tf-test-pki")
+	resourceType := "vault_pki_secret_backend_issuer"
+	resourceName := resourceType + ".test"
+
+	issuerName := acctest.RandomWithPrefix("tf-pki-issuer")
+
+	config_disable_all := fmt.Sprintf(`%s = "true"
+									%s = "true"
+									%s = "true"
+									%s = "true"`,
+		consts.FieldDisableCriticalExtensionChecks,
+		consts.FieldDisablePathLengthChecks,
+		consts.FieldDisableNameChecks,
+		consts.FieldDisableNameConstraintChecks)
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		PreCheck: func() {
+			testutil.TestEntPreCheck(t)
+			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion119)
+		},
+		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypePKI, consts.FieldBackend),
+		Steps: []resource.TestStep{
+			// Check all disable_ fields default to false
+			{
+				Config: testAccPKISecretBackendIssuer_basic(backend, ""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldBackend, backend),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldIssuerName, ""),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldLeafNotAfterBehavior, "err"),
+					resource.TestCheckResourceAttrSet(resourceName, consts.FieldIssuerRef),
+					resource.TestCheckResourceAttrSet(resourceName, consts.FieldIssuerID),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldDisableCriticalExtensionChecks, "false"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldDisablePathLengthChecks, "false"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldDisableNameChecks, "false"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldDisableNameConstraintChecks, "false"),
+				),
+			},
+			// Set all the certificate verification check disable_ fields to true
+			{
+				Config: testAccPKISecretBackendIssuer_basic(backend, config_disable_all),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldBackend, backend),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldIssuerName, ""),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldLeafNotAfterBehavior, "err"),
+					resource.TestCheckResourceAttrSet(resourceName, consts.FieldIssuerRef),
+					resource.TestCheckResourceAttrSet(resourceName, consts.FieldIssuerID),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldDisableCriticalExtensionChecks, "true"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldDisablePathLengthChecks, "true"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldDisableNameChecks, "true"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldDisableNameConstraintChecks, "true"),
+				),
+			},
+			{
+				Config: testAccPKISecretBackendIssuer_basic(backend,
+					fmt.Sprintf(`issuer_name = "%s"`, issuerName)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldBackend, backend),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldIssuerName, issuerName),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldLeafNotAfterBehavior, "err"),
+					resource.TestCheckResourceAttrSet(resourceName, consts.FieldIssuerRef),
+					resource.TestCheckResourceAttrSet(resourceName, consts.FieldIssuerID),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldDisableCriticalExtensionChecks, "false"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldDisablePathLengthChecks, "false"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldDisableNameChecks, "false"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldDisableNameConstraintChecks, "false"),
+				),
+			},
+			{
+				Config: testAccPKISecretBackendIssuer_basic(backend,
+					fmt.Sprintf(`issuer_name = "%s"
+									%s`, issuerName, config_disable_all)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldBackend, backend),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldIssuerName, issuerName),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldLeafNotAfterBehavior, "err"),
+					resource.TestCheckResourceAttrSet(resourceName, consts.FieldIssuerRef),
+					resource.TestCheckResourceAttrSet(resourceName, consts.FieldIssuerID),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldDisableCriticalExtensionChecks, "true"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldDisablePathLengthChecks, "true"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldDisableNameChecks, "true"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldDisableNameConstraintChecks, "true"),
+				),
+			},
+			// confirm error case when updating issuer by sending invalid option
+			{
+				Config: testAccPKISecretBackendIssuer_basic(backend,
+					fmt.Sprintf(`issuer_name = "%s"
+										leaf_not_after_behavior = "invalid"`, issuerName)),
+				ExpectError: regexp.MustCompile("error updating issuer data"),
+			},
+			// ensure JSON merge patch functions as expected. No overwrites
+			{
+				Config: testAccPKISecretBackendIssuer_basic(backend,
+					fmt.Sprintf(`issuer_name = "%s"
+										leaf_not_after_behavior = "truncate"`, issuerName)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldBackend, backend),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldIssuerName, issuerName),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldLeafNotAfterBehavior, "truncate"),
+					resource.TestCheckResourceAttrSet(resourceName, consts.FieldIssuerRef),
+					resource.TestCheckResourceAttrSet(resourceName, consts.FieldIssuerID),
+				),
+			},
+			// ignore changes in 'usage' field since it can be returned in any order
+			// example, error in attribute equivalence in following
+			// Import returns "crl-signing,read-only,issuing-certificates"
+			// TF state returns "read-only,issuing-certificates,crl-signing"
+			testutil.GetImportTestStep(resourceName, false, nil, consts.FieldUsage),
+		},
+	})
+}
+
 func testAccPKISecretBackendIssuer_basic(path, extraFields string) string {
 	return fmt.Sprintf(`
 resource "vault_mount" "test" {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
Add the following fields:

  * "disable_critical_extension_checks"
  * "disable_path_length_checks"
  * "disable_name_checks"
  * "disable_name_constraint_checks"

To resources:

  * data_source_pki_secret_backend_issuer
  * resource_pki_secret_backend_issuer

The fields require Vault Enterprise 1.19+.

See https://github.com/hashicorp/vault-enterprise/pull/6937.
### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

