### PR TITLE
merge JWT tune block fields using user provided values and tune API response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ BUILD:
 
 BUGS:
 * Fix panic when reading the `vault_gcp_secret_backend` resource. ([#2549](https://github.com/hashicorp/terraform-provider-vault/pull/2549))
+* Fix the tune block issue where it always updates unless field values match Vault server defaults
+  * `vault_jwt_auth_backend` resource ([#2546](https://github.com/hashicorp/terraform-provider-vault/pull/2546))
 
 ## 5.1.0 (Jul 9, 2025)
 

--- a/vault/resource_jwt_auth_backend.go
+++ b/vault/resource_jwt_auth_backend.go
@@ -339,7 +339,15 @@ func jwtAuthBackendRead(ctx context.Context, d *schema.ResourceData, meta interf
 	if err != nil {
 		return diag.Errorf("error reading tune information from Vault: %s", err)
 	}
-	if err := d.Set("tune", []map[string]interface{}{rawTune}); err != nil {
+
+	input, err := retrieveMountConfigInput(d)
+	if err != nil {
+		return diag.Errorf("error retrieving tune configuration from state: %s", err)
+	}
+
+	mergedTune := mergeAuthMethodTune(rawTune, input)
+
+	if err := d.Set("tune", []map[string]interface{}{mergedTune}); err != nil {
 		log.Printf("[ERROR] Error when setting tune config from path %q to state: %s", path+"/tune", err)
 		return diag.FromErr(err)
 	}

--- a/vault/resource_jwt_auth_backend_test.go
+++ b/vault/resource_jwt_auth_backend_test.go
@@ -12,8 +12,10 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/vault/api"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -68,6 +70,12 @@ func TestAccJWTAuthBackend(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceName, "bound_issuer", "api://default"),
 						resource.TestCheckResourceAttr(resourceName, "jwt_supported_algs.#", "1"),
 						resource.TestCheckResourceAttr(resourceName, "type", "jwt"),
+						resource.TestCheckResourceAttr(resourceName, "tune.0.token_type", "default-service"),
+						// ensure the global default effect from Vault tune API is ignored,
+						// these fields should stay empty
+						resource.TestCheckResourceAttr(resourceName, "tune.0.listing_visibility", ""),
+						resource.TestCheckResourceAttr(resourceName, "tune.0.default_lease_ttl", ""),
+						resource.TestCheckResourceAttr(resourceName, "tune.0.max_lease_ttl", ""),
 					)...,
 				),
 			},
@@ -79,6 +87,12 @@ func TestAccJWTAuthBackend(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceName, "bound_issuer", "api://default"),
 						resource.TestCheckResourceAttr(resourceName, "jwt_supported_algs.#", "2"),
 						resource.TestCheckResourceAttr(resourceName, "type", "jwt"),
+						resource.TestCheckResourceAttr(resourceName, "tune.0.token_type", "default-service"),
+						// ensure the global default effect from Vault tune API is ignored,
+						// these fields should stay empty
+						resource.TestCheckResourceAttr(resourceName, "tune.0.listing_visibility", ""),
+						resource.TestCheckResourceAttr(resourceName, "tune.0.default_lease_ttl", ""),
+						resource.TestCheckResourceAttr(resourceName, "tune.0.max_lease_ttl", ""),
 					)...,
 				),
 			},
@@ -367,6 +381,9 @@ resource "vault_jwt_auth_backend" "jwt" {
   bound_issuer       = "%s"
   jwt_supported_algs = [%s]
   path               = "%s"
+  tune {
+    token_type         = "default-service"
+  }
 `, oidcDiscoveryUrl, boundIssuer, supportedAlgs, path)
 
 	var fragments []string
@@ -706,4 +723,47 @@ EOT`
 			},
 		},
 	})
+}
+
+func TestAccJWTAuthBackend_importTuning(t *testing.T) {
+	testutil.SkipTestAcc(t)
+
+	path := acctest.RandomWithPrefix("jwt")
+	resourceType := "vault_jwt_auth_backend"
+	resourceName := resourceType + ".test"
+	var resAuth api.AuthMount
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutil.TestAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		CheckDestroy:             testCheckMountDestroyed(resourceType, consts.MountTypeJWT, consts.FieldPath),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccJWTAuthBackendConfig_tuning(path),
+				Check: testutil.TestAccCheckAuthMountExists(resourceName,
+					&resAuth,
+					testProvider.Meta().(*provider.ProviderMeta).MustGetClient()),
+			},
+			testutil.GetImportTestStep(resourceName, false, nil, "description", "disable_remount"),
+		},
+	})
+}
+
+func testAccJWTAuthBackendConfig_tuning(path string) string {
+	return fmt.Sprintf(`
+resource "vault_jwt_auth_backend" "test" {
+  description        = "JWT backend"
+  oidc_discovery_url = "https://myco.auth0.com/"
+  path			     = "%s"
+  tune {
+    default_lease_ttl = "10m"
+    max_lease_ttl = "20m"
+    listing_visibility = "hidden"
+    audit_non_hmac_request_keys = ["key1", "key2"]
+    audit_non_hmac_response_keys = ["key3", "key4"]
+    passthrough_request_headers = ["X-Custom-Header", "X-Forwarded-To"]
+    allowed_response_headers = ["X-Custom-Response-Header", "X-Forwarded-Response-To"]
+    token_type = "batch"
+  }
+}
+`, path)
 }

