### PR TITLE
merge JWT tune block fields using user provided values and tune API response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ FEATURES:
 * Add support for managed key parameters in the SSH CA config endpoint ([#2480](https://github.com/hashicorp/terraform-provider-vault/pull/2480))
 * Add new resources `vault_oci_auth_backend` and `vault_oci_auth_backend_role` to manage OCI auth backend and roles. ([#1761](https://github.com/hashicorp/terraform-provider-vault/pull/1761))
 
+BUGS:
+* Fix the tune block issue where it always updates unless field values match Vault server defaults
+  * `vault_jwt_auth_backend` resource ([#2546](https://github.com/hashicorp/terraform-provider-vault/pull/2546))
+
 ## 5.1.0 (Jul 9, 2025)
 
 FEATURES:

--- a/vault/resource_jwt_auth_backend.go
+++ b/vault/resource_jwt_auth_backend.go
@@ -420,9 +420,6 @@ func jwtAuthBackendUpdate(ctx context.Context, d *schema.ResourceData, meta inte
 		return diag.Errorf("error updating configuration to Vault for path %s: %s", path, err)
 	}
 
-	old, new := d.GetChange("tune")
-	log.Printf("[DEBUG] d('tune') %+v \n old %+v\n new %+v\n", d.Get("tune"), old, new)
-
 	if d.HasChange("tune") {
 		log.Printf("[INFO] JWT/OIDC Auth '%q' tune configuration changed", d.Id())
 		if raw, ok := d.GetOk("tune"); ok {

--- a/vault/resource_jwt_auth_backend_test.go
+++ b/vault/resource_jwt_auth_backend_test.go
@@ -68,6 +68,10 @@ func TestAccJWTAuthBackend(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceName, "bound_issuer", "api://default"),
 						resource.TestCheckResourceAttr(resourceName, "jwt_supported_algs.#", "1"),
 						resource.TestCheckResourceAttr(resourceName, "type", "jwt"),
+						resource.TestCheckResourceAttr(resourceName, "tune.0.token_type", "default-service"),
+						resource.TestCheckResourceAttr(resourceName, "tune.0.listing_visibility", "hidden"),
+						resource.TestCheckResourceAttr(resourceName, "tune.0.default_lease_ttl", ""),
+						resource.TestCheckResourceAttr(resourceName, "tune.0.max_lease_ttl", ""),
 					)...,
 				),
 			},
@@ -79,6 +83,10 @@ func TestAccJWTAuthBackend(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceName, "bound_issuer", "api://default"),
 						resource.TestCheckResourceAttr(resourceName, "jwt_supported_algs.#", "2"),
 						resource.TestCheckResourceAttr(resourceName, "type", "jwt"),
+						resource.TestCheckResourceAttr(resourceName, "tune.0.token_type", "default-service"),
+						resource.TestCheckResourceAttr(resourceName, "tune.0.listing_visibility", "hidden"),
+						resource.TestCheckResourceAttr(resourceName, "tune.0.default_lease_ttl", ""),
+						resource.TestCheckResourceAttr(resourceName, "tune.0.max_lease_ttl", ""),
 					)...,
 				),
 			},
@@ -367,6 +375,10 @@ resource "vault_jwt_auth_backend" "jwt" {
   bound_issuer       = "%s"
   jwt_supported_algs = [%s]
   path               = "%s"
+  tune {
+    token_type         = "default-service"
+    listing_visibility = "hidden"
+  }
 `, oidcDiscoveryUrl, boundIssuer, supportedAlgs, path)
 
 	var fragments []string

--- a/vault/resource_jwt_auth_backend_test.go
+++ b/vault/resource_jwt_auth_backend_test.go
@@ -69,7 +69,9 @@ func TestAccJWTAuthBackend(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceName, "jwt_supported_algs.#", "1"),
 						resource.TestCheckResourceAttr(resourceName, "type", "jwt"),
 						resource.TestCheckResourceAttr(resourceName, "tune.0.token_type", "default-service"),
-						resource.TestCheckResourceAttr(resourceName, "tune.0.listing_visibility", "hidden"),
+						// ensure the global default effect from Vault tune API is ignored,
+						// these fields should stay empty
+						resource.TestCheckResourceAttr(resourceName, "tune.0.listing_visibility", ""),
 						resource.TestCheckResourceAttr(resourceName, "tune.0.default_lease_ttl", ""),
 						resource.TestCheckResourceAttr(resourceName, "tune.0.max_lease_ttl", ""),
 					)...,
@@ -84,7 +86,9 @@ func TestAccJWTAuthBackend(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceName, "jwt_supported_algs.#", "2"),
 						resource.TestCheckResourceAttr(resourceName, "type", "jwt"),
 						resource.TestCheckResourceAttr(resourceName, "tune.0.token_type", "default-service"),
-						resource.TestCheckResourceAttr(resourceName, "tune.0.listing_visibility", "hidden"),
+						// ensure the global default effect from Vault tune API is ignored,
+						// these fields should stay empty
+						resource.TestCheckResourceAttr(resourceName, "tune.0.listing_visibility", ""),
 						resource.TestCheckResourceAttr(resourceName, "tune.0.default_lease_ttl", ""),
 						resource.TestCheckResourceAttr(resourceName, "tune.0.max_lease_ttl", ""),
 					)...,
@@ -377,7 +381,6 @@ resource "vault_jwt_auth_backend" "jwt" {
   path               = "%s"
   tune {
     token_type         = "default-service"
-    listing_visibility = "hidden"
   }
 `, oidcDiscoveryUrl, boundIssuer, supportedAlgs, path)
 

--- a/vault/structures.go
+++ b/vault/structures.go
@@ -86,6 +86,10 @@ func mergeAuthMethodTune(rawTune map[string]interface{}, input *api.MountConfigI
 		if input.MaxLeaseTTL == "" {
 			rawTune["max_lease_ttl"] = ""
 		}
+
+		if input.ListingVisibility == "" {
+			rawTune["listing_visibility"] = ""
+		}
 	}
 
 	return rawTune

--- a/vault/structures_test.go
+++ b/vault/structures_test.go
@@ -72,3 +72,47 @@ func TestFlattenAuthMethodTune(t *testing.T) {
 			expected)
 	}
 }
