### PR TITLE
add tune block and merge its fields using user provided values and tune API response - SAML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ BUGS:
 * Fix the tune block issue where it always updates unless field values match Vault server defaults
   * `vault_jwt_auth_backend` resource ([#2560](https://github.com/hashicorp/terraform-provider-vault/pull/2560))
   * `vault_github_auth_backend` and `vault_auth_backend` resources ([#2565](https://github.com/hashicorp/terraform-provider-vault/pull/2565))
+  * `vault_saml_auth_backend` resource ([#2566](https://github.com/hashicorp/terraform-provider-vault/pull/2566))
 
 ## 5.1.0 (Jul 9, 2025)
 

--- a/vault/resource_saml_auth_backend.go
+++ b/vault/resource_saml_auth_backend.go
@@ -117,6 +117,7 @@ func samlAuthBackendResource() *schema.Resource {
 					"during the SAML exchange according to the current logging level. Not " +
 					"recommended for production.",
 			},
+			consts.FieldTune: authMountTuneSchema(),
 		},
 	}, true)
 }
@@ -185,6 +186,19 @@ func samlAuthBackendUpdate(ctx context.Context, d *schema.ResourceData, meta int
 	// set ID to where engine is mounted
 	d.SetId(path)
 
+	if d.HasChange(consts.FieldTune) {
+		log.Printf("[INFO] SAML Auth '%q' tune configuration changed", d.Id())
+		if raw, ok := d.GetOk(consts.FieldTune); ok {
+			log.Printf("[DEBUG] Writing SAML auth tune to '%q'", path)
+			config := expandAuthMethodTune(raw.(*schema.Set).List())
+			err := tuneMount(ctx, client, "auth/"+path, config)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			log.Printf("[INFO] Written SAML auth tune to '%q'", path)
+		}
+	}
+
 	return samlAuthBackendRead(ctx, d, meta)
 }
 
@@ -219,6 +233,24 @@ func samlAuthBackendRead(ctx context.Context, d *schema.ResourceData, meta inter
 				return diag.Errorf("error setting state key %q: err=%s", k, err)
 			}
 		}
+	}
+
+	log.Printf("[DEBUG] Reading saml auth tune from %q", id+"/tune")
+	rawTune, err := authMountTuneGet(ctx, client, "auth/"+id)
+	if err != nil {
+		return diag.Errorf("error reading tune information from Vault: %s", err)
+	}
+
+	input, err := retrieveMountConfigInput(d)
+	if err != nil {
+		return diag.Errorf("error retrieving tune configuration from state: %s", err)
+	}
+
+	mergedTune := mergeAuthMethodTune(rawTune, input)
+
+	if err := d.Set(consts.FieldTune, []map[string]interface{}{mergedTune}); err != nil {
+		log.Printf("[ERROR] Error when setting tune config from path %q to state: %s", id+"/tune", err)
+		return diag.FromErr(err)
 	}
 
 	return nil

