### PR TITLE
Revert change to allow for [] capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+BUGS:
+* fix `vault_policy_document` data source regression to allow empty `capabilities` ([#2466](https://github.com/hashicorp/terraform-provider-vault/pull/2466))
+
 ## 4.8.0 (Apr 23, 2025)
 
 FEATURES:

--- a/vault/data_source_policy_document.go
+++ b/vault/data_source_policy_document.go
@@ -220,8 +220,8 @@ func policyDocumentDataSourceRead(d *schema.ResourceData, meta interface{}) erro
 				return fmt.Errorf("missing field: capabilities")
 			}
 			capList, ok := capVal.([]interface{})
-			if !ok || len(capList) == 0 {
-				return fmt.Errorf("invalid or empty capabilities list, expected a list of strings")
+			if !ok {
+				return fmt.Errorf("invalid capabilities list, expected a list of strings")
 			}
 			rule.Capabilities = policyDecodeConfigListOfStrings(capList)
 

--- a/vault/data_source_policy_document_test.go
+++ b/vault/data_source_policy_document_test.go
@@ -88,6 +88,11 @@ data "vault_policy_document" "test" {
     path                = "secret/test3/"
     capabilities        = ["read", "list"]
   }
+
+ rule {
+    path                = "secret/test4/"
+    capabilities        = []
+  }
 }
 `
 
@@ -124,6 +129,10 @@ path "secret/test2/*" {
 
 path "secret/test3/" {
   capabilities = ["read", "list"]
+}
+
+path "secret/test4/" {
+  capabilities = []
 }
 `
 


### PR DESCRIPTION
Fixing a regression I introduced with this [PR](https://github.com/hashicorp/terraform-provider-vault/pull/2445). My understanding by looking at the docs, both [TFVP](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/data-sources/policy_document#argument-reference) and [Vault](https://developer.hashicorp.com/vault/docs/concepts/policies#capabilities), was that this param is required and shouldn't be empty. Looking at the Vault code more closely now, we do allow for [], and I misunderstood the docs. Reverting this change and added a test case.