+
+func TestMergeAuthMethodTune(t *testing.T) {
+	rawTune := map[string]interface{}{
+		"default_lease_ttl":            "768h", // global default
+		"max_lease_ttl":                "768h", // global default
+		"audit_non_hmac_request_keys":  []interface{}{"foo", "bar"},
+		"audit_non_hmac_response_keys": []interface{}{},
+		"listing_visibility":           "",
+		"passthrough_request_headers":  []interface{}{"X-Custom", "X-Mas"},
+		"allowed_response_headers":     []interface{}{"X-Response-Custom", "X-Response-Mas"},
+		"token_type":                   "default-service",
+	}
+
+	input := &api.MountConfigInput{
+		DefaultLeaseTTL:           "",
+		MaxLeaseTTL:               "",
+		AuditNonHMACRequestKeys:   []string{"foo", "bar"},
+		AuditNonHMACResponseKeys:  []string{},
+		ListingVisibility:         "",
+		PassthroughRequestHeaders: []string{"X-Custom", "X-Mas"},
+		AllowedResponseHeaders:    []string{"X-Response-Custom", "X-Response-Mas"},
+		TokenType:                 "default-service",
+	}
+
+	expected := map[string]interface{}{
+		"default_lease_ttl":            "",
+		"max_lease_ttl":                "",
+		"audit_non_hmac_request_keys":  []interface{}{"foo", "bar"},
+		"audit_non_hmac_response_keys": []interface{}{},
+		"listing_visibility":           "",
+		"passthrough_request_headers":  []interface{}{"X-Custom", "X-Mas"},
+		"allowed_response_headers":     []interface{}{"X-Response-Custom", "X-Response-Mas"},
+		"token_type":                   "default-service",
+	}
+
+	actual := mergeAuthMethodTune(rawTune, input)
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf(
+			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
+			actual,
+			expected)
+	}
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
The  PR merges the raw tune GET API response with the user input parsed from the tune schema. Any field with the Vault APIs's global default effect will be set to empty when the user did not provide a value even if the Vault API response returns non-empty. This is to ensure the tune block reflects the user provided values.


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #2234


### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ TF_ACC_ENTERPRISE=1 TF_ACC=1 go test -v ./vault -run TestAccJWTAuthBackend
=== RUN   TestAccJWTAuthBackendRole_import
=== PAUSE TestAccJWTAuthBackendRole_import
=== RUN   TestAccJWTAuthBackendRole_basic
=== PAUSE TestAccJWTAuthBackendRole_basic
=== RUN   TestAccJWTAuthBackendRole_update
=== PAUSE TestAccJWTAuthBackendRole_update
=== RUN   TestAccJWTAuthBackendRole_full
=== PAUSE TestAccJWTAuthBackendRole_full
=== RUN   TestAccJWTAuthBackendRoleOIDC_full
=== PAUSE TestAccJWTAuthBackendRoleOIDC_full
=== RUN   TestAccJWTAuthBackendRoleOIDC_disableParsing
=== PAUSE TestAccJWTAuthBackendRoleOIDC_disableParsing
=== RUN   TestAccJWTAuthBackendRole_fullUpdate
=== PAUSE TestAccJWTAuthBackendRole_fullUpdate
=== RUN   TestAccJWTAuthBackend
=== PAUSE TestAccJWTAuthBackend
=== RUN   TestAccJWTAuthBackendProviderConfig
=== PAUSE TestAccJWTAuthBackendProviderConfig
=== RUN   TestAccJWTAuthBackend_OIDC
=== PAUSE TestAccJWTAuthBackend_OIDC
=== RUN   TestAccJWTAuthBackend_invalid
=== PAUSE TestAccJWTAuthBackend_invalid
=== RUN   TestAccJWTAuthBackend_missingMandatory
=== PAUSE TestAccJWTAuthBackend_missingMandatory
=== RUN   TestAccJWTAuthBackendProviderConfigConversionBool
=== PAUSE TestAccJWTAuthBackendProviderConfigConversionBool
=== RUN   TestAccJWTAuthBackendProviderConfigConversionInt
=== PAUSE TestAccJWTAuthBackendProviderConfigConversionInt
=== RUN   TestAccJWTAuthBackendProviderConfig_negative
    resource_jwt_auth_backend_test.go:608: true
