### PR TITLE
Address Azure propagation issue by creating a new token for each validation attempt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ FEATURES:
 
 * Add support for `recursive` search in `data_vault_namespaces` [#2408](https://github.com/hashicorp/terraform-provider-vault/pull/2408)
 
+BUGS:
+
+* Fix credential validation failures in `vault_azure_access_credentials` data source caused by Azure RBAC propagation delays using `azure_groups` [#2437](https://github.com/hashicorp/terraform-provider-vault/pull/2437)
+
 ## 4.7.0 (Mar 12, 2025)
 
 FEATURES:

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -151,6 +151,23 @@ func GetTestAzureConf(t *testing.T) *AzureTestConf {
 	}
 }
 
+func GetTestAzureConfForGroups(t *testing.T) *AzureTestConf {
+	t.Helper()
+
+	v := SkipTestEnvUnset(t,
+		"AZURE_SUBSCRIPTION_ID",
+		"AZURE_TENANT_ID",
+		"AZURE_CLIENT_ID",
+		"AZURE_CLIENT_SECRET")
+
+	return &AzureTestConf{
+		SubscriptionID: v[0],
+		TenantID:       v[1],
+		ClientID:       v[2],
+		ClientSecret:   v[3],
+	}
+}
+
 func GetTestAzureConfExistingSP(t *testing.T) *AzureTestConf {
 	v := SkipTestEnvUnset(t,
 		"AZURE_SUBSCRIPTION_ID",

--- a/vault/data_source_azure_access_credentials.go
+++ b/vault/data_source_azure_access_credentials.go
@@ -252,7 +252,7 @@ func azureAccessCredentialsDataSourceRead(ctx context.Context, d *schema.Resourc
 		creds, err := azidentity.NewClientSecretCredential(
 			tenantID, clientID, clientSecret, &azidentity.ClientSecretCredentialOptions{})
 		if err != nil {
-			return diag.Errorf("failed to create new credential during retry: %w", err)
+			return diag.Errorf("failed to create new credential during retry: %s", err)
 		}
 
 		providerClient, err := armresources.NewProvidersClient(subscriptionID, creds, &arm.ClientOptions{
@@ -261,7 +261,7 @@ func azureAccessCredentialsDataSourceRead(ctx context.Context, d *schema.Resourc
 			},
 		})
 		if err != nil {
-			return diag.Errorf("failed to create new provider client during retry: %w", err)
+			return diag.Errorf("failed to create new provider client during retry: %s", err)
 		}
 
 		pager := providerClient.NewListPager(&armresources.ProvidersClientListOptions{

--- a/vault/data_source_azure_access_credentials.go
+++ b/vault/data_source_azure_access_credentials.go
@@ -252,7 +252,7 @@ func azureAccessCredentialsDataSourceRead(ctx context.Context, d *schema.Resourc
 		creds, err := azidentity.NewClientSecretCredential(
 			tenantID, clientID, clientSecret, &azidentity.ClientSecretCredentialOptions{})
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("failed to create new credential during retry: %w", err))
+			return diag.Errorf("failed to create new credential during retry: %w", err)
 		}
 
 		providerClient, err := armresources.NewProvidersClient(subscriptionID, creds, &arm.ClientOptions{
@@ -261,7 +261,7 @@ func azureAccessCredentialsDataSourceRead(ctx context.Context, d *schema.Resourc
 			},
 		})
 		if err != nil {
-			return diag.FromErr(fmt.Errorf("failed to create new provider client during retry: %w", err))
+			return diag.Errorf("failed to create new provider client during retry: %w", err)
 		}
 
 		pager := providerClient.NewListPager(&armresources.ProvidersClientListOptions{


### PR DESCRIPTION
This PR involves updating the Azure cred validation logic by generating a new Azure token on each retry attempt, rather than reusing the same one across all retries.

When using `validate_creds = true` in the `vault_azure_access_credentials data source`, we were seeing failures due to Azure RBAC propagation delays, especially when using `azure_groups` in role assignments. Even though the Azure API reports a successful assignment, the permissions take some time to fully propagate (known issue with azure eventual consistency). Vault tries to immediately validate the newly generated credentials by making Azure API calls, but since the permissions didn't propagate yet, it would result in 403 AuthorizationFailed errors during the validation step.

`----------------------- │ RESPONSE 403: 403 Forbidden │ ERROR CODE: AuthorizationFailed │ -------------------------------------------------------------------------------- │ { │ "error": { │ "code": "AuthorizationFailed", │ "message": "The client '901210a1-9d6b-xxxxxd' with object id '901210a1-9d6b-41xxxxxx9d' does not have authorization to perform action 'Microsoft.Resources/subscriptions/providers/read' over scope '/subscriptions/970xxxxx8464-fafcdacb3018' or the scope is invalid. If access was recently granted, please refresh your credentials." │ } │ } │ --------`

Previously, the Azure credential ([NewClientSecretCredential](https://github.com/hashicorp/terraform-provider-vault/blob/3df58bba7de7d66de513b8bdf73e08630139f112/vault/data_source_azure_access_credentials.go#L252)) was initialized once before the retry loop, and reused across all validation attempts. This doesn't work well in scenarios with permission propagation delays because the credential internally caches the access token, meaning the same "stale" token is used for all retries, even after permissions are technically granted on the Azure side.

To fix this, we now generate a fresh credential on each retry attempt to ensure each validation uses a new token that accurately reflects the current permission state.