### PR TITLE
Add vault_pki_secret_backend_config_est for PKI SCEP support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 FEATURES:
 
-* Add support for `recursive` search in `data_vault_namespaces` [#2408](https://github.com/hashicorp/terraform-provider-vault/pull/2408)
+* Add support for `recursive` search in `data_vault_namespaces` [#2408](https://github.com/hashicorp/terraform-provider-vault/pull/2408).
 * Add support for `explicit_max_ttl` in `vault_azure_secret_backend_role` resources. Requires Vault 1.18+ ([#2438](https://github.com/hashicorp/terraform-provider-vault/pull/2438)).
+* Add new data source and resource `vault_pki_secret_backend_config_scep`. Requires Vault 1.20+ ([#2447](https://github.com/hashicorp/terraform-provider-vault/pull/2447)).
 
 BUGS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 FEATURES:
 
-* Add support for `recursive` search in `data_vault_namespaces` [#2408](https://github.com/hashicorp/terraform-provider-vault/pull/2408).
+* Add support for `recursive` search in `data_vault_namespaces` ([#2408](https://github.com/hashicorp/terraform-provider-vault/pull/2408)).
 * Add support for `explicit_max_ttl` in `vault_azure_secret_backend_role` resources. Requires Vault 1.18+ ([#2438](https://github.com/hashicorp/terraform-provider-vault/pull/2438)).
 * Add new data source and resource `vault_pki_secret_backend_config_scep`. Requires Vault 1.20+ ([#2447](https://github.com/hashicorp/terraform-provider-vault/pull/2447)).
 

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -267,6 +267,8 @@ const (
 	FieldAllowLocalhost                = "allow_localhost"
 	FieldAllowedDomains                = "allowed_domains"
 	FieldAllowedDomainsTemplate        = "allowed_domains_template"
+	FieldAllowedEncryptionAlgorithms   = "allowed_encryption_algorithms"
+	FieldAllowedDigestAlgorithms       = "allowed_digest_algorithms"
 	FieldAllowBareDomains              = "allow_bare_domains"
 	FieldAllowSubdomains               = "allow_subdomains"
 	FieldAllowGlobDomains              = "allow_glob_domains"
@@ -606,6 +608,7 @@ const (
 	VaultVersion118  = "1.18.0"
 	VaultVersion1185 = "1.18.5"
 	VaultVersion119  = "1.19.0"
+	VaultVersion120  = "1.20.0"
 
 	/*
 		Vault auth methods

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -46,6 +46,7 @@ var (
 	VaultVersion118  = version.Must(version.NewSemver(consts.VaultVersion118))
 	VaultVersion1185 = version.Must(version.NewSemver(consts.VaultVersion1185))
 	VaultVersion119  = version.Must(version.NewSemver(consts.VaultVersion119))
+	VaultVersion120  = version.Must(version.NewSemver(consts.VaultVersion120))
 
 	TokenTTLMinRecommended = time.Minute * 15
 )

--- a/vault/data_source_pki_secret_backend_config_est.go
+++ b/vault/data_source_pki_secret_backend_config_est.go
@@ -153,12 +153,12 @@ func verifyPkiEstFeatureSupported(meta interface{}) error {
 
 	minVersion := provider.VaultVersion116
 	if !provider.IsAPISupported(meta, minVersion) {
-		return fmt.Errorf("feature not enabled on current Vault version. min version required=%s; "+
+		return fmt.Errorf("EST feature not enabled on current Vault version. Minimum version required=%s; "+
 			"current vault version=%s", minVersion, currentVersion)
 	}
 
 	if !provider.IsEnterpriseSupported(meta) {
-		return errors.New("feature requires Vault Enterprise")
+		return errors.New("EST feature requires Vault Enterprise")
 	}
 	return nil
 }

--- a/vault/data_source_pki_secret_backend_config_scep.go
+++ b/vault/data_source_pki_secret_backend_config_scep.go
@@ -1,0 +1,165 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package vault
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+	"github.com/hashicorp/vault/api"
+)
+
+func pkiSecretBackendConfigScepSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		consts.FieldBackend: {
+			Type:        schema.TypeString,
+			Required:    true,
+			Description: "The PKI secret backend the resource belongs to",
+			ForceNew:    true,
+		},
+		consts.FieldEnabled: {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "Specifies whether SCEP is enabled",
+		},
+		consts.FieldDefaultPathPolicy: {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: `The policy to be used for non-role-qualified SCEP requests; valid values are 'sign-verbatim', or "role:<role_name>" to specify a role to use as this policy.`,
+		},
+		consts.FieldAllowedEncryptionAlgorithms: {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Computed:    true,
+			Description: "The list of allowed encryption algorithms for SCEP requests",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		consts.FieldAllowedDigestAlgorithms: {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Computed:    true,
+			Description: "The list of allowed digest algorithms for SCEP requests",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		consts.FieldAuthenticators: {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Computed:    true,
+			Description: "Lists the mount accessors SCEP should delegate authentication requests towards",
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"cert": {
+						Type:     schema.TypeMap,
+						Optional: true,
+					},
+					"userpass": {
+						Type:     schema.TypeMap,
+						Optional: true,
+					},
+				},
+			},
+			MaxItems: 1,
+		},
+		consts.FieldLastUpdated: {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "A read-only timestamp representing the last time the configuration was updated",
+		},
+	}
+}
+
+func pkiSecretBackendConfigScepDataSource() *schema.Resource {
+	return &schema.Resource{
+		Description: "Reads Vault PKI SCEP configuration",
+		ReadContext: provider.ReadContextWrapper(readPKISecretBackendConfigScep),
+		Schema:      pkiSecretBackendConfigScepSchema(),
+	}
+}
+
+func readPKISecretBackendConfigScep(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	if err := verifyPkiScepFeatureSupported(meta); err != nil {
+		return diag.FromErr(err)
+	}
+
+	client, err := provider.GetClient(d, meta)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("failed getting client: %w", err))
+	}
+
+	backend := d.Get(consts.FieldBackend).(string)
+	path := pkiSecretBackendConfigScepPath(backend)
+
+	if err := readScepConfig(ctx, d, client, path); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func readScepConfig(ctx context.Context, d *schema.ResourceData, client *api.Client, path string) error {
+	resp, err := client.Logical().ReadWithContext(ctx, path)
+	if err != nil {
+		return fmt.Errorf("error reading from Vault: %w", err)
+	}
+	if resp == nil {
+		return fmt.Errorf("got nil response from Vault from path: %q", path)
+	}
+
+	d.SetId(path)
+
+	keyComputedFields := []string{
+		consts.FieldEnabled,
+		consts.FieldDefaultPathPolicy,
+		consts.FieldAllowedEncryptionAlgorithms,
+		consts.FieldAllowedDigestAlgorithms,
+		consts.FieldLastUpdated,
+	}
+
+	for _, k := range keyComputedFields {
+		if fieldVal, ok := resp.Data[k]; ok {
+			if err := d.Set(k, fieldVal); err != nil {
+				return fmt.Errorf("failed setting field [%s] with val [%s]: %w", k, fieldVal, err)
+			}
+		}
+	}
+
+	if authenticators, authOk := resp.Data[consts.FieldAuthenticators]; authOk {
+		if err := d.Set(consts.FieldAuthenticators, []interface{}{authenticators}); err != nil {
+			return fmt.Errorf("failed setting field [%s] with val [%s]: %w", consts.FieldAuthenticators, authenticators, err)
+		}
+	}
+
+	return nil
+}
+
+// verifyPkiScepFeatureSupported verifies that we are talking to a Vault enterprise edition
+// and its version 1.20.0 or higher, returns nil if the above is met, otherwise an error
+func verifyPkiScepFeatureSupported(meta interface{}) error {
+	currentVersion := meta.(*provider.ProviderMeta).GetVaultVersion()
+
+	minVersion := provider.VaultVersion120
+	if !provider.IsAPISupported(meta, minVersion) {
+		return fmt.Errorf("feature not enabled on current Vault version. min version required=%s; "+
+			"current vault version=%s", minVersion, currentVersion)
+	}
+
+	if !provider.IsEnterpriseSupported(meta) {
+		return errors.New("feature requires Vault Enterprise")
+	}
+	return nil
+}
+
+func pkiSecretBackendConfigScepPath(backend string) string {
+	return strings.Trim(backend, "/") + "/config/scep"
+}

--- a/vault/data_source_pki_secret_backend_config_scep.go
+++ b/vault/data_source_pki_secret_backend_config_scep.go
@@ -150,12 +150,12 @@ func verifyPkiScepFeatureSupported(meta interface{}) error {
 
 	minVersion := provider.VaultVersion120
 	if !provider.IsAPISupported(meta, minVersion) {
-		return fmt.Errorf("feature not enabled on current Vault version. min version required=%s; "+
+		return fmt.Errorf("SCEP feature not enabled on current Vault version. Minimum version required=%s; "+
 			"current vault version=%s", minVersion, currentVersion)
 	}
 
 	if !provider.IsEnterpriseSupported(meta) {
-		return errors.New("feature requires Vault Enterprise")
+		return errors.New("SCEP feature requires Vault Enterprise")
 	}
 	return nil
 }

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -179,6 +179,10 @@ var (
 			Resource:      UpdateSchemaResource(pkiSecretBackendConfigEstDataSource()),
 			PathInventory: []string{"/pki/config/est"},
 		},
+		"vault_pki_secret_backend_config_scep": {
+			Resource:      UpdateSchemaResource(pkiSecretBackendConfigScepDataSource()),
+			PathInventory: []string{"/pki/config/scep"},
+		},
 		"vault_pki_secret_backend_issuer": {
 			Resource:      UpdateSchemaResource(pkiSecretBackendIssuerDataSource()),
 			PathInventory: []string{"/pki/issuer/{issuer_ref}"},
@@ -618,6 +622,10 @@ var (
 		"vault_pki_secret_backend_config_est": {
 			Resource:      UpdateSchemaResource(pkiSecretBackendConfigEstResource()),
 			PathInventory: []string{"/pki/config/est"},
+		},
+		"vault_pki_secret_backend_config_scep": {
+			Resource:      UpdateSchemaResource(pkiSecretBackendConfigScepResource()),
+			PathInventory: []string{"/pki/config/scep"},
 		},
 		"vault_pki_secret_backend_config_urls": {
 			Resource:      UpdateSchemaResource(pkiSecretBackendConfigUrlsResource()),

--- a/vault/resource_pki_secret_backend_config_scep.go
+++ b/vault/resource_pki_secret_backend_config_scep.go
@@ -18,7 +18,7 @@ import (
 func pkiSecretBackendConfigScepResource() *schema.Resource {
 	return &schema.Resource{
 		Description:   "Manages Vault PKI SCEP configuration",
-		CreateContext: provider.MountCreateContextWrapper(pkiSecretBackendConfigScepWrite, provider.VaultVersion116),
+		CreateContext: provider.MountCreateContextWrapper(pkiSecretBackendConfigScepWrite, provider.VaultVersion120),
 		UpdateContext: pkiSecretBackendConfigScepWrite,
 		ReadContext:   pkiSecretBackendConfigScepRead,
 		DeleteContext: pkiSecretBackendConfigScepDelete,

--- a/vault/resource_pki_secret_backend_config_scep.go
+++ b/vault/resource_pki_secret_backend_config_scep.go
@@ -1,0 +1,112 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package vault
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+)
+
+func pkiSecretBackendConfigScepResource() *schema.Resource {
+	return &schema.Resource{
+		Description:   "Manages Vault PKI SCEP configuration",
+		CreateContext: provider.MountCreateContextWrapper(pkiSecretBackendConfigScepWrite, provider.VaultVersion116),
+		UpdateContext: pkiSecretBackendConfigScepWrite,
+		ReadContext:   pkiSecretBackendConfigScepRead,
+		DeleteContext: pkiSecretBackendConfigScepDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: pkiSecretBackendConfigScepSchema(),
+	}
+}
+
+func pkiSecretBackendConfigScepWrite(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	if err := verifyPkiScepFeatureSupported(meta); err != nil {
+		return diag.FromErr(err)
+	}
+
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
+
+	backend := d.Get(consts.FieldBackend).(string)
+	path := pkiSecretBackendConfigScepPath(backend)
+
+	fieldsToSet := []string{
+		consts.FieldEnabled,
+		consts.FieldDefaultMount,
+		consts.FieldDefaultPathPolicy,
+		consts.FieldAllowedEncryptionAlgorithms,
+		consts.FieldAllowedDigestAlgorithms,
+	}
+
+	data := map[string]interface{}{}
+	for _, field := range fieldsToSet {
+		if val, ok := d.GetOk(field); ok {
+			data[field] = val
+		}
+	}
+
+	if authenticatorsRaw, ok := d.GetOk(consts.FieldAuthenticators); ok {
+		authenticators := authenticatorsRaw.([]interface{})
+		var authenticator interface{}
+		if len(authenticators) > 0 {
+			authenticator = authenticators[0]
+		}
+
+		data[consts.FieldAuthenticators] = authenticator
+	}
+
+	log.Printf("[DEBUG] Updating SCEP config on PKI secret backend %q:\n%v", backend, data)
+	_, err := client.Logical().WriteWithContext(ctx, path, data)
+	if err != nil {
+		return diag.Errorf("error updating SCEP config for PKI secret backend %q: %s", backend, err)
+	}
+	log.Printf("[DEBUG] Updated SCEP config on PKI secret backend %q", backend)
+
+	d.SetId(path)
+
+	return pkiSecretBackendConfigScepRead(ctx, d, meta)
+}
+
+func pkiSecretBackendConfigScepRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	id := d.Id()
+	if id == "" {
+		return diag.FromErr(fmt.Errorf("no path set for import, id=%q", id))
+	}
+
+	backend := strings.TrimSuffix(id, "/config/scep")
+	if err := d.Set("backend", backend); err != nil {
+		return diag.FromErr(fmt.Errorf("failed setting field [%s] with value [%v]: %w", "backend", backend, err))
+	}
+
+	if err := verifyPkiScepFeatureSupported(meta); err != nil {
+		return diag.FromErr(err)
+	}
+
+	client, err := provider.GetClient(d, meta)
+	if err != nil {
+		return diag.FromErr(fmt.Errorf("failed getting client: %w", err))
+	}
+
+	if err := readScepConfig(ctx, d, client, id); err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func pkiSecretBackendConfigScepDelete(_ context.Context, _ *schema.ResourceData, _ interface{}) diag.Diagnostics {
+	// There isn't any delete API for the SCEP config.
+	return nil
+}

--- a/vault/resource_pki_secret_backend_config_scep_test.go
+++ b/vault/resource_pki_secret_backend_config_scep_test.go
@@ -1,0 +1,200 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package vault
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/testutil"
+)
+
+func TestAccPKISecretBackendConfigScep_Empty(t *testing.T) {
+	t.Parallel()
+
+	backend := acctest.RandomWithPrefix("tf-test-pki")
+	resourceType := "vault_pki_secret_backend_config_scep"
+	resourceBackend := resourceType + ".test"
+	dataName := "data.vault_pki_secret_backend_config_scep.test"
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		PreCheck: func() {
+			testutil.TestAccPreCheck(t)
+			testutil.TestEntPreCheck(t)
+			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion120)
+		},
+		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypePKI, consts.FieldBackend),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPKISecretBackendConfigScepDisabled(backend),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldBackend, backend),
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldEnabled, "false"),
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldDefaultPathPolicy, ""),
+
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldAllowedEncryptionAlgorithms+".#", "4"),
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldAllowedEncryptionAlgorithms+".0", "aes128-cbc"),
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldAllowedEncryptionAlgorithms+".1", "aes128-gcm"),
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldAllowedEncryptionAlgorithms+".2", "aes256-cbc"),
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldAllowedEncryptionAlgorithms+".3", "aes256-gcm"),
+
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldAllowedDigestAlgorithms+".#", "3"),
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldAllowedDigestAlgorithms+".0", "sha-256"),
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldAllowedDigestAlgorithms+".1", "sha-384"),
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldAllowedDigestAlgorithms+".2", "sha-512"),
+
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldAuthenticators+".#", "1"),
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldAuthenticators+".0.%", "2"),
+					resource.TestCheckNoResourceAttr(resourceBackend, consts.FieldAuthenticators+".0.cert"),
+					resource.TestCheckNoResourceAttr(resourceBackend, consts.FieldAuthenticators+".0.userpass"),
+					resource.TestCheckResourceAttrSet(dataName, consts.FieldLastUpdated),
+					func(s *terraform.State) error {
+						_ = s
+						return nil
+					},
+
+					// Validate we read back the data back as we did upon creation
+					resource.TestCheckResourceAttr(dataName, consts.FieldBackend, backend),
+					resource.TestCheckResourceAttr(dataName, consts.FieldEnabled, "false"),
+					resource.TestCheckResourceAttr(dataName, consts.FieldDefaultPathPolicy, ""),
+					resource.TestCheckResourceAttr(dataName, consts.FieldAuthenticators+".#", "1"),
+					resource.TestCheckResourceAttr(dataName, consts.FieldAuthenticators+".0.%", "2"),
+					resource.TestCheckNoResourceAttr(dataName, consts.FieldAuthenticators+".0.cert"),
+					resource.TestCheckNoResourceAttr(dataName, consts.FieldAuthenticators+".0.userpass"),
+					resource.TestCheckResourceAttrSet(dataName, consts.FieldLastUpdated),
+				),
+			},
+			testutil.GetImportTestStep(resourceBackend, false, nil),
+		},
+	})
+
+}
+
+func TestAccPKISecretBackendConfigScep_AllFields(t *testing.T) {
+	t.Parallel()
+
+	backend := acctest.RandomWithPrefix("tf-test-pki")
+	resourceType := "vault_pki_secret_backend_config_scep"
+	resourceBackend := resourceType + ".test"
+	dataName := "data.vault_pki_secret_backend_config_scep.test"
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		PreCheck: func() {
+			testutil.TestAccPreCheck(t)
+			testutil.TestEntPreCheck(t)
+			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion120)
+		},
+		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypePKI, consts.FieldBackend),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPKISecretBackendConfigScepComplete(backend),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldBackend, backend),
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldEnabled, "true"),
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldDefaultPathPolicy, "role:scep-role"),
+
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldAllowedEncryptionAlgorithms+".#", "2"),
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldAllowedEncryptionAlgorithms+".0", "des-cbc"),
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldAllowedEncryptionAlgorithms+".1", "3des-cbc"),
+
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldAllowedDigestAlgorithms+".#", "2"),
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldAllowedDigestAlgorithms+".0", "sha-1"),
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldAllowedDigestAlgorithms+".1", "sha-256"),
+
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldAuthenticators+".#", "1"),
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldAuthenticators+".0.%", "2"),
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldAuthenticators+".0.cert.%", "2"),
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldAuthenticators+".0.cert.accessor", "the-cert-accessor"),
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldAuthenticators+".0.cert.cert_role", "a-role"),
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldAuthenticators+".0.userpass.%", "2"),
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldAuthenticators+".0.userpass.accessor", "the-userpass-accessor"),
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldAuthenticators+".0.userpass.username", "the-scep-user"),
+					resource.TestCheckResourceAttrSet(dataName, consts.FieldLastUpdated),
+
+					// Validate that the data property can read back everything filled in
+					resource.TestCheckResourceAttr(dataName, consts.FieldBackend, backend),
+					resource.TestCheckResourceAttr(dataName, consts.FieldEnabled, "true"),
+					resource.TestCheckResourceAttr(dataName, consts.FieldAllowedEncryptionAlgorithms+".#", "2"),
+					resource.TestCheckResourceAttr(dataName, consts.FieldAllowedEncryptionAlgorithms+".0", "des-cbc"),
+					resource.TestCheckResourceAttr(dataName, consts.FieldAllowedEncryptionAlgorithms+".1", "3des-cbc"),
+
+					resource.TestCheckResourceAttr(dataName, consts.FieldAllowedDigestAlgorithms+".#", "2"),
+					resource.TestCheckResourceAttr(dataName, consts.FieldAllowedDigestAlgorithms+".0", "sha-1"),
+					resource.TestCheckResourceAttr(dataName, consts.FieldAllowedDigestAlgorithms+".1", "sha-256"),
+
+					resource.TestCheckResourceAttr(dataName, consts.FieldAuthenticators+".#", "1"),
+					resource.TestCheckResourceAttr(dataName, consts.FieldAuthenticators+".0.%", "2"),
+					resource.TestCheckResourceAttr(dataName, consts.FieldAuthenticators+".0.cert.%", "2"),
+					resource.TestCheckResourceAttr(dataName, consts.FieldAuthenticators+".0.cert.accessor", "the-cert-accessor"),
+					resource.TestCheckResourceAttr(dataName, consts.FieldAuthenticators+".0.cert.cert_role", "a-role"),
+					resource.TestCheckResourceAttr(dataName, consts.FieldAuthenticators+".0.userpass.%", "2"),
+					resource.TestCheckResourceAttr(dataName, consts.FieldAuthenticators+".0.userpass.accessor", "the-userpass-accessor"),
+					resource.TestCheckResourceAttr(dataName, consts.FieldAuthenticators+".0.userpass.username", "the-scep-user"),
+					resource.TestCheckResourceAttrSet(dataName, consts.FieldLastUpdated),
+				),
+			},
+			testutil.GetImportTestStep(resourceBackend, false, nil),
+		},
+	})
+}
+
+func testAccPKISecretBackendConfigScepComplete(pkiPath string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "test" {
+	path        = "%s"
+	type        = "pki"
+    description = "PKI secret engine mount"
+}
+
+resource "vault_pki_secret_backend_role" "scep_role" {
+  backend = vault_mount.test.path
+  name = "scep-role"
+  ttl = 3600
+  key_type = "ec"
+  key_bits = "256"
+}
+
+resource "vault_pki_secret_backend_config_scep" "test" {
+  backend = vault_mount.test.path
+  enabled = true
+  default_path_policy = format("role:%%s", vault_pki_secret_backend_role.scep_role.name)
+  allowed_encryption_algorithms = ["des-cbc", "3des-cbc"]
+  allowed_digest_algorithms = ["sha-1", "sha-256"]
+  authenticators { 
+	cert = { "accessor" = "the-cert-accessor", "cert_role" = "a-role" }
+	userpass = { "accessor" = "the-userpass-accessor", "username" = "the-scep-user" } 
+  }	
+}
+
+data "vault_pki_secret_backend_config_scep" "test" {
+  backend = vault_pki_secret_backend_config_scep.test.backend	
+}
+`, pkiPath)
+}
+
+func testAccPKISecretBackendConfigScepDisabled(path string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "test" {
+	path        = "%s"
+	type        = "pki"
+    description = "PKI secret engine mount"
+}
+
+resource "vault_pki_secret_backend_config_scep" "test" {
+  backend = vault_mount.test.path
+}
+
+data "vault_pki_secret_backend_config_scep" "test" {
+  backend = vault_pki_secret_backend_config_scep.test.backend	
+}
+`, path)
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
Add a resource and data source to enable support for the SCEP enrollment protocol to a PKI mount, and to manage its configuration.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
❯ make testacc TESTARGS='-run=TestAccPKISecretBackendConfigScep -v'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -run=TestAccPKISecretBackendConfigScep -v -timeout 30m ./...
?   	github.com/hashicorp/terraform-provider-vault	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/generate	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/helper	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/consts	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/group	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/mfa	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/pki	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/codegen	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/internal/identity/entity	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/internal/rotation	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/sync	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/schema	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/internal/provider	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/testutil	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/util	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/util/mountutil	(cached) [no tests to run]
=== RUN   TestAccPKISecretBackendConfigScep_Empty
=== PAUSE TestAccPKISecretBackendConfigScep_Empty
=== RUN   TestAccPKISecretBackendConfigScep_AllFields
=== PAUSE TestAccPKISecretBackendConfigScep_AllFields
=== CONT  TestAccPKISecretBackendConfigScep_Empty
=== CONT  TestAccPKISecretBackendConfigScep_AllFields
--- PASS: TestAccPKISecretBackendConfigScep_Empty (0.90s)
--- PASS: TestAccPKISecretBackendConfigScep_AllFields (0.94s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/vault	1.503s
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

