### PR TITLE
:sparkles: support for subscribe_event_types

### DIFF
--- a/vault/data_source_policy_document_test.go
+++ b/vault/data_source_policy_document_test.go
@@ -26,6 +26,21 @@ func TestDataSourcePolicyDocument(t *testing.T) {
 	})
 }
 
+func TestDataSourcePolicyDocument_withSubscribeEvents(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		PreCheck:          func() { testutil.TestAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourcePolicyDocument_withSubscribeEvents,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.vault_policy_document.test", "hcl", testResultPolicyHCLDocument_withSubscribeEvents),
+				),
+			},
+		},
+	})
+}
+
 var testDataSourcePolicyDocument_config = `
 data "vault_policy_document" "test" {
   rule {
@@ -119,6 +134,21 @@ path "secret/test2/*" {
 
 path "secret/test3/" {
   capabilities = ["read", "list"]
+}
+`
+
+var testDataSourcePolicyDocument_withSubscribeEvents = `
+data "vault_policy_document" "test" {
+  rule {
+    path                   = "secret/test1/*"
+    capabilities           = ["read", "list", "subscribe"]
+    subscribe_event_types  = ["*"]
+  }
+}
+`
+var testResultPolicyHCLDocument_withSubscribeEvents = `path "secret/test1/*" {
+  capabilities = ["read", "list", "subscribe"]
+  subscribe_event_types = ["*"]
 }
 `
 

--- a/website/docs/d/policy_document.md
+++ b/website/docs/d/policy_document.md
@@ -47,6 +47,8 @@ Each document configuration may have one or more `rule` blocks, which each accep
 
 * `max_wrapping_ttl` - (Optional) The maximum allowed TTL that clients can specify for a wrapped response.
 
+* `subscribe_event_types` - (Optional) Event types to subscribe to. See [Vault Documentation](https://developer.hashicorp.com/vault/docs/concepts/events) for possible event types.
+
 ### Parameters
 
 Each of `*_parameter` attributes can optionally further restrict paths based on the keys and data at those keys when evaluating the permissions for a path.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
Add support for setting subscribe_event_types on vault policy data source.


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2380


### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ TF_ACC=1 go test -v -count=1 -run 'TestDataSourcePolicyDocument' ./vault/...
=== RUN   TestDataSourcePolicyDocument
--- PASS: TestDataSourcePolicyDocument (0.83s)
=== RUN   TestDataSourcePolicyDocument_withSubscribeEvents
--- PASS: TestDataSourcePolicyDocument_withSubscribeEvents (0.65s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     1.964s
...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

