### PR TITLE
Add max_crl_entries to vault_pki_secret_backend_crl_config resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ FEATURES:
 * Add support for `use_pss`, `no_store_metadata`, and `serial_number_source` to `vault_pki_secret_backend_role` [#2420](https://github.com/hashicorp/terraform-provider-vault/pull/2420)
 * Add support for Transit `sign` and `verify` endpoints ([#2418](https://github.com/hashicorp/terraform-provider-vault/pull/2418))
 * Add new data source `vault_pki_secret_backend_cert_metadata` and support for `cert_metadata` in `vault_pki_secret_backend_cert` and `vault_pki_secret_backend_sign` [#2422](https://github.com/hashicorp/terraform-provider-vault/pull/2422)
+* Add support for `max_crl_entries` in `vault_pki_secret_backend_crl_config` [#2423](https://github.com/hashicorp/terraform-provider-vault/pull/2423)
 
 BUGS:
 

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -463,6 +463,7 @@ const (
 	FieldEabKey                        = "key"
 	FieldAcmeDirectory                 = "acme_directory"
 	FieldEabId                         = "eab_id"
+	FieldMaxCrlEntries                 = "max_crl_entries"
 
 	FieldDisableCriticalExtensionChecks = "disable_critical_extension_checks"
 	FieldDisablePathLengthChecks        = "disable_path_length_checks"

--- a/vault/resource_pki_secret_backend_crl_config.go
+++ b/vault/resource_pki_secret_backend_crl_config.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
@@ -107,6 +108,14 @@ func pkiSecretBackendCrlConfigResource() *schema.Resource {
 					"cluster-local paths.",
 				Computed: true,
 			},
+			consts.FieldMaxCrlEntries: {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Description: "The maximum number of entries a CRL can contain. This option exists to " +
+					"prevent accidental runaway issuance/revocation from overloading Vault. If set " +
+					"to -1, the limit is disabled.",
+				Computed: true,
+			},
 		},
 	}
 }
@@ -141,6 +150,12 @@ func pkiSecretBackendCrlConfigCreate(d *schema.ResourceData, meta interface{}) e
 			"cross_cluster_revocation",
 			"unified_crl",
 			"unified_crl_on_existing_paths",
+		}...)
+	}
+
+	if provider.IsAPISupported(meta, provider.VaultVersion119) {
+		fields = append(fields, []string{
+			consts.FieldMaxCrlEntries,
 		}...)
 	}
 
@@ -218,6 +233,12 @@ func pkiSecretBackendCrlConfigUpdate(d *schema.ResourceData, meta interface{}) e
 			"cross_cluster_revocation",
 			"unified_crl",
 			"unified_crl_on_existing_paths",
+		}...)
+	}
+
+	if provider.IsAPISupported(meta, provider.VaultVersion119) {
+		fields = append(fields, []string{
+			consts.FieldMaxCrlEntries,
 		}...)
 	}
 

--- a/vault/resource_pki_secret_backend_crl_config_test.go
+++ b/vault/resource_pki_secret_backend_crl_config_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
-func getCRLConfigChecks(resourceName string, isUpdate, unifiedCrl bool) resource.TestCheckFunc {
+func getCRLConfigChecks(resourceName string, isUpdate, unifiedCrl bool, maxCrlEntries int) resource.TestCheckFunc {
 	baseChecks := []resource.TestCheckFunc{
 		resource.TestCheckResourceAttr(resourceName, "expiry", "72h"),
 		resource.TestCheckResourceAttr(resourceName, "disable", "true"),
@@ -54,29 +54,36 @@ func getCRLConfigChecks(resourceName string, isUpdate, unifiedCrl bool) resource
 		resource.TestCheckResourceAttr(resourceName, "unified_crl_on_existing_paths", strconv.FormatBool(unifiedCrl)),
 	}
 
+	v119Checks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(resourceName, "max_crl_entries", strconv.FormatInt(int64(maxCrlEntries), 10)),
+	}
+
 	return func(state *terraform.State) error {
 		var checks []resource.TestCheckFunc
 		meta := testProvider.Meta().(*provider.ProviderMeta)
-		isVaultVersion113 := meta.IsAPISupported(provider.VaultVersion113)
 		isVaultVersion112 := meta.IsAPISupported(provider.VaultVersion112)
-		switch {
-		case isVaultVersion113:
+		isVaultVersion113 := meta.IsAPISupported(provider.VaultVersion113)
+		isVaultVersion119 := meta.IsAPISupported(provider.VaultVersion119)
+
+		checks = baseChecks
+		if isVaultVersion112 {
+			if !isUpdate {
+				checks = append(checks, v112BaseChecks...)
+			} else {
+				checks = append(checks, v112UpdateChecks...)
+			}
+		}
+		if isVaultVersion113 {
 			if !isUpdate {
 				checks = append(checks, v113BaseChecks...)
-				checks = append(checks, v112BaseChecks...)
 			} else {
 				checks = append(checks, v113UpdateChecks...)
-				checks = append(checks, v112UpdateChecks...)
 			}
-		case isVaultVersion112:
-			if !isUpdate {
-				checks = append(checks, v112BaseChecks...)
-			} else {
-				checks = append(checks, v112UpdateChecks...)
-			}
-		default:
-			checks = baseChecks
 		}
+		if isVaultVersion119 {
+			checks = append(checks, v119Checks...)
+		}
+
 		return resource.ComposeAggregateTestCheckFunc(checks...)(state)
 	}
 }
@@ -97,6 +104,7 @@ func TestPkiSecretBackendCrlConfig(t *testing.T) {
 			"cross_cluster_revocation",
 			"unified_crl",
 			"unified_crl_on_existing_paths",
+			"max_crl_entries",
 		)
 	})
 
