### PR TITLE
feat(data_vault_namespaces): add recursive search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+FEATURES:
+
+* Add support for `recursive` search in `data_vault_namespaces` [#2408](https://github.com/hashicorp/terraform-provider-vault/pull/2408)
+
 ## 4.7.0 (Mar 12, 2025)
 
 FEATURES:

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -41,6 +41,7 @@ const (
 	FieldNamespaceID                   = "namespace_id"
 	FieldNamespacePath                 = "namespace_path"
 	FieldPathFQ                        = "path_fq"
+	FieldPathsFQ                       = "paths_fq"
 	FieldData                          = "data"
 	FieldDisableRead                   = "disable_read"
 	FieldName                          = "name"

--- a/vault/data_source_namespace_test.go
+++ b/vault/data_source_namespace_test.go
@@ -23,9 +23,9 @@ func TestAccDataSourceNamespace(t *testing.T) {
 	pathChild := acctest.RandomWithPrefix("tf-child")
 
 	resource.Test(t, resource.TestCase{
-		Providers:    testProviders,
-		PreCheck:     func() { testutil.TestAccPreCheck(t) },
-		CheckDestroy: testNamespaceDestroy(path),
+		ProviderFactories: providerFactories,
+		PreCheck:          func() { testutil.TestAccPreCheck(t) },
+		CheckDestroy:      testNamespaceDestroy(path),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNamespaceConfig_nested(path, pathChild),
@@ -43,7 +43,7 @@ func TestAccDataSourceNamespace(t *testing.T) {
 	})
 
 	resource.Test(t, resource.TestCase{
-		Providers: testProviders,
+		ProviderFactories: providerFactories,
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
 			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion112)
@@ -63,9 +63,9 @@ func TestAccDataSourceNamespace(t *testing.T) {
 	})
 
 	resource.Test(t, resource.TestCase{
-		Providers:    testProviders,
-		PreCheck:     func() { testutil.TestAccPreCheck(t) },
-		CheckDestroy: testNamespaceDestroy(path),
+		ProviderFactories: providerFactories,
+		PreCheck:          func() { testutil.TestAccPreCheck(t) },
+		CheckDestroy:      testNamespaceDestroy(path),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNamespaceConfig_current(path),

--- a/vault/data_source_namespaces.go
+++ b/vault/data_source_namespaces.go
@@ -6,6 +6,7 @@ package vault
 import (
 	"context"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -21,34 +22,87 @@ func namespacesDataSource() *schema.Resource {
 		ReadContext: provider.ReadContextWrapper(namespacesDataSourceRead),
 
 		Schema: map[string]*schema.Schema{
+			"recursive": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "True to fetch all child namespaces.",
+			},
 			consts.FieldPaths: {
 				Type:        schema.TypeSet,
 				Computed:    true,
 				Description: "Namespace paths.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
+			consts.FieldPathsFQ: {
+				Type:        schema.TypeSet,
+				Computed:    true,
+				Description: "The fully qualified namespace paths.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
 
-func namespacesDataSourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client, e := provider.GetClient(d, meta)
-	if e != nil {
-		return diag.FromErr(e)
-	}
+func namespacesReadNamespacePaths(ctx context.Context, client *api.Client, namespace string, recursive bool) ([]string, diag.Diagnostics) {
+	var allNamespaces []string
 
-	log.Printf("[DEBUG] Reading namespaces from Vault")
+	client.SetNamespace(namespace)
 
 	resp, err := client.Logical().ListWithContext(ctx, consts.SysNamespaceRoot)
 	if err != nil {
-		return diag.Errorf("error reading namespaces from Vault: %s", err)
-	}
-	if err := d.Set(consts.FieldPaths, flattenPaths(resp)); err != nil {
-		return diag.Errorf("error setting %q to state: %s", consts.FieldPaths, err)
+		return nil, diag.Errorf("error reading namespaces from Vault: %v", err)
 	}
 
-	id := mountutil.NormalizeMountPath(client.Namespace())
+	prefix := ""
+	if namespace != "" {
+		prefix = namespace + "/"
+	}
+
+	for _, ns := range flattenPaths(resp) {
+		allNamespaces = append(allNamespaces, prefix+ns)
+
+		if recursive {
+			subNamespaces, diags := namespacesReadNamespacePaths(ctx, client, prefix+ns, true)
+			if diags.HasError() {
+				return nil, diags
+			}
+			allNamespaces = append(allNamespaces, subNamespaces...)
+		}
+	}
+
+	return allNamespaces, nil
+}
+
+func namespacesDataSourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, err := provider.GetClient(d, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	namespace := client.Namespace()
+	id := mountutil.NormalizeMountPath(namespace)
 	d.SetId(id)
+
+	log.Printf("[DEBUG] Reading namespaces from Vault")
+
+	absolutePaths, diags := namespacesReadNamespacePaths(ctx, client, namespace, d.Get("recursive").(bool))
+	if diags.HasError() {
+		return diags
+	}
+
+	if err := d.Set(consts.FieldPathsFQ, absolutePaths); err != nil {
+		return diag.Errorf("error setting %q to state: %v", consts.FieldPathsFQ, err)
+	}
+
+	var relativePaths []string
+	for _, absolutePath := range absolutePaths {
+		relativePaths = append(relativePaths, strings.TrimPrefix(absolutePath, namespace+"/"))
+	}
+
+	if err := d.Set(consts.FieldPaths, relativePaths); err != nil {
+		return diag.Errorf("error setting %q to state: %v", consts.FieldPaths, err)
+	}
 
 	return nil
 }

--- a/vault/data_source_namespaces_test.go
+++ b/vault/data_source_namespaces_test.go
@@ -21,20 +21,67 @@ func TestAccDataSourceNamespaces(t *testing.T) {
 	resourceName := "data.vault_namespaces"
 
 	resource.Test(t, resource.TestCase{
-		Providers: testProviders,
-		PreCheck:  func() { testutil.TestAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		PreCheck:          func() { testutil.TestAccPreCheck(t) },
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceNamespacesConfig(ns, 3),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName+".test", consts.FieldPaths+".#", "3"),
-					resource.TestCheckTypeSetElemAttr(resourceName+".test", consts.FieldPaths+".*", "test-0"),
-					resource.TestCheckTypeSetElemAttr(resourceName+".test", consts.FieldPaths+".*", "test-1"),
-					resource.TestCheckTypeSetElemAttr(resourceName+".test", consts.FieldPaths+".*", "test-2"),
-					resource.TestCheckResourceAttr(resourceName+".test", consts.FieldNamespace, ns),
-					// test nested which will not have any namespaces under it
-					resource.TestCheckResourceAttr(resourceName+".nested", consts.FieldPaths+".#", "0"),
-					resource.TestCheckResourceAttr(resourceName+".nested", consts.FieldNamespace, ns+"/test-0/nested"),
+					resource.TestCheckResourceAttr(resourceName+".test_root", "recursive", "false"),
+					resource.TestCheckTypeSetElemAttr(resourceName+".test_root", consts.FieldPaths+".*", ns),
+					resource.TestCheckTypeSetElemAttr(resourceName+".test_root", consts.FieldPathsFQ+".*", ns),
+
+					resource.TestCheckResourceAttr(resourceName+".test_level0", "recursive", "false"),
+					resource.TestCheckResourceAttr(resourceName+".test_level0", consts.FieldNamespace, ns),
+					resource.TestCheckResourceAttr(resourceName+".test_level0", consts.FieldPaths+".#", "3"),
+					resource.TestCheckTypeSetElemAttr(resourceName+".test_level0", consts.FieldPaths+".*", "level1-ns-0"),
+					resource.TestCheckTypeSetElemAttr(resourceName+".test_level0", consts.FieldPaths+".*", "level1-ns-1"),
+					resource.TestCheckTypeSetElemAttr(resourceName+".test_level0", consts.FieldPaths+".*", "level1-ns-2"),
+					resource.TestCheckResourceAttr(resourceName+".test_level0", consts.FieldPathsFQ+".#", "3"),
+					resource.TestCheckTypeSetElemAttr(resourceName+".test_level0", consts.FieldPathsFQ+".*", ns+"/level1-ns-0"),
+					resource.TestCheckTypeSetElemAttr(resourceName+".test_level0", consts.FieldPathsFQ+".*", ns+"/level1-ns-1"),
+					resource.TestCheckTypeSetElemAttr(resourceName+".test_level0", consts.FieldPathsFQ+".*", ns+"/level1-ns-2"),
+
+					resource.TestCheckResourceAttr(resourceName+".test_level1", "recursive", "false"),
+					resource.TestCheckResourceAttr(resourceName+".test_level1", consts.FieldNamespace, ns+"/level1-ns-0"),
+					resource.TestCheckResourceAttr(resourceName+".test_level1", consts.FieldPaths+".#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName+".test_level1", consts.FieldPaths+".*", "level2-ns-0"),
+					resource.TestCheckResourceAttr(resourceName+".test_level1", consts.FieldPathsFQ+".#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName+".test_level1", consts.FieldPathsFQ+".*", ns+"/level1-ns-0/level2-ns-0"),
+
+					resource.TestCheckResourceAttr(resourceName+".test_level2", "recursive", "false"),
+					resource.TestCheckResourceAttr(resourceName+".test_level2", consts.FieldNamespace, ns+"/level1-ns-0/level2-ns-0"),
+					resource.TestCheckResourceAttr(resourceName+".test_level2", consts.FieldPaths+".#", "0"),
+					resource.TestCheckResourceAttr(resourceName+".test_level2", consts.FieldPathsFQ+".#", "0"),
+
+					resource.TestCheckResourceAttr(resourceName+".test_root_recursive", "recursive", "true"),
+					resource.TestCheckTypeSetElemAttr(resourceName+".test_root_recursive", consts.FieldPaths+".*", ns+"/level1-ns-0/level2-ns-0"),
+					resource.TestCheckTypeSetElemAttr(resourceName+".test_root_recursive", consts.FieldPathsFQ+".*", ns+"/level1-ns-0/level2-ns-0"),
+
+					resource.TestCheckResourceAttr(resourceName+".test_level0_recursive", "recursive", "true"),
+					resource.TestCheckResourceAttr(resourceName+".test_level0_recursive", consts.FieldNamespace, ns),
+					resource.TestCheckResourceAttr(resourceName+".test_level0_recursive", consts.FieldPaths+".#", "4"),
+					resource.TestCheckTypeSetElemAttr(resourceName+".test_level0_recursive", consts.FieldPaths+".*", "level1-ns-0"),
+					resource.TestCheckTypeSetElemAttr(resourceName+".test_level0_recursive", consts.FieldPaths+".*", "level1-ns-0/level2-ns-0"),
+					resource.TestCheckTypeSetElemAttr(resourceName+".test_level0_recursive", consts.FieldPaths+".*", "level1-ns-1"),
+					resource.TestCheckTypeSetElemAttr(resourceName+".test_level0_recursive", consts.FieldPaths+".*", "level1-ns-2"),
+					resource.TestCheckResourceAttr(resourceName+".test_level0_recursive", consts.FieldPathsFQ+".#", "4"),
+					resource.TestCheckTypeSetElemAttr(resourceName+".test_level0_recursive", consts.FieldPathsFQ+".*", ns+"/level1-ns-0"),
+					resource.TestCheckTypeSetElemAttr(resourceName+".test_level0_recursive", consts.FieldPathsFQ+".*", ns+"/level1-ns-0/level2-ns-0"),
+					resource.TestCheckTypeSetElemAttr(resourceName+".test_level0_recursive", consts.FieldPathsFQ+".*", ns+"/level1-ns-1"),
+					resource.TestCheckTypeSetElemAttr(resourceName+".test_level0_recursive", consts.FieldPathsFQ+".*", ns+"/level1-ns-2"),
+
+					resource.TestCheckResourceAttr(resourceName+".test_level1_recursive", "recursive", "true"),
+					resource.TestCheckResourceAttr(resourceName+".test_level1_recursive", consts.FieldNamespace, ns+"/level1-ns-0"),
+					resource.TestCheckResourceAttr(resourceName+".test_level1_recursive", consts.FieldPaths+".#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName+".test_level1_recursive", consts.FieldPaths+".*", "level2-ns-0"),
+					resource.TestCheckResourceAttr(resourceName+".test_level1_recursive", consts.FieldPathsFQ+".#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName+".test_level1_recursive", consts.FieldPathsFQ+".*", ns+"/level1-ns-0/level2-ns-0"),
+
+					resource.TestCheckResourceAttr(resourceName+".test_level2_recursive", "recursive", "true"),
+					resource.TestCheckResourceAttr(resourceName+".test_level2_recursive", consts.FieldNamespace, ns+"/level1-ns-0/level2-ns-0"),
+					resource.TestCheckResourceAttr(resourceName+".test_level2_recursive", consts.FieldPaths+".#", "0"),
+					resource.TestCheckResourceAttr(resourceName+".test_level2_recursive", consts.FieldPathsFQ+".#", "0"),
 				),
 			},
 		},
@@ -43,29 +90,62 @@ func TestAccDataSourceNamespaces(t *testing.T) {
 
 func testAccDataSourceNamespacesConfig(ns string, count int) string {
 	config := fmt.Sprintf(`
-resource "vault_namespace" "parent" {
+resource "vault_namespace" "level0" {
   path = %q
 }
 
-resource "vault_namespace" "test" {
+resource "vault_namespace" "level1" {
   count     = %d
-  namespace = vault_namespace.parent.path
-  path      = "test-${count.index}"
+  namespace = vault_namespace.level0.path_fq
+  path      = "level1-ns-${count.index}"
 }
 
-# this will create a namespace with the path "test/test-0/nested"
-resource "vault_namespace" "nested" {
-  namespace = vault_namespace.test[0].path_fq
-  path      = "nested"
+# this will create a namespace with the path "level0-ns/level1-ns-0/level2-ns-0"
+resource "vault_namespace" "level2" {
+  namespace = vault_namespace.level1[0].path_fq
+  path      = "level2-ns-0"
 }
 
-data "vault_namespaces" "test" {
-	namespace  = vault_namespace.parent.path
-	depends_on = [vault_namespace.test]
+data "vault_namespaces" "test_root" {
+  depends_on = [vault_namespace.level0, vault_namespace.level1, vault_namespace.level2]
 }
 
-data "vault_namespaces" "nested" {
-	namespace  = vault_namespace.nested.path_fq
+data "vault_namespaces" "test_level0" {
+  namespace  = vault_namespace.level0.path_fq
+  depends_on = [vault_namespace.level1, vault_namespace.level2]
+}
+
+data "vault_namespaces" "test_level1" {
+  namespace  = vault_namespace.level1[0].path_fq
+  depends_on = [vault_namespace.level1, vault_namespace.level2]
+}
+
+data "vault_namespaces" "test_level2" {
+  namespace  = vault_namespace.level2.path_fq
+  depends_on = [vault_namespace.level1, vault_namespace.level2]
+}
+
+data "vault_namespaces" "test_root_recursive" {
+  recursive  = true
+  depends_on = [vault_namespace.level0, vault_namespace.level1, vault_namespace.level2]
+}
+
+data "vault_namespaces" "test_level0_recursive" {
+  namespace  = vault_namespace.level0.path_fq
+  recursive  = true
+  depends_on = [vault_namespace.level1, vault_namespace.level2]
+}
+
+data "vault_namespaces" "test_level1_recursive" {
+  namespace  = vault_namespace.level1[0].path_fq
+  recursive  = true
+  depends_on = [vault_namespace.level1, vault_namespace.level2]
+}
+
+data "vault_namespaces" "test_level2_recursive" {
+  namespace  = vault_namespace.level2.path_fq
+  recursive  = true
+  depends_on = [vault_namespace.level1, vault_namespace.level2]
 }
 	`, ns, count)
 

--- a/website/docs/d/namespaces.html.md
+++ b/website/docs/d/namespaces.html.md
@@ -3,26 +3,34 @@ layout: "vault"
 page_title: "Vault: vault_namespaces data source"
 sidebar_current: "docs-vault-datasource-namespaces"
 description: |-
-  Fetches a list of all direct child namespaces in Vault
+  List of all child namespaces in Vault
 ---
 
 # vault\_namespace
 
-Lists all direct child [Namespaces](https://developer.hashicorp.com/vault/docs/enterprise/namespaces) in Vault.
+Lists all child [Namespaces](https://developer.hashicorp.com/vault/docs/enterprise/namespaces) in Vault.
 
 **Note** this feature is available only with Vault Enterprise.
 
 ## Example Usage
 
-### Child namespaces
+### Direct child namespaces
 
 ```hcl
 data "vault_namespaces" "children" {}
 ```
 
-### Nested namespace
+### All child namespaces
 
-To fetch the details of nested namespaces:
+```hcl
+data "vault_namespaces" "children" {
+  recursive = true
+}
+```
+
+### Child namespace details
+
+To fetch the details of child namespaces:
 
 ```hcl
 data "vault_namespaces" "children" {
@@ -43,9 +51,11 @@ The following arguments are supported:
 * `namespace` - (Optional) The namespace to provision the resource in.
   The value should not contain leading or trailing forward slashes.
   The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault#namespace).
+* `recursive` - (Optional) If `true`, it will returns all child namespaces of the given namespace. Defaults to `false`, which returns only direct child namespaces.
 
 ## Attributes Reference
 
 In addition to the above arguments, the following attributes are exported:
 
-* `paths` - Set of the paths of direct child namespaces.
+* `paths` - Set of the paths of child namespaces.
+* `paths_fq` - Set of the fully qualified paths of child namespaces.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description

This PR adds a `recursive` boolean to the `data_vault_namespaces` data source, allowing it to return all child namespaces, not just direct children. By default, `recursive` is set to `false` to preserve performance and maintain backward compatibility.

### Checklist

- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc-ent TESTARGS='-run=TestAccDataSourceNamespace -v'
make testacc TF_ACC_ENTERPRISE=1
make[1]: Entering directory '/workspaces/terraform-provider-vault'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -run=TestAccDataSourceNamespace -v -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/mfa     [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/pki      [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/codegen   0.014s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  0.044s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/rotation [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/sync     [no test files]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/internal/provider 0.036s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/testutil  0.016s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/util      0.016s [no tests to run]
testing: warning: no tests to run
PASS
ok      github.com/hashicorp/terraform-provider-vault/util/mountutil    0.008s [no tests to run]
=== RUN   TestAccDataSourceNamespace
    data_source_namespace_test.go:49: Vault server version "1.18.4+ent"
--- PASS: TestAccDataSourceNamespace (16.19s)
=== RUN   TestAccDataSourceNamespaces
--- PASS: TestAccDataSourceNamespaces (6.24s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     22.489s
make[1]: Leaving directory '/workspaces/terraform-provider-vault'
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

