### PR TITLE
Add key_usage support to vault_pki_secret_backend_root_sign_intermediate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,10 +64,10 @@ jobs:
       matrix:
         image:
         - "vault-enterprise:1.15.16-ent"
-        - "vault-enterprise:1.16.15-ent"
-        - "vault-enterprise:1.17.11-ent"
-        - "vault-enterprise:1.18.4-ent"
-        - "vault-enterprise:1.19.0-ent"
+        - "vault-enterprise:1.16.21-ent"
+        - "vault-enterprise:1.17.17-ent"
+        - "vault-enterprise:1.18.10-ent"
+        - "vault-enterprise:1.19.5-ent"
         - "vault:latest"
     services:
       vault:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+* Add support for key_usage to `vault_pki_secret_backend_root_sign_intermediate` ([#2421])(https://github.com/hashicorp/terraform-provider-vault/pull/2421)
+
+
 ## 5.0.0 (May 21, 2025)
 
 **Important**: `5.X` multiplexes the Vault provider to use the [Terraform Plugin Framework](https://developer.hashicorp.com/terraform/plugin/framework),

--- a/vault/resource_pki_secret_backend_root_sign_intermediate.go
+++ b/vault/resource_pki_secret_backend_root_sign_intermediate.go
@@ -115,6 +115,15 @@ func pkiSecretBackendRootSignIntermediateResource() *schema.Resource {
 				ForceNew:    true,
 				Default:     -1,
 			},
+			consts.FieldKeyUsage: {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: `Specify the key usages to be added to the existing set of key usages ("CRL", "CertSign") on the generated certificate.`,
+				ForceNew:    true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 			consts.FieldExcludeCNFromSans: {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -361,6 +370,7 @@ func pkiSecretBackendRootSignIntermediateCreate(ctx context.Context, d *schema.R
 		consts.FieldURISans,
 		consts.FieldOtherSans,
 		consts.FieldPermittedDNSDomains,
+		consts.FieldKeyUsage,
 	}
 
 	// Whether name constraints fields (other than permitted_dns_domains), are supproted,

--- a/vault/resource_pki_secret_backend_root_sign_intermediate_test.go
+++ b/vault/resource_pki_secret_backend_root_sign_intermediate_test.go
@@ -204,6 +204,25 @@ func TestPkiSecretBackendRootSignIntermediate_basic_default(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, consts.FieldUsePSS, "true"),
 				),
 			},
+			{
+				SkipFunc: skip(provider.VaultVersion118),
+				Config: testPkiSecretBackendRootSignIntermediateConfig_basic(rootPath, intermediatePath, false,
+					`key_usage = ["CertSign", "DigitalSignature"]`),
+				Check: resource.ComposeTestCheckFunc(
+					checks,
+					resource.TestCheckResourceAttr(resourceName, consts.FieldKeyUsage+".#", "2"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldKeyUsage+".0", "CertSign"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldKeyUsage+".1", "DigitalSignature"),
+					testPKICert(resourceName, func(cert *x509.Certificate) error {
+						if 0 == cert.KeyUsage&x509.KeyUsageCertSign {
+							return fmt.Errorf("KeyUsage expected %b, got %b",
+								x509.KeyUsageKeyAgreement|x509.KeyUsageCertSign,
+								cert.KeyUsage)
+						}
+						return nil
+					}),
+				),
+			},
 		},
 	})
 }

--- a/website/docs/r/pki_secret_backend_root_sign_intermediate.html.md
+++ b/website/docs/r/pki_secret_backend_root_sign_intermediate.html.md
@@ -53,6 +53,8 @@ The following arguments are supported:
 
 * `max_path_length` - (Optional) The maximum path length to encode in the generated certificate
 
+* `key_usage` - (Optional) Specify the key usages to be added to the existing set of key usages ("CRL", "CertSign") on the generated certificate.
+
 * `exclude_cn_from_sans` - (Optional) Flag to exclude CN from SANs
 
 * `use_csr_values` - (Optional) Preserve CSR values
@@ -89,6 +91,10 @@ The following arguments are supported:
 
 * `signature_bits` - (Optional) The number of bits to use in the signature algorithm
 
+* `skid` - (Optional) Value for the Subject Key Identifier field (see https://tools.ietf.org/html/rfc5280#section-4.2.1.2). Specified as a string in hex format.
+
+* `use_pss` - (Optional) Specifies whether or not to use PSS signatures over PKCS#1v1.5 signatures when a RSA-type issuer is used. Ignored for ECDSA/Ed25519 issuers.
+
 * `revoke` - If set to `true`, the certificate will be revoked on resource destruction.
 
 * `issuer_ref` - (Optional) Specifies the default issuer of this request. May
@@ -99,6 +105,8 @@ The following arguments are supported:
 * `not_after` - (Optional) Set the Not After field of the certificate with specified date value. 
 The value format should be given in UTC format YYYY-MM-ddTHH:MM:SSZ. Supports the Y10K end date 
 for IEEE 802.1AR-2018 standard devices, 9999-12-31T23:59:59Z.
+
+* `not_before_duration` - (Optional) Specifies the [duration](https://developer.hashicorp.com/vault/docs/concepts/duration-format) by which to backdate the NotBefore property.
 
 ## Attributes Reference
 


### PR DESCRIPTION

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->

Add key_usage support to vault_pki_secret_backend_root_sign_intermediate.

### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

