### PR TITLE
Update validation check for IAMAlias on vault_aws_auth_backend_config_identity resource

### DIFF
--- a/vault/resource_aws_auth_backend_config_identity.go
+++ b/vault/resource_aws_auth_backend_config_identity.go
@@ -36,7 +36,7 @@ func awsAuthBackendConfigIdentityResource() *schema.Resource {
 				Optional:     true,
 				Default:      "role_id",
 				Description:  "How to generate the identity alias when using the iam auth method.",
-				ValidateFunc: validation.StringInSlice([]string{"role_id", "unique_id", "full_arn"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"role_id", "unique_id", "full_arn", "canonical_arn"}, false),
 			},
 			consts.FieldIAMMetadata: {
 				Type:        schema.TypeSet,

--- a/website/docs/r/aws_auth_backend_config_identity.html.md
+++ b/website/docs/r/aws_auth_backend_config_identity.html.md
@@ -36,7 +36,7 @@ The following arguments are supported:
    *Available only for Vault Enterprise*.
 
 * `iam_alias` - (Optional) How to generate the identity alias when using the iam auth method. Valid choices are
-  `role_id`, `unique_id`, and `full_arn`. Defaults to `role_id`
+  `role_id`, `unique_id`, `full_arn`, and `canonical_arn`. Defaults to `role_id`
 
 * `iam_metadata` - (Optional) The metadata to include on the token returned by the `login` endpoint. This metadata will be
   added to both audit logs, and on the `iam_alias`


### PR DESCRIPTION
### Description
Update validation logic for IAMAlias parameter on ```vault_aws_auth_backend_config_identity``` resource. Vault added support for ```canonical_arn``` in Vault 1.16 but the Vault provider has a validation check that only allows ```role_id```, ```unique_id```, and ```full_arn```.

This change:
* Updates the validation logic to allow ```canonical_arn``` to be specified as a valid value for IAMAlias on  ```vault_aws_auth_backend_config_identity``` resource
* Updates the documentation for  ```vault_aws_auth_backend_config_identity``` resource

### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
