### PR TITLE
Update test to key_usage that is supported on a CA certificate.

### DIFF
--- a/vault/resource_pki_secret_backend_root_sign_intermediate_test.go
+++ b/vault/resource_pki_secret_backend_root_sign_intermediate_test.go
@@ -205,16 +205,16 @@ func TestPkiSecretBackendRootSignIntermediate_basic_default(t *testing.T) {
 			{
 				SkipFunc: skip(provider.VaultVersion118),
 				Config: testPkiSecretBackendRootSignIntermediateConfig_basic(rootPath, intermediatePath, false,
-					`key_usage = ["KeyAgreement", "CertSign"]`),
+					`key_usage = ["DigitalSignature", "CertSign"]`),
 				Check: resource.ComposeTestCheckFunc(
 					checks,
 					resource.TestCheckResourceAttr(resourceName, consts.FieldKeyUsage+".#", "2"),
-					resource.TestCheckResourceAttr(resourceName, consts.FieldKeyUsage+".0", "KeyAgreement"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldKeyUsage+".0", "DigitialSignature"),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldKeyUsage+".1", "CertSign"),
 					testPKICert(resourceName, func(cert *x509.Certificate) error {
 						if 0 == cert.KeyUsage&x509.KeyUsageKeyAgreement || 0 == cert.KeyUsage&x509.KeyUsageCertSign {
 							return fmt.Errorf("KeyUsage expected %b, got %b",
-								x509.KeyUsageKeyAgreement|x509.KeyUsageCertSign,
+								x509.KeyUsageDigitalSignature|x509.KeyUsageCertSign|x509.KeyUsageCRLSign,
 								cert.KeyUsage)
 						}
 						return nil


### PR DESCRIPTION
### Description
This PR updates the test for key_usage to be testing a key_usage that is acceptable on a CA (Certificate Authority) certificate.  In general, CA Certificates should not have keys used for things unrelated to their function as CAs (like KeyAgreement).

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request


