### PR TITLE
Feature: allow params to support tfe team multitoken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ scratch
 
 # others
 .swp
+.vscode

--- a/vault/resource_terraform_cloud_secret_role_test.go
+++ b/vault/resource_terraform_cloud_secret_role_test.go
@@ -73,6 +73,56 @@ func TestTerraformCloudSecretRole(t *testing.T) {
 	})
 }
 
+func TestTerraformCloudSecretRole_options(t *testing.T) {
+	backend := acctest.RandomWithPrefix("tf-test-backend")
+	name := acctest.RandomWithPrefix("tf-test-name")
+	vals := testutil.SkipTestEnvUnset(t, "TEST_TF_TOKEN", "TEST_TF_TEAM_ID")
+	token, teamID := vals[0], vals[1]
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		PreCheck: func() {
+			testutil.TestAccPreCheck(t)
+		},
+		CheckDestroy: testAccTerraformCloudSecretRoleCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testTerraformCloudSecretRole_optionsInitialConfig(backend, token, name, teamID),
+				Check: resource.ComposeTestCheckFunc(
+					// resource.TestCheckResourceAttr("vault_terraform_cloud_secret_role.test_team", "name", name+"_team_id"),
+					// resource.TestCheckResourceAttr("vault_terraform_cloud_secret_role.test_team", "description", "team role"),
+					// resource.TestCheckResourceAttr("vault_terraform_cloud_secret_role.test_team", "credential_type", "team"),
+					// resource.TestCheckResourceAttr("vault_terraform_cloud_secret_role.test_team", "team_id", teamID),
+					// resource.TestCheckResourceAttr("vault_terraform_cloud_secret_role.test_team", "ttl", "100"),
+					// resource.TestCheckResourceAttr("vault_terraform_cloud_secret_role.test_team", "max_ttl", "200"),
+
+					resource.TestCheckResourceAttr("vault_terraform_cloud_secret_role.test_team_legacy", "name", name+"_team_legacy_id"),
+					resource.TestCheckResourceAttr("vault_terraform_cloud_secret_role.test_team_legacy", "credential_type", "team_legacy"),
+					resource.TestCheckResourceAttr("vault_terraform_cloud_secret_role.test_team_legacy", "team_id", teamID),
+					// resource.TestCheckResourceAttr("vault_terraform_cloud_secret_role.test_team_legacy", "ttl", "0"),
+					// resource.TestCheckResourceAttr("vault_terraform_cloud_secret_role.test_team_legacy", "max_ttl", "0"),
+				),
+			},
+			{
+				Config: testTerraformCloudSecretRole_optionsUpdatedConfig(backend, token, name, teamID),
+				Check: resource.ComposeTestCheckFunc(
+					// resource.TestCheckResourceAttr("vault_terraform_cloud_secret_role.test_team", "name", name+"_team_id"),
+					// resource.TestCheckResourceAttr("vault_terraform_cloud_secret_role.test_team", "description", "team role2"),
+					// resource.TestCheckResourceAttr("vault_terraform_cloud_secret_role.test_team", "credential_type", "team"),
+					// resource.TestCheckResourceAttr("vault_terraform_cloud_secret_role.test_team", "team_id", teamID),
+					// resource.TestCheckResourceAttr("vault_terraform_cloud_secret_role.test_team", "ttl", "200"),
+					// resource.TestCheckResourceAttr("vault_terraform_cloud_secret_role.test_team", "max_ttl", "300"),
+
+					resource.TestCheckResourceAttr("vault_terraform_cloud_secret_role.test_team_legacy", "name", name+"_team_legacy_id"),
+					resource.TestCheckResourceAttr("vault_terraform_cloud_secret_role.test_team_legacy", "credential_type", "team_legacy"),
+					resource.TestCheckResourceAttr("vault_terraform_cloud_secret_role.test_team_legacy", "team_id", teamID),
+					// resource.TestCheckResourceAttr("vault_terraform_cloud_secret_role.test_team_legacy", "ttl", "0"),
+					// resource.TestCheckResourceAttr("vault_terraform_cloud_secret_role.test_team_legacy", "max_ttl", "0"),
+				),
+			},
+		},
+	})
+}
+
 func testAccTerraformCloudSecretRoleCheckDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "vault_terraform_cloud_secret_role" {
@@ -161,6 +211,60 @@ resource "vault_terraform_cloud_secret_role" "test_user" {
   ttl = 120
 }
 `, backend, token, name, organization, teamId, userId)
+}
+
+func testTerraformCloudSecretRole_optionsInitialConfig(backend, token, name, teamId string) string {
+	return fmt.Sprintf(`
+// resource "vault_terraform_cloud_secret_backend" "test" {
+//   backend     = "terraform"
+//   description = "test description"
+//   token       = "%s"
+// }
+
+// resource "vault_terraform_cloud_secret_role" "test_team" {"
+//   backend         = "terraform"
+//   name            = "%[3]s_team_id"
+//   team_id         = "%[4]s"
+//   credential_type = "team"
+//   description     = "team role"
+//   ttl             = 100
+//   max_ttl         = 200
+// }
+
+resource "vault_terraform_cloud_secret_role" "test_team_legacy" {
+  backend         = "terraform"
+  name            = "%[3]s_team_legacy_id"
+  team_id         = "%[4]s"
+  credential_type = "team_legacy"
+}
+`, backend, token, name, teamId)
+}
+
+func testTerraformCloudSecretRole_optionsUpdatedConfig(backend, token, name, teamId string) string {
+	return fmt.Sprintf(`
+// resource "vault_terraform_cloud_secret_backend" "test" {
+//   backend     = "terraform"
+//   description = "test description"
+//   token       = "%s"
+// }
+
+// resource "vault_terraform_cloud_secret_role" "test_team" {
+//   backend         = "terraform"
+//   name            = "%[3]s_team_id"
+//   team_id         = "%[4]s"
+//   credential_type = "team"
+//   description     = "team role2"
+//   ttl             = 200
+//   max_ttl         = 300
+// }
+
+resource "vault_terraform_cloud_secret_role" "test_team_legacy" {
+  backend         = "terraform"
+  name            = "%[3]s_team_legacy_id"
+  team_id         = "%[4]s"
+  credential_type = "team_legacy"
+}
+`, backend, token, name, teamId)
 }
 
 func TestTerraformCloudSecretBackendRoleNameFromPath(t *testing.T) {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #2497 


### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

NOTE: I CANNOT run the other pre-existing test because it will blow away my org token and deactivate my doormat tfc org

```
$ TF_ACC=1 go test -v -run TestTerraformCloudSecretRole_ -timeout 10m ./...
?   	github.com/hashicorp/terraform-provider-vault	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/generate	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/codegen	0.326s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/helper	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/consts	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/framework/base	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/framework/client	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/framework/errutil	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/framework/model	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/internal/framework/validators	0.326s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/internal/identity/entity	0.502s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/group	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/mfa	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/pki	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/internal/provider	0.492s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/internal/provider/fwprovider	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/providertest	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/rotation	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/sync	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/internal/vault/secrets/ephemeral	0.575s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/internal/vault/sys	0.584s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/schema	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/testutil	0.714s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/util	1.030s [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/util/mountutil	0.824s [no tests to run]
=== RUN   TestTerraformCloudSecretRole_options
--- PASS: TestTerraformCloudSecretRole_options (1.42s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/vault	2.347s

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

