### PR TITLE
Update pki_secret_backend_crl_config to be more resilent to unknown response fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ BUGS:
 
 * Do not panic on Vault PKI roles without the cn_validations field: ([#2398](https://github.com/hashicorp/terraform-provider-vault/pull/2398))
 
+IMPROVEMENTS:
+
+* Update pki_secret_backend_crl_config to be more resilent to unknown response fields ([#2429](https://github.com/hashicorp/terraform-provider-vault/pull/2429))
+
 ## 4.6.0 (Jan 15, 2025)
 
 FEATURES:

--- a/vault/resource_pki_secret_backend_crl_config.go
+++ b/vault/resource_pki_secret_backend_crl_config.go
@@ -4,10 +4,11 @@
 package vault
 
 import (
-	"fmt"
+	"context"
 	"log"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 
@@ -21,16 +22,16 @@ const (
 
 func pkiSecretBackendCrlConfigResource() *schema.Resource {
 	return &schema.Resource{
-		Create: pkiSecretBackendCrlConfigCreate,
-		Read:   provider.ReadWrapper(pkiSecretBackendCrlConfigRead),
-		Update: pkiSecretBackendCrlConfigUpdate,
-		Delete: pkiSecretBackendCrlConfigDelete,
+		CreateContext: pkiSecretBackendCrlConfigCreate,
+		ReadContext:   provider.ReadContextWrapper(pkiSecretBackendCrlConfigRead),
+		UpdateContext: pkiSecretBackendCrlConfigUpdate,
+		DeleteContext: pkiSecretBackendCrlConfigDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{
-			"backend": {
+			consts.FieldBackend: {
 				Type:        schema.TypeString,
 				Required:    true,
 				Description: "The path of the PKI secret backend the resource belongs to.",
@@ -120,61 +121,32 @@ func pkiSecretBackendCrlConfigResource() *schema.Resource {
 	}
 }
 
-func pkiSecretBackendCrlConfigCreate(d *schema.ResourceData, meta interface{}) error {
+func pkiSecretBackendCrlConfigCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client, e := provider.GetClient(d, meta)
 	if e != nil {
-		return e
+		return diag.Errorf("failed getting client: %v", e)
 	}
 
-	backend := d.Get("backend").(string)
+	backend := d.Get(consts.FieldBackend).(string)
 	path := pkiSecretBackendCrlConfigPath(backend)
-
-	fields := []string{
-		"expiry",
-		"disable",
-	}
-
-	if provider.IsAPISupported(meta, provider.VaultVersion112) {
-		fields = append(fields, []string{
-			"ocsp_disable",
-			"ocsp_expiry",
-			"auto_rebuild",
-			"auto_rebuild_grace_period",
-			"enable_delta",
-			"delta_rebuild_interval",
-		}...)
-	}
-
-	if provider.IsAPISupported(meta, provider.VaultVersion113) {
-		fields = append(fields, []string{
-			"cross_cluster_revocation",
-			"unified_crl",
-			"unified_crl_on_existing_paths",
-		}...)
-	}
-
-	if provider.IsAPISupported(meta, provider.VaultVersion119) {
-		fields = append(fields, []string{
-			consts.FieldMaxCrlEntries,
-		}...)
-	}
+	fields := buildConfigCRLFields(meta)
 
 	data := util.GetAPIRequestDataWithSliceOk(d, fields)
 	log.Printf("[DEBUG] Creating CRL config on PKI secret backend %q", backend)
 	_, err := client.Logical().Write(path, data)
 	if err != nil {
-		return fmt.Errorf("error creating CRL config PKI secret backend %q: %s", backend, err)
+		return diag.Errorf("error creating CRL config PKI secret backend %q: %s", backend, err)
 	}
 	log.Printf("[DEBUG] Created CRL config on PKI secret backend %q", backend)
 
 	d.SetId(path)
-	return pkiSecretBackendCrlConfigRead(d, meta)
+	return pkiSecretBackendCrlConfigRead(ctx, d, meta)
 }
 
-func pkiSecretBackendCrlConfigRead(d *schema.ResourceData, meta interface{}) error {
+func pkiSecretBackendCrlConfigRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client, e := provider.GetClient(d, meta)
 	if e != nil {
-		return e
+		return diag.Errorf("failed getting client: %v", e)
 	}
 
 	path := d.Id()
@@ -183,35 +155,59 @@ func pkiSecretBackendCrlConfigRead(d *schema.ResourceData, meta interface{}) err
 	if err != nil {
 		log.Printf("[WARN] Removing path %q its ID is invalid, err=%s", path, err)
 		d.SetId("")
-		return fmt.Errorf("invalid path ID %q: %w", path, err)
+		return diag.Errorf("invalid path ID %q: %v", path, err)
 	}
 
 	if config == nil {
 		d.SetId("")
-		return nil
+		return diag.Errorf("received nil response from %q", path)
 	}
 
-	if _, ok := d.GetOk("backend"); !ok {
+	if _, ok := d.GetOk(consts.FieldBackend); !ok {
 		// ensure that the backend is set on import
-		if err := d.Set("backend", strings.TrimRight(path, crlConfigPathBase)); err != nil {
-			return err
+		if err := d.Set(consts.FieldBackend, strings.TrimRight(path, crlConfigPathBase)); err != nil {
+			return diag.Errorf("failed setting field %s: %v", consts.FieldBackend, err)
 		}
 	}
 
-	if err := util.SetResourceData(d, config.Data); err != nil {
-		return err
+	for _, field := range buildConfigCRLFields(meta) {
+		if err := d.Set(field, config.Data[field]); err != nil {
+			return diag.Errorf("failed setting field %s: %v", field, err)
+		}
 	}
 
 	return nil
 }
 
-func pkiSecretBackendCrlConfigUpdate(d *schema.ResourceData, meta interface{}) error {
+func pkiSecretBackendCrlConfigUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client, e := provider.GetClient(d, meta)
 	if e != nil {
-		return e
+		return diag.Errorf("failed getting client: %v", e)
 	}
 
 	path := d.Id()
+	fields := buildConfigCRLFields(meta)
+
+	data := util.GetAPIRequestDataWithSliceOk(d, fields)
+	log.Printf("[DEBUG] Updating CRL config on PKI secret path %q", path)
+	_, err := client.Logical().Write(path, data)
+	if err != nil {
+		return diag.Errorf("error updating CRL config for PKI secret path %q: %s", path, err)
+	}
+	log.Printf("[DEBUG] Updated CRL config on PKI secret path %q", path)
+
+	return pkiSecretBackendCrlConfigRead(ctx, d, meta)
+}
+
+func pkiSecretBackendCrlConfigDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	return nil
+}
+
+func pkiSecretBackendCrlConfigPath(backend string) string {
+	return strings.Trim(backend, "/") + crlConfigPathBase
+}
+
+func buildConfigCRLFields(meta interface{}) []string {
 	fields := []string{
 		"expiry",
 		"disable",
@@ -242,21 +238,5 @@ func pkiSecretBackendCrlConfigUpdate(d *schema.ResourceData, meta interface{}) e
 		}...)
 	}
 
-	data := util.GetAPIRequestDataWithSliceOk(d, fields)
-	log.Printf("[DEBUG] Updating CRL config on PKI secret path %q", path)
-	_, err := client.Logical().Write(path, data)
-	if err != nil {
-		return fmt.Errorf("error updating CRL config for PKI secret path %q: %s", path, err)
-	}
-	log.Printf("[DEBUG] Updated CRL config on PKI secret path %q", path)
-
-	return pkiSecretBackendCrlConfigRead(d, meta)
-}
-
-func pkiSecretBackendCrlConfigDelete(d *schema.ResourceData, meta interface{}) error {
-	return nil
-}
-
-func pkiSecretBackendCrlConfigPath(backend string) string {
-	return strings.Trim(backend, "/") + crlConfigPathBase
+	return fields
 }

--- a/vault/resource_pki_secret_backend_crl_config_test.go
+++ b/vault/resource_pki_secret_backend_crl_config_test.go
@@ -122,7 +122,7 @@ func TestPkiSecretBackendCrlConfig(t *testing.T) {
 		)
 	})
 
-	// test against vault-1.13 and above
+	// test against vault-1.13 up to and including 1.18
 	t.Run("vault-1.13-to-1.18", func(t *testing.T) {
 		setupCRLConfigTest(t, func() {
 			testutil.TestAccPreCheck(t)


### PR DESCRIPTION
### Description

Do not pass in the PKI CRL configuration response map directly into `util.SetResourceData` as this will fail if an unknown field is returned from Vault that isn't listed in the resource's schema. We encountered this within the Vault 1.19 release where the resource broke when `max_crl_entries` was added. 

```
│ Error: error setting resource data for key "max_crl_entries", err=Invalid address to set: []string{"max_crl_entries"}
│
│   with vault_pki_secret_backend_crl_config.crl_config,
│   on main.tf line 8, in resource "vault_pki_secret_backend_crl_config" "crl_config":
│    8: resource "vault_pki_secret_backend_crl_config" "crl_config" {

```

Also this includes a slight refactoring to update the methods to the non-deprecated values along with removing duplication by adding a common method that builds up the list of fields based on Vault version.


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [X] Acceptance tests where run against all supported Vault Versions

### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

