### PR TITLE
Support field signature_bits in relevant PKI resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ FEATURES:
 * Update `vault_pki_secret_backend_role` to support the `cn_validations` role field ([#1820](https://github.com/hashicorp/terraform-provider-vault/pull/1820)).
 * Add new resource `vault_pki_secret_backend_acme_eab` to manage PKI ACME external account binding tokens. Requires Vault 1.14+. ([#2367](https://github.com/hashicorp/terraform-provider-vault/pull/2367))
 * Add new data source and resource `vault_pki_secret_backend_config_cmpv2`. Requires Vault 1.18+. *Available only for Vault Enterprise* ([#2330](https://github.com/hashicorp/terraform-provider-vault/pull/2330))
+* Add support for signature_bits field to `vault_pki_secret_backend_role`, `vault_pki_secret_backend_root_sign_intermediate` and `vault_pki_secret_backend_intermediate_cert_request` ([#2401])(https://github.com/hashicorp/terraform-provider-vault/pull/2401)
 
 IMPROVEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ FEATURES:
 * Update `vault_pki_secret_backend_role` to support the `cn_validations` role field ([#1820](https://github.com/hashicorp/terraform-provider-vault/pull/1820)).
 * Add new resource `vault_pki_secret_backend_acme_eab` to manage PKI ACME external account binding tokens. Requires Vault 1.14+. ([#2367](https://github.com/hashicorp/terraform-provider-vault/pull/2367))
 * Add new data source and resource `vault_pki_secret_backend_config_cmpv2`. Requires Vault 1.18+. *Available only for Vault Enterprise* ([#2330](https://github.com/hashicorp/terraform-provider-vault/pull/2330))
-* Add support for signature_bits field to `vault_pki_secret_backend_role`, `vault_pki_secret_backend_root_sign_intermediate` and `vault_pki_secret_backend_intermediate_cert_request` ([#2401])(https://github.com/hashicorp/terraform-provider-vault/pull/2401)
+* Add support for signature_bits field to `vault_pki_secret_backend_role`, `vault_pki_secret_backend_root_cert`, `vault_pki_secret_backend_root_sign_intermediate` and `vault_pki_secret_backend_intermediate_cert_request` ([#2401])(https://github.com/hashicorp/terraform-provider-vault/pull/2401)
 
 IMPROVEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ FEATURES:
 * Update `vault_pki_secret_backend_root_cert` and `vault_pki_secret_backend_root_sign_intermediate` to support the new fields for the name constraints extension. Requires Vault 1.19+ ([#2396](https://github.com/hashicorp/terraform-provider-vault/pull/2396)).
 * Update `vault_pki_secret_backend_issuer` resource with the new issuer configuration fields to control certificate verification. Requires Vault Enterprise 1.19+ ([#2400](https://github.com/hashicorp/terraform-provider-vault/pull/2400)).
 * Add support for certificate revocation with `revoke_with_key` in `vault_pki_secret_backend_cert` ([#2242](https://github.com/hashicorp/terraform-provider-vault/pull/2242))
+* Add support for signature_bits field to `vault_pki_secret_backend_role`, `vault_pki_secret_backend_root_cert`, `vault_pki_secret_backend_root_sign_intermediate` and `vault_pki_secret_backend_intermediate_cert_request` ([#2401])(https://github.com/hashicorp/terraform-provider-vault/pull/2401)
 
 BUGS:
 
@@ -20,7 +21,6 @@ FEATURES:
 * Update `vault_pki_secret_backend_role` to support the `cn_validations` role field ([#1820](https://github.com/hashicorp/terraform-provider-vault/pull/1820)).
 * Add new resource `vault_pki_secret_backend_acme_eab` to manage PKI ACME external account binding tokens. Requires Vault 1.14+. ([#2367](https://github.com/hashicorp/terraform-provider-vault/pull/2367))
 * Add new data source and resource `vault_pki_secret_backend_config_cmpv2`. Requires Vault 1.18+. *Available only for Vault Enterprise* ([#2330](https://github.com/hashicorp/terraform-provider-vault/pull/2330))
-* Add support for signature_bits field to `vault_pki_secret_backend_role`, `vault_pki_secret_backend_root_cert`, `vault_pki_secret_backend_root_sign_intermediate` and `vault_pki_secret_backend_intermediate_cert_request` ([#2401])(https://github.com/hashicorp/terraform-provider-vault/pull/2401)
 
 IMPROVEMENTS:
 

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -80,6 +80,7 @@ const (
 	FieldTokenLabel                    = "token_label"
 	FieldCurve                         = "curve"
 	FieldKeyBits                       = "key_bits"
+	FieldSignatureBits                 = "signature_bits"
 	FieldForceRWSession                = "force_rw_session"
 	FieldAccessKey                     = "access_key"
 	FieldSecretKey                     = "secret_key"

--- a/vault/resource_pki_secret_backend_intermediate_cert_request.go
+++ b/vault/resource_pki_secret_backend_intermediate_cert_request.go
@@ -114,6 +114,12 @@ func pkiSecretBackendIntermediateCertRequestResource() *schema.Resource {
 				ForceNew:    true,
 				Default:     2048,
 			},
+			consts.FieldSignatureBits: {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "The number of bits to use in the signature algorithm.",
+				ForceNew:    true,
+			},
 			consts.FieldExcludeCNFromSans: {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -268,7 +274,7 @@ func pkiSecretBackendIntermediateCertRequestCreate(ctx context.Context, d *schem
 
 	// Fields only used when we are generating a key
 	if !(intermediateType == keyTypeKMS || intermediateType == consts.FieldExisting) {
-		intermediateCertAPIFields = append(intermediateCertAPIFields, consts.FieldKeyType, consts.FieldKeyBits)
+		intermediateCertAPIFields = append(intermediateCertAPIFields, consts.FieldKeyType, consts.FieldKeyBits, consts.FieldSignatureBits)
 	}
 
 	if isIssuerAPISupported {
@@ -333,7 +339,6 @@ func pkiSecretBackendIntermediateCertRequestCreate(ctx context.Context, d *schem
 		if err := d.Set(consts.FieldPrivateKeyType, resp.Data[consts.FieldPrivateKeyType]); err != nil {
 			return diag.FromErr(err)
 		}
-
 	}
 
 	id := path

--- a/vault/resource_pki_secret_backend_intermediate_cert_request.go
+++ b/vault/resource_pki_secret_backend_intermediate_cert_request.go
@@ -255,6 +255,7 @@ func pkiSecretBackendIntermediateCertRequestCreate(ctx context.Context, d *schem
 		consts.FieldPostalCode,
 		consts.FieldManagedKeyName,
 		consts.FieldManagedKeyID,
+		consts.FieldSignatureBits,
 	}
 
 	intermediateCertBooleanAPIFields := []string{
@@ -274,7 +275,7 @@ func pkiSecretBackendIntermediateCertRequestCreate(ctx context.Context, d *schem
 
 	// Fields only used when we are generating a key
 	if !(intermediateType == keyTypeKMS || intermediateType == consts.FieldExisting) {
-		intermediateCertAPIFields = append(intermediateCertAPIFields, consts.FieldKeyType, consts.FieldKeyBits, consts.FieldSignatureBits)
+		intermediateCertAPIFields = append(intermediateCertAPIFields, consts.FieldKeyType, consts.FieldKeyBits)
 	}
 
 	if isIssuerAPISupported {

--- a/vault/resource_pki_secret_backend_intermediate_cert_request_test.go
+++ b/vault/resource_pki_secret_backend_intermediate_cert_request_test.go
@@ -4,7 +4,10 @@
 package vault
 
 import (
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"strconv"
 	"testing"
 
@@ -95,20 +98,61 @@ func TestPkiSecretBackendIntermediateCertRequest_signature_bits(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testPkiSecretBackendIntermediateCertRequestConfig_signature_bits(path, ""),
-				Check:  resource.ComposeTestCheckFunc(append(testCheckFunc, resource.TestCheckNoResourceAttr(resourceName, consts.FieldSignatureBits))...),
+				Check: resource.ComposeTestCheckFunc(append(testCheckFunc,
+					resource.TestCheckNoResourceAttr(resourceName, consts.FieldSignatureBits),
+					assertCsrAttributes(resourceName, x509.SHA256WithRSA),
+				)...),
 			},
 			{
 				Config: testPkiSecretBackendIntermediateCertRequestConfig_signature_bits(path, "384"),
 				Check: resource.ComposeTestCheckFunc(append(testCheckFunc,
-					resource.TestCheckResourceAttr(resourceName, consts.FieldSignatureBits, "384"))...),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldSignatureBits, "384"),
+					assertCsrAttributes(resourceName, x509.SHA384WithRSA),
+				)...),
 			},
 			{
 				Config: testPkiSecretBackendIntermediateCertRequestConfig_signature_bits(path, "512"),
 				Check: resource.ComposeTestCheckFunc(append(testCheckFunc,
-					resource.TestCheckResourceAttr(resourceName, consts.FieldSignatureBits, "512"))...),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldSignatureBits, "512"),
+					assertCsrAttributes(resourceName, x509.SHA512WithRSA),
+				)...),
 			},
 		},
 	})
+}
+
+// assertCsrAttributes so far only checks signature algorithm...
+func assertCsrAttributes(resourceName string, expectedSignatureAlgorithm x509.SignatureAlgorithm) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, err := testutil.GetResourceFromRootModule(s, resourceName)
+		if err != nil {
+			return err
+		}
+
+		attrs := rs.Primary.Attributes
+
+		if attrs["format"] != "pem" {
+			// assumes that the certificate `format` is `pem`
+			return fmt.Errorf("test only valid for resources configured with the 'pem' format")
+		}
+
+		csrPEM := attrs["csr"]
+		if csrPEM == "" {
+			return fmt.Errorf("CSR from state cannot be empty")
+		}
+
+		c, _ := pem.Decode([]byte(csrPEM))
+		csr, err := x509.ParseCertificateRequest(c.Bytes)
+		if err != nil {
+			return err
+		}
+
+		if expectedSignatureAlgorithm != csr.SignatureAlgorithm {
+			return fmt.Errorf("expected signature algorithm (form signature_bits) %s, actual %s", expectedSignatureAlgorithm, csr.SignatureAlgorithm)
+		}
+
+		return nil
+	}
 }
 
 func testPkiSecretBackendIntermediateCertRequestConfig_signature_bits(path string, optionalSignatureBits string) string {

--- a/vault/resource_pki_secret_backend_role.go
+++ b/vault/resource_pki_secret_backend_role.go
@@ -258,10 +258,9 @@ func pkiSecretBackendRoleResource() *schema.Resource {
 			},
 			consts.FieldSignatureBits: {
 				Type:        schema.TypeInt,
-				Required:    false,
 				Optional:    true,
+				Computed:    true,
 				Description: "The number of bits to use in the signature algorithm.",
-				Default:     256,
 			},
 			consts.FieldKeyUsage: {
 				Type:        schema.TypeList,

--- a/vault/resource_pki_secret_backend_role.go
+++ b/vault/resource_pki_secret_backend_role.go
@@ -33,6 +33,7 @@ var pkiSecretFields = []string{
 	consts.FieldAllowedURISans,
 	consts.FieldCountry,
 	consts.FieldKeyBits,
+	consts.FieldSignatureBits,
 	consts.FieldKeyType,
 	consts.FieldLocality,
 	consts.FieldMaxTTL,
@@ -254,6 +255,13 @@ func pkiSecretBackendRoleResource() *schema.Resource {
 				Optional:    true,
 				Description: "The number of bits of generated keys.",
 				Default:     2048,
+			},
+			consts.FieldSignatureBits: {
+				Type:        schema.TypeInt,
+				Required:    false,
+				Optional:    true,
+				Description: "The number of bits to use in the signature algorithm.",
+				Default:     256,
 			},
 			consts.FieldKeyUsage: {
 				Type:        schema.TypeList,
@@ -593,12 +601,12 @@ func pkiSecretBackendRoleRead(_ context.Context, d *schema.ResourceData, meta in
 		switch {
 		case k == consts.FieldNotBeforeDuration:
 			d.Set(k, flattenVaultDuration(secret.Data[k]))
-		case k == consts.FieldKeyBits:
-			keyBits, err := secret.Data[consts.FieldKeyBits].(json.Number).Int64()
+		case k == consts.FieldKeyBits || k == consts.FieldSignatureBits:
+			keyBits, err := secret.Data[k].(json.Number).Int64()
 			if err != nil {
-				return diag.Errorf("expected key_bits %q to be a number", secret.Data[consts.FieldKeyBits])
+				return diag.Errorf("expected %s %q to be a number", k, secret.Data[k])
 			}
-			d.Set(consts.FieldKeyBits, keyBits)
+			d.Set(k, keyBits)
 		default:
 			d.Set(k, secret.Data[k])
 		}

--- a/vault/resource_pki_secret_backend_role_test.go
+++ b/vault/resource_pki_secret_backend_role_test.go
@@ -155,6 +155,7 @@ func TestPkiSecretBackendRole_basic(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceName, "email_protection_flag", "false"),
 		resource.TestCheckResourceAttr(resourceName, "key_type", "rsa"),
 		resource.TestCheckResourceAttr(resourceName, "key_bits", "2048"),
+		resource.TestCheckResourceAttr(resourceName, "signature_bits", "512"),
 		resource.TestCheckResourceAttr(resourceName, "email_protection_flag", "false"),
 		resource.TestCheckResourceAttr(resourceName, "email_protection_flag", "false"),
 		resource.TestCheckResourceAttr(resourceName, "key_usage.#", "3"),
@@ -378,6 +379,7 @@ resource "vault_pki_secret_backend_role" "test" {
   email_protection_flag              = false
   key_type                           = "rsa"
   key_bits                           = 2048
+  signature_bits                     = 512
   ext_key_usage                      = []
   ext_key_usage_oids                 = ["1.3.6.1.4.1.311.4"]
   use_csr_common_name                = true

--- a/vault/resource_pki_secret_backend_root_cert.go
+++ b/vault/resource_pki_secret_backend_root_cert.go
@@ -200,6 +200,12 @@ func pkiSecretBackendRootCertResource() *schema.Resource {
 				ForceNew:    true,
 				Default:     2048,
 			},
+			consts.FieldSignatureBits: {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: "The number of bits to use in the signature algorithm.",
+			},
 			consts.FieldMaxPathLength: {
 				Type:        schema.TypeInt,
 				Optional:    true,
@@ -423,6 +429,7 @@ func pkiSecretBackendRootCertCreate(_ context.Context, d *schema.ResourceData, m
 		consts.FieldPostalCode,
 		consts.FieldManagedKeyName,
 		consts.FieldManagedKeyID,
+		consts.FieldSignatureBits,
 	}
 
 	rootCertBooleanAPIFields := []string{

--- a/vault/resource_pki_secret_backend_root_cert_test.go
+++ b/vault/resource_pki_secret_backend_root_cert_test.go
@@ -35,13 +35,14 @@ func TestPkiSecretBackendRootCertificate_basic(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceName, consts.FieldPrivateKeyFormat, "der"),
 		resource.TestCheckResourceAttr(resourceName, consts.FieldKeyType, "rsa"),
 		resource.TestCheckResourceAttr(resourceName, consts.FieldKeyBits, "4096"),
+		resource.TestCheckResourceAttr(resourceName, consts.FieldSignatureBits, "512"),
 		resource.TestCheckResourceAttr(resourceName, consts.FieldOu, "test"),
 		resource.TestCheckResourceAttr(resourceName, consts.FieldOrganization, "test"),
 		resource.TestCheckResourceAttr(resourceName, consts.FieldCountry, "test"),
 		resource.TestCheckResourceAttr(resourceName, consts.FieldLocality, "test"),
 		resource.TestCheckResourceAttr(resourceName, consts.FieldProvince, "test"),
 		resource.TestCheckResourceAttrSet(resourceName, consts.FieldSerialNumber),
-		assertCertificateAttributes(resourceName),
+		assertCertificateAttributes(resourceName, x509.SHA512WithRSA),
 	}
 
 	testPkiSecretBackendRootCertificate(t, path, config, resourceName, checks, nil)
@@ -378,6 +379,7 @@ resource "vault_pki_secret_backend_root_cert" "test" {
   private_key_format   = "der"
   key_type             = "rsa"
   key_bits             = 4096
+  signature_bits       = 512
   exclude_cn_from_sans = true
   ou                   = "test"
   organization         = "test"

--- a/vault/resource_pki_secret_backend_root_sign_intermediate.go
+++ b/vault/resource_pki_secret_backend_root_sign_intermediate.go
@@ -242,6 +242,12 @@ func pkiSecretBackendRootSignIntermediateResource() *schema.Resource {
 				Description: "The postal code.",
 				ForceNew:    true,
 			},
+			consts.FieldSignatureBits: {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "The number of bits to use in the signature algorithm.",
+				ForceNew:    true,
+			},
 			consts.FieldCertificate: {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -310,6 +316,7 @@ func pkiSecretBackendRootSignIntermediateCreate(ctx context.Context, d *schema.R
 		consts.FieldProvince,
 		consts.FieldStreetAddress,
 		consts.FieldPostalCode,
+		consts.FieldSignatureBits,
 	}
 
 	intermediateSignBooleanAPIFields := []string{

--- a/website/docs/r/pki_secret_backend_intermediate_cert_request.html.md
+++ b/website/docs/r/pki_secret_backend_intermediate_cert_request.html.md
@@ -64,6 +64,8 @@ The following arguments are supported:
 
 * `key_bits` - (Optional) The number of bits to use
 
+* `signature_bits` - (Optional) The number of bits to use in the signature algorithm
+
 * `exclude_cn_from_sans` - (Optional) Flag to exclude CN from SANs
 
 * `ou` - (Optional) The organization unit

--- a/website/docs/r/pki_secret_backend_role.html.md
+++ b/website/docs/r/pki_secret_backend_role.html.md
@@ -97,6 +97,8 @@ The following arguments are supported:
 
 * `key_bits` - (Optional) The number of bits of generated keys
 
+* `signature_bits` - (Optional) The number of bits to use in the signature algorithm
+
 * `key_usage` - (Optional) Specify the allowed key usage constraint on issued
   certificates. Defaults to `["DigitalSignature", "KeyAgreement", "KeyEncipherment"])`.
   To specify no default key usage constraints, set this to an empty list `[]`.

--- a/website/docs/r/pki_secret_backend_root_cert.html.md
+++ b/website/docs/r/pki_secret_backend_root_cert.html.md
@@ -74,6 +74,8 @@ The following arguments are supported:
 
 * `key_bits` - (Optional) The number of bits to use
 
+* `signature_bits` - (Optional) The number of bits to use in the signature algorithm
+
 * `max_path_length` - (Optional) The maximum path length to encode in the generated certificate
 
 * `exclude_cn_from_sans` - (Optional) Flag to exclude CN from SANs

--- a/website/docs/r/pki_secret_backend_root_sign_intermediate.html.md
+++ b/website/docs/r/pki_secret_backend_root_sign_intermediate.html.md
@@ -87,6 +87,8 @@ The following arguments are supported:
 
 * `postal_code` - (Optional) The postal code
 
+* `signature_bits` - (Optional) The number of bits to use in the signature algorithm
+
 * `revoke` - If set to `true`, the certificate will be revoked on resource destruction.
 
 * `issuer_ref` - (Optional) Specifies the default issuer of this request. May


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
Add support for signature_bits field to 
* `vault_pki_secret_backend_role`
* `vault_pki_secret_backend_root_cert`
* `vault_pki_secret_backend_root_sign_intermediate` 
* `vault_pki_secret_backend_intermediate_cert_request` 


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2239


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

