### PR TITLE
Add support for gcp auth and gcp secrets automated root rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ FEATURES:
 * Add new data source `vault_pki_secret_backend_cert_metadata` and support for `cert_metadata` in `vault_pki_secret_backend_cert` and `vault_pki_secret_backend_sign` [#2422](https://github.com/hashicorp/terraform-provider-vault/pull/2422)
 * Add support for `max_crl_entries` in `vault_pki_secret_backend_crl_config` [#2423](https://github.com/hashicorp/terraform-provider-vault/pull/2423)
 * Add support for new Automated Root Rotation parameters to AWS Auth/Secrets and DB Secrets resources. Requires Vault Enterprise 1.19.0+ ([#2414](https://github.com/hashicorp/terraform-provider-vault/pull/2414)).
+* Add support for new Automated Root Rotation parameters to GCP Auth/Secrets resources. Requires Vault Enterprise 1.19.0+ ([#2414](https://github.com/hashicorp/terraform-provider-vault/pull/2427)).
 * Add new resource `vault_pki_secret_backend_config_auto_tidy` to set PKI automatic tidy configuration [#1934](https://github.com/hashicorp/terraform-provider-vault/pull/1934)
 
 BUGS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,10 @@ FEATURES:
 * Add support for `max_crl_entries` in `vault_pki_secret_backend_crl_config` [#2423](https://github.com/hashicorp/terraform-provider-vault/pull/2423)
 * Add support for new Automated Root Rotation parameters in several plugins. Requires Vault Enterprise 1.19.0+.
   * AWS Auth/Secrets ([#2414](https://github.com/hashicorp/terraform-provider-vault/pull/2414))
-  * Azure Auth/Secrets
+  * Azure Auth/Secrets ([#2428](https://github.com/hashicorp/terraform-provider-vault/pull/2428))
   * DB Secrets ([#2414](https://github.com/hashicorp/terraform-provider-vault/pull/2414)).
-  * LDAP Auth/Secrets
+  * LDAP Auth/Secrets ([#2428](https://github.com/hashicorp/terraform-provider-vault/pull/2428))
+  * GCP Auth/Secrets ([#2427](https://github.com/hashicorp/terraform-provider-vault/pull/2427))
 * Add new resource `vault_pki_secret_backend_config_auto_tidy` to set PKI automatic tidy configuration [#1934](https://github.com/hashicorp/terraform-provider-vault/pull/1934)
 
 BUGS:

--- a/internal/provider/schema_util.go
+++ b/internal/provider/schema_util.go
@@ -163,23 +163,23 @@ func GetAutomatedRootRotationSchema() map[string]*schema.Schema {
 		consts.FieldRotationSchedule: {
 			Type:        schema.TypeString,
 			Optional:    true,
-			Description: "Schedule",
+			Description: "The cron-style schedule for the root credential to be rotated on. Cannot be used with rotation_period.",
 		},
 		consts.FieldRotationPeriod: {
 			Type:        schema.TypeInt,
 			Optional:    true,
-			Description: "Period",
+			Description: "The period of time in seconds between each rotation of the root credential. Cannot be used with rotation_schedule.",
 		},
 		consts.FieldRotationWindow: {
 			Type:        schema.TypeInt,
 			Optional:    true,
-			Description: "Window",
+			Description: "The maximum amount of time in seconds Vault is allowed to complete a rotation once a scheduled rotation is triggered. Can only be used with rotation_schedule.",
 		},
 		consts.FieldDisableAutomatedRotation: {
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Computed:    true,
-			Description: "Disable",
+			Description: "Stops rotation of the root credential until set to false.",
 		},
 	}
 }

--- a/internal/provider/schema_util.go
+++ b/internal/provider/schema_util.go
@@ -178,7 +178,6 @@ func GetAutomatedRootRotationSchema() map[string]*schema.Schema {
 		consts.FieldDisableAutomatedRotation: {
 			Type:        schema.TypeBool,
 			Optional:    true,
-			Computed:    true,
 			Description: "Stops rotation of the root credential until set to false.",
 		},
 	}

--- a/internal/rotation/automated_rotation.go
+++ b/internal/rotation/automated_rotation.go
@@ -5,6 +5,7 @@ package automatedrotationutil
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/vault/api"

--- a/vault/resource_aws_auth_backend_client.go
+++ b/vault/resource_aws_auth_backend_client.go
@@ -5,10 +5,11 @@ package vault
 
 import (
 	"context"
-	automatedrotationutil "github.com/hashicorp/terraform-provider-vault/internal/rotation"
 	"log"
 	"regexp"
 	"strings"
+
+	automatedrotationutil "github.com/hashicorp/terraform-provider-vault/internal/rotation"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -167,7 +168,6 @@ func awsAuthBackendWrite(ctx context.Context, d *schema.ResourceData, meta inter
 	if provider.IsAPISupported(meta, provider.VaultVersion119) && provider.IsEnterpriseSupported(meta) {
 		// parse automated root rotation fields if Enterprise 1.19 server
 		automatedrotationutil.ParseAutomatedRotationFields(d, data)
-
 	}
 
 	// sts_endpoint and sts_region are required to be set together

--- a/vault/resource_aws_secret_backend.go
+++ b/vault/resource_aws_secret_backend.go
@@ -6,9 +6,10 @@ package vault
 import (
 	"context"
 	"fmt"
-	automatedrotationutil "github.com/hashicorp/terraform-provider-vault/internal/rotation"
 	"log"
 	"strings"
+
+	automatedrotationutil "github.com/hashicorp/terraform-provider-vault/internal/rotation"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -8,14 +8,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	automatedrotationutil "github.com/hashicorp/terraform-provider-vault/internal/rotation"
 	"log"
 	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	automatedrotationutil "github.com/hashicorp/terraform-provider-vault/internal/rotation"
 
 	"github.com/hashicorp/go-secure-stdlib/parseutil"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -1866,7 +1867,6 @@ func writeDatabaseSecretConfig(ctx context.Context, d *schema.ResourceData, clie
 	if provider.IsAPISupported(meta, provider.VaultVersion119) && provider.IsEnterpriseSupported(meta) {
 		// parse automated root rotation fields if Enterprise 1.19 server
 		automatedrotationutil.ParseAutomatedRotationFieldsWithFieldPrefix(d, data, prefix)
-
 	}
 
 	log.Printf("[DEBUG] Writing connection config to %q", path)

--- a/vault/resource_database_secrets_mount.go
+++ b/vault/resource_database_secrets_mount.go
@@ -6,9 +6,10 @@ package vault
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
 	"sync"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"

--- a/vault/resource_gcp_auth_backend.go
+++ b/vault/resource_gcp_auth_backend.go
@@ -268,8 +268,8 @@ func gcpAuthBackendUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 
 	data := map[string]interface{}{}
 
-	if v, ok := d.GetOk(consts.FieldCredentials); ok {
-		data[consts.FieldCredentials] = v
+	if d.HasChange(consts.FieldCredentials) {
+		data[consts.FieldCredentials] = d.Get(consts.FieldCredentials)
 	}
 
 	epField := consts.FieldCustomEndpoint

--- a/vault/resource_gcp_auth_backend.go
+++ b/vault/resource_gcp_auth_backend.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+	automatedrotationutil "github.com/hashicorp/terraform-provider-vault/internal/rotation"
 	"github.com/hashicorp/terraform-provider-vault/util"
 	"github.com/hashicorp/terraform-provider-vault/util/mountutil"
 )
@@ -31,7 +32,7 @@ const (
 )
 
 func gcpAuthBackendResource() *schema.Resource {
-	return provider.MustAddMountMigrationSchema(&schema.Resource{
+	r := provider.MustAddMountMigrationSchema(&schema.Resource{
 		CreateContext: gcpAuthBackendWrite,
 		UpdateContext: gcpAuthBackendUpdate,
 		ReadContext:   provider.ReadContextWrapper(gcpAuthBackendRead),
@@ -123,6 +124,11 @@ func gcpAuthBackendResource() *schema.Resource {
 			consts.FieldTune: authMountTuneSchema(),
 		},
 	}, false)
+
+	// Add common automated root rotation schema to the resource.
+	provider.MustAddSchema(r, provider.GetAutomatedRootRotationSchema())
+
+	return r
 }
 
 func gcpAuthCustomEndpointSchema() map[string]*schema.Schema {
@@ -234,6 +240,8 @@ func gcpAuthBackendUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 	gcpPath := d.Id()
 	gcpAuthPath := "auth/" + gcpPath
 	path := gcpAuthBackendConfigPath(gcpPath)
+	useAPIVer117Ent := provider.IsAPISupported(meta, provider.VaultVersion117) && provider.IsEnterpriseSupported(meta)
+	useAPIVer119Ent := provider.IsAPISupported(meta, provider.VaultVersion119) && provider.IsEnterpriseSupported(meta)
 
 	if !d.IsNewResource() {
 		newMount, err := util.Remount(d, client, consts.FieldPath, true)
@@ -249,7 +257,6 @@ func gcpAuthBackendUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 			config := api.MountConfigInput{
 				Description: &desc,
 			}
-			useAPIVer117Ent := provider.IsAPISupported(meta, provider.VaultVersion117) && provider.IsEnterpriseSupported(meta)
 			if useAPIVer117Ent {
 				config.IdentityTokenKey = d.Get(consts.FieldIdentityTokenKey).(string)
 			}
@@ -298,8 +305,7 @@ func gcpAuthBackendUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		}
 	}
 
-	useAPIver117Ent := provider.IsAPISupported(meta, provider.VaultVersion117) && provider.IsEnterpriseSupported(meta)
-	if useAPIver117Ent {
+	if useAPIVer117Ent {
 		fields := []string{
 			consts.FieldIdentityTokenAudience,
 			consts.FieldIdentityTokenTTL,
@@ -311,6 +317,11 @@ func gcpAuthBackendUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 				data[k] = v
 			}
 		}
+	}
+
+	if useAPIVer119Ent {
+		// Parse automated root rotation fields if running Vault Enterprise 1.19 or newer.
+		automatedrotationutil.ParseAutomatedRotationFields(d, data)
 	}
 
 	log.Printf("[DEBUG] Writing %s config at path %q", gcpAuthType, path)
@@ -356,13 +367,18 @@ func gcpAuthBackendRead(ctx context.Context, d *schema.ResourceData, meta interf
 		consts.FieldLocal,
 	}
 
-	useAPIver117Ent := provider.IsAPISupported(meta, provider.VaultVersion117) && provider.IsEnterpriseSupported(meta)
-	if useAPIver117Ent {
-		params = append(params,
-			consts.FieldIdentityTokenAudience,
-			consts.FieldIdentityTokenTTL,
-			consts.FieldServiceAccountEmail,
-		)
+	if provider.IsEnterpriseSupported(meta) {
+		if provider.IsAPISupported(meta, provider.VaultVersion117) {
+			params = append(params,
+				consts.FieldIdentityTokenAudience,
+				consts.FieldIdentityTokenTTL,
+				consts.FieldServiceAccountEmail,
+			)
+		}
+
+		if provider.IsAPISupported(meta, provider.VaultVersion119) {
+			params = append(params, automatedrotationutil.AutomatedRotationFields...)
+		}
 	}
 
 	for _, param := range params {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
Adds automated root rotation support for gcp secrets and gcp auth.


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
=== RUN   TestAccGCPAuthBackendClient_automatedRotation
    /Users/robmonte/github/terraform-provider-vault/vault/resource_gcp_auth_backend_test.go:306: Vault server version "1.20.0-beta1+ent"
--- PASS: TestAccGCPAuthBackendClient_automatedRotation (2.96s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/vault	3.865s
```

```
=== RUN   TestAccGCPSecretBackend_automatedRotation
    /Users/robmonte/github/terraform-provider-vault/vault/resource_gcp_secret_backend_test.go:123: Vault server version "1.20.0-beta1+ent"
--- PASS: TestAccGCPSecretBackend_automatedRotation (3.24s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/vault	3.907s
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

