### PR TITLE
merge tune block fields using user provided values and tune API response - GitHub and generic auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ BUGS:
 * Fix panic when reading the `vault_gcp_secret_backend` resource. ([#2549](https://github.com/hashicorp/terraform-provider-vault/pull/2549))
 * Fix the tune block issue where it always updates unless field values match Vault server defaults
   * `vault_jwt_auth_backend` resource ([#2560](https://github.com/hashicorp/terraform-provider-vault/pull/2560))
+  * `vault_github_auth_backend` and `vault_auth_backend` resources ([#2565](https://github.com/hashicorp/terraform-provider-vault/pull/2565))
 
 ## 5.1.0 (Jul 9, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+BEHAVIOR CHANGES: Please refer to the [upgrade topics](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/guides/version_5_upgrade.html#upgrade-topics)
+in the guide for details on all behavior changes.
 
 FEATURES:
 * Add support for `jwks_pairs` in `vault_jwt_auth_backend` resource. Requires Vault 1.16+ ([#2523](https://github.com/hashicorp/terraform-provider-vault/pull/2523))

--- a/vault/resource_github_auth_backend_test.go
+++ b/vault/resource_github_auth_backend_test.go
@@ -52,6 +52,12 @@ func TestAccGithubAuthBackend_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "token_ttl", "1200"),
 					resource.TestCheckResourceAttr(resourceName, "token_max_ttl", "3000"),
 					resource.TestCheckResourceAttrPtr(resourceName, "accessor", &resAuth.Accessor),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.token_type", "default-service"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.max_lease_ttl", "1h"),
+					// ensure the global default effect from Vault tune API is ignored,
+					// these fields should stay empty
+					resource.TestCheckResourceAttr(resourceName, "tune.0.listing_visibility", ""),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.default_lease_ttl", ""),
 				),
 			},
 			{
@@ -67,6 +73,12 @@ func TestAccGithubAuthBackend_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "token_ttl", "2400"),
 					resource.TestCheckResourceAttr(resourceName, "token_max_ttl", "6000"),
 					resource.TestCheckResourceAttrPtr(resourceName, "accessor", &resAuth.Accessor),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.token_type", "batch"),
+					// ensure the global default effect from Vault tune API is ignored,
+					// these fields should stay empty
+					resource.TestCheckResourceAttr(resourceName, "tune.0.listing_visibility", ""),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.default_lease_ttl", ""),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.max_lease_ttl", ""),
 				),
 			},
 		},
@@ -243,30 +255,7 @@ func TestAccGithubAuthBackend_description(t *testing.T) {
 	})
 }
 
