### PR TITLE
Add a private key field to Snowflake DB mount configuration for Snowflake key-pair auth support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 FEATURES:
 * Add support for key_usage to `vault_pki_secret_backend_root_sign_intermediate` ([#2421])(https://github.com/hashicorp/terraform-provider-vault/pull/2421)
 
-* Add private_key field to Snowflake DB secrets engine configs ([#2508])(https://github.com/hashicorp/terraform-provider-vault/pull/2508)
+* Add private_key_wo and private_key_wo_version fields to Snowflake DB secrets engine config ([#2508])(https://github.com/hashicorp/terraform-provider-vault/pull/2508)
 
 * Add support for `group_by` and `secondary_rate` on resource `vault_quota_rate_limit`. Requires Vault Enterprise 1.20.0+ ([#2476](https://github.com/hashicorp/terraform-provider-vault/pull/2476))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Add support for key_usage to `vault_pki_secret_backend_root_sign_intermediate` ([#2421])(https://github.com/hashicorp/terraform-provider-vault/pull/2421)
 
+* Add private_key field to Snowflake DB secrets engine configs ([#2508])(https://github.com/hashicorp/terraform-provider-vault/pull/2508)
+
 
 ## 5.0.0 (May 21, 2025)
 

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -625,6 +625,7 @@ const (
 	VaultVersion118  = "1.18.0"
 	VaultVersion1185 = "1.18.5"
 	VaultVersion119  = "1.19.0"
+	VaultVersion120  = "1.20.0"
 
 	/*
 		Vault auth methods

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -539,6 +539,8 @@ const (
 	FieldCredentialsWOVersion = "credentials_wo_version"
 	FieldDataJSONWO           = "data_json_wo"
 	FieldDataJSONWOVersion    = "data_json_wo_version"
+	FieldPrivateKeyWO         = "private_key_wo"
+	FieldPrivateKeyWOVersion  = "private_key_wo_version"
 
 	/*
 		common environment variables

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -48,6 +48,7 @@ var (
 	VaultVersion118  = version.Must(version.NewSemver(consts.VaultVersion118))
 	VaultVersion1185 = version.Must(version.NewSemver(consts.VaultVersion1185))
 	VaultVersion119  = version.Must(version.NewSemver(consts.VaultVersion119))
+	VaultVersion120  = version.Must(version.NewSemver(consts.VaultVersion120))
 
 	TokenTTLMinRecommended = time.Minute * 15
 )

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -692,13 +692,10 @@ func getDatabaseSchema(typ schema.ValueType) schemaMap {
 			ConflictsWith: util.CalculateConflictsWith(dbEngineRedshift.Name(), dbEngineTypes),
 		},
 		dbEngineSnowflake.name: {
-			Type:        typ,
-			Optional:    true,
-			Description: "Connection parameters for the snowflake-database-plugin plugin.",
-			Elem: connectionStringResource(&connectionStringConfig{
-				includeUserPass:   true,
-				includePrivateKey: true,
-			}),
+			Type:          typ,
+			Optional:      true,
+			Description:   "Connection parameters for the snowflake-database-plugin plugin.",
+			Elem:          snowflakeConnectionStringResource(),
 			MaxItems:      1,
 			ConflictsWith: util.CalculateConflictsWith(dbEngineSnowflake.Name(), dbEngineTypes),
 		},
@@ -790,6 +787,7 @@ func connectionStringResource(config *connectionStringConfig) *schema.Resource {
 			Optional:    true,
 			Description: "The private key configured for the admin user in Snowflake.",
 			Sensitive:   true,
+			WriteOnly:   true,
 		}
 	}
 
@@ -927,6 +925,18 @@ func oracleConnectionStringResource() *schema.Resource {
 		Description: "Set to true to disconnect any open sessions prior to running the revocation statements.",
 		Default:     true,
 	}
+
+	return r
+}
+
+func snowflakeConnectionStringResource() *schema.Resource {
+	r := connectionStringResource(&connectionStringConfig{
+		includeUserPass:   true,
+		includePrivateKey: true,
+	})
+
+	r.Schema[consts.FieldPassword].Deprecated = "Snowflake is ending support for single-factor password authentication " +
+		"by November 2025. Refer to the documentation for more information on migrating to key-pair authentication."
 
 	return r
 }

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -1872,8 +1872,9 @@ func setDatabaseConnectionDataWithUserAndPrivateKey(d *schema.ResourceData, pref
 		panic(fmt.Sprintf("[ERROR] field %q can only be used with Vault version %s or newer", consts.FieldPrivateKeyWO, provider.VaultVersion120))
 	}
 
-	setDatabaseConnectionData(d, prefix, data)
-
+	// Once password auth for snowflake is removed, this can be changed to setDatabaseConnectionData.
+	// The username field is set below in anticipation of that change.
+	setDatabaseConnectionDataWithUserPass(d, prefix, data)
 	data[consts.FieldUsername] = d.Get(prefix + consts.FieldUsername)
 
 	privateKeyWriteOnlyVersionKey := prefix + consts.FieldPrivateKeyWOVersion

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -1041,7 +1041,7 @@ func getDatabaseAPIDataForEngine(engine *dbEngine, idx int, d *schema.ResourceDa
 	case dbEngineRedisElastiCache:
 		setRedisElastiCacheDatabaseConnectionData(d, prefix, data)
 	case dbEngineSnowflake:
-		setDatabaseConnectionDataWithUserPassAndPrivateKey(d, prefix, data)
+		setDatabaseConnectionDataWithUserAndPrivateKey(d, prefix, data)
 	case dbEngineRedshift:
 		setDatabaseConnectionDataWithDisableEscaping(d, prefix, data)
 	default:
@@ -1873,10 +1873,8 @@ func setDatabaseConnectionDataWithDisableEscaping(d *schema.ResourceData, prefix
 	data["disable_escaping"] = d.Get(prefix + "disable_escaping")
 }
 
-func setDatabaseConnectionDataWithUserPassAndPrivateKey(d *schema.ResourceData, prefix string, data map[string]interface{}) {
-	setDatabaseConnectionDataWithUserPass(d, prefix, data)
-
-	// data[consts.FieldPrivateKey] = d.Get(prefix + consts.FieldPrivateKey)
+func setDatabaseConnectionDataWithUserAndPrivateKey(d *schema.ResourceData, prefix string, data map[string]interface{}) {
+	setDatabaseConnectionData(d, prefix, data)
 
 	privateKeyWriteOnlyVersionKey := prefix + consts.FieldPrivateKeyWOVersion
 	if d.IsNewResource() || d.HasChange(privateKeyWriteOnlyVersionKey) {
@@ -1896,7 +1894,7 @@ func setDatabaseConnectionDataWithUserPassAndPrivateKey(d *schema.ResourceData, 
 			// construct path to use GetRawConfig
 			path := cty.GetAttrPath(engineName).IndexInt(idx).GetAttr(consts.FieldPrivateKeyWO)
 			if pwWo, _ := d.GetRawConfigAt(path); !pwWo.IsNull() {
-				data[consts.FieldPrivateKeyWO] = pwWo.AsString()
+				data[consts.FieldPrivateKey] = pwWo.AsString()
 			}
 		}
 	}

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -1892,12 +1892,13 @@ func setDatabaseConnectionDataWithUserAndPrivateKey(d *schema.ResourceData, pref
 
 		// ensure Vault version has private key support
 		vaultVersion120Check := provider.IsAPISupported(meta, provider.VaultVersion120)
-		if !vaultVersion120Check {
-			log.Printf("[WARN] field %q can only be used with Vault version %s or newer", consts.FieldPrivateKeyWO, provider.VaultVersion120)
-		}
 
-		if pwWo, _ := d.GetRawConfigAt(path); !pwWo.IsNull() && vaultVersion120Check {
-			data[consts.FieldPrivateKey] = pwWo.AsString()
+		if pwWo, _ := d.GetRawConfigAt(path); !pwWo.IsNull() {
+			if vaultVersion120Check {
+				data[consts.FieldPrivateKey] = pwWo.AsString()
+			} else {
+				log.Printf("[WARN] field %q can only be used with Vault version %s or newer", consts.FieldPrivateKeyWO, provider.VaultVersion120)
+			}
 		}
 	}
 }

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -1874,26 +1874,26 @@ func setDatabaseConnectionDataWithUserAndPrivateKey(d *schema.ResourceData, pref
 
 	setDatabaseConnectionData(d, prefix, data)
 
+	data[consts.FieldUsername] = d.Get(prefix + consts.FieldUsername)
+
 	privateKeyWriteOnlyVersionKey := prefix + consts.FieldPrivateKeyWOVersion
 	if d.IsNewResource() || d.HasChange(privateKeyWriteOnlyVersionKey) {
-		if d.HasChange(privateKeyWriteOnlyVersionKey) {
-			engineName, engineIdx, err := databaseEngineNameAndIndexFromPrefix(prefix)
-			if err != nil {
-				// this should not happen, since we control how the prefix is created
-				panic(fmt.Sprintf("[ERROR] invalid prefix %q for database connection: %s", prefix, err))
-			}
+		engineName, engineIdx, err := databaseEngineNameAndIndexFromPrefix(prefix)
+		if err != nil {
+			// this should not happen, since we control how the prefix is created
+			panic(fmt.Sprintf("[ERROR] invalid prefix %q for database connection: %s", prefix, err))
+		}
 
-			idx, err := strconv.Atoi(engineIdx)
-			if err != nil {
-				// this should not happen, since we control how the index has been set
-				panic(fmt.Sprintf("[ERROR] unable to convert string index to integer: %s", err))
-			}
+		idx, err := strconv.Atoi(engineIdx)
+		if err != nil {
+			// this should not happen, since we control how the index has been set
+			panic(fmt.Sprintf("[ERROR] unable to convert string index to integer: %s", err))
+		}
 
-			// construct path to use GetRawConfig
-			path := cty.GetAttrPath(engineName).IndexInt(idx).GetAttr(consts.FieldPrivateKeyWO)
-			if pwWo, _ := d.GetRawConfigAt(path); !pwWo.IsNull() {
-				data[consts.FieldPrivateKey] = pwWo.AsString()
-			}
+		// construct path to use GetRawConfig
+		path := cty.GetAttrPath(engineName).IndexInt(idx).GetAttr(consts.FieldPrivateKeyWO)
+		if pwWo, _ := d.GetRawConfigAt(path); !pwWo.IsNull() {
+			data[consts.FieldPrivateKey] = pwWo.AsString()
 		}
 	}
 }

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -9,8 +9,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-testing/plancheck"
-	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -20,6 +18,9 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 
 	_ "github.com/denisenkom/go-mssqldb"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -1135,7 +1136,7 @@ func TestAccDatabaseSecretBackendConnection_elasticsearch(t *testing.T) {
 	})
 }
 
-func TestAccDatabaseSecretBackendConnection_snowflake(t *testing.T) {
+func TestAccDatabaseSecretBackendConnection_snowflake_userpass(t *testing.T) {
 	MaybeSkipDBTests(t, dbEngineSnowflake)
 
 	// TODO: make these fatal once we auto provision the required test infrastructure.
@@ -1149,7 +1150,7 @@ func TestAccDatabaseSecretBackendConnection_snowflake(t *testing.T) {
 	name := acctest.RandomWithPrefix("db")
 	userTempl := "{{.DisplayName}}"
 
-	config := testAccDatabaseSecretBackendConnectionConfig_snowflake(name, backend, connURL, username, password, userTempl)
+	config := testAccDatabaseSecretBackendConnectionConfig_snowflake_userpass(name, backend, connURL, username, password, userTempl)
 	resource.Test(t, resource.TestCase{
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck:                 func() { testutil.TestAccPreCheck(t) },
@@ -1165,6 +1166,43 @@ func TestAccDatabaseSecretBackendConnection_snowflake(t *testing.T) {
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "snowflake.0.connection_url", connURL),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "snowflake.0.username", username),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "snowflake.0.password", password),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "snowflake.0.username_template", userTempl),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatabaseSecretBackendConnection_snowflake_keypair(t *testing.T) {
+	MaybeSkipDBTests(t, dbEngineSnowflake)
+
+	// TODO: make these fatal once we auto provision the required test infrastructure.
+	values := testutil.SkipTestEnvUnset(t, "SNOWFLAKE_URL")
+	connURL := values[0]
+
+	username := os.Getenv("SNOWFLAKE_USERNAME")
+	privateKey := os.Getenv("SNOWFLAKE_PRIVATE_KEY")
+	backend := acctest.RandomWithPrefix("tf-test-db")
+	pluginName := dbEngineSnowflake.DefaultPluginName()
+	name := acctest.RandomWithPrefix("db")
+	userTempl := "{{.DisplayName}}"
+
+	config := testAccDatabaseSecretBackendConnectionConfig_snowflake_keypair(name, backend, connURL, username, privateKey, userTempl)
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		PreCheck:                 func() { testutil.TestAccPreCheck(t) },
+		CheckDestroy:             testAccDatabaseSecretBackendConnectionCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: testComposeCheckFuncCommonDatabaseSecretBackend(name, backend, pluginName,
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "verify_connection", "true"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "snowflake.0.connection_url", connURL),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "snowflake.0.username", username),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "snowflake.0.password", privateKey),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "snowflake.0.username_template", userTempl),
 				),
 			},
@@ -1322,7 +1360,6 @@ func TestAccDatabaseSecretBackendConnection_redshift(t *testing.T) {
 }
 
 func TestDatabaseEngineNameAndIndexFromPrefix(t *testing.T) {
-
 	testcases := []struct {
 		name         string
 		prefix       string
@@ -2084,7 +2121,7 @@ resource "vault_database_secret_backend_connection" "test" {
 `, path, name, connUrl, username, password, version)
 }
 
-func testAccDatabaseSecretBackendConnectionConfig_snowflake(name, path, url, username, password, userTempl string) string {
+func testAccDatabaseSecretBackendConnectionConfig_snowflake_userpass(name, path, url, username, password, userTempl string) string {
 	return fmt.Sprintf(`
 resource "vault_mount" "db" {
   path = "%s"
@@ -2105,6 +2142,31 @@ resource "vault_database_secret_backend_connection" "test" {
   }
 }
 `, path, name, url, username, password, userTempl)
+}
+
+func testAccDatabaseSecretBackendConnectionConfig_snowflake_keypair(name, path, url, username, privateKey, userTempl string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "db" {
+  path = "%s"
+  type = "database"
+}
+
+resource "vault_database_secret_backend_connection" "test" {
+  backend = vault_mount.db.path
+  name = "%s"
+  allowed_roles = ["dev", "prod"]
+  root_rotation_statements = ["FOOBAR"]
+
+  snowflake {
+    connection_url = "%s"
+    username = "%s"
+    private_key = <<-EOT
+%s
+EOT
+    username_template = "%s"
+  }
+}
+`, path, name, url, username, privateKey, userTempl)
 }
 
 func testAccDatabaseSecretBackendConnectionConfig_redis(name, path, host, port, username, password, allowedRoles string) string {

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -1210,6 +1210,11 @@ func TestAccDatabaseSecretBackendConnection_snowflake_keypair(t *testing.T) {
 			},
 			{
 				Config: testAccDatabaseSecretBackendConnectionConfig_snowflake_keypair(name, backend, connURL, username+"new", userTempl, privateKey, "2"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(testDefaultDatabaseSecretBackendResource, plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: testComposeCheckFuncCommonDatabaseSecretBackend(name, backend, pluginName,
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "allowed_roles.#", "2"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "allowed_roles.0", "dev"),

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -1190,8 +1190,11 @@ func TestAccDatabaseSecretBackendConnection_snowflake_keypair(t *testing.T) {
 	config := testAccDatabaseSecretBackendConnectionConfig_snowflake_keypair(name, backend, connURL, username, privateKey, userTempl)
 	resource.Test(t, resource.TestCase{
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
-		PreCheck:                 func() { testutil.TestAccPreCheck(t) },
-		CheckDestroy:             testAccDatabaseSecretBackendConnectionCheckDestroy,
+		PreCheck: func() {
+			testutil.TestAccPreCheck(t)
+			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion120)
+		},
+		CheckDestroy: testAccDatabaseSecretBackendConnectionCheckDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -1202,7 +1205,6 @@ func TestAccDatabaseSecretBackendConnection_snowflake_keypair(t *testing.T) {
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "verify_connection", "true"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "snowflake.0.connection_url", connURL),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "snowflake.0.username", username),
-					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "snowflake.0.private_key_wo", privateKey),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "snowflake.0.private_key_wo_version", "1"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "snowflake.0.username_template", userTempl),
 				),

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -1202,7 +1202,8 @@ func TestAccDatabaseSecretBackendConnection_snowflake_keypair(t *testing.T) {
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "verify_connection", "true"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "snowflake.0.connection_url", connURL),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "snowflake.0.username", username),
-					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "snowflake.0.password", privateKey),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "snowflake.0.private_key_wo", privateKey),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "snowflake.0.private_key_wo_version", "1"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "snowflake.0.username_template", userTempl),
 				),
 			},
@@ -2160,9 +2161,10 @@ resource "vault_database_secret_backend_connection" "test" {
   snowflake {
     connection_url = "%s"
     username = "%s"
-    private_key = <<-EOT
+    private_key_wo = <<-EOT
 %s
 EOT
+    private_key_wo_version = 1
     username_template = "%s"
   }
 }

--- a/website/docs/r/database_secret_backend_connection.md
+++ b/website/docs/r/database_secret_backend_connection.md
@@ -460,7 +460,7 @@ See the [Vault
 
 * `username` - (Optional) The username to be used in the connection (the account admin level).
 
-* `password` - (Optional) The password to be used in the connection.
+* `password` - **Deprecated** (Optional) The password to be used in the connection. Please begin migrating to key-pair authentication by [November 2025](https://www.snowflake.com/en/blog/blocking-single-factor-password-authentification/).
 
 * `private_key` - (Optional) The private key associated with the Snowflake user.
 

--- a/website/docs/r/database_secret_backend_connection.md
+++ b/website/docs/r/database_secret_backend_connection.md
@@ -460,7 +460,7 @@ See the [Vault
 
 * `username` - (Optional) The username to be used in the connection (the account admin level).
 
-* `password` - **Deprecated** (Optional) The password to be used in the connection. Please begin migrating to key-pair authentication by [November 2025](https://www.snowflake.com/en/blog/blocking-single-factor-password-authentification/).
+* `password` - **Deprecated** (Optional) The password to be used in the connection. Please migrate to key-pair authentication by [November 2025](https://www.snowflake.com/en/blog/blocking-single-factor-password-authentification/).
 
 * `private_key` - (Optional) The private key associated with the Snowflake user.
 

--- a/website/docs/r/database_secret_backend_connection.md
+++ b/website/docs/r/database_secret_backend_connection.md
@@ -462,7 +462,7 @@ See the [Vault
 
 * `password` - **Deprecated** (Optional) The password to be used in the connection. Please migrate to key-pair authentication by [November 2025](https://www.snowflake.com/en/blog/blocking-single-factor-password-authentification/).
 
-* `private_key` - (Optional) The private key associated with the Snowflake user.
+* `private_key_wo_version` - (Optional)  The version of the `private_key_wo`. For more info see [updating write-only attributes](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/guides/using_write_only_attributes.html#updating-write-only-attributes).
 
 * `username_template` - (Optional) - [Template](https://www.vaultproject.io/docs/concepts/username-templating) describing how dynamic usernames are generated.
 
@@ -498,6 +498,11 @@ See the [Vault
 The following write-only attributes are supported for all DBs that support username/password:
 
 * `password_wo` - (Optional) The password for the user. Can be updated.
+  **Note**: This property is write-only and will not be read from the API.
+
+The following write-only attribute is supported only for Snowflake DB:
+
+* `private_key_wo` - (Optional) The private key associated with the Snowflake user.
   **Note**: This property is write-only and will not be read from the API.
 
 ## Attributes Reference

--- a/website/docs/r/database_secret_backend_connection.md
+++ b/website/docs/r/database_secret_backend_connection.md
@@ -462,6 +462,8 @@ See the [Vault
 
 * `password` - (Optional) The password to be used in the connection.
 
+* `private_key` - (Optional) The private key associated with the Snowflake user.
+
 * `username_template` - (Optional) - [Template](https://www.vaultproject.io/docs/concepts/username-templating) describing how dynamic usernames are generated.
 
 * `password_wo_version` - (Optional)  The version of the `password_wo`. For more info see [updating write-only attributes](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/guides/using_write_only_attributes.html#updating-write-only-attributes).


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
Adds a private_key field to the snowflake block in a database secrets mount resource.


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccDatabaseSecretBackendConnection'

==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -run=TestAccDatabaseSecretBackendConnection -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/codegen   (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/framework/base[no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/framework/client      [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/framework/errutil     [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/framework/model       [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/framework/validators  (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity       (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group[no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/mfa [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/pki      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/provider (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/provider/fwprovider   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/providertest [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/rotation [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/sync     [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/vault/secrets/ephemeral       (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/vault/sys    (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
ok      github.com/hashicorp/terraform-provider-vault/testutil  (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util/mountutil    (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/vault     2.375s
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