--- SKIP: TestAccJWTAuthBackendProviderConfig_negative (0.00s)
=== RUN   TestAccJWTAuthBackendJWKSPairs_expectedError
--- PASS: TestAccJWTAuthBackendJWKSPairs_expectedError (1.77s)
=== CONT  TestAccJWTAuthBackendRoleOIDC_full
=== CONT  TestAccJWTAuthBackendRole_full
=== CONT  TestAccJWTAuthBackendProviderConfigConversionInt
=== CONT  TestAccJWTAuthBackend_invalid
=== CONT  TestAccJWTAuthBackendProviderConfigConversionBool
--- PASS: TestAccJWTAuthBackendProviderConfigConversionInt (0.00s)
=== CONT  TestAccJWTAuthBackendRole_basic
=== CONT  TestAccJWTAuthBackendRole_import
=== CONT  TestAccJWTAuthBackend_missingMandatory
=== CONT  TestAccJWTAuthBackend
=== RUN   TestAccJWTAuthBackend/basic
=== PAUSE TestAccJWTAuthBackend/basic
=== RUN   TestAccJWTAuthBackend/ns
=== PAUSE TestAccJWTAuthBackend/ns
=== CONT  TestAccJWTAuthBackendRole_update
=== CONT  TestAccJWTAuthBackendRole_fullUpdate
=== CONT  TestAccJWTAuthBackend_OIDC
--- PASS: TestAccJWTAuthBackendProviderConfigConversionBool (0.00s)
=== RUN   TestAccJWTAuthBackend_OIDC/basic
=== PAUSE TestAccJWTAuthBackend_OIDC/basic
=== RUN   TestAccJWTAuthBackend_OIDC/ns
=== PAUSE TestAccJWTAuthBackend_OIDC/ns
=== CONT  TestAccJWTAuthBackendProviderConfig
=== RUN   TestAccJWTAuthBackendProviderConfig/basic
=== PAUSE TestAccJWTAuthBackendProviderConfig/basic
=== RUN   TestAccJWTAuthBackendProviderConfig/ns
=== PAUSE TestAccJWTAuthBackendProviderConfig/ns
=== CONT  TestAccJWTAuthBackendRoleOIDC_disableParsing
=== CONT  TestAccJWTAuthBackend/basic
=== CONT  TestAccJWTAuthBackend/ns
--- PASS: TestAccJWTAuthBackend_invalid (0.63s)
=== CONT  TestAccJWTAuthBackend_OIDC/basic
--- PASS: TestAccJWTAuthBackendRole_basic (1.91s)
--- PASS: TestAccJWTAuthBackendRole_full (2.41s)
=== CONT  TestAccJWTAuthBackendProviderConfig/basic
--- PASS: TestAccJWTAuthBackendRoleOIDC_disableParsing (2.41s)
=== CONT  TestAccJWTAuthBackend_OIDC/ns
--- PASS: TestAccJWTAuthBackendRole_import (2.80s)
=== CONT  TestAccJWTAuthBackendProviderConfig/ns
--- PASS: TestAccJWTAuthBackendRoleOIDC_full (2.97s)
--- PASS: TestAccJWTAuthBackend_missingMandatory (3.28s)
--- PASS: TestAccJWTAuthBackendRole_update (3.51s)
--- PASS: TestAccJWTAuthBackendRole_fullUpdate (4.48s)
--- PASS: TestAccJWTAuthBackend_OIDC (0.00s)
    --- PASS: TestAccJWTAuthBackend_OIDC/basic (2.44s)
    --- PASS: TestAccJWTAuthBackend_OIDC/ns (4.11s)
--- PASS: TestAccJWTAuthBackendProviderConfig (0.00s)
    --- PASS: TestAccJWTAuthBackendProviderConfig/basic (2.36s)
    --- PASS: TestAccJWTAuthBackendProviderConfig/ns (5.00s)
--- PASS: TestAccJWTAuthBackend (0.00s)
    --- PASS: TestAccJWTAuthBackend/basic (7.61s)
    --- PASS: TestAccJWTAuthBackend/ns (9.18s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     12.339s
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