-func TestAccGithubAuthBackend_importTuning(t *testing.T) {
-	testutil.SkipTestAcc(t)
-
-	path := acctest.RandomWithPrefix("github")
-	resourceType := "vault_github_auth_backend"
-	resourceName := resourceType + ".test"
-	var resAuth api.AuthMount
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testutil.TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
-		CheckDestroy:             testCheckMountDestroyed(resourceType, consts.MountTypeGitHub, consts.FieldPath),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccGithubAuthBackendConfig_tuning(path),
-				Check: testutil.TestAccCheckAuthMountExists(resourceName,
-					&resAuth,
-					testProvider.Meta().(*provider.ProviderMeta).MustGetClient()),
-			},
-			testutil.GetImportTestStep(resourceName, false, nil, "disable_remount"),
-		},
-	})
-}
-
-func TestGithubAuthBackend_remount(t *testing.T) {
+func TestAccGithubAuthBackend_remount(t *testing.T) {
 	testutil.SkipTestAcc(t)
 
 	path := acctest.RandomWithPrefix("tf-test-gh")
@@ -315,7 +304,53 @@ func TestGithubAuthBackend_remount(t *testing.T) {
 					resource.TestCheckResourceAttrPtr(resourceName, "accessor", &resAuth.Accessor),
 				),
 			},
-			testutil.GetImportTestStep(resourceName, false, nil, "disable_remount"),
+		},
+	})
+}
+
+func TestAccGithubAuthBackend_importTune(t *testing.T) {
+	testutil.SkipTestAcc(t)
+
+	orgMeta := testutil.GetGHOrgResponse(t, testGHOrg)
+	backend := acctest.RandomWithPrefix("github-import-tune")
+	resourceType := "vault_github_auth_backend"
+	resourceName := resourceType + ".test"
+	var resAuth api.AuthMount
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		PreCheck:                 func() { testutil.TestAccPreCheck(t) },
+		CheckDestroy:             testCheckMountDestroyed(resourceType, consts.MountTypeGitHub, consts.FieldPath),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGithubAuthBackendConfig_tuning(backend),
+				Check: resource.ComposeTestCheckFunc(
+					testutil.TestAccCheckAuthMountExists(resourceName,
+						&resAuth,
+						testProvider.Meta().(*provider.ProviderMeta).MustGetClient()),
+					resource.TestCheckResourceAttr(resourceName, "id", backend),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, backend),
+					resource.TestCheckResourceAttr(resourceName, "organization", testGHOrg),
+					resource.TestCheckResourceAttr(resourceName, "organization_id", strconv.Itoa(orgMeta.ID)),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.default_lease_ttl", "10m"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.max_lease_ttl", "20m"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.listing_visibility", "hidden"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.token_type", "batch"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.audit_non_hmac_request_keys.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.audit_non_hmac_request_keys.0", "key1"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.audit_non_hmac_request_keys.1", "key2"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.audit_non_hmac_response_keys.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.audit_non_hmac_response_keys.0", "key3"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.audit_non_hmac_response_keys.1", "key4"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.passthrough_request_headers.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.passthrough_request_headers.0", "X-Custom-Header"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.passthrough_request_headers.1", "X-Forwarded-To"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.allowed_response_headers.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.allowed_response_headers.0", "X-Custom-Response-Header"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.allowed_response_headers.1", "X-Forwarded-Response-To"),
+				),
+			},
+			testutil.GetImportTestStep(resourceName, false, nil, consts.FieldDisableRemount),
 		},
 	})
 }
@@ -327,6 +362,10 @@ resource "vault_github_auth_backend" "test" {
 	organization = "%s"
 	token_ttl = 1200
 	token_max_ttl = 3000
+	tune {
+		token_type = "default-service"
+		max_lease_ttl = "1h"
+	}
 }
 `, path, org)
 }
@@ -357,6 +396,9 @@ resource "vault_github_auth_backend" "test" {
 	organization_id = %d
 	token_ttl = 2400
 	token_max_ttl = 6000
+	tune {
+		token_type = "batch"
+	}
 }
 `, path, org, orgID)
 }

