### PR TITLE
Add support for disabled_validations to the PKI CMPv2 config resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ FEATURES:
 * Add support for `not_after` in `vault_pki_secret_backend_cert`, `vault_pki_secret_backend_role`, `vault_pki_secret_backend_root_cert`, `vault_pki_secret_backend_root_sign_intermediate`, and `vault_pki_secret_backend_sign` ([#2385](https://github.com/hashicorp/terraform-provider-vault/pull/2385)). 
 * Update `vault_pki_secret_backend_config_acme` to support the `max_ttl` field. [#2411](https://github.com/hashicorp/terraform-provider-vault/pull/2411)
 * Add new data source `vault_ssh_secret_backend_sign`. ([#2409](https://github.com/hashicorp/terraform-provider-vault/pull/2409))
+* Add suppor for `disabled_validations` in `vault_pki_secret_backend_config_cmpv2` [#2412](https://github.com/hashicorp/terraform-provider-vault/pull/2412)
 
 BUGS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ FEATURES:
 * Add support for `not_after` in `vault_pki_secret_backend_cert`, `vault_pki_secret_backend_role`, `vault_pki_secret_backend_root_cert`, `vault_pki_secret_backend_root_sign_intermediate`, and `vault_pki_secret_backend_sign` ([#2385](https://github.com/hashicorp/terraform-provider-vault/pull/2385)). 
 * Update `vault_pki_secret_backend_config_acme` to support the `max_ttl` field. [#2411](https://github.com/hashicorp/terraform-provider-vault/pull/2411)
 * Add new data source `vault_ssh_secret_backend_sign`. ([#2409](https://github.com/hashicorp/terraform-provider-vault/pull/2409))
-* Add suppor for `disabled_validations` in `vault_pki_secret_backend_config_cmpv2` [#2412](https://github.com/hashicorp/terraform-provider-vault/pull/2412)
+* Add support for `disabled_validations` in `vault_pki_secret_backend_config_cmpv2` [#2412](https://github.com/hashicorp/terraform-provider-vault/pull/2412)
 
 BUGS:
 

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -542,17 +542,18 @@ const (
 	/*
 		Vault version constants
 	*/
-	VaultVersion190 = "1.9.0"
-	VaultVersion110 = "1.10.0"
-	VaultVersion111 = "1.11.0"
-	VaultVersion112 = "1.12.0"
-	VaultVersion113 = "1.13.0"
-	VaultVersion114 = "1.14.0"
-	VaultVersion115 = "1.15.0"
-	VaultVersion116 = "1.16.0"
-	VaultVersion117 = "1.17.0"
-	VaultVersion118 = "1.18.0"
-	VaultVersion119 = "1.19.0"
+	VaultVersion190  = "1.9.0"
+	VaultVersion110  = "1.10.0"
+	VaultVersion111  = "1.11.0"
+	VaultVersion112  = "1.12.0"
+	VaultVersion113  = "1.13.0"
+	VaultVersion114  = "1.14.0"
+	VaultVersion115  = "1.15.0"
+	VaultVersion116  = "1.16.0"
+	VaultVersion117  = "1.17.0"
+	VaultVersion118  = "1.18.0"
+	VaultVersion1185 = "1.18.5"
+	VaultVersion119  = "1.19.0"
 
 	/*
 		Vault auth methods

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -442,6 +442,7 @@ const (
 	FieldAuthenticators                = "authenticators"
 	FieldEnableSentinelParsing         = "enable_sentinel_parsing"
 	FieldAuditFields                   = "audit_fields"
+	FieldDisabledValidations           = "disabled_validations"
 	FieldLastUpdated                   = "last_updated"
 	FieldCustomEndpoint                = "custom_endpoint"
 	FieldPrivateKeyID                  = "private_key_id"

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -35,16 +35,17 @@ const (
 var (
 	MaxHTTPRetriesCCC int
 
-	VaultVersion110 = version.Must(version.NewSemver(consts.VaultVersion110))
-	VaultVersion111 = version.Must(version.NewSemver(consts.VaultVersion111))
-	VaultVersion112 = version.Must(version.NewSemver(consts.VaultVersion112))
-	VaultVersion113 = version.Must(version.NewSemver(consts.VaultVersion113))
-	VaultVersion114 = version.Must(version.NewSemver(consts.VaultVersion114))
-	VaultVersion115 = version.Must(version.NewSemver(consts.VaultVersion115))
-	VaultVersion116 = version.Must(version.NewSemver(consts.VaultVersion116))
-	VaultVersion117 = version.Must(version.NewSemver(consts.VaultVersion117))
-	VaultVersion118 = version.Must(version.NewSemver(consts.VaultVersion118))
-	VaultVersion119 = version.Must(version.NewSemver(consts.VaultVersion119))
+	VaultVersion110  = version.Must(version.NewSemver(consts.VaultVersion110))
+	VaultVersion111  = version.Must(version.NewSemver(consts.VaultVersion111))
+	VaultVersion112  = version.Must(version.NewSemver(consts.VaultVersion112))
+	VaultVersion113  = version.Must(version.NewSemver(consts.VaultVersion113))
+	VaultVersion114  = version.Must(version.NewSemver(consts.VaultVersion114))
+	VaultVersion115  = version.Must(version.NewSemver(consts.VaultVersion115))
+	VaultVersion116  = version.Must(version.NewSemver(consts.VaultVersion116))
+	VaultVersion117  = version.Must(version.NewSemver(consts.VaultVersion117))
+	VaultVersion118  = version.Must(version.NewSemver(consts.VaultVersion118))
+	VaultVersion1185 = version.Must(version.NewSemver(consts.VaultVersion1185))
+	VaultVersion119  = version.Must(version.NewSemver(consts.VaultVersion119))
 
 	TokenTTLMinRecommended = time.Minute * 15
 )

--- a/vault/data_source_pki_secret_backend_config_cmpv2.go
+++ b/vault/data_source_pki_secret_backend_config_cmpv2.go
@@ -63,6 +63,15 @@ func pkiSecretBackendConfigCMPV2DataSource() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			consts.FieldDisabledValidations: {
+				Type:        schema.TypeList,
+				Required:    false,
+				Optional:    true,
+				Description: "A comma-separated list of validations not to perform on CMPv2 messages.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 			consts.FieldLastUpdated: {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -108,6 +117,7 @@ func readCMPV2Config(ctx context.Context, d *schema.ResourceData, client *api.Cl
 		consts.FieldDefaultPathPolicy,
 		consts.FieldEnableSentinelParsing,
 		consts.FieldAuditFields,
+		consts.FieldDisabledValidations,
 		consts.FieldLastUpdated,
 	}
 

--- a/vault/resource_pki_secret_backend_config_cmpv2.go
+++ b/vault/resource_pki_secret_backend_config_cmpv2.go
@@ -72,6 +72,15 @@ func pkiSecretBackendConfigCMPV2Resource() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			consts.FieldDisabledValidations: {
+				Type:        schema.TypeList,
+				Required:    false,
+				Optional:    true,
+				Description: "A comma-separated list of validations not to perform on CMPv2 messages.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 			consts.FieldLastUpdated: {
 				Type:        schema.TypeString,
 				Computed:    true, // read-only property
@@ -99,6 +108,7 @@ func pkiSecretBackendConfigCMPV2Write(ctx context.Context, d *schema.ResourceDat
 		consts.FieldDefaultPathPolicy,
 		consts.FieldEnableSentinelParsing,
 		consts.FieldAuditFields,
+		consts.FieldDisabledValidations,
 	}
 
 	data := map[string]interface{}{}

--- a/vault/resource_pki_secret_backend_config_cmpv2_test.go
+++ b/vault/resource_pki_secret_backend_config_cmpv2_test.go
@@ -5,13 +5,13 @@ package vault
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
-	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -88,7 +88,10 @@ func TestAccPKISecretBackendConfigCMPV2_AllFields(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceBackend, consts.FieldAuthenticators+".0.cert.cert_role", "a-role"),
 					resource.TestCheckResourceAttr(resourceBackend, consts.FieldEnableSentinelParsing, "true"),
 					resource.TestCheckResourceAttr(resourceBackend, consts.FieldAuditFields+".#", "20"),
-					resource.TestCheckResourceAttrSet(dataName, consts.FieldLastUpdated),
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldDisabledValidations+".#", "2"),
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldDisabledValidations+".0", "DisableMatchingKeyIdValidation"),
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldDisabledValidations+".1", "DisableCertTimeValidation"),
+					resource.TestCheckResourceAttrSet(resourceBackend, consts.FieldLastUpdated),
 
 					// Validate that the data property can read back everything filled in
 					resource.TestCheckResourceAttr(dataName, consts.FieldBackend, backend),
@@ -98,9 +101,11 @@ func TestAccPKISecretBackendConfigCMPV2_AllFields(t *testing.T) {
 					resource.TestCheckResourceAttr(dataName, consts.FieldAuthenticators+".0.%", "1"),
 					resource.TestCheckResourceAttr(dataName, consts.FieldAuthenticators+".0.cert.%", "2"),
 					resource.TestCheckResourceAttr(dataName, consts.FieldAuthenticators+".0.cert.accessor", "test"),
-					resource.TestCheckResourceAttr(resourceBackend, consts.FieldAuthenticators+".0.cert.cert_role", "a-role"),
+					resource.TestCheckResourceAttr(dataName, consts.FieldAuthenticators+".0.cert.cert_role", "a-role"),
 					resource.TestCheckResourceAttr(dataName, consts.FieldEnableSentinelParsing, "true"),
 					resource.TestCheckResourceAttr(dataName, consts.FieldAuditFields+".#", "20"),
+					resource.TestCheckResourceAttr(dataName, consts.FieldDisabledValidations+".0", "DisableMatchingKeyIdValidation"),
+					resource.TestCheckResourceAttr(dataName, consts.FieldDisabledValidations+".1", "DisableCertTimeValidation"),
 					resource.TestCheckResourceAttrSet(dataName, consts.FieldLastUpdated),
 				),
 			},
@@ -145,6 +150,7 @@ resource "vault_pki_secret_backend_config_cmpv2" "test" {
                   "signature_bits", "exclude_cn_from_sans", "ou", "organization", "country", 
                   "locality", "province", "street_address", "postal_code", "serial_number",
                   "use_pss", "key_type", "key_bits", "add_basic_constraints"]
+  disabled_validations = ["DisableMatchingKeyIdValidation", "DisableCertTimeValidation"]
 }
 
 data "vault_pki_secret_backend_config_cmpv2" "test" {

--- a/website/docs/d/pki_secret_backend_config_cmpv2.html.md
+++ b/website/docs/d/pki_secret_backend_config_cmpv2.html.md
@@ -56,6 +56,8 @@ The following arguments are supported:
 
 * `audit_fields` - Fields parsed from the CSR that appear in the audit and can be used by sentinel policies.
 
+* `disabled_validations` - A comma-separated list of validations not to perform on CMPv2 messages.
+
 * `last_updated` - A read-only timestamp representing the last time the configuration was updated.
 
 <a id="nestedatt--authenticators"></a>

--- a/website/docs/r/pki_secret_backend_config_cmpv2.html.md
+++ b/website/docs/r/pki_secret_backend_config_cmpv2.html.md
@@ -50,6 +50,7 @@ resource "vault_pki_secret_backend_config_cmpv2" "example" {
     "signature_bits", "exclude_cn_from_sans", "ou", "organization", "country",
     "locality", "province", "street_address", "postal_code", "serial_number",
     "use_pss", "key_type", "key_bits", "add_basic_constraints"]
+  disabled_validations = ["DisableMatchingKeyIdValidation"]
 }
 ```
 
@@ -72,8 +73,10 @@ The following arguments are supported:
 * `enable_sentinel_parsing` - (Optional) If set, parse out fields from the provided CSR making them available for Sentinel policies.
 
 * `enabled` - (Optional) Specifies whether CMPv2 is enabled.
-
+  
 * `audit_fields` - (Optional) Fields parsed from the CSR that appear in the audit and can be used by sentinel policies.
+  
+* `disabled_validations` - (Optional) A comma-separated list of validations not to perform on CMPv2 messages.
 
 <a id="nestedatt--authenticators"></a>
 ### Nested Schema for `authenticators`


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description

Add support for disabled_validations to the PKI CMPv2 config resource.

### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

