### PR TITLE
Add missing parameters for vault_pki_secret_backend_root_sign_intermediate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
           terraform_wrapper: false
 
       - name: Cache go build
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: |
             ~/.cache/go-build
@@ -183,7 +183,7 @@ jobs:
           echo "command=${PLUGIN}" >> "${GITHUB_OUTPUT}"
 
       - name: Cache go build
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: |
             ~/.cache/go-build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ FEATURES:
 * Add new data source `vault_ssh_secret_backend_sign`. ([#2409](https://github.com/hashicorp/terraform-provider-vault/pull/2409))
 * Add support for `disabled_validations` in `vault_pki_secret_backend_config_cmpv2` [#2412](https://github.com/hashicorp/terraform-provider-vault/pull/2412)
 * Add `credential_type` and `credential_config` to `database_secret_backend_static_role` to support features like rsa keys for Snowflake DB engines with static roles [#2384](https://github.com/hashicorp/terraform-provider-vault/pull/2384)
+* Add support for missing parameters to `vault_pki_secret_backend_root_sign_intermediate`: `not_before_duration`, `skid` and `use_pss` [#2417](https://github.com/hashicorp/terraform-provider-vault/pull/2417)
 
 BUGS:
 

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -81,6 +81,7 @@ const (
 	FieldCurve                         = "curve"
 	FieldKeyBits                       = "key_bits"
 	FieldSignatureBits                 = "signature_bits"
+	FieldSKID                          = "skid"
 	FieldForceRWSession                = "force_rw_session"
 	FieldAccessKey                     = "access_key"
 	FieldSecretKey                     = "secret_key"

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -82,6 +82,7 @@ const (
 	FieldKeyBits                       = "key_bits"
 	FieldSignatureBits                 = "signature_bits"
 	FieldSKID                          = "skid"
+	FieldUsePSS                        = "use_pss"
 	FieldForceRWSession                = "force_rw_session"
 	FieldAccessKey                     = "access_key"
 	FieldSecretKey                     = "secret_key"

--- a/vault/resource_pki_secret_backend_cert_test.go
+++ b/vault/resource_pki_secret_backend_cert_test.go
@@ -447,6 +447,28 @@ func testPKICertRevocation(path string, store *testPKICertStore) resource.TestCh
 	}
 }
 
+func testPKICert(resourceName string, check func(*x509.Certificate) error) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, err := testutil.GetResourceFromRootModule(s, resourceName)
+		if err != nil {
+			return err
+		}
+
+		certificate, ok := rs.Primary.Attributes["certificate"]
+		if !ok {
+			return fmt.Errorf("certificate not found in state")
+		}
+
+		p, _ := pem.Decode([]byte(certificate))
+		cert, err := x509.ParseCertificate(p.Bytes)
+		if err != nil {
+			return err
+		}
+
+		return check(cert)
+	}
+}
+
 func testPKICertReIssued(resourceName string, store *testPKICertStore) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, err := testutil.GetResourceFromRootModule(s, resourceName)

--- a/vault/resource_pki_secret_backend_root_sign_intermediate.go
+++ b/vault/resource_pki_secret_backend_root_sign_intermediate.go
@@ -248,6 +248,12 @@ func pkiSecretBackendRootSignIntermediateResource() *schema.Resource {
 				Description: "The number of bits to use in the signature algorithm.",
 				ForceNew:    true,
 			},
+			consts.FieldSKID: {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Value for the Subject Key Identifier field\n  (RFC 5280 Section 4.2.1.2). Specified as a string in hex format.",
+				ForceNew:    true,
+			},
 			consts.FieldCertificate: {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -332,6 +338,7 @@ func pkiSecretBackendRootSignIntermediateCreate(ctx context.Context, d *schema.R
 		consts.FieldStreetAddress,
 		consts.FieldPostalCode,
 		consts.FieldSignatureBits,
+		consts.FieldSKID,
 		consts.FieldNotAfter,
 		consts.FieldNotBeforeDuration,
 	}
@@ -403,14 +410,14 @@ func pkiSecretBackendRootSignIntermediateCreate(ctx context.Context, d *schema.R
 	}
 	log.Printf("[DEBUG] Created root sign-intermediate on PKI secret backend %q", backend)
 
-	certFieldsMap := map[string]string{
-		consts.FieldCertificate:  consts.FieldCertificate,
-		consts.FieldIssuingCA:    consts.FieldIssuingCA,
-		consts.FieldSerialNumber: consts.FieldSerialNumber,
+	computedFields := []string{
+		consts.FieldCertificate,
+		consts.FieldIssuingCA,
+		consts.FieldSerialNumber,
 	}
 
-	for k, v := range certFieldsMap {
-		if err := d.Set(k, resp.Data[v]); err != nil {
+	for _, k := range computedFields {
+		if err := d.Set(k, resp.Data[k]); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/vault/resource_pki_secret_backend_root_sign_intermediate.go
+++ b/vault/resource_pki_secret_backend_root_sign_intermediate.go
@@ -278,6 +278,14 @@ func pkiSecretBackendRootSignIntermediateResource() *schema.Resource {
 				Computed:    true,
 				Description: "The certificate's serial number, hex formatted.",
 			},
+			consts.FieldNotBeforeDuration: {
+				Type:         schema.TypeString,
+				Required:     false,
+				Optional:     true,
+				Computed:     true,
+				Description:  "Specifies the duration by which to backdate the NotBefore property.",
+				ValidateFunc: provider.ValidateDuration,
+			},
 			consts.FieldRevoke: {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -325,6 +333,7 @@ func pkiSecretBackendRootSignIntermediateCreate(ctx context.Context, d *schema.R
 		consts.FieldPostalCode,
 		consts.FieldSignatureBits,
 		consts.FieldNotAfter,
+		consts.FieldNotBeforeDuration,
 	}
 
 	intermediateSignBooleanAPIFields := []string{

--- a/vault/resource_pki_secret_backend_root_sign_intermediate.go
+++ b/vault/resource_pki_secret_backend_root_sign_intermediate.go
@@ -254,6 +254,12 @@ func pkiSecretBackendRootSignIntermediateResource() *schema.Resource {
 				Description: "Value for the Subject Key Identifier field\n  (RFC 5280 Section 4.2.1.2). Specified as a string in hex format.",
 				ForceNew:    true,
 			},
+			consts.FieldUsePSS: {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Specifies whether or not to use PSS signatures\n  over PKCS#1v1.5 signatures when a RSA-type issuer is used.",
+				ForceNew:    true,
+			},
 			consts.FieldCertificate: {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -346,6 +352,7 @@ func pkiSecretBackendRootSignIntermediateCreate(ctx context.Context, d *schema.R
 	intermediateSignBooleanAPIFields := []string{
 		consts.FieldExcludeCNFromSans,
 		consts.FieldUseCSRValues,
+		consts.FieldUsePSS,
 	}
 
 	intermediateSignStringArrayFields := []string{

--- a/vault/resource_pki_secret_backend_root_sign_intermediate.go
+++ b/vault/resource_pki_secret_backend_root_sign_intermediate.go
@@ -294,8 +294,8 @@ func pkiSecretBackendRootSignIntermediateResource() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     false,
 				Optional:     true,
-				Computed:     true,
 				Description:  "Specifies the duration by which to backdate the NotBefore property.",
+				ForceNew:     true,
 				ValidateFunc: provider.ValidateDuration,
 			},
 			consts.FieldRevoke: {

--- a/vault/resource_pki_secret_backend_root_sign_intermediate_test.go
+++ b/vault/resource_pki_secret_backend_root_sign_intermediate_test.go
@@ -193,6 +193,15 @@ func TestPkiSecretBackendRootSignIntermediate_basic_default(t *testing.T) {
 					}),
 				),
 			},
+			{
+				SkipFunc: skip(provider.VaultVersion112),
+				Config: testPkiSecretBackendRootSignIntermediateConfig_basic(rootPath, intermediatePath, false,
+					`use_pss = true`),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckPKISecretRootSignIntermediate(resourceName, rootPath, commonName, format, "", x509.SHA256WithRSAPSS, false),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldUsePSS, "true"),
+				),
+			},
 		},
 	})
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->

Add support for the parameters missing for vault_pki_secret_backend_root_sign_intermediate (API [pki/root/sign-intermediate](https://developer.hashicorp.com/vault/api-docs/v1.19.x/secret/pki#sign-intermediate)).

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