--- a/vault/resource_jwt_auth_backend_test.go
+++ b/vault/resource_jwt_auth_backend_test.go
@@ -729,7 +729,7 @@ EOT`
 	})
 }
 
-func TestAccJWTAuthBackend_importTuning(t *testing.T) {
+func TestAccJWTAuthBackend_importTune(t *testing.T) {
 	testutil.SkipTestAcc(t)
 
 	path := acctest.RandomWithPrefix("jwt")

--- a/vault/structures.go
+++ b/vault/structures.go
@@ -106,15 +106,17 @@ func mergeAuthMethodTune(rawTune map[string]interface{}, input *api.MountConfigI
 		if input.TokenType == "" {
 			rawTune[consts.FieldTokenType] = ""
 		}
-		if input.DefaultLeaseTTL == "" {
-			rawTune[consts.FieldDefaultLeaseTTL] = ""
-		}
-		if input.MaxLeaseTTL == "" {
-			rawTune[consts.FieldMaxLeaseTTL] = ""
-		}
 		if input.ListingVisibility == "" {
 			rawTune[consts.FieldListingVisibility] = ""
 		}
+
+		// Some tune API GET responses may convert *TTL fields of string
+		// e.g. default_lease_ttl = "200s", which
+		// is the user provided value, will be converted to "3m20s".
+		//
+		// The merged takes the user provided value
+		rawTune[consts.FieldDefaultLeaseTTL] = input.DefaultLeaseTTL
+		rawTune[consts.FieldMaxLeaseTTL] = input.MaxLeaseTTL
 	}
 
 	return rawTune

--- a/vault/structures_test.go
+++ b/vault/structures_test.go
@@ -132,7 +132,7 @@ func TestMergeAuthMethodTune(t *testing.T) {
 					consts.FieldTokenType:         "default-service",
 				},
 				input: &api.MountConfigInput{
-					MaxLeaseTTL: "20m",
+					MaxLeaseTTL: "20h",
 					TokenType:   "default-service",
 				},
 			},

--- a/website/docs/guides/version_5_upgrade.html.markdown
+++ b/website/docs/guides/version_5_upgrade.html.markdown
@@ -84,6 +84,7 @@ state changes in the meantime.
 - [Provider: `address`](#provider-address)
 - [Provider: `token`](#provider-token)
 - [Resource: `vault_kv_secret_v2`](#resource-vault_kv_secret_v2)
+- [Resource: all `auth_backend`](#resource-all-auth_backend)
 - [Deprecated Field Removals](#deprecated-field-removals)
     - [Okta Auth Backend](#okta-auth-backend)
         - [`ttl`](#okta-secret-backend)
@@ -150,6 +151,13 @@ This resource will still store metadata and other parameters on the secret, but 
   It is also recommended to switch to using the new write-only attributes `data_json_wo` and `data_json_wo_version` to avoid 
   leaking the secret data to the TF state.
 
+## Resource: all `auth_backend`
+`vault_jwt_auth_backend`, `vault_github_auth_backend`, `vault_auth_backend`, `vault_saml_auth_backend`
+
+*BEHAVIOR CHANGE*
+With the fix for [the auth resources' tune block failure where it always updates unless its fields match Vault server defaults](https://github.com/hashicorp/terraform-provider-vault/issues/2234), Terraform Vault Provider versions `5.2.X` and greater will also read the tune metadata of the auth engines as part of tune updates.
+
+Please see the [Vault Policies and the Terraform Vault Provider](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/guides/policies) for more info about permitting Terraform Vault Provider to read the tune metadata.
 
 ## Deprecated Field Removals
 
@@ -164,3 +172,6 @@ The following deprecated fields have been removed:
 ### Azure Secret Backend
 
 * `use_microsoft_graph_api` - removed from the `vault_azure_secret_backend` resource.
+
+
+[def]: #resource-


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
The PR applies the solution in https://github.com/hashicorp/terraform-provider-vault/pull/2560 to the `resource_github_auth_backend` and generic `resource_auth_backend`.

As some tune API GET responses may convert TTL fields of string. e.g. default_lease_ttl = "200s", which is the user provided value, will be converted to "3m20s". The merging strategy for the TTL fields is to take the user provided value either it's empty or not.

The PR adds unit tests for tune importing for both resources.


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-vault/issues/2234 OR Closes

### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ TF_ACC_ENTERPRISE=1 TF_ACC=1 go test -v ./vault -run TestAccAuthBackend
=== RUN   TestAccAuthBackend_importBasic
--- PASS: TestAccAuthBackend_importBasic (1.61s)
=== RUN   TestAccAuthBackend
--- PASS: TestAccAuthBackend (2.04s)
=== RUN   TestAccAuthBackend_remount
--- PASS: TestAccAuthBackend_remount (3.27s)
=== RUN   TestAccAuthBackend_tuning
--- PASS: TestAccAuthBackend_tuning (2.29s)
=== RUN   TestAccAuthBackend_importTune
--- PASS: TestAccAuthBackend_importTune (1.82s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     11.662s

$ TF_ACC_ENTERPRISE=1 TF_ACC=1 go test -v ./vault -run  TestAccGithubAuthBackend
=== RUN   TestAccGithubAuthBackend_basic
2025/08/18 16:15:00 [INFO] Using Vault token with the following policies: root
--- PASS: TestAccGithubAuthBackend_basic (3.33s)
=== RUN   TestAccGithubAuthBackend_ns
--- PASS: TestAccGithubAuthBackend_ns (2.51s)
=== RUN   TestAccGithubAuthBackend_tuning
--- PASS: TestAccGithubAuthBackend_tuning (2.70s)
=== RUN   TestAccGithubAuthBackend_description
--- PASS: TestAccGithubAuthBackend_description (2.47s)
=== RUN   TestAccGithubAuthBackend_remount
--- PASS: TestAccGithubAuthBackend_remount (3.71s)
=== RUN   TestAccGithubAuthBackend_importTune
--- PASS: TestAccGithubAuthBackend_importTune (2.00s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     (cached)
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