--- a/vault/structures_test.go
+++ b/vault/structures_test.go
@@ -72,3 +72,47 @@ func TestFlattenAuthMethodTune(t *testing.T) {
 			expected)
 	}
 }
+
+func TestMergeAuthMethodTune(t *testing.T) {
+	rawTune := map[string]interface{}{
+		"default_lease_ttl":            "768h", // global default
+		"max_lease_ttl":                "768h", // global default
+		"audit_non_hmac_request_keys":  []interface{}{"foo", "bar"},
+		"audit_non_hmac_response_keys": []interface{}{},
+		"listing_visibility":           "",
+		"passthrough_request_headers":  []interface{}{"X-Custom", "X-Mas"},
+		"allowed_response_headers":     []interface{}{"X-Response-Custom", "X-Response-Mas"},
+		"token_type":                   "default-service",
+	}
+
+	input := &api.MountConfigInput{
+		DefaultLeaseTTL:           "",
+		MaxLeaseTTL:               "",
+		AuditNonHMACRequestKeys:   []string{"foo", "bar"},
+		AuditNonHMACResponseKeys:  []string{},
+		ListingVisibility:         "",
+		PassthroughRequestHeaders: []string{"X-Custom", "X-Mas"},
+		AllowedResponseHeaders:    []string{"X-Response-Custom", "X-Response-Mas"},
+		TokenType:                 "default-service",
+	}
+
+	expected := map[string]interface{}{
+		"default_lease_ttl":            "",
+		"max_lease_ttl":                "",
+		"audit_non_hmac_request_keys":  []interface{}{"foo", "bar"},
+		"audit_non_hmac_response_keys": []interface{}{},
+		"listing_visibility":           "",
+		"passthrough_request_headers":  []interface{}{"X-Custom", "X-Mas"},
+		"allowed_response_headers":     []interface{}{"X-Response-Custom", "X-Response-Mas"},
+		"token_type":                   "default-service",
+	}
+
+	actual := mergeAuthMethodTune(rawTune, input)
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf(
+			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
+			actual,
+			expected)
+	}
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->

The PR merges the raw tune GET API response with the user input parsed from the tune schema. Any field with the Vault APIs's global default effect will be set to empty when the user did not provide a value even if the Vault API response returns non-empty. This is to ensure the tune block reflects the user provided values.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Relates OR Closes https://github.com/hashicorp/terraform-provider-vault/issues/2234

### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ TF_ACC_ENTERPRISE=1 TF_ACC=1 go test -v ./vault -run TestAccJWTAuthBackend
=== RUN   TestAccJWTAuthBackendRole_import
=== PAUSE TestAccJWTAuthBackendRole_import
=== RUN   TestAccJWTAuthBackendRole_basic
=== PAUSE TestAccJWTAuthBackendRole_basic
=== RUN   TestAccJWTAuthBackendRole_update
=== PAUSE TestAccJWTAuthBackendRole_update
=== RUN   TestAccJWTAuthBackendRole_full
=== PAUSE TestAccJWTAuthBackendRole_full
=== RUN   TestAccJWTAuthBackendRoleOIDC_full
=== PAUSE TestAccJWTAuthBackendRoleOIDC_full
=== RUN   TestAccJWTAuthBackendRoleOIDC_disableParsing
=== PAUSE TestAccJWTAuthBackendRoleOIDC_disableParsing
=== RUN   TestAccJWTAuthBackendRole_fullUpdate
=== PAUSE TestAccJWTAuthBackendRole_fullUpdate
=== RUN   TestAccJWTAuthBackend
=== PAUSE TestAccJWTAuthBackend
=== RUN   TestAccJWTAuthBackendProviderConfig
=== PAUSE TestAccJWTAuthBackendProviderConfig
=== RUN   TestAccJWTAuthBackend_OIDC
=== PAUSE TestAccJWTAuthBackend_OIDC
=== RUN   TestAccJWTAuthBackend_invalid
=== PAUSE TestAccJWTAuthBackend_invalid
=== RUN   TestAccJWTAuthBackend_missingMandatory
=== PAUSE TestAccJWTAuthBackend_missingMandatory
=== RUN   TestAccJWTAuthBackendProviderConfigConversionBool
=== PAUSE TestAccJWTAuthBackendProviderConfigConversionBool
=== RUN   TestAccJWTAuthBackendProviderConfigConversionInt
=== PAUSE TestAccJWTAuthBackendProviderConfigConversionInt
=== RUN   TestAccJWTAuthBackendProviderConfig_negative
    resource_jwt_auth_backend_test.go:613: true
