### PR TITLE
feat(azure): add explicit_max_ttl for azure roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 FEATURES:
 
 * Add support for `recursive` search in `data_vault_namespaces` [#2408](https://github.com/hashicorp/terraform-provider-vault/pull/2408)
+* Add support for `explicit_max_ttl` in `vault_azure_secret_backend_role` resources. Requires Vault 1.18+ ([#2438](https://github.com/hashicorp/terraform-provider-vault/pull/2438)).
 
 ## 4.7.0 (Mar 12, 2025)
 

--- a/vault/resource_azure_secret_backend_role.go
+++ b/vault/resource_azure_secret_backend_role.go
@@ -120,6 +120,11 @@ func azureSecretBackendRoleResource() *schema.Resource {
 				Optional:    true,
 				Description: "Human-friendly description of the mount for the backend.",
 			},
+			consts.FieldExplicitMaxTTL: {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Description: "Specifies the explicit maximum lifetime of the lease and service principal, in seconds.",
+			},
 			consts.FieldSignInAudience: {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -180,6 +185,13 @@ func azureSecretBackendRoleUpdateFields(_ context.Context, d *schema.ResourceDat
 	for _, k := range azureSecretFields {
 		if v, ok := d.GetOk(k); ok {
 			data[k] = v.(string)
+		}
+	}
+
+	useAPIVer118 := provider.IsAPISupported(meta, provider.VaultVersion118)
+	if useAPIVer118 {
+		if v, ok := d.GetOk(consts.FieldExplicitMaxTTL); ok && v != "" {
+			data[consts.FieldExplicitMaxTTL] = v
 		}
 	}
 
@@ -264,6 +276,13 @@ func azureSecretBackendRoleRead(_ context.Context, d *schema.ResourceData, meta 
 	if v, ok := resp.Data[consts.FieldPermanentlyDelete]; ok {
 		if err := d.Set(consts.FieldPermanentlyDelete, v); err != nil {
 			return diag.Errorf("error setting permanently delete field: %s", err)
+		}
+	}
+
+	useAPIVer118 := provider.IsAPISupported(meta, provider.VaultVersion118)
+	if useAPIVer118 {
+		if err := d.Set(consts.FieldExplicitMaxTTL, resp.Data[consts.FieldExplicitMaxTTL]); err != nil {
+			return diag.FromErr(err)
 		}
 	}
 

--- a/vault/resource_azure_secret_backend_role.go
+++ b/vault/resource_azure_secret_backend_role.go
@@ -121,9 +121,9 @@ func azureSecretBackendRoleResource() *schema.Resource {
 				Description: "Human-friendly description of the mount for the backend.",
 			},
 			consts.FieldExplicitMaxTTL: {
-				Type:        schema.TypeInt,
+				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Specifies the explicit maximum lifetime of the lease and service principal, in seconds.",
+				Description: "Specifies the explicit maximum lifetime of the lease and service principal.",
 			},
 			consts.FieldSignInAudience: {
 				Type:        schema.TypeString,

--- a/vault/resource_azure_secret_backend_role_test.go
+++ b/vault/resource_azure_secret_backend_role_test.go
@@ -66,6 +66,14 @@ func TestAzureSecretBackendRole_AzureRoles(t *testing.T) {
 			resource.TestCheckResourceAttr(resourceName+".test_azure_roles", "tags.1", "project:vault_testing"))
 	}
 
+	isVaultVersion118 := provider.IsAPISupported(testProvider.Meta(), provider.VaultVersion118)
+	if !isVaultVersion118 {
+		azureRoleInitialCheckFuncs = append(azureRoleInitialCheckFuncs,
+			resource.TestCheckResourceAttr(resourceName+".test_azure_roles", "explicit_max_ttl", "0"))
+		azureRoleUpdatedCheckFuncs = append(azureRoleUpdatedCheckFuncs,
+			resource.TestCheckResourceAttr(resourceName+".test_azure_roles", "explicit_max_ttl", "2592000"))
+	}
+
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		PreCheck: func() {
@@ -208,7 +216,8 @@ resource "vault_azure_secret_backend_role" "test_azure_roles" {
  role             = "%[6]s-azure-roles"
  ttl              = 300
  max_ttl          = 600
- description	   = "Test for Vault Provider"
+ explicit_max_ttl = 0
+ description	  = "Test for Vault Provider"
  sign_in_audience = "AzureADMyOrg"
  tags             = ["team:engineering"]
 
@@ -259,6 +268,7 @@ resource "vault_azure_secret_backend_role" "test_azure_roles" {
   role        	   = "%[6]s-azure-roles"
   ttl        	   = 600
   max_ttl    	   = 900
+  explicit_max_ttl = 2592000
   description 	   = "Test for Vault Provider"
   sign_in_audience = "AzureADMultipleOrgs"
   tags       	   = ["environment:development","project:vault_testing"]
@@ -306,11 +316,12 @@ resource "vault_azure_secret_backend" "azure" {
 }
 
 resource "vault_azure_secret_backend_role" "test_azure_roles" {
-  backend     = vault_azure_secret_backend.azure.path
-  role        = "%[6]s-azure-roles"
-  ttl         = 300
-  max_ttl     = 600
-  description = "Test for Vault Provider"
+  backend          = vault_azure_secret_backend.azure.path
+  role             = "%[6]s-azure-roles"
+  ttl              = 300
+  max_ttl          = 600
+  explicit_max_ttl = 2592000
+  description      = "Test for Vault Provider"
 
   azure_roles {
     role_name = "Reader"

--- a/vault/resource_azure_secret_backend_role_test.go
+++ b/vault/resource_azure_secret_backend_role_test.go
@@ -320,8 +320,10 @@ resource "vault_azure_secret_backend_role" "test_azure_roles" {
   role             = "%[6]s-azure-roles"
   ttl              = 300
   max_ttl          = 600
-  explicit_max_ttl = 2592000
+  explicit_max_ttl = 0
   description      = "Test for Vault Provider"
+  sign_in_audience = "AzureADMultipleOrgs"
+  tags       	   = ["environment:development","project:vault_testing"]
 
   azure_roles {
     role_name = "Reader"

--- a/vault/resource_azure_secret_backend_role_test.go
+++ b/vault/resource_azure_secret_backend_role_test.go
@@ -54,7 +54,7 @@ func TestAzureSecretBackendRole_AzureRoles(t *testing.T) {
 	}
 
 	isVaultVersion116 := provider.IsAPISupported(testProvider.Meta(), provider.VaultVersion116)
-	if !isVaultVersion116 {
+	if isVaultVersion116 {
 		azureRoleInitialCheckFuncs = append(azureRoleInitialCheckFuncs,
 			resource.TestCheckResourceAttr(resourceName+".test_azure_roles", "sign_in_audience", "AzureADMyOrg"),
 			resource.TestCheckResourceAttr(resourceName+".test_azure_roles", "tags.#", "1"),
@@ -67,7 +67,7 @@ func TestAzureSecretBackendRole_AzureRoles(t *testing.T) {
 	}
 
 	isVaultVersion118 := provider.IsAPISupported(testProvider.Meta(), provider.VaultVersion118)
-	if !isVaultVersion118 {
+	if isVaultVersion118 {
 		azureRoleInitialCheckFuncs = append(azureRoleInitialCheckFuncs,
 			resource.TestCheckResourceAttr(resourceName+".test_azure_roles", "explicit_max_ttl", "0"))
 		azureRoleUpdatedCheckFuncs = append(azureRoleUpdatedCheckFuncs,

--- a/website/docs/r/azure_secret_backend_role.html.md
+++ b/website/docs/r/azure_secret_backend_role.html.md
@@ -73,7 +73,7 @@ The following arguments are supported:
   Accepts time suffixed strings ("1h") or an integer number of seconds. Defaults to the system/engine default TTL time.
 * `max_ttl` – (Optional) Specifies the maximum TTL for service principals generated using this role. Accepts time
   suffixed strings ("1h") or an integer number of seconds. Defaults to the system/engine max TTL time.
-* `explicit_max_ttl` - (Optional) Specifies the explicit maximum lifetime of the lease and service principal generated using this role. If not set or set to 0, will use the system default (10 years).
+* `explicit_max_ttl` - (Optional) Specifies the explicit maximum lifetime of the lease and service principal generated using this role. If not set or set to 0, will use the system default (10 years). Requires Vault 1.18+.
 * `sign_in_audience` - (Optional) Specifies the security principal types that are allowed to sign in to the application.
   Valid values are: AzureADMyOrg, AzureADMultipleOrgs, AzureADandPersonalMicrosoftAccount, PersonalMicrosoftAccount. Requires Vault 1.16+.
 * `tags` - (Optional) - A list of Azure tags to attach to an application. Requires Vault 1.16+.

--- a/website/docs/r/azure_secret_backend_role.html.md
+++ b/website/docs/r/azure_secret_backend_role.html.md
@@ -73,7 +73,7 @@ The following arguments are supported:
   Accepts time suffixed strings ("1h") or an integer number of seconds. Defaults to the system/engine default TTL time.
 * `max_ttl` – (Optional) Specifies the maximum TTL for service principals generated using this role. Accepts time
   suffixed strings ("1h") or an integer number of seconds. Defaults to the system/engine max TTL time.
-* `explicit_max_ttl` - (Optional) Specifies the explicit maximum lifetime, in seconds, of the lease and service principal generated using this role. If not set or set to 0, will use the system default (10 years).
+* `explicit_max_ttl` - (Optional) Specifies the explicit maximum lifetime of the lease and service principal generated using this role. If not set or set to 0, will use the system default (10 years).
 * `sign_in_audience` - (Optional) Specifies the security principal types that are allowed to sign in to the application.
   Valid values are: AzureADMyOrg, AzureADMultipleOrgs, AzureADandPersonalMicrosoftAccount, PersonalMicrosoftAccount. Requires Vault 1.16+.
 * `tags` - (Optional) - A list of Azure tags to attach to an application. Requires Vault 1.16+.

--- a/website/docs/r/azure_secret_backend_role.html.md
+++ b/website/docs/r/azure_secret_backend_role.html.md
@@ -73,6 +73,7 @@ The following arguments are supported:
   Accepts time suffixed strings ("1h") or an integer number of seconds. Defaults to the system/engine default TTL time.
 * `max_ttl` – (Optional) Specifies the maximum TTL for service principals generated using this role. Accepts time
   suffixed strings ("1h") or an integer number of seconds. Defaults to the system/engine max TTL time.
+* `explicit_max_ttl` - (Optional) Specifies the explicit maximum lifetime, in seconds, of the lease and service principal generated using this role. If not set or set to 0, will use the system default (10 years).
 * `sign_in_audience` - (Optional) Specifies the security principal types that are allowed to sign in to the application.
   Valid values are: AzureADMyOrg, AzureADMultipleOrgs, AzureADandPersonalMicrosoftAccount, PersonalMicrosoftAccount. Requires Vault 1.16+.
 * `tags` - (Optional) - A list of Azure tags to attach to an application. Requires Vault 1.16+.


### PR DESCRIPTION
### Description
Update the `azure_secret_backend_role` resource to add support for `explicit_max_ttl` for Azure Secrets roles. This field was introduced as part of Azure Secrets plugin v0.20.0, incorporated into Vault 1.18.0 and later.

Closes #2434.

### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
# Running against Vault 1.16.17+ent
$ make testacc TESTARGS='-run=TestAzureSecretBackendRole_AzureRoles' TEST_PATH='./vault/...'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -run=TestAzureSecretBackendRole_AzureRoles -timeout 30m ./vault/...
ok      github.com/hashicorp/terraform-provider-vault/vault     3.977s

# Running against Vault 1.19.0+ent, after cleaning test cache
$ make testacc TESTARGS='-run=TestAzureSecretBackendRole_AzureRoles' TEST_PATH='./vault/...'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -run=TestAzureSecretBackendRole_AzureRoles -timeout 30m ./vault/...
ok      github.com/hashicorp/terraform-provider-vault/vault     3.636s
```

**IMPORTANT NOTE:** I applied the patch below to work around the acceptance test failing on `main`:

<details>
<summary>Acceptance test patch</summary>

```diff
diff --git a/vault/resource_azure_secret_backend_role_test.go b/vault/resource_azure_secret_backend_role_test.go
index 69652e60..1a938280 100644
--- a/vault/resource_azure_secret_backend_role_test.go
+++ b/vault/resource_azure_secret_backend_role_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
+const azReaderRoleId string = "acdd72a7-3385-48ef-bd42-f606fba81ae7"
+
 func TestAzureSecretBackendRole_AzureRoles(t *testing.T) {
 	subscriptionID := os.Getenv("ARM_SUBSCRIPTION_ID")
 	if subscriptionID == "" {
@@ -31,15 +33,18 @@ func TestAzureSecretBackendRole_AzureRoles(t *testing.T) {
 	path := acctest.RandomWithPrefix("tf-test-azure")
 	role := acctest.RandomWithPrefix("tf-test-azure-role")
 
+	azRoleId := fmt.Sprintf(
+		"/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/%s",
+		subscriptionID, azReaderRoleId)
+
 	azureRoleInitialCheckFuncs := []resource.TestCheckFunc{
 		resource.TestCheckResourceAttr(resourceName+".test_azure_roles", "role", role+"-azure-roles"),
 		resource.TestCheckResourceAttr(resourceName+".test_azure_roles", "description", "Test for Vault Provider"),
 		resource.TestCheckResourceAttr(resourceName+".test_azure_roles", "ttl", "300"),
 		resource.TestCheckResourceAttr(resourceName+".test_azure_roles", "max_ttl", "600"),
 		resource.TestCheckResourceAttr(resourceName+".test_azure_roles", "azure_roles.#", "1"),
-		resource.TestCheckResourceAttr(resourceName+".test_azure_roles", "azure_roles.0.role_name", "Reader"),
+		resource.TestCheckResourceAttr(resourceName+".test_azure_roles", "azure_roles.0.role_id", azRoleId),
 		resource.TestCheckResourceAttrSet(resourceName+".test_azure_roles", "azure_roles.0.scope"),
-		resource.TestCheckResourceAttrSet(resourceName+".test_azure_roles", "azure_roles.0.role_id"),
 	}
 
 	azureRoleUpdatedCheckFuncs := []resource.TestCheckFunc{
@@ -48,9 +53,8 @@ func TestAzureSecretBackendRole_AzureRoles(t *testing.T) {
 		resource.TestCheckResourceAttr(resourceName+".test_azure_roles", "ttl", "600"),
 		resource.TestCheckResourceAttr(resourceName+".test_azure_roles", "max_ttl", "900"),
 		resource.TestCheckResourceAttr(resourceName+".test_azure_roles", "azure_roles.#", "1"),
-		resource.TestCheckResourceAttr(resourceName+".test_azure_roles", "azure_roles.0.role_name", "Reader"),
+		resource.TestCheckResourceAttr(resourceName+".test_azure_roles", "azure_roles.0.role_id", azRoleId),
 		resource.TestCheckResourceAttrSet(resourceName+".test_azure_roles", "azure_roles.0.scope"),
-		resource.TestCheckResourceAttrSet(resourceName+".test_azure_roles", "azure_roles.0.role_id"),
 	}
 
 	isVaultVersion116 := provider.IsAPISupported(testProvider.Meta(), provider.VaultVersion116)
@@ -101,9 +105,8 @@ func TestAzureSecretBackendRole_AzureRoles(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName+".test_azure_roles", "description", "Test for Vault Provider"),
 					resource.TestCheckResourceAttr(resourceName+".test_azure_roles", "permanently_delete", "false"),
 					resource.TestCheckResourceAttr(resourceName+".test_azure_roles", "azure_roles.#", "1"),
-					resource.TestCheckResourceAttr(resourceName+".test_azure_roles", "azure_roles.0.role_name", "Reader"),
+					resource.TestCheckResourceAttr(resourceName+".test_azure_roles", "azure_roles.0.role_id", azRoleId),
 					resource.TestCheckResourceAttrSet(resourceName+".test_azure_roles", "azure_roles.0.scope"),
-					resource.TestCheckResourceAttrSet(resourceName+".test_azure_roles", "azure_roles.0.role_id"),
 				),
 			},
 		},
@@ -222,11 +225,11 @@ resource "vault_azure_secret_backend_role" "test_azure_roles" {
  tags             = ["team:engineering"]
 
  azure_roles {
-   role_name = "Reader"
-   scope =  "/subscriptions/%[1]s/resourceGroups/%[7]s"
+   role_id = "/subscriptions/%[1]s/providers/Microsoft.Authorization/roleDefinitions/%[8]s"
+   scope   = "/subscriptions/%[1]s/resourceGroups/%[7]s"
  }
 }
-`, subscriptionID, tenantID, clientID, clientSecret, path, role, resourceGroup)
+`, subscriptionID, tenantID, clientID, clientSecret, path, role, resourceGroup, azReaderRoleId)
 }
 
 func testAzureSecretBackendRoleInitialConfig_azureGroups(subscriptionID string, tenantID string, clientID string, clientSecret string, path string, role string, resourceGroup string) string {
@@ -274,11 +277,11 @@ resource "vault_azure_secret_backend_role" "test_azure_roles" {
   tags       	   = ["environment:development","project:vault_testing"]
 
   azure_roles {
-    role_name = "Reader"
-    scope =  "/subscriptions/%[1]s/resourceGroups/%[7]s"
+    role_id = "/subscriptions/%[1]s/providers/Microsoft.Authorization/roleDefinitions/%[8]s"
+    scope   = "/subscriptions/%[1]s/resourceGroups/%[7]s"
   }
 }
-`, subscriptionID, tenantID, clientID, clientSecret, path, role, resourceGroup)
+`, subscriptionID, tenantID, clientID, clientSecret, path, role, resourceGroup, azReaderRoleId)
 }
 
 func testAzureSecretBackendRole_updatedAzureGroups(subscriptionID string, tenantID string, clientID string, clientSecret string, path string, role string, resourceGroup string) string {
@@ -322,13 +325,15 @@ resource "vault_azure_secret_backend_role" "test_azure_roles" {
   max_ttl          = 600
   explicit_max_ttl = 2592000
   description      = "Test for Vault Provider"
+  sign_in_audience = "AzureADMultipleOrgs"
+  tags       	   = ["environment:development","project:vault_testing"]
 
   azure_roles {
-    role_name = "Reader"
-    scope =  "/subscriptions/%[1]s/resourceGroups/%[7]s"
+    role_id = "/subscriptions/%[1]s/providers/Microsoft.Authorization/roleDefinitions/%[8]s"
+    scope   = "/subscriptions/%[1]s/resourceGroups/%[7]s"
   }
 }
-`, subscriptionID, tenantID, clientID, clientSecret, path, role, resourceGroup)
+`, subscriptionID, tenantID, clientID, clientSecret, path, role, resourceGroup, azReaderRoleId)
 }
 
 func testAzureSecretBackendRolePermanentlyDelete_azureGroups(subscriptionID string, tenantID string, clientID string, clientSecret string, path string, role string, resourceGroup string) string {
```

</details>

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

