### PR TITLE
VAULT-35631: support RLQ fields "group_by" and "secondary_rate"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+FEATURES:
+* Add support for `group_by` and `secondary_rate` on resource `vault_quota_rate_limit`. Requires Vault Enterprise 1.20.0+ ([#2476](https://github.com/hashicorp/terraform-provider-vault/pull/2476))
+
 ## 5.0.0 (May 21, 2025)
 
 **Important**: `5.X` multiplexes the Vault provider to use the [Terraform Plugin Framework](https://developer.hashicorp.com/terraform/plugin/framework),

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -623,6 +623,7 @@ const (
 	VaultVersion118  = "1.18.0"
 	VaultVersion1185 = "1.18.5"
 	VaultVersion119  = "1.19.0"
+	VaultVersion120  = "1.20.0"
 
 	/*
 		Vault auth methods

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -623,8 +623,7 @@ const (
 	VaultVersion118  = "1.18.0"
 	VaultVersion1185 = "1.18.5"
 	VaultVersion119  = "1.19.0"
-	// TODO change to 1.20
-	VaultVersion120 = "1.20.0-beta1+ent"
+	VaultVersion120  = "1.20.0"
 
 	/*
 		Vault auth methods

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -623,7 +623,8 @@ const (
 	VaultVersion118  = "1.18.0"
 	VaultVersion1185 = "1.18.5"
 	VaultVersion119  = "1.19.0"
-	VaultVersion120  = "1.20.0"
+	// TODO change to 1.20
+	VaultVersion120 = "1.20.0-beta1+ent"
 
 	/*
 		Vault auth methods

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -48,6 +48,7 @@ var (
 	VaultVersion118  = version.Must(version.NewSemver(consts.VaultVersion118))
 	VaultVersion1185 = version.Must(version.NewSemver(consts.VaultVersion1185))
 	VaultVersion119  = version.Must(version.NewSemver(consts.VaultVersion119))
+	VaultVersion120  = version.Must(version.NewSemver(consts.VaultVersion120))
 
 	TokenTTLMinRecommended = time.Minute * 15
 )

--- a/vault/resource_quota_rate_limit.go
+++ b/vault/resource_quota_rate_limit.go
@@ -52,7 +52,6 @@ func quotaRateLimitResource() *schema.Resource {
 			"secondary_rate": {
 				Type:         schema.TypeFloat,
 				Optional:     true,
-				Computed:     true,
 				Description:  `Only available when using the "entity_then_ip" or "entity_then_none" group_by modes. This is the rate limit applied to the requests that fall under the "ip" or "none" groupings, while the authenticated requests that contain an entity ID are subject to the "rate" field instead. Defaults to the same value as "rate".`,
 				ValidateFunc: validation.FloatAtLeast(0.0),
 			},
@@ -82,7 +81,6 @@ func quotaRateLimitResource() *schema.Resource {
 			"group_by": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
 				Description: `Attribute by which to group requests by. Valid group_by modes are: 1) "ip" that groups` +
 					` requests by their source IP address (group_by defaults to ip if unset); 2) "none" that groups all` +
 					` requests that match the rate limit quota rule together; 3) "entity_then_ip" that groups requests` +
@@ -198,21 +196,25 @@ func quotaRateLimitRead(d *schema.ResourceData, meta interface{}) error {
 	if provider.IsAPISupported(meta, provider.VaultVersion112) {
 		fields = append(fields, consts.FieldRole)
 	}
-	if provider.IsAPISupported(meta, provider.VaultVersion120) {
-		fields = append(fields, "group_by", "secondary_rate")
+
+	if provider.IsAPISupported(meta, provider.VaultVersion115) {
+		if _, ok := d.GetOkExists("inheritable"); ok {
+			fields = append(fields, "inheritable")
+		}
 	}
 
-	// If not explicitly set by the user the backend will use a sane default depending on the path, but we can't
-	// reflect it on the state because the field is not computed. We could make it optional+computed, but making it
-	// computed would mean a diff on upgrade, which could be considered a breaking change.
-	if _, ok := d.GetOkExists("inheritable"); ok {
-		fields = append(fields, "inheritable")
+	if provider.IsAPISupported(meta, provider.VaultVersion120) {
+		if _, ok := d.GetOk("group_by"); ok {
+			fields = append(fields, "group_by")
+		}
+		if _, ok := d.GetOk("secondary_rate"); ok {
+			fields = append(fields, "secondary_rate")
+		}
 	}
 
 	for _, k := range fields {
 		v, ok := resp.Data[k]
 		if ok {
-			fmt.Printf("[DEBUG] Resource Rate Limit Quota %s: %s = %v\n", name, k, v)
 			if err := d.Set(k, v); err != nil {
 				return fmt.Errorf("error setting %s for Resource Rate Limit Quota %s: %q", k, name, err)
 			}
@@ -223,7 +225,6 @@ func quotaRateLimitRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func quotaRateLimitUpdate(d *schema.ResourceData, meta interface{}) error {
-	fmt.Printf("[DEBUG] updating Resource Rate Limit Quota %s\n", d.Id())
 	client, e := provider.GetClient(d, meta)
 	if e != nil {
 		return e
@@ -275,8 +276,6 @@ func quotaRateLimitUpdate(d *schema.ResourceData, meta interface{}) error {
 			data[consts.FieldRole] = v
 		}
 	}
-
-	fmt.Printf("[DEBUG] Writing data for Resource Rate Limit Quota %s: %v\n", name, data)
 
 	_, err := client.Logical().Write(path, data)
 	if err != nil {

--- a/vault/resource_quota_rate_limit.go
+++ b/vault/resource_quota_rate_limit.go
@@ -83,13 +83,14 @@ func quotaRateLimitResource() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				Description: `Attribute by which to group requests by. Valid group_by modes are: 1) "ip" that groups` +
-					` requests by their source IP address (group_by defaults to ip if unset); 2) "none" that groups all` +
-					` requests that match the rate limit quota rule together; 3) "entity_then_ip" that groups requests` +
-					` by their entity ID for authenticated requests that carry one, or by their IP for unauthenticated` +
-					` requests (or requests whose authentication is not connected to an entity); and 4) "entity_then_none"` +
-					` which also groups requests by their entity ID when available, but the rest is all grouped together` +
-					` (i.e. unauthenticated or with authentication not connected to an entity).`,
+				Description: `Attribute used to group requests for rate limiting. Limits are enforced independently` +
+					` for each group. Valid group_by modes are: 1) "ip" that groups requests by their source IP` +
+					` address (group_by defaults to ip if unset); 2) "none" that groups all requests that match the` +
+					` rate limit quota rule together; 3) "entity_then_ip" that groups requests by their entity ID for` +
+					` authenticated requests that carry one, or by their IP for unauthenticated requests (or requests` +
+					` whose authentication is not connected to an entity); and 4) "entity_then_none" which also` +
+					` groups requests by their entity ID when available, but the rest is all grouped together (i.e.` +
+					` unauthenticated or with authentication not connected to an entity).`,
 				ValidateFunc: validation.StringInSlice([]string{"ip", "none", "entity_then_ip", "entity_then_none"}, false),
 			},
 		},
@@ -263,7 +264,7 @@ func quotaRateLimitUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if provider.IsAPISupported(meta, provider.VaultVersion115) {
-		// we should probably fail if the field is set on an unsupported version instead of ignoring it, but changin
+		// we should probably fail if the field is set on an unsupported version instead of ignoring it, but changing
 		// that would be a breaking change
 		if v, ok := d.GetOkExists("inheritable"); ok {
 			data["inheritable"] = v.(bool)
@@ -271,7 +272,7 @@ func quotaRateLimitUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if provider.IsAPISupported(meta, provider.VaultVersion112) {
-		// we should probably fail if the field is set on an unsupported version instead of ignoring it, but changin
+		// we should probably fail if the field is set on an unsupported version instead of ignoring it, but changing
 		// that would be a breaking change
 		if v, ok := d.GetOk(consts.FieldRole); ok {
 			data[consts.FieldRole] = v

--- a/vault/resource_quota_rate_limit.go
+++ b/vault/resource_quota_rate_limit.go
@@ -150,7 +150,7 @@ func quotaRateLimitCreate(d *schema.ResourceData, meta interface{}) error {
 	if v, ok := d.GetOk("group_by"); ok {
 		if !provider.IsAPISupported(meta, provider.VaultVersion120) {
 			d.SetId("")
-			return fmt.Errorf("group_by is only supported in Vault 1.20 and later")
+			return fmt.Errorf("group_by is only supported in Vault Enterprise 1.20 and later")
 		}
 		data["group_by"] = v
 	}
@@ -158,7 +158,7 @@ func quotaRateLimitCreate(d *schema.ResourceData, meta interface{}) error {
 	if v, ok := d.GetOk("secondary_rate"); ok {
 		if !provider.IsAPISupported(meta, provider.VaultVersion120) {
 			d.SetId("")
-			return fmt.Errorf("secondary_rate is only supported in Vault 1.20 and later")
+			return fmt.Errorf("secondary_rate is only supported in Vault Enterprise 1.20 and later")
 		}
 		data["secondary_rate"] = v
 	}
@@ -250,14 +250,14 @@ func quotaRateLimitUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("group_by"); ok {
 		if !provider.IsAPISupported(meta, provider.VaultVersion120) {
-			return fmt.Errorf("group_by is only supported in Vault 1.20 and later")
+			return fmt.Errorf("group_by is only supported in Vault Enterpprise 1.20 and later")
 		}
 		data["group_by"] = v
 	}
 
 	if v, ok := d.GetOk("secondary_rate"); ok {
 		if !provider.IsAPISupported(meta, provider.VaultVersion120) {
-			return fmt.Errorf("secondary_rate is only supported in Vault 1.20 and later")
+			return fmt.Errorf("secondary_rate is only supported in Vault Enterprise 1.20 and later")
 		}
 		data["secondary_rate"] = v
 	}

--- a/vault/resource_quota_rate_limit_test.go
+++ b/vault/resource_quota_rate_limit_test.go
@@ -217,6 +217,7 @@ func TestQuotaRateLimitWithNamespaceInheritable(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "inheritable", "false"),
 				),
 			},
+			testutil.GetImportTestStep(resourceName, false, nil),
 		},
 	})
 }
@@ -320,6 +321,7 @@ resource "vault_quota_rate_limit" "foobar" {
 					resource.TestCheckResourceAttr(resourceName, "secondary_rate", "0"),
 				),
 			},
+			testutil.GetImportTestStep(resourceName, false, nil),
 		},
 	})
 }

--- a/website/docs/r/quota_rate_limit.md
+++ b/website/docs/r/quota_rate_limit.md
@@ -55,6 +55,18 @@ The following arguments are supported:
 
 * `inheritable` - (Optional) If set to `true` on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to `true` if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default. Requires Vault 1.15+.
 
+* `group_by` - (Optional) Attribute by which to group requests by. Valid `group_by` modes are: 1) `ip` that groups 
+  requests by their source IP address (**`group_by` defaults to `ip` if unset, which is the only supported mode in 
+  community edition**); 2) `none` that groups together all requests that match the rate limit quota rule; 3)
+  `entity_then_ip` that groups requests by their entity ID for authenticated requests that carry one, or by their IP for
+  unauthenticated requests (or requests whose authentication is not connected to an entity); and 4) `entity_then_none` 
+  which also groups requests by their entity ID when available, but the rest is all grouped together (i.e.
+  unauthenticated or with authentication not connected to an entity).
+
+* `secondary_rate` - (Optional) Can only be set for the `group_by` modes `entity_then_ip` or `entity_then_none`. This is
+  the rate limit applied to the requests that fall under the "ip" or "none" groupings, while the authenticated requests
+  that contain an entity ID are subject to the `rate` field instead. Defaults to the same value as `rate`.
+
 ## Attributes Reference
 
 No additional attributes are exported by this resource.

--- a/website/docs/r/quota_rate_limit.md
+++ b/website/docs/r/quota_rate_limit.md
@@ -55,13 +55,13 @@ The following arguments are supported:
 
 * `inheritable` - (Optional) If set to `true` on a quota where path is set to a namespace, the same quota will be cumulatively applied to all child namespace. The inheritable parameter cannot be set to `true` if the path does not specify a namespace. Only the quotas associated with the root namespace are inheritable by default. Requires Vault 1.15+.
 
-* `group_by` - (Optional) Attribute by which to group requests by. Valid `group_by` modes are: 1) `ip` that groups 
-  requests by their source IP address (**`group_by` defaults to `ip` if unset, which is the only supported mode in 
-  community edition**); 2) `none` that groups together all requests that match the rate limit quota rule; 3)
-  `entity_then_ip` that groups requests by their entity ID for authenticated requests that carry one, or by their IP for
-  unauthenticated requests (or requests whose authentication is not connected to an entity); and 4) `entity_then_none` 
-  which also groups requests by their entity ID when available, but the rest is all grouped together (i.e.
-  unauthenticated or with authentication not connected to an entity).
+* `group_by` - (Optional) Attribute used to group requests for rate limiting. Limits are enforced independently for each
+  group. Valid `group_by` modes are: 1) `ip` that groups requests by their source IP address (**`group_by` defaults to
+ `ip` if unset, which is the only supported mode in community edition**); 2) `none` that groups together all requests
+  that match the rate limit quota rule; 3) `entity_then_ip` that groups requests by their entity ID for authenticated
+  requests that carry one, or by their IP for unauthenticated requests (or requests whose authentication is not 
+  connected to an entity); and 4) `entity_then_none` which also groups requests by their entity ID when available, but
+  the rest is all grouped together (i.e. unauthenticated or with authentication not connected to an entity).
 
 * `secondary_rate` - (Optional) Can only be set for the `group_by` modes `entity_then_ip` or `entity_then_none`. This is
   the rate limit applied to the requests that fall under the "ip" or "none" groupings, while the authenticated requests


### PR DESCRIPTION
### Description

This PR adds supports to the new `group_by` and `secondary_rate` fields to the `vault_quota_rate_limit` resource, added to the API in https://github.com/hashicorp/vault/pull/30447. These new collective and entity-based rate limits are an enterprise-only functionality, but the default option `group_by: ip` is allowed on community edition and maintains the standard, backwards-compatible behavior of rate limit quotas.

As described in code comments I had a lot of trouble with the default value semantics for the fields, as leaving `group_by` unset is allowed and defaults to `ip`, and leaving `secondary_rate` unset makes it default to 0 on `ip` and `none` modes, and `rate` on the entity-based modes. There are 2 approaches I considered:

1. **Optional + set state if in config**: this is the approach that's already being used by the inheritable field, it is configured as an `Optional` field but **not** `Computed`, and we only call the `Set` function to commit its value to the tf state if it was already in the config/state, which means that if the user doesn't specify anything in the TF config then the value won't be written to the state.

  Pros:
   * when the practitioner updates the `inheritable` field from some value to unset in the TF config the result if for the TF state to contain a zero value for the setting. Still not perfect, but the SDK v2 can't distinguish between zero value and unset, so that's the best we can hope for

   Cons:
   * doesn't work with TF import. That's actually a bug we have, even if `inheritable` is set in the backend the field will be left unset in the resulting imported configuration
   * the default value of fields like `inheritable` can't be referenced by the TF config, it's only visible when set.
2. **Optional + computed**: mark the field as both optional and computed, so regardless if the `group_by` and `secondary_rate` fields are set in the TF config they will show up

Pros:
   * TF import works properly
   * fields can always be depended upon to be a source of truth, even having the default values assigned by the external API

Cons:
   * when the practitioner changes a field from a value to unset the terraform state is maintained. As seen in the tests, that results in a bug where removing `secondary_rate` doesn't bring it back to the default state expected if the RLQ had been originally created with the field unset.

Overall it seems like the approach 2 is the best. I considered migrating `inheritable` to this same approach, fixing the bug with terraform import, but that could be considered a breaking change so I'm not sure if it's a viable approach.

Jira: [VAULT-35631](https://hashicorp.atlassian.net/browse/VAULT-35631)


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestQuotaRateLimitGroupBy'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -run=TestQuotaRateLimitGroupBy -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/framework/base   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/framework/client [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/framework/errutil        [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/framework/model  [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/mfa     [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/pki      [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/provider/fwprovider      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/codegen   0.014s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/framework/validators     0.016s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  0.034s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/provider 0.020s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/providertest     [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/rotation [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/sync     [no test files]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/vault/secrets/ephemeral  0.014s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/vault/sys        0.013s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/testutil  0.005s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util      0.006s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util/mountutil    0.003s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/vault     0.014s
...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

[VAULT-35631]: https://hashicorp.atlassian.net/browse/VAULT-35631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