### PR TITLE
Add support for log_level PKI SCEP configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
         - "vault-enterprise:1.17.17-ent"
         - "vault-enterprise:1.18.10-ent"
         - "vault-enterprise:1.19.5-ent"
-        - "vault-enterprise:1.20.0-ent"
+        - "vault-enterprise:1.20.1-ent"
         - "vault:latest"
     services:
       vault:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ FEATURES:
 * Add support for `root_password_ttl` in `vault_azure_secret_backend` resource. Requires Vault 1.15+ ([#2529](https://github.com/hashicorp/terraform-provider-vault/pull/2529))
 * Add support for managed key parameters in the SSH CA config endpoint ([#2480](https://github.com/hashicorp/terraform-provider-vault/pull/2480))
 * Add new resources `vault_oci_auth_backend` and `vault_oci_auth_backend_role` to manage OCI auth backend and roles. ([#1761](https://github.com/hashicorp/terraform-provider-vault/pull/1761))
+* Add support for `log_level` in `vault_pki_secret_backend_config_scep` resource. Requires Vault 1.20.1+ ([#2525](https://github.com/hashicorp/terraform-provider-vault/pull/2525))
 
 ## 5.1.0 (Jul 9, 2025)
 

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -67,6 +67,7 @@ const (
 	FieldLastPassword                   = "last_password"
 	FieldLastVaultRotation              = "last_vault_rotation"
 	FieldLocal                          = "local"
+	FieldLogLevel                       = "log_level"
 	FieldSealWrap                       = "seal_wrap"
 	FieldExternalEntropyAccess          = "external_entropy_access"
 	FieldAWS                            = "aws"

--- a/vault/data_source_pki_secret_backend_config_scep.go
+++ b/vault/data_source_pki_secret_backend_config_scep.go
@@ -91,6 +91,11 @@ var pkiSecretBackendConfigScepDataSourceSchema = map[string]*schema.Schema{
 			},
 		},
 	},
+	consts.FieldLogLevel: {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "The level of logging verbosity, affects only SCEP logs on this mount",
+	},
 	consts.FieldLastUpdated: {
 		Type:        schema.TypeString,
 		Computed:    true,

--- a/vault/resource_pki_secret_backend_config_scep.go
+++ b/vault/resource_pki_secret_backend_config_scep.go
@@ -106,6 +106,12 @@ var pkiSecretBackendConfigScepResourceSchema = map[string]*schema.Schema{
 			},
 		},
 	},
+	consts.FieldLogLevel: {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Computed:    true,
+		Description: "The level of logging verbosity, affects only SCEP logs on this mount",
+	},
 	consts.FieldLastUpdated: {
 		Type:        schema.TypeString,
 		Computed:    true, // read-only property

--- a/vault/resource_pki_secret_backend_config_scep_test.go
+++ b/vault/resource_pki_secret_backend_config_scep_test.go
@@ -56,6 +56,7 @@ func TestAccPKISecretBackendConfigScep_Empty(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceBackend, consts.FieldExternalValidation+".#", "1"),
 					resource.TestCheckResourceAttr(resourceBackend, consts.FieldExternalValidation+".0.%", "1"),
 					resource.TestCheckResourceAttr(resourceBackend, consts.FieldExternalValidation+".0.intune.%", "0"),
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldLogLevel, ""),
 					resource.TestCheckResourceAttrSet(resourceBackend, consts.FieldLastUpdated),
 
 					// Validate we read back the data back as we did upon creation
@@ -75,6 +76,7 @@ func TestAccPKISecretBackendConfigScep_Empty(t *testing.T) {
 					resource.TestCheckResourceAttr(dataName, consts.FieldExternalValidation+".#", "1"),
 					resource.TestCheckResourceAttr(dataName, consts.FieldExternalValidation+".0.%", "1"),
 					resource.TestCheckResourceAttr(dataName, consts.FieldExternalValidation+".0.intune.%", "0"),
+					resource.TestCheckResourceAttr(dataName, consts.FieldLogLevel, ""),
 					resource.TestCheckResourceAttrSet(dataName, consts.FieldLastUpdated),
 				),
 			},
@@ -132,6 +134,7 @@ resource "vault_pki_secret_backend_config_scep" "test" {
   allowed_encryption_algorithms = ["des-cbc", "3des-cbc"]
   allowed_digest_algorithms = ["sha-1"]
   restrict_ca_chain_to_issuer = true
+  log_level = "trace"
   authenticators { 
 	cert = { "accessor" = "test", "cert_role" = "cert-role" }
     scep = { "accessor" = "auth-scep-accessor", "scep_role" = "scep-role"}
@@ -172,6 +175,7 @@ data "vault_pki_secret_backend_config_scep" "test" {
 					resource.TestCheckResourceAttr(resourceBackend, consts.FieldExternalValidation+".0.intune.%", "2"),
 					resource.TestCheckResourceAttr(resourceBackend, consts.FieldExternalValidation+".0.intune.client_id", "the client ID"),
 					resource.TestCheckResourceAttr(resourceBackend, consts.FieldExternalValidation+".0.intune.tenant_id", "the tenant ID"),
+					resource.TestCheckResourceAttr(resourceBackend, consts.FieldLogLevel, "trace"),
 
 					resource.TestCheckResourceAttr(dataName, consts.FieldBackend, backend),
 					resource.TestCheckResourceAttr(dataName, consts.FieldEnabled, "true"),
@@ -195,6 +199,7 @@ data "vault_pki_secret_backend_config_scep" "test" {
 					resource.TestCheckResourceAttr(dataName, consts.FieldExternalValidation+".0.intune.%", "2"),
 					resource.TestCheckResourceAttr(dataName, consts.FieldExternalValidation+".0.intune.client_id", "the client ID"),
 					resource.TestCheckResourceAttr(dataName, consts.FieldExternalValidation+".0.intune.tenant_id", "the tenant ID"),
+					resource.TestCheckResourceAttr(dataName, consts.FieldLogLevel, "trace"),
 				),
 			},
 			{

--- a/website/docs/d/pki_secret_backend_config_scep.html.md
+++ b/website/docs/d/pki_secret_backend_config_scep.html.md
@@ -62,6 +62,7 @@ The following arguments are supported:
 
 * `restrict_ca_chain_to_issuer` - If true, only return the issuer CA, otherwise the entire CA certificate chain will be returned if available from the PKI mount.
 
+* `log_level` - The level of logging verbosity, affects only SCEP logs on this mount.
 
 <a id="nestedatt--authenticators"></a>
 ### Nested Schema for `authenticators`

--- a/website/docs/r/pki_secret_backend_config_scep.html.md
+++ b/website/docs/r/pki_secret_backend_config_scep.html.md
@@ -72,6 +72,8 @@ The following arguments are supported:
 
 * `restrict_ca_chain_to_issuer` - (Optional) If true, only return the issuer CA, otherwise the entire CA certificate chain will be returned if available from the PKI mount.
 
+* `log_level` - (Optional) The level of logging verbosity, affects only SCEP logs on this mount.
+
 
 <a id="nestedatt--authenticators"></a>
 ### Nested Schema for `authenticators`


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
Add support for log_level PKI SCEP configuration.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Relates to #2487.

### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
❯ TESTARGS="--run 'Test.*ConfigScep'" make -C ~/hc/terraform-provider-vault testacc-ent
make testacc TF_ACC_ENTERPRISE=1
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test --run 'Test.*ConfigScep' -timeout 30m ./...
?   	github.com/hashicorp/terraform-provider-vault	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/generate	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/codegen	0.244s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/helper	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/consts	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/framework/base	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/framework/client	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/framework/errutil	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/framework/model	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/internal/framework/validators	0.343s [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/internal/identity/entity	0.475s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/group	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/mfa	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/pki	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/internal/provider	0.453s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/internal/provider/fwprovider	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/providertest	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/rotation	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/sync	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/internal/vault/secrets/ephemeral	0.454s [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/internal/vault/sys	1.176s [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/schema	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/testutil	0.467s [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/util	0.823s [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/util/mountutil	0.579s [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/vault	3.603s...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
