### PR TITLE
secrets/ldap: static role support for racf passphrases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,11 +156,11 @@ jobs:
       fail-fast: false
       matrix:
         image:
-        - "vault-enterprise:1.16.24-ent"
+        - "vault-enterprise:1.16.25-ent"
         - "vault-enterprise:1.17.18-ent"
-        - "vault-enterprise:1.18.13-ent"
-        - "vault-enterprise:1.19.8-ent"
-        - "vault-enterprise:1.20.2-ent"
+        - "vault-enterprise:1.18.14-ent"
+        - "vault-enterprise:1.19.9-ent"
+        - "vault-enterprise:1.20.3-ent"
         - "vault:latest"
         terraform_version:
         - "latest" # always test against the latest stable, which might be a duplicate matrix member.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+FEATURES:
+
+* Add support for password phrases via the `credential_type` field in the `vault_ldap_secret_backend` resource ([#2548](https://github.com/hashicorp/terraform-provider-vault/pull/2548))
+
 BUGS:
 
 * Fix `azure_secret_backend_role` to prevent persistent diff for null value on `max_ttl` and  `explicit_max_ttl` argument ([#2581](https://github.com/hashicorp/terraform-provider-vault/pull/2581))

--- a/vault/resource_ldap_secret_backend_test.go
+++ b/vault/resource_ldap_secret_backend_test.go
@@ -70,6 +70,20 @@ func TestLDAPSecretBackend(t *testing.T) {
 				Check:  resource.TestCheckResourceAttr(resourceName, consts.FieldSkipStaticRoleImportRotation, "true"),
 			},
 			{
+				SkipFunc: func() (bool, error) {
+					return !testProvider.Meta().(*provider.ProviderMeta).IsAPISupported(provider.VaultVersion118), nil
+				},
+				Config: testLDAPSecretBackendConfig_defaults(path, bindDN, bindPass),
+				Check:  resource.TestCheckResourceAttr(resourceName, consts.FieldCredentialType, "password"),
+			},
+			{
+				SkipFunc: func() (bool, error) {
+					return !testProvider.Meta().(*provider.ProviderMeta).IsAPISupported(provider.VaultVersion118), nil
+				},
+				Config: testLDAPSecretBackendConfig_withCredType(path, bindDN, bindPass),
+				Check:  resource.TestCheckResourceAttr(resourceName, consts.FieldCredentialType, "phrase"),
+			},
+			{
 				Config: testLDAPSecretBackendConfig(path, updatedDescription, bindDN, bindPass, url, updatedUserDN, "openldap", false),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
@@ -246,6 +260,17 @@ resource "vault_ldap_secret_backend" "test" {
   binddn                    = "%s"
   bindpass                  = "%s"
   skip_static_role_import_rotation = true
+}`, path, bindDN, bindPass)
+}
+
+func testLDAPSecretBackendConfig_withCredType(path, bindDN, bindPass string) string {
+	return fmt.Sprintf(`
+resource "vault_ldap_secret_backend" "test" {
+  path            = "%s"
+  description     = "test description"
+  binddn          = "%s"
+  bindpass        = "%s"
+  credential_type = "phrase"
 }`, path, bindDN, bindPass)
 }
 

--- a/vault/resource_ldap_secret_backend_test.go
+++ b/vault/resource_ldap_secret_backend_test.go
@@ -71,14 +71,16 @@ func TestLDAPSecretBackend(t *testing.T) {
 			},
 			{
 				SkipFunc: func() (bool, error) {
-					return !testProvider.Meta().(*provider.ProviderMeta).IsAPISupported(provider.VaultVersion118), nil
+					supported := !testProvider.Meta().(*provider.ProviderMeta).IsAPISupported(provider.VaultVersion118) && provider.IsEnterpriseSupported(testProvider.Meta())
+					return supported, nil
 				},
 				Config: testLDAPSecretBackendConfig_defaults(path, bindDN, bindPass),
 				Check:  resource.TestCheckResourceAttr(resourceName, consts.FieldCredentialType, "password"),
 			},
 			{
 				SkipFunc: func() (bool, error) {
-					return !testProvider.Meta().(*provider.ProviderMeta).IsAPISupported(provider.VaultVersion118), nil
+					supported := !testProvider.Meta().(*provider.ProviderMeta).IsAPISupported(provider.VaultVersion118) && provider.IsEnterpriseSupported(testProvider.Meta())
+					return supported, nil
 				},
 				Config: testLDAPSecretBackendConfig_withCredType(path, bindDN, bindPass),
 				Check:  resource.TestCheckResourceAttr(resourceName, consts.FieldCredentialType, "phrase"),

--- a/vault/resource_ldap_secret_backend_test.go
+++ b/vault/resource_ldap_secret_backend_test.go
@@ -42,7 +42,6 @@ func TestLDAPSecretBackend(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion112)
 		}, PreventPostDestroyRefresh: true,
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeLDAP, consts.FieldPath),
 		Steps: []resource.TestStep{
@@ -71,16 +70,16 @@ func TestLDAPSecretBackend(t *testing.T) {
 			},
 			{
 				SkipFunc: func() (bool, error) {
-					supported := !testProvider.Meta().(*provider.ProviderMeta).IsAPISupported(provider.VaultVersion118) && provider.IsEnterpriseSupported(testProvider.Meta())
-					return supported, nil
+					meta := testProvider.Meta().(*provider.ProviderMeta)
+					return !(meta.IsAPISupported(provider.VaultVersion118) && meta.IsEnterpriseSupported()), nil
 				},
 				Config: testLDAPSecretBackendConfig_defaults(path, bindDN, bindPass),
 				Check:  resource.TestCheckResourceAttr(resourceName, consts.FieldCredentialType, "password"),
 			},
 			{
 				SkipFunc: func() (bool, error) {
-					supported := !testProvider.Meta().(*provider.ProviderMeta).IsAPISupported(provider.VaultVersion118) && provider.IsEnterpriseSupported(testProvider.Meta())
-					return supported, nil
+					meta := testProvider.Meta().(*provider.ProviderMeta)
+					return !(meta.IsAPISupported(provider.VaultVersion118) && meta.IsEnterpriseSupported()), nil
 				},
 				Config: testLDAPSecretBackendConfig_withCredType(path, bindDN, bindPass),
 				Check:  resource.TestCheckResourceAttr(resourceName, consts.FieldCredentialType, "phrase"),

--- a/website/docs/r/ldap_secret_backend.html.md
+++ b/website/docs/r/ldap_secret_backend.html.md
@@ -71,6 +71,8 @@ The following arguments are supported:
 
 * `schema` - (Optional)  The LDAP schema to use when storing entry passwords. Valid schemas include `openldap`, `ad`, and `racf`. Default is `openldap`.
 
+* `credential_type` - (Optional) The type of credential to generate. Valid values include `password` and `phrase`. Default is `password`.
+
 * `upndomain` - (Optional) Enables userPrincipalDomain login with [username]@UPNDomain.
 
 * `url` - (Required) LDAP URL to connect to. Multiple URLs can be specified by concatenating


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
Support RACF password phrase management for static roles in `vault_ldap_secret_backend`

Relates to https://github.com/hashicorp/vault-plugin-secrets-openldap/pull/184

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000


### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
