### PR TITLE
Fix panic when reading vault_gcp_secret_backend resource

### DIFF
--- a/vault/resource_gcp_secret_backend.go
+++ b/vault/resource_gcp_secret_backend.go
@@ -231,6 +231,9 @@ func gcpSecretBackendRead(ctx context.Context, d *schema.ResourceData, meta inte
 		if err != nil {
 			return diag.FromErr(err)
 		}
+		if resp == nil {
+			return diag.FromErr(fmt.Errorf("GCP backend config %q not found", path))
+		}
 
 		fields := []string{
 			consts.FieldIdentityTokenAudience,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->



### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->

Add a guard before using the response of Vault's gcp/config endpoint, which can return a nil response and no errors.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->


### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
❯ TESTARGS="--run 'TestGCP|TestAccGCP'" make -C ~/hc/terraform-provider-vault testacc
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test --run 'TestGCP|TestAccGCP' -timeout 30m ./...
?   	github.com/hashicorp/terraform-provider-vault	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/coverage	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/cmd/generate	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/codegen	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/helper	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/consts	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/framework/base	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/framework/client	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/framework/errutil	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/framework/model	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/internal/framework/validators	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/internal/identity/entity	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/group	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/identity/mfa	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/pki	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/internal/provider	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/internal/provider/fwprovider	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/providertest	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/rotation	[no test files]
?   	github.com/hashicorp/terraform-provider-vault/internal/sync	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/internal/vault/secrets/ephemeral	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/internal/vault/sys	(cached) [no tests to run]
?   	github.com/hashicorp/terraform-provider-vault/schema	[no test files]
ok  	github.com/hashicorp/terraform-provider-vault/testutil	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/util	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/util/mountutil	(cached) [no tests to run]
ok  	github.com/hashicorp/terraform-provider-vault/vault	12.338s
...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
