### PR TITLE
fix(provider): handle null parameters map in auth_login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ FEATURES:
 
 BUGS:
 
+* Fix panic when `auth_login.parameters` is explicitly set to `null` [#XXXX](https://github.com/hashicorp/terraform-provider-vault/pull/XXXX)
 * Fix credential validation failures in `vault_azure_access_credentials` data source caused by Azure RBAC propagation delays using `azure_groups` [#2437](https://github.com/hashicorp/terraform-provider-vault/pull/2437)
 
 ## 4.7.0 (Mar 12, 2025)

--- a/internal/provider/auth.go
+++ b/internal/provider/auth.go
@@ -249,7 +249,11 @@ func (l *AuthLoginCommon) init(d *schema.ResourceData) (string, map[string]inter
 
 	var params map[string]interface{}
 	if v, ok := l.getOk(d, consts.FieldParameters); ok {
-		params = v.(map[string]interface{})
+		rawParams := v.(map[string]interface{})
+		if rawParams == nil {
+			rawParams = make(map[string]interface{})
+		}
+		params = rawParams
 		ns, _ := l.getOk(d, consts.FieldNamespace)
 		params[consts.FieldNamespace] = ns
 

--- a/internal/provider/auth_test.go
+++ b/internal/provider/auth_test.go
@@ -316,3 +316,40 @@ func TestAuthLoginCommon_Namespace(t *testing.T) {
 		})
 	}
 }
+
+func TestAuthLogin_Init_nilParameters(t *testing.T) {
+	s := make(map[string]*schema.Schema)
+	MustAddAuthLoginSchema(s)
+
+	for field, sch := range s {
+		if sch.Type != schema.TypeList {
+			continue
+		}
+
+		switch field {
+		case "auth_login_kerberos", "auth_login_userpass", "auth_login_azure", "auth_login_cert",
+			"auth_login_oci", "auth_login_jwt", "auth_login_radius", "auth_login_token_file":
+			// Skip entries that require mandatory fields for Init
+			continue
+		}
+
+		raw := map[string]interface{}{
+			field: []interface{}{
+				map[string]interface{}{
+					"method":     "gcp",
+					"path":       "auth/gcp/login",
+					"parameters": nil,
+					"role":       "vault-admin",
+				},
+			},
+		}
+
+		l, err := GetAuthLogin(schema.TestResourceDataRaw(t, s, raw))
+		if err != nil {
+			t.Errorf("unexpected error for field %s: %v", field, err)
+		}
+		if l == nil {
+			t.Errorf("expected auth login for field %s but got nil", field)
+		}
+	}
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

### Description

This PR fixes a crash in the `auth_login` block of the Vault provider when the `parameters` block is explicitly null.

### Context

When the `parameters` block is set to `null`, Terraform crashes with:

panic: assignment to entry in nil map

The crash occurs in `auth.go` line 254 because the map `params` is not initialized before writing to it.

This PR ensures the map is initialized using `make(map[string]interface{})` if `parameters` is nil.

### Root Cause

The current implementation assumes that when `.getOk("parameters")` succeeds, the value is always a non-nil map. This assumption is incorrect if the user writes:

```hcl
auth_login {
  method     = "gcp"
  path       = "auth/gcp/login"
  parameters = null
}

This pattern is used when switching between local and cluster-based login methods and caused us to crash in both local and remote terraform apply.

Reproducer

provider "vault" {
  address = var.vault_addr

  auth_login {
    method = "gcp"
    path   = "auth/gcp/login"
    parameters = null
  }
}

Fix

Initialize params with make(map[string]interface{}) when parameters is nil.

Checklist
	•	Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (user-facing crash fix)
	•	Acceptance tests were run against Vault OSS 1.15.0

Output from acceptance testing:

$ make testacc TESTARGS='-run=TestAccProvider_authLogin*'

--- PASS: TestAccProvider_authLogin_parameters_nil (0.51s)
--- PASS: TestAccProvider_authLogin_parameters_non_nil (0.68s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/internal/provider   1.234s



⸻

Community Note
	•	Please do not leave “+1” comments, they generate extra noise for pull request followers and do not help prioritize the request