### PR TITLE
Add fields key_usage and serial_number to vault_pki_secret_backend_intermediate_cert_request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ FEATURES:
 * Update `vault_pki_secret_backend_issuer` resource with the new issuer configuration fields to control certificate verification. Requires Vault Enterprise 1.19+ ([#2400](https://github.com/hashicorp/terraform-provider-vault/pull/2400)).
 * Add support for certificate revocation with `revoke_with_key` in `vault_pki_secret_backend_cert` ([#2242](https://github.com/hashicorp/terraform-provider-vault/pull/2242))
 * Add support for signature_bits field to `vault_pki_secret_backend_role`, `vault_pki_secret_backend_root_cert`, `vault_pki_secret_backend_root_sign_intermediate` and `vault_pki_secret_backend_intermediate_cert_request` ([#2401])(https://github.com/hashicorp/terraform-provider-vault/pull/2401)
+* Add support for key_usage and serial_number to `vault_pki_secret_backend_intermediate_cert_request` ([#2404])(https://github.com/hashicorp/terraform-provider-vault/pull/2404)
 
 BUGS:
 

--- a/vault/resource_pki_secret_backend_intermediate_cert_request.go
+++ b/vault/resource_pki_secret_backend_intermediate_cert_request.go
@@ -206,6 +206,15 @@ a workaround in some compatibility scenarios with Active Directory Certificate S
 				Default:  false,
 				Optional: true,
 			},
+			consts.FieldKeyUsage: {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Specify the key usages to encode in the generated certificate.",
+				ForceNew:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 			consts.FieldKeyName: {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -268,6 +277,7 @@ func pkiSecretBackendIntermediateCertRequestCreate(ctx context.Context, d *schem
 		consts.FieldIPSans,
 		consts.FieldURISans,
 		consts.FieldOtherSans,
+		consts.FieldKeyUsage,
 	}
 
 	// add multi-issuer write API fields if supported

--- a/vault/resource_pki_secret_backend_intermediate_cert_request.go
+++ b/vault/resource_pki_secret_backend_intermediate_cert_request.go
@@ -168,6 +168,12 @@ func pkiSecretBackendIntermediateCertRequestResource() *schema.Resource {
 				Description: "The postal code.",
 				ForceNew:    true,
 			},
+			consts.FieldSerialNumber: {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The requested Subject's named serial number.",
+				ForceNew:    true,
+			},
 			consts.FieldCSR: {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -262,6 +268,7 @@ func pkiSecretBackendIntermediateCertRequestCreate(ctx context.Context, d *schem
 		consts.FieldProvince,
 		consts.FieldStreetAddress,
 		consts.FieldPostalCode,
+		consts.FieldSerialNumber,
 		consts.FieldManagedKeyName,
 		consts.FieldManagedKeyID,
 		consts.FieldSignatureBits,

--- a/website/docs/r/pki_secret_backend_intermediate_cert_request.html.md
+++ b/website/docs/r/pki_secret_backend_intermediate_cert_request.html.md
@@ -82,6 +82,8 @@ The following arguments are supported:
 
 * `postal_code` - (Optional) The postal code
 
+* `serial_number` - (Optional) The requested Subject's named Serial Number
+
 * `managed_key_name` - (Optional) The name of the previously configured managed key. This field is
   required if `type` is `kms`  and it conflicts with `managed_key_id`
 

--- a/website/docs/r/pki_secret_backend_intermediate_cert_request.html.md
+++ b/website/docs/r/pki_secret_backend_intermediate_cert_request.html.md
@@ -92,6 +92,8 @@ The following arguments are supported:
   Only needed as a workaround in some compatibility scenarios with Active Directory
   Certificate Services
 
+* `key_usage` - (Optional) Specifies key_usage to encode in the generated certificate.
+
 * `key_name` - (Optional) When a new key is created with this request, optionally specifies
   the name for this. The global ref `default` may not be used as a name.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
Add fields key_usage and serial_number to vault_pki_secret_backend_intermediate_cert_request


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions




<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

