### PR TITLE
Fix empty data_json attribute

### DIFF
--- a/internal/vault/secrets/ephemeral/kv_secret_v2.go
+++ b/internal/vault/secrets/ephemeral/kv_secret_v2.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
+
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -16,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-vault/internal/framework/errutil"
 	"github.com/hashicorp/terraform-provider-vault/internal/framework/model"
 	"github.com/hashicorp/vault/api"
-	"strconv"
 )
 
 // Ensure the implementation satisfies the resource.ResourceWithConfigure interface
@@ -181,9 +182,10 @@ func (r *KVV2EphemeralSecretResource) Open(ctx context.Context, req ephemeral.Op
 	resp.Diagnostics.Append(diag...)
 	data.Data = secretData
 
-	jsonData, err := json.Marshal(data.Data)
+	jsonData, err := json.Marshal(readResp.Data)
 	if err != nil {
 		resp.Diagnostics.AddError("Error marshalling data to JSON", err.Error())
+		return
 	}
 
 	data.DataJSON = types.StringValue(string(jsonData))


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->

This PR updates the `vault_kv_secret_v2` resource to correctly populate the `data_json` attribute. 

The issue was `readResp.Data` which is a map[string]interface{} that contains the actual secret data, but the code was trying to marshal `[data.Data]` which is a `[types.Map]` (Terraform Framework type). Rather than throw an error, the resulting marshalled JSON was empty `{}`. The updated code marshals `readResp.Data` instead to populate the `data_json` attribute.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Closes #2520 


### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ TESTARGS="--run TestAccKVV2Secret" make testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test --run TestAccKVV2Secret -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/codegen   (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/framework/base[no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/framework/client       [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/framework/errutil      [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/framework/model[no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/framework/validators   (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity(cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group[no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/mfa  [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/pki      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/provider (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/provider/fwprovider    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/providertest  [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/rotation [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/sync     [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/vault/secrets/ephemeral        1.527s
ok      github.com/hashicorp/terraform-provider-vault/internal/vault/sys     (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
ok      github.com/hashicorp/terraform-provider-vault/testutil  (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util/mountutil    (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/vault     (cached) [no tests to run]
...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