@@ -110,14 +118,26 @@ func TestPkiSecretBackendCrlConfig(t *testing.T) {
 			"cross_cluster_revocation",
 			"unified_crl",
 			"unified_crl_on_existing_paths",
+			"max_crl_entries",
 		)
 	})
 
 	// test against vault-1.13 and above
-	t.Run("vault-1.13-and-above", func(t *testing.T) {
+	t.Run("vault-1.13-to-1.18", func(t *testing.T) {
 		setupCRLConfigTest(t, func() {
 			testutil.TestAccPreCheck(t)
 			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion113)
+			SkipIfAPIVersionGTE(t, testProvider.Meta(), provider.VaultVersion119)
+		},
+			"max_crl_entries",
+		)
+	})
+
+	// test against vault-1.19 and above
+	t.Run("vault-1.19-and-above", func(t *testing.T) {
+		setupCRLConfigTest(t, func() {
+			testutil.TestAccPreCheck(t)
+			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion119)
 		},
 		)
 	})
@@ -133,11 +153,11 @@ func setupCRLConfigTest(t *testing.T, preCheck func(), ignoreImportFields ...str
 	steps := []resource.TestStep{
 		{
 			Config: testPkiSecretBackendCrlConfigConfig_defaults(rootPath),
-			Check:  getCRLConfigChecks(resourceName, false, unifiedCrl),
+			Check:  getCRLConfigChecks(resourceName, false, unifiedCrl, 100000),
 		},
 		{
-			Config: testPkiSecretBackendCrlConfigConfig_explicit(rootPath, unifiedCrl),
-			Check:  getCRLConfigChecks(resourceName, true, unifiedCrl),
+			Config: testPkiSecretBackendCrlConfigConfig_explicit(rootPath, unifiedCrl, 100),
+			Check:  getCRLConfigChecks(resourceName, true, unifiedCrl, 100),
 		},
 		testutil.GetImportTestStep(resourceName, false, nil, ignoreImportFields...),
 	}
@@ -190,7 +210,7 @@ resource "vault_pki_secret_backend_crl_config" "test" {
 `, testPkiSecretBackendCrlConfigConfig_base(rootPath))
 }
 
-func testPkiSecretBackendCrlConfigConfig_explicit(rootPath string, unifiedCrl bool) string {
+func testPkiSecretBackendCrlConfigConfig_explicit(rootPath string, unifiedCrl bool, maxCrlEntries int) string {
 	return fmt.Sprintf(`
 %[1]s
 
@@ -207,6 +227,7 @@ resource "vault_pki_secret_backend_crl_config" "test" {
   cross_cluster_revocation  	= %[2]s
   unified_crl					= %[2]s
   unified_crl_on_existing_paths = %[2]s
+  max_crl_entries				= %[3]d
 }
-`, testPkiSecretBackendCrlConfigConfig_base(rootPath), strconv.FormatBool(unifiedCrl))
+`, testPkiSecretBackendCrlConfigConfig_base(rootPath), strconv.FormatBool(unifiedCrl), maxCrlEntries)
 }

--- a/vault/resource_pki_secret_backend_role.go
+++ b/vault/resource_pki_secret_backend_role.go
@@ -474,6 +474,7 @@ func pkiSecretBackendRoleResource() *schema.Resource {
 			consts.FieldSerialNumberSource: {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				Description: "Specifies the source of the subject serial number. Valid values are json-csr (default) " +
 					"or json. When set to json-csr, the subject serial number is taken from the serial_number " +
 					"parameter and falls back to the serial number in the CSR. When set to json, the subject " +

--- a/vault/resource_pki_secret_backend_root_sign_intermediate_test.go
+++ b/vault/resource_pki_secret_backend_root_sign_intermediate_test.go
@@ -9,12 +9,13 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
-	"github.com/hashicorp/go-version"
 	"reflect"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/go-version"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -299,7 +300,7 @@ func TestPkiSecretBackendRootSignIntermediate_name_constraints_pem_bundle(t *tes
 		Steps: []resource.TestStep{
 			{
 				Config: testPkiSecretBackendRootSignIntermediateConfig_name_constraints(rootPath, intermediatePath, format, false, ""),
-				Check:  testCheckPKISecretRootSignIntermediate("vault_pki_secret_backend_root_sign_intermediate.test", rootPath, commonName, "", format, x509.SHA256WithRSA, true),
+				Check:  testCheckPKISecretRootSignIntermediate("vault_pki_secret_backend_root_sign_intermediate.test", rootPath, commonName, format, "", x509.SHA256WithRSA, true),
 			},
 		},
 	})

--- a/website/docs/r/pki_secret_backend_crl_config.html.md
+++ b/website/docs/r/pki_secret_backend_crl_config.html.md
@@ -63,6 +63,9 @@ The following arguments are supported:
 * `unified_crl_on_existing_paths` - (Optional) Enables serving the unified CRL and OCSP on the existing, previously
  cluster-local paths. **Vault 1.13+**
 
+* `max_crl_entries` - (Optional) The maximum number of entries a CRL can contain. This option exists to prevent 
+ accidental runaway issuance/revocation from overloading Vault. If set to -1, the limit is disabled. **Vault 1.19**
+
 ## Attributes Reference
 
 No additional attributes are exported by this resource.


### PR DESCRIPTION
### Description

 - Add new 1.19 field max_crl_entries to the vault_pki_secret_backend_crl_config resource
 - Add missing Computed flag on the 1.19 PKI role field serial_number_source


### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [X] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