--- SKIP: TestAccJWTAuthBackendProviderConfig_negative (0.00s)
=== RUN   TestAccJWTAuthBackendJWKSPairs_expectedError
--- PASS: TestAccJWTAuthBackendJWKSPairs_expectedError (1.49s)
=== RUN   TestAccJWTAuthBackend_importTuning
--- PASS: TestAccJWTAuthBackend_importTuning (2.22s)
=== CONT  TestAccJWTAuthBackendRole_import
=== CONT  TestAccJWTAuthBackend_invalid
=== CONT  TestAccJWTAuthBackendProviderConfigConversionInt
=== CONT  TestAccJWTAuthBackendRoleOIDC_full
=== CONT  TestAccJWTAuthBackendRole_update
=== CONT  TestAccJWTAuthBackendRole_full
=== CONT  TestAccJWTAuthBackendRole_basic
=== CONT  TestAccJWTAuthBackendRole_fullUpdate
=== CONT  TestAccJWTAuthBackend
=== CONT  TestAccJWTAuthBackend_missingMandatory
=== RUN   TestAccJWTAuthBackend/basic
=== PAUSE TestAccJWTAuthBackend/basic
=== RUN   TestAccJWTAuthBackend/ns
=== PAUSE TestAccJWTAuthBackend/ns
=== CONT  TestAccJWTAuthBackend_OIDC
=== RUN   TestAccJWTAuthBackend_OIDC/basic
=== PAUSE TestAccJWTAuthBackend_OIDC/basic
=== RUN   TestAccJWTAuthBackend_OIDC/ns
=== PAUSE TestAccJWTAuthBackend_OIDC/ns
--- PASS: TestAccJWTAuthBackendProviderConfigConversionInt (0.00s)
=== CONT  TestAccJWTAuthBackendProviderConfigConversionBool
--- PASS: TestAccJWTAuthBackendProviderConfigConversionBool (0.00s)
=== CONT  TestAccJWTAuthBackendRoleOIDC_disableParsing
=== CONT  TestAccJWTAuthBackendProviderConfig
=== RUN   TestAccJWTAuthBackendProviderConfig/basic
=== PAUSE TestAccJWTAuthBackendProviderConfig/basic
=== RUN   TestAccJWTAuthBackendProviderConfig/ns
=== PAUSE TestAccJWTAuthBackendProviderConfig/ns
=== CONT  TestAccJWTAuthBackend/basic
--- PASS: TestAccJWTAuthBackend_invalid (0.60s)
=== CONT  TestAccJWTAuthBackend/ns
=== CONT  TestAccJWTAuthBackend_OIDC/basic
--- PASS: TestAccJWTAuthBackendRoleOIDC_disableParsing (1.99s)
--- PASS: TestAccJWTAuthBackendRoleOIDC_full (2.41s)
=== CONT  TestAccJWTAuthBackend_OIDC/ns
--- PASS: TestAccJWTAuthBackendRole_basic (2.46s)
=== CONT  TestAccJWTAuthBackendProviderConfig/basic
=== CONT  TestAccJWTAuthBackendProviderConfig/ns
--- PASS: TestAccJWTAuthBackendRole_full (2.46s)
--- PASS: TestAccJWTAuthBackendRole_import (3.16s)
--- PASS: TestAccJWTAuthBackend_missingMandatory (3.31s)
--- PASS: TestAccJWTAuthBackendRole_update (3.87s)
--- PASS: TestAccJWTAuthBackendRole_fullUpdate (5.27s)
--- PASS: TestAccJWTAuthBackend_OIDC (0.00s)
    --- PASS: TestAccJWTAuthBackend_OIDC/basic (2.53s)
    --- PASS: TestAccJWTAuthBackend_OIDC/ns (4.53s)
--- PASS: TestAccJWTAuthBackendProviderConfig (0.00s)
    --- PASS: TestAccJWTAuthBackendProviderConfig/basic (2.59s)
    --- PASS: TestAccJWTAuthBackendProviderConfig/ns (5.42s)
--- PASS: TestAccJWTAuthBackend (0.00s)
    --- PASS: TestAccJWTAuthBackend/basic (7.65s)
    --- PASS: TestAccJWTAuthBackend/ns (9.33s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault   14.553s
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
