### PR TITLE
Add parameter allowed_metadata_extensions to resource vault_cert_auth_backend_role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,7 @@ FEATURES:
   * GCP Auth/Secrets ([#2427](https://github.com/hashicorp/terraform-provider-vault/pull/2427))
 * Add new resource `vault_pki_secret_backend_config_auto_tidy` to set PKI automatic tidy configuration [#1934](https://github.com/hashicorp/terraform-provider-vault/pull/1934)
 * Add support for cross-account management of static roles in AWS Secrets: ([#2413](https://github.com/hashicorp/terraform-provider-vault/pull/2413))
+* Add support for whitelisting certificate extensions with `allowed_metadata_extensions` in `vault_cert_auth_backend_role`: ([#2436](https://github.com/hashicorp/terraform-provider-vault/pull/2436))
 
 BUGS:
 

--- a/vault/resource_cert_auth_backend_role.go
+++ b/vault/resource_cert_auth_backend_role.go
@@ -29,6 +29,7 @@ const (
 	fieldOCSPQueryAllServers        = "ocsp_query_all_servers"
 	fieldOCSPServersOverride        = "ocsp_servers_override"
 	fieldRequiredExtensions         = "required_extensions"
+	fieldAllowedMetadataExtensions  = "allowed_metadata_extensions"
 )
 
 var (
@@ -46,6 +47,7 @@ var (
 		fieldAllowedURISans,
 		fieldOCSPServersOverride,
 		fieldRequiredExtensions,
+		fieldAllowedMetadataExtensions,
 	}
 	certAuthBoolFields = []string{
 		fieldOCSPEnabled,
@@ -181,6 +183,14 @@ func certAuthBackendRoleResource() *schema.Resource {
 			Description: "If set to true, rather than accepting the first " +
 				"successful OCSP response, query all servers and consider the " +
 				"certificate valid only if all servers agree.",
+		},
+		fieldAllowedMetadataExtensions: {
+			Type:        schema.TypeSet,
+			Optional:    true,
+			Description: "A array of oid extensions.",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
 		},
 	}
 
@@ -381,6 +391,17 @@ func certAuthResourceRead(_ context.Context, d *schema.ResourceData, meta interf
 				schema.HashString, resp.Data["required_extensions"].([]interface{})))
 	} else {
 		d.Set("required_extensions",
+			schema.NewSet(
+				schema.HashString, []interface{}{}))
+	}
+
+	// Vault sometimes returns these as null instead of an empty list.
+	if resp.Data["allowed_metadata_extensions"] != nil {
+		d.Set("allowed_metadata_extensions",
+			schema.NewSet(
+				schema.HashString, resp.Data["allowed_metadata_extensions"].([]interface{})))
+	} else {
+		d.Set("allowed_metadata_extensions",
 			schema.NewSet(
 				schema.HashString, []interface{}{}))
 	}

--- a/website/docs/r/cert_auth_backend_role.html.md
+++ b/website/docs/r/cert_auth_backend_role.html.md
@@ -56,6 +56,9 @@ The following arguments are supported:
 
 * `allowed_organizational_units` - (Optional array: []) Allowed organization units for authenticated client certificates.
 
+* `allowed_metadata_extensions` - (Optional array: []) Allowed oid extensions. Upon successful authentication,
+  these extensions will be added as metadata if they are present in the certificate.
+
 * `required_extensions` - (Optional array: []) TLS extensions required on
   client certificates
 


### PR DESCRIPTION
### Description
rebasing/fixing #1703 

### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestCertAuthBackend'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

