### PR TITLE
[New Data Source]: `vault_kv_secret_v2_metadata`

### DIFF
--- a/vault/data_source_kv_secret_v2.go
+++ b/vault/data_source_kv_secret_v2.go
@@ -91,7 +91,7 @@ func kvSecretV2DataSource() *schema.Resource {
 	}
 }
 
-func kvSecretV2DataSourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func kvSecretV2DataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client, e := provider.GetClient(d, meta)
 	if e != nil {
 		return diag.FromErr(e)
@@ -138,14 +138,14 @@ func kvSecretV2DataSourceRead(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.FromErr(err)
 	}
 
-	if v, ok := data.(map[string]interface{}); ok {
+	if v, ok := data.(map[string]any); ok {
 		if err := d.Set(consts.FieldData, serializeDataMapToString(v)); err != nil {
 			return diag.FromErr(err)
 		}
 	}
 
 	if v, ok := secret.Data["metadata"]; ok {
-		metadata := v.(map[string]interface{})
+		metadata := v.(map[string]any)
 
 		if v, ok := metadata["created_time"]; ok {
 			if err := d.Set("created_time", v); err != nil {
@@ -172,7 +172,7 @@ func kvSecretV2DataSourceRead(ctx context.Context, d *schema.ResourceData, meta 
 		}
 
 		if customMetadata, ok := metadata["custom_metadata"]; ok && customMetadata != nil {
-			if v, ok := customMetadata.(map[string]interface{}); ok {
+			if v, ok := customMetadata.(map[string]any); ok {
 				if err := d.Set("custom_metadata", serializeDataMapToString(v)); err != nil {
 					return diag.FromErr(err)
 				}

--- a/vault/data_source_kv_secret_v2.go
+++ b/vault/data_source_kv_secret_v2.go
@@ -91,7 +91,7 @@ func kvSecretV2DataSource() *schema.Resource {
 	}
 }
 
-func kvSecretV2DataSourceRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func kvSecretV2DataSourceRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client, e := provider.GetClient(d, meta)
 	if e != nil {
 		return diag.FromErr(e)
@@ -113,10 +113,10 @@ func kvSecretV2DataSourceRead(_ context.Context, d *schema.ResourceData, meta in
 		data := map[string][]string{
 			"version": {strconv.Itoa(v.(int))},
 		}
-		secret, err = client.Logical().ReadWithData(path, data)
+		secret, err = client.Logical().ReadWithDataWithContext(ctx, path, data)
 		log.Printf("[DEBUG] Reading secret at %q (version %d) from Vault", path, v)
 	} else {
-		secret, err = client.Logical().Read(path)
+		secret, err = client.Logical().ReadWithContext(ctx, path)
 		log.Printf("[DEBUG] Reading secret at %q (latest version) from Vault", path)
 	}
 

--- a/vault/data_source_kv_secret_v2.go
+++ b/vault/data_source_kv_secret_v2.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"log"
+	"maps"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -17,81 +18,107 @@ import (
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
+var kvSecretV2DataSourceMetadataFields = map[string]*schema.Schema{
+	consts.FieldMount: {
+		Type:        schema.TypeString,
+		Required:    true,
+		Description: "Path where KV-V2 engine is mounted",
+	},
+
+	consts.FieldName: {
+		Type:     schema.TypeString,
+		Required: true,
+		Description: "Full name of the secret. For a nested secret, " +
+			"the name is the nested path excluding the mount and data " +
+			"prefix. For example, for a secret at 'kvv2/data/foo/bar/baz', " +
+			"the name is 'foo/bar/baz'",
+	},
+
+	consts.FieldVersion: {
+		Type:        schema.TypeInt,
+		Optional:    true,
+		Description: "Version of the secret to retrieve",
+	},
+
+	consts.FieldPath: {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "Full path where the KVV2 secret is written.",
+	},
+
+	"created_time": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "Time at which the secret was created",
+	},
+
+	"custom_metadata": {
+		Type:        schema.TypeMap,
+		Computed:    true,
+		Description: "Custom metadata for the secret",
+	},
+
+	"deletion_time": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "Deletion time for the secret",
+	},
+
+	"destroyed": {
+		Type:        schema.TypeBool,
+		Computed:    true,
+		Description: "Indicates whether the secret has been destroyed",
+	},
+}
+
+var kvSecretV2DataSourceDataFields = map[string]*schema.Schema{
+	consts.FieldDataJSON: {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "JSON-encoded secret data read from Vault.",
+		Sensitive:   true,
+	},
+
+	consts.FieldData: {
+		Type:        schema.TypeMap,
+		Computed:    true,
+		Description: "Map of strings read from Vault.",
+		Sensitive:   true,
+	},
+}
+
 func kvSecretV2DataSource() *schema.Resource {
 	return &schema.Resource{
-		ReadContext:        provider.ReadContextWrapper(kvSecretV2DataSourceRead),
+		ReadContext: provider.ReadContextWrapper(func(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+			const includeData = true
+
+			return kvSecretV2DataSourceRead(ctx, d, meta, includeData)
+		}),
 		DeprecationMessage: "Deprecated. Please use new Ephemeral KVV2 Secret resource `vault_kv_secret_v2` instead",
 
-		Schema: map[string]*schema.Schema{
-			consts.FieldMount: {
-				Type:        schema.TypeString,
-				Required:    true,
-				Description: "Path where KV-V2 engine is mounted",
-			},
-
-			consts.FieldName: {
-				Type:     schema.TypeString,
-				Required: true,
-				Description: "Full name of the secret. For a nested secret, " +
-					"the name is the nested path excluding the mount and data " +
-					"prefix. For example, for a secret at 'kvv2/data/foo/bar/baz', " +
-					"the name is 'foo/bar/baz'",
-			},
-
-			consts.FieldVersion: {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Description: "Version of the secret to retrieve",
-			},
-
-			consts.FieldPath: {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Full path where the KVV2 secret is written.",
-			},
-
-			consts.FieldDataJSON: {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "JSON-encoded secret data read from Vault.",
-				Sensitive:   true,
-			},
-
-			consts.FieldData: {
-				Type:        schema.TypeMap,
-				Computed:    true,
-				Description: "Map of strings read from Vault.",
-				Sensitive:   true,
-			},
-
-			"created_time": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Time at which the secret was created",
-			},
-
-			"custom_metadata": {
-				Type:        schema.TypeMap,
-				Computed:    true,
-				Description: "Custom metadata for the secret",
-			},
-
-			"deletion_time": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Deletion time for the secret",
-			},
-
-			"destroyed": {
-				Type:        schema.TypeBool,
-				Computed:    true,
-				Description: "Indicates whether the secret has been destroyed",
-			},
-		},
+		Schema: mergeSchemaFields(
+			kvSecretV2DataSourceMetadataFields,
+			kvSecretV2DataSourceDataFields,
+		),
 	}
 }
 
-func kvSecretV2DataSourceRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+func mergeSchemaFields(ms ...map[string]*schema.Schema) map[string]*schema.Schema {
+	var size int
+	for _, m := range ms {
+		size += len(m)
+	}
+
+	out := make(map[string]*schema.Schema, size)
+
+	for _, m := range ms {
+		maps.Copy(out, m)
+	}
+
+	return out
+}
+
+func kvSecretV2DataSourceRead(ctx context.Context, d *schema.ResourceData, meta any, includeData bool) diag.Diagnostics {
 	client, e := provider.GetClient(d, meta)
 	if e != nil {
 		return diag.FromErr(e)
@@ -102,6 +129,8 @@ func kvSecretV2DataSourceRead(ctx context.Context, d *schema.ResourceData, meta 
 
 	// prefix for v2 secrets is "data"
 	path := getKVV2Path(mount, name, consts.FieldData)
+
+	d.SetId(path)
 
 	if err := d.Set(consts.FieldPath, path); err != nil {
 		return diag.FromErr(err)
@@ -125,23 +154,6 @@ func kvSecretV2DataSourceRead(ctx context.Context, d *schema.ResourceData, meta 
 	}
 	if secret == nil {
 		return diag.Errorf("no secret found at %q", path)
-	}
-
-	data := secret.Data["data"]
-
-	jsonData, err := json.Marshal(data)
-	if err != nil {
-		return diag.Errorf("error marshaling JSON for %q: %s", path, err)
-	}
-
-	if err := d.Set(consts.FieldDataJSON, string(jsonData)); err != nil {
-		return diag.FromErr(err)
-	}
-
-	if v, ok := data.(map[string]any); ok {
-		if err := d.Set(consts.FieldData, serializeDataMapToString(v)); err != nil {
-			return diag.FromErr(err)
-		}
 	}
 
 	if v, ok := secret.Data["metadata"]; ok {
@@ -180,7 +192,26 @@ func kvSecretV2DataSourceRead(ctx context.Context, d *schema.ResourceData, meta 
 		}
 	}
 
-	d.SetId(path)
+	if !includeData {
+		return nil
+	}
+
+	data := secret.Data["data"]
+
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return diag.Errorf("error marshaling JSON for %q: %s", path, err)
+	}
+
+	if err := d.Set(consts.FieldDataJSON, string(jsonData)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	if v, ok := data.(map[string]any); ok {
+		if err := d.Set(consts.FieldData, serializeDataMapToString(v)); err != nil {
+			return diag.FromErr(err)
+		}
+	}
 
 	return nil
 }

--- a/vault/data_source_kv_secret_v2_metadata.go
+++ b/vault/data_source_kv_secret_v2_metadata.go
@@ -1,0 +1,20 @@
+package vault
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+)
+
+func kvSecretV2MetadataDataSource() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: provider.ReadContextWrapper(func(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+			const includeData = false
+
+			return kvSecretV2DataSourceRead(ctx, d, meta, includeData)
+		}),
+		Schema: kvSecretV2DataSourceMetadataFields,
+	}
+}

--- a/vault/data_source_kv_secret_v2_metadata_test.go
+++ b/vault/data_source_kv_secret_v2_metadata_test.go
@@ -1,0 +1,167 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package vault
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/vault/api"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+	"github.com/hashicorp/terraform-provider-vault/testutil"
+)
+
+func TestDataSourceKVV2SecretMetadata(t *testing.T) {
+	t.Parallel()
+	mount := acctest.RandomWithPrefix("tf-kv")
+	name := acctest.RandomWithPrefix("foo")
+
+	resourceName := "data.vault_kv_secret_v2_metadata.test"
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		PreCheck:                 func() { testutil.TestAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testDataSourceKVV2SecretMetadataConfig(mount, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldMount, mount),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldName, name),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, fmt.Sprintf("%s/data/%s", mount, name)),
+					resource.TestCheckResourceAttr(resourceName, "destroyed", "false"),
+				),
+			},
+			{
+				Config: testDataSourceKVV2SecretMetadataWithVersionConfig(mount, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldMount, mount),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldName, name),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, fmt.Sprintf("%s/data/%s", mount, name)),
+					resource.TestCheckResourceAttr(resourceName, "destroyed", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestDataSourceKVV2SecretMetadata_deletedSecret(t *testing.T) {
+	mount := acctest.RandomWithPrefix("tf-kv")
+	name := acctest.RandomWithPrefix("foo")
+
+	config := fmt.Sprintf(`
+data "vault_kv_secret_v2_metadata" "test" {
+  mount = "%s"
+  name  = "%s"
+}
+`, mount, name)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		PreCheck:                 func() { testutil.TestAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() {
+					client := testProvider.Meta().(*provider.ProviderMeta).MustGetClient()
+
+					err := client.Sys().Mount(mount, &api.MountInput{
+						Type:        "kv-v2",
+						Description: "Mount for testing KV datasource",
+					})
+					if err != nil {
+						t.Fatalf("error mounting kvv2 engine; err=%s", err)
+					}
+
+					m := map[string]interface{}{
+						"foo": "bar",
+						"baz": "qux",
+					}
+
+					data := map[string]interface{}{
+						consts.FieldData: m,
+					}
+
+					// Write data at path
+					path := fmt.Sprintf("%s/data/%s", mount, name)
+					resp, err := client.Logical().Write(path, data)
+					if err != nil {
+						t.Fatalf("error writing to Vault; err=%s", err)
+					}
+
+					if resp == nil {
+						t.Fatalf("empty response")
+					}
+
+					// Soft Delete KV V2 secret at path
+					// Secret data returned from Vault is nil
+					// confirm that plan does not result in panic
+					_, err = client.Logical().Delete(path)
+					if err != nil {
+						t.Fatal(err)
+					}
+				},
+				Config:   config,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func testDataSourceKVV2SecretMetadataConfig(mount, name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "vault_kv_secret_v2" "test" {
+  mount                      = vault_mount.kvv2.path
+  name                       = "%s"
+  cas                        = 1
+  delete_all_versions        = true
+  data_json                  = jsonencode(
+  {
+      zip  = "zap",
+      foo  = "bar",
+      test = false
+      baz = {
+          riff = "raff"
+        }
+  }
+  )
+}
+
+data "vault_kv_secret_v2_metadata" "test" {
+  mount = vault_mount.kvv2.path
+  name  = vault_kv_secret_v2.test.name
+}`, kvV2MountConfig(mount), name)
+}
+
+func testDataSourceKVV2SecretMetadataWithVersionConfig(mount, name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "vault_kv_secret_v2" "test" {
+  mount                      = vault_mount.kvv2.path
+  name                       = "%s"
+  cas                        = 1
+  delete_all_versions        = true
+  data_json                  = jsonencode(
+  {
+      zip  = "zap",
+      foo  = "bar",
+      test = false
+      baz = {
+          riff = "raff"
+        }
+  }
+  )
+}
+
+data "vault_kv_secret_v2_metadata" "test" {
+  mount = vault_mount.kvv2.path
+  name  = vault_kv_secret_v2.test.name
+  version = 1
+}`, kvV2MountConfig(mount), name)
+}

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -151,6 +151,10 @@ var (
 			Resource:      UpdateSchemaResource(kvSecretV2DataSource()),
 			PathInventory: []string{"/secret/data/{path}/?version={version}}"},
 		},
+		"vault_kv_secret_v2_metadata": {
+			Resource:      UpdateSchemaResource(kvSecretV2MetadataDataSource()),
+			PathInventory: []string{"/secret/data/{path}/?version={version}}"},
+		},
 		"vault_kv_secrets_list": {
 			Resource:      UpdateSchemaResource(kvSecretListDataSource()),
 			PathInventory: []string{"/secret/{path}/?list=true"},

--- a/website/docs/d/kv_secret_v2_metadata.html.md
+++ b/website/docs/d/kv_secret_v2_metadata.html.md
@@ -1,0 +1,82 @@
+---
+layout: "vault"
+page_title: "Vault: vault_kv_secret_v2_metadata data source"
+sidebar_current: "docs-vault-datasource-kv-secret-v2-metadata"
+description: |-
+ Reads a KV-V2 secret's metadata from a given path in Vault
+---
+
+# vault\_kv\_secret\_v2\_metadata
+
+Reads a KV-V2 secret's metadata from a given path in Vault without exposing the secret content.
+
+This data source is primarily intended to be used with the `vault_kv_secret_v2` ephemeral data source.
+It provides non-ephemeral access to the secret's version number and other metadata without loading the sensitive secret content into the state file.
+The non-ephemeral version can then be used to [control updates of write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral/write-only#update-write-only-arguments-with-versions).
+
+
+## Example Usage
+
+```hcl
+data "vault_kv_secret_v2_metadata" "example" {
+  mount = "mount"
+  name  = "secret"
+}
+
+# Load explicit version to avoid drift between the stateful version and the ephemeral secret data.
+ephemeral "vault_kv_secret_v2" "example" {
+  mount   = data.vault_kv_secret_v2_metadata.example.mount
+  name    = data.vault_kv_secret_v2_metadata.example.name
+  version = data.vault_kv_secret_v2_metadata.example.version
+}
+
+# Use the ephemeral secret data and stateful version to control updates of write-only arguments.
+resource "vault_database_secret_backend_connection" "postgres" {
+  postgresql {
+    username    = ephemeral.vault_kv_secret_v2.example.data.username
+    password_wo = ephemeral.vault_kv_secret_v2.example.data.password
+
+    # Use non-ephemeral version from metadata data source to trigger updates when needed
+    password_wo_version = data.vault_kv_secret_v2_metadata.example.version
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `namespace` - (Optional) The namespace of the target resource.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
+  *Available only for Vault Enterprise*.
+
+* `mount` - (Required) Path where KV-V2 engine is mounted.
+
+* `name` - (Required) Full name of the secret. For a nested secret
+  the name is the nested path excluding the mount and data
+  prefix. For example, for a secret at `kvv2/data/foo/bar/baz`
+  the name is `foo/bar/baz`.
+
+* `version` - (Optional) Specific version of the secret metadata to retrieve.
+  If not specified, the latest version's metadata is returned.
+
+## Required Vault Capabilities
+
+Use of this resource requires the `read` capability on the given path.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `path` - (string) Full path where the KVV2 secret is written.
+
+* `created_time` - (string) Time at which secret was created.
+
+* `custom_metadata` - (map of strings) Custom metadata for the secret.
+
+* `deletion_time` - (string) Deletion time for the secret.
+
+* `destroyed` - (bool) Indicates whether the secret has been destroyed.
+
+* `version` - (int) Version of the secret.


### PR DESCRIPTION
### Description
This PR adds a new data source `vault_kv_secret_v2_metadata` that allows retrieving metadata from a KV-V2 secret without exposing the secret content itself.

The primary use case is to obtain non-ephemeral version information that can be used with write-only version arguments in downstream resources, solving a common issue when working with ephemeral secrets. This enables proper change tracking for Vault secrets while maintaining security by keeping the actual secret content ephemeral.

The new data source complements the existing `vault_kv_secret_v2` ephemeral data source by providing just the metadata (particularly the version number) without storing sensitive data in the Terraform state.

Closes #2537

### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry
- [x] Acceptance tests were run against all supported Vault Versions

### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestDataSourceKVV2SecretMetadata,TestDataSourceKVV2SecretMetadata_deletedSecret'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -run=TestDataSourceKVV2SecretMetadata,TestDataSourceKVV2SecretMetadata_deletedSecret -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/codegen   0.493s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/framework/base   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/framework/client [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/framework/errutil        [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/framework/model  [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/framework/validators     0.583s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  0.873s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/mfa     [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/pki      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/provider 0.835s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/provider/fwprovider      [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/providertest     [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/rotation [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/sync     [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/vault/secrets/ephemeral  0.666s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/vault/sys        1.221s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
ok      github.com/hashicorp/terraform-provider-vault/testutil  1.722s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util      1.457s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util/mountutil    0.751s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/vault     1.499s [no tests to run]
```

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
