### PR TITLE
Fix permanent diff on vault_rabbitmq_secret_backend_role

### DIFF
--- a/vault/resource_rabbitmq_secret_backend_role.go
+++ b/vault/resource_rabbitmq_secret_backend_role.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"sort"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -289,8 +290,17 @@ func expandRabbitMQSecretBackendRoleVhostTopic(vhost []interface{}) (string, err
 
 func flattenRabbitMQSecretBackendRoleVhost(vhost map[string]interface{}) []map[string]interface{} {
 	var vhosts []map[string]interface{}
-	for id, val := range vhost {
-		vals := val.(map[string]interface{})
+
+	// Get sorted keys
+	keys := make([]string, 0, len(vhost))
+	for k := range vhost {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	// Process in sorted order
+	for _, id := range keys {
+		vals := vhost[id].(map[string]interface{})
 		vhosts = append(vhosts, map[string]interface{}{
 			"host":      id,
 			"configure": vals["configure"],


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
This PR fixes https://github.com/hashicorp/terraform-provider-vault/issues/952
Add sorting for vhosts after read
Add test


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes https://github.com/hashicorp/terraform-provider-vault/issues/952

### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
$ make test TESTARGS='-v -run=TestFlattenRabbitMQSecretBackendRoleVhost_Order'                                                        (orbstack)
==> Checking that code complies with gofmt requirements...
TF_ACC= VAULT_TOKEN= go test -v -run=TestFlattenRabbitMQSecretBackendRoleVhost_Order -timeout 10m ./...
?   	github.com/hashicorp/terraform-provider-vault	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/generate	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/codegen	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/helper	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/consts	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/internal/identity/entity	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/group	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/mfa	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/pki	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/internal/provider	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/internal/rotation	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/sync	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/schema	[no test files]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/testutil	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/util	(cached) [no tests to run]
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/terraform-provider-vault/util/mountutil	(cached) [no tests to run]
=== RUN   TestFlattenRabbitMQSecretBackendRoleVhost_Order
--- PASS: TestFlattenRabbitMQSecretBackendRoleVhost_Order (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/vault	2.700s
...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
