### PR TITLE
Fix Azure login method and utilize DefaultAzureCredential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+BUGS:
+
+* Fix Azure login method and utilize DefaultAzureCredential for authenticating with Azure.
+
 ## 4.8.0 (Apr 23, 2025)
 
 FEATURES:

--- a/internal/provider/auth_azure.go
+++ b/internal/provider/auth_azure.go
@@ -174,8 +174,8 @@ func (l *AuthLoginAzure) Login(client *api.Client) (*api.Secret, error) {
 }
 
 func (l *AuthLoginAzure) getJWT(ctx context.Context) (string, error) {
-	if v, ok := l.params[consts.FieldJWT]; ok {
-		return v.(string), nil
+	if jwt, ok := l.params[consts.FieldJWT].(string); ok && jwt != "" {
+		return jwt, nil
 	}
 
 	// attempt to get the token from Azure

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -560,6 +560,7 @@ The `auth_login_azure` configuration block accepts the following arguments:
 * `jwt` - (Optional) The signed JSON Web Token against which the login is being attempted. 
  If not provided a token will be created from Azure's managed identities for Azure resources API.
   *Can be specified with the `TERRAFORM_VAULT_AZURE_AUTH_JWT` environment variable.*
+ If this value is not provided, a [`DefaultAzureCredential`](https://learn.microsoft.com/en-gb/azure/developer/go/sdk/authentication/credential-chains#defaultazurecredential-overview) will be used to perform authentication via numerous methods in order until one succeeds.
 
 * `subscription_id` - (Required) The subscription ID for the machine that generated the MSI token.
   This information can be obtained through instance metadata.
@@ -575,9 +576,9 @@ The `auth_login_azure` configuration block accepts the following arguments:
 
 * `tenant_id` - (Optional) Provides the tenant ID to use in a multi-tenant authentication scenario.
 
-* `client_id` - (Optional) The identity's client ID.
+* `client_id` - (Optional) Provides the client ID of the identity to use when multiple identities are available.
 
-* `scope` - (Optional) The scopes to include in the token request. Defaults to `https://management.azure.com/`
+* `scope` - (Optional) The scopes to include in the token request. Defaults to `https://management.azure.com//.default`
 
 
 ### Token File


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
This PR fixes a logic bug that made authenticating to Vault via the `azure` login method never actually work unless a JWT was pre-supplied because of a logic error. Additionally, more logic errors due to copy/paste typos were fixed and the azure authentication method was changed from `ManagedIdentityCredential` to `DefaultAzureCredential` (which includes `ManagedIdentityCredential`, but is more flexible as it also includes more authentication options which cover more use-cases), implications of this can be found here: https://learn.microsoft.com/en-gb/azure/developer/go/sdk/authentication/credential-chains#defaultazurecredential-overview

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

I did not run any acceptance tests as it is not clear how to run them or what the requirements are from this PR template, I just made sure the unit tests still pass and I can confirm that this PR is working fine as I have been using this branch in production for the last 6 months.


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