--- a/vault/resource_saml_auth_backend_test.go
+++ b/vault/resource_saml_auth_backend_test.go
@@ -95,3 +95,115 @@ resource "vault_saml_auth_backend" "test" {
 `, path)
 	return ret
 }
+
+func TestAccSAMLAuthBackend_tune(t *testing.T) {
+	path := acctest.RandomWithPrefix("saml-tune")
+	resourceType := "vault_saml_auth_backend"
+	resourceName := resourceType + ".test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testutil.TestEntPreCheck(t)
+			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion115)
+		},
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		CheckDestroy:             testCheckMountDestroyed(resourceType, consts.MountTypeSAML, consts.FieldPath),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSAMLAuthBackendConfig_tuning(path),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "tune.0.default_lease_ttl", "2m"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.max_lease_ttl", "5m"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.listing_visibility", "unauth"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.token_type", "default-batch"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.audit_non_hmac_request_keys.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.audit_non_hmac_request_keys.0", "key1"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.audit_non_hmac_request_keys.1", "key2"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.audit_non_hmac_response_keys.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.audit_non_hmac_response_keys.0", "key3"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.audit_non_hmac_response_keys.1", "key4"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.passthrough_request_headers.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.passthrough_request_headers.0", "X-Custom-Header"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.passthrough_request_headers.1", "X-Forwarded-To"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.allowed_response_headers.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.allowed_response_headers.0", "X-Custom-Response-Header"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.allowed_response_headers.1", "X-Forwarded-Response-To"),
+				),
+			},
+			{
+				Config: testAccSAMLAuthBackendConfig_tuneUpdated(path),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "tune.0.default_lease_ttl", "3m"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.max_lease_ttl", "6m"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.listing_visibility", "hidden"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.token_type", "service"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.audit_non_hmac_request_keys.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.audit_non_hmac_response_keys.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.passthrough_request_headers.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tune.0.allowed_response_headers.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccSAMLAuthBackendConfig_tuning(path string) string {
+	return fmt.Sprintf(`
+resource "vault_saml_auth_backend" "test" {
+  path             = "%s"
+  idp_metadata_url = "https://company.okta.com/app/abc123eb9xnIfzlaf697/sso/saml/metadata"
+  entity_id        = "https://my.vault/v1/auth/saml"
+  acs_urls         = ["https://my.vault.primary/v1/auth/saml/callback"]
+  default_role     = "admin"
+  tune {
+    default_lease_ttl  = "2m"
+    max_lease_ttl      = "5m"
+    listing_visibility = "unauth"
+    token_type         = "default-batch"
+	audit_non_hmac_request_keys = ["key1", "key2"]
+	audit_non_hmac_response_keys = ["key3", "key4"]
+	passthrough_request_headers = ["X-Custom-Header", "X-Forwarded-To"]
+	allowed_response_headers = ["X-Custom-Response-Header", "X-Forwarded-Response-To"]
+  }
+}
+`, path)
+}
+
+func testAccSAMLAuthBackendConfig_tuneUpdated(path string) string {
+	return fmt.Sprintf(`
+resource "vault_saml_auth_backend" "test" {
+  path             = "%s"
+  idp_metadata_url = "https://company.okta.com/app/abc123eb9xnIfzlaf697/sso/saml/metadata"
+  entity_id        = "https://my.vault/v1/auth/saml"
+  acs_urls         = ["https://my.vault.primary/v1/auth/saml/callback"]
+  default_role     = "admin"
+  tune {
+    default_lease_ttl  = "3m"
+    max_lease_ttl      = "6m"
+    listing_visibility = "hidden"
+    token_type         = "service"
+  }
+}
+`, path)
+}
+
+func TestAccSAMLAuthBackend_importTune(t *testing.T) {
+	path := acctest.RandomWithPrefix("saml-import-tune")
+	resourceType := "vault_saml_auth_backend"
+	resourceName := resourceType + ".test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testutil.TestEntPreCheck(t)
+			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion115)
+		},
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		CheckDestroy:             testCheckMountDestroyed(resourceType, consts.MountTypeSAML, consts.FieldPath),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSAMLAuthBackendConfig_tuning(path),
+			},
+			testutil.GetImportTestStep(resourceName, false, nil, consts.FieldDisableRemount),
+		},
+	})
+}

--- a/website/docs/r/saml_auth_backend.html.md
+++ b/website/docs/r/saml_auth_backend.html.md
@@ -61,6 +61,36 @@ The following arguments are supported:
   information during the SAML exchange according to the current logging level. Not 
   recommended for production.
 
+* `tune` - (Optional) Extra configuration block. Structure is documented below.
+
+The `tune` block is used to tune the auth backend:
+
+* `default_lease_ttl` - (Optional) Specifies the default time-to-live.
+  If set, this overrides the global default.
+  Must be a valid [duration string](https://golang.org/pkg/time/#ParseDuration)
+
+* `max_lease_ttl` - (Optional) Specifies the maximum time-to-live.
+  If set, this overrides the global default.
+  Must be a valid [duration string](https://golang.org/pkg/time/#ParseDuration)
+
+* `audit_non_hmac_response_keys` - (Optional) Specifies the list of keys that will
+  not be HMAC'd by audit devices in the response data object.
+
+* `audit_non_hmac_request_keys` - (Optional) Specifies the list of keys that will
+  not be HMAC'd by audit devices in the request data object.
+
+* `listing_visibility` - (Optional) Specifies whether to show this mount in
+  the UI-specific listing endpoint. Valid values are "unauth" or "hidden".
+
+* `passthrough_request_headers` - (Optional) List of headers to whitelist and
+  pass from the request to the backend.
+
+* `allowed_response_headers` - (Optional) List of headers to whitelist and allowing
+  a plugin to include them in the response.
+
+* `token_type` - (Optional) Specifies the type of tokens that should be returned by
+  the mount. Valid values are "default-service", "default-batch", "service", "batch".
+
 ## Attributes Reference
 
 No additional attributes are exported by this resource.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
The PR adds support for tune block to the `resource_saml_auth_backend`. Handling tune update and import is similar to the solution in https://github.com/hashicorp/terraform-provider-vault/pull/2560 .

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates https://github.com/hashicorp/terraform-provider-vault/issues/2234 OR Closes


### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ TF_ACC_ENTERPRISE=1 TF_ACC=1 go test -v ./vault -run TestAccSAMLAuthBackend
=== RUN   TestAccSAMLAuthBackendRole_basic
    resource_saml_auth_backend_role_test.go:29: Vault server version "1.21.0-beta1+ent"
--- PASS: TestAccSAMLAuthBackendRole_basic (2.66s)
=== RUN   TestAccSAMLAuthBackend_basic
    resource_saml_auth_backend_test.go:27: Vault server version "1.21.0-beta1+ent"
--- PASS: TestAccSAMLAuthBackend_basic (2.39s)
=== RUN   TestAccSAMLAuthBackend_tune
    resource_saml_auth_backend_test.go:107: Vault server version "1.21.0-beta1+ent"
--- PASS: TestAccSAMLAuthBackend_tune (2.53s)
=== RUN   TestAccSAMLAuthBackend_importTune
    resource_saml_auth_backend_test.go:198: Vault server version "1.21.0-beta1+ent"
--- PASS: TestAccSAMLAuthBackend_importTune (1.91s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     10.129s
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
