### PR TITLE
Correct field constraints on the same path level for auth blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+BUGS:
+* Fix `auth_login_gcp` field constraint on field `credentials` `service_account`
+* Fix `auth_login_azure` field constraint on field `vmss_name` `tenant_id` `client_id` `scope`
+* Fix `auth_login_kerberos` field constraint on fields `username` `service` `realm` `krb5conf_path` `keytab_path` `disable_fast_negotiation` `remove_instance_name`
+* Fix `auth_login_userpass` field constraint on field `password_file`
+* Fix `auth_login` field constraint on field `use_root_namespace`
+
 ## 5.2.0 (Aug 18, 2025)
 
 FEATURES:

--- a/internal/provider/fwprovider/auth.go
+++ b/internal/provider/fwprovider/auth.go
@@ -37,7 +37,7 @@ func mustAddLoginSchema(s *schema.ListNestedBlock, defaultMount string) schema.B
 			),
 			Validators: []validator.Bool{
 				boolvalidator.ConflictsWith(
-					path.MatchRelative().AtParent().AtName(consts.FieldUseRootNamespace),
+					path.MatchRelative().AtParent().AtName(consts.FieldNamespace),
 				),
 			},
 		},

--- a/internal/provider/fwprovider/auth_azure.go
+++ b/internal/provider/fwprovider/auth_azure.go
@@ -21,6 +21,13 @@ func AuthLoginAzureSchema() schema.Block {
 					Optional: true,
 					Description: "A signed JSON Web Token. If not specified on will be " +
 						"created automatically",
+					Validators: []validator.String{
+						stringvalidator.ConflictsWith(
+							path.MatchRelative().AtParent().AtName(consts.FieldTenantID),
+							path.MatchRelative().AtParent().AtName(consts.FieldClientID),
+							path.MatchRelative().AtParent().AtName(consts.FieldScope),
+						),
+					},
 				},
 				consts.FieldRole: schema.StringAttribute{
 					Required:    true,
@@ -40,6 +47,11 @@ func AuthLoginAzureSchema() schema.Block {
 					Optional: true,
 					Description: "The virtual machine name for the machine that generated the MSI token. " +
 						"This information can be obtained through instance metadata.",
+					Validators: []validator.String{
+						stringvalidator.ConflictsWith(
+							path.MatchRelative().AtParent().AtName(consts.FieldVMSSName),
+						),
+					},
 				},
 				consts.FieldVMSSName: schema.StringAttribute{
 					Optional: true,
@@ -47,7 +59,7 @@ func AuthLoginAzureSchema() schema.Block {
 						"the MSI token. This information can be obtained through instance metadata.",
 					Validators: []validator.String{
 						stringvalidator.ConflictsWith(
-							path.MatchRelative().AtName(consts.FieldVMName),
+							path.MatchRelative().AtParent().AtName(consts.FieldVMName),
 						),
 					},
 				},
@@ -57,7 +69,7 @@ func AuthLoginAzureSchema() schema.Block {
 						"authentication scenario.",
 					Validators: []validator.String{
 						stringvalidator.ConflictsWith(
-							path.MatchRelative().AtName(consts.FieldJWT),
+							path.MatchRelative().AtParent().AtName(consts.FieldJWT),
 						),
 					},
 				},
@@ -66,7 +78,7 @@ func AuthLoginAzureSchema() schema.Block {
 					Description: "The identity's client ID.",
 					Validators: []validator.String{
 						stringvalidator.ConflictsWith(
-							path.MatchRelative().AtName(consts.FieldJWT),
+							path.MatchRelative().AtParent().AtName(consts.FieldJWT),
 						),
 					},
 				},
@@ -75,7 +87,7 @@ func AuthLoginAzureSchema() schema.Block {
 					Description: "The scopes to include in the token request.",
 					Validators: []validator.String{
 						stringvalidator.ConflictsWith(
-							path.MatchRelative().AtName(consts.FieldJWT),
+							path.MatchRelative().AtParent().AtName(consts.FieldJWT),
 						),
 					},
 				},

--- a/internal/provider/fwprovider/auth_gcp.go
+++ b/internal/provider/fwprovider/auth_gcp.go
@@ -27,7 +27,7 @@ func AuthLoginGCPSchema() schema.Block {
 					Description: "A signed JSON Web Token.",
 					Validators: []validator.String{
 						stringvalidator.ConflictsWith(
-							path.MatchRelative().AtName(consts.FieldCredentials),
+							path.MatchRelative().AtParent().AtName(consts.FieldCredentials),
 						),
 					},
 				},

--- a/internal/provider/fwprovider/auth_gcp.go
+++ b/internal/provider/fwprovider/auth_gcp.go
@@ -28,6 +28,7 @@ func AuthLoginGCPSchema() schema.Block {
 					Validators: []validator.String{
 						stringvalidator.ConflictsWith(
 							path.MatchRelative().AtParent().AtName(consts.FieldCredentials),
+							path.MatchRelative().AtParent().AtName(consts.FieldServiceAccount),
 						),
 					},
 				},
@@ -36,7 +37,7 @@ func AuthLoginGCPSchema() schema.Block {
 					Description: "Path to the Google Cloud credentials file.",
 					Validators: []validator.String{
 						stringvalidator.ConflictsWith(
-							path.MatchRelative().AtName(consts.FieldJWT),
+							path.MatchRelative().AtParent().AtName(consts.FieldJWT),
 						),
 						stringvalidator.LengthAtLeast(1),
 						validators.GCPCredentialsValidator(),
@@ -47,7 +48,7 @@ func AuthLoginGCPSchema() schema.Block {
 					Description: "IAM service account.",
 					Validators: []validator.String{
 						stringvalidator.ConflictsWith(
-							path.MatchRelative().AtName(consts.FieldJWT),
+							path.MatchRelative().AtParent().AtName(consts.FieldJWT),
 						),
 					},
 				},

--- a/internal/provider/fwprovider/auth_kerberos.go
+++ b/internal/provider/fwprovider/auth_kerberos.go
@@ -24,6 +24,15 @@ func AuthLoginKerberosSchema() schema.Block {
 					Description: "Simple and Protected GSSAPI Negotiation Mechanism (SPNEGO) token",
 					Validators: []validator.String{
 						validators.KRBNegTokenValidator(),
+						stringvalidator.ConflictsWith(
+							path.MatchRelative().AtParent().AtName(consts.FieldUsername),
+							path.MatchRelative().AtParent().AtName(consts.FieldService),
+							path.MatchRelative().AtParent().AtName(consts.FieldRealm),
+							path.MatchRelative().AtParent().AtName(consts.FieldKRB5ConfPath),
+							path.MatchRelative().AtParent().AtName(consts.FieldKeytabPath),
+							path.MatchRelative().AtParent().AtName(consts.FieldDisableFastNegotiation),
+							path.MatchRelative().AtParent().AtName(consts.FieldRemoveInstanceName),
+						),
 					},
 				},
 				consts.FieldUsername: schema.StringAttribute{
@@ -31,7 +40,7 @@ func AuthLoginKerberosSchema() schema.Block {
 					Description: "The username to login into Kerberos with.",
 					Validators: []validator.String{
 						stringvalidator.ConflictsWith(
-							path.MatchRelative().AtName(consts.FieldToken),
+							path.MatchRelative().AtParent().AtName(consts.FieldToken),
 						),
 					},
 				},
@@ -40,7 +49,7 @@ func AuthLoginKerberosSchema() schema.Block {
 					Description: "The service principle name.",
 					Validators: []validator.String{
 						stringvalidator.ConflictsWith(
-							path.MatchRelative().AtName(consts.FieldToken),
+							path.MatchRelative().AtParent().AtName(consts.FieldToken),
 						),
 					},
 				},
@@ -49,7 +58,7 @@ func AuthLoginKerberosSchema() schema.Block {
 					Description: "The Kerberos server's authoritative authentication domain",
 					Validators: []validator.String{
 						stringvalidator.ConflictsWith(
-							path.MatchRelative().AtName(consts.FieldToken),
+							path.MatchRelative().AtParent().AtName(consts.FieldToken),
 						),
 					},
 				},
@@ -59,7 +68,7 @@ func AuthLoginKerberosSchema() schema.Block {
 					Validators: []validator.String{
 						validators.FileExistsValidator(),
 						stringvalidator.ConflictsWith(
-							path.MatchRelative().AtName(consts.FieldToken),
+							path.MatchRelative().AtParent().AtName(consts.FieldToken),
 						),
 					},
 				},
@@ -69,7 +78,7 @@ func AuthLoginKerberosSchema() schema.Block {
 					Validators: []validator.String{
 						validators.FileExistsValidator(),
 						stringvalidator.ConflictsWith(
-							path.MatchRelative().AtName(consts.FieldToken),
+							path.MatchRelative().AtParent().AtName(consts.FieldToken),
 						),
 					},
 				},
@@ -77,7 +86,7 @@ func AuthLoginKerberosSchema() schema.Block {
 					Optional: true,
 					Validators: []validator.Bool{
 						boolvalidator.ConflictsWith(
-							path.MatchRelative().AtName(consts.FieldToken),
+							path.MatchRelative().AtParent().AtName(consts.FieldToken),
 						),
 					},
 					Description: "Disable the Kerberos FAST negotiation.",
@@ -86,7 +95,7 @@ func AuthLoginKerberosSchema() schema.Block {
 					Optional: true,
 					Validators: []validator.Bool{
 						boolvalidator.ConflictsWith(
-							path.MatchRelative().AtName(consts.FieldToken),
+							path.MatchRelative().AtParent().AtName(consts.FieldToken),
 						),
 					},
 					Description: "Strip the host from the username found in the keytab.",

--- a/internal/provider/fwprovider/auth_userpass.go
+++ b/internal/provider/fwprovider/auth_userpass.go
@@ -25,13 +25,18 @@ func AuthLoginUserpassSchema() schema.Block {
 				consts.FieldPassword: schema.StringAttribute{
 					Optional:    true,
 					Description: "Login with password",
+					Validators: []validator.String{
+						stringvalidator.ConflictsWith(
+							path.MatchRelative().AtParent().AtName(consts.FieldPasswordFile),
+						),
+					},
 				},
 				consts.FieldPasswordFile: schema.StringAttribute{
 					Optional:    true,
 					Description: "Login with password from a file",
 					Validators: []validator.String{
 						stringvalidator.ConflictsWith(
-							path.MatchRelative().AtName(consts.FieldPassword),
+							path.MatchRelative().AtParent().AtName(consts.FieldPassword),
 						),
 					},
 				},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
Fix the field path when checking and comparing field conflictswith constraints. Currently using these fields gives an error such as

```
│ Error: Invalid Path Expression for Schema
│ 
│   with provider["registry.terraform.io/hashicorp/vault"],
│   on auth_login_gcp.tf line 10, in provider "vault":
│   10: provider "vault" {
│ 
│ The Terraform Provider unexpectedly provided a path expression that does
│ not match the current schema. This can happen if the path expression does
│ not correctly follow the schema in structure or types. Please report this
│ to the provider developers.
│ 
│ Path Expression: auth_login_gcp[0].jwt.credentials
```

Notice that it is looking for the credentials field as a sub-field of jwt, which it is not.

### Comparison

Before:
```
auth_login_gcp {
  mount = "gcp"
  role  = "root"
  jwt   = "/path/to/gcp-token.json"
}

Error: Path Expression: auth_login_gcp[0].jwt.credentials
```

```
auth_login_userpass {
  username = "root"
  password_file = "root"
}

Error: Path Expression: auth_login_userpass[0].password_file.password
```

```
auth_login_kerberos {
  username = "root"
}

Error: Path Expression: auth_login_kerberos[0].username.token
```

```
auth_login_azure {
  role = "root"
  subscription_id = "00000000-0000-0000-0000-000000000000"
  resource_group_name = "resource-group"
  vmss_name = "root"
}

Error: Path Expression: auth_login_azure[0].vmss_name.vm_name
```

After:
```
Terraform will perform the following actions:

  # vault_kv_secret_backend_v2.example will be created
  + resource "vault_kv_secret_backend_v2" "example" {
      + cas_required         = true
      + delete_version_after = 12600
      + id                   = (known after apply)
      + max_versions         = 5
      + mount                = "kvv2"
    }

  # vault_kv_secret_v2.example will be created
  + resource "vault_kv_secret_v2" "example" {
      + cas                 = 1
      + data                = (sensitive value)
      + data_json           = (sensitive value)
      + data_json_wo        = (write-only attribute)
      + delete_all_versions = true
      + disable_read        = false
      + id                  = (known after apply)
      + metadata            = (known after apply)
      + mount               = "kvv2"
      + name                = "secret"
      + path                = (known after apply)

      + custom_metadata {
          + data         = {
              + "bar" = "12345"
              + "foo" = "vault@example.com"
            }
          + max_versions = 5
        }
    }

  # vault_mount.kvv2 will be created
  + resource "vault_mount" "kvv2" {
      + accessor                     = (known after apply)
      + audit_non_hmac_request_keys  = (known after apply)
      + audit_non_hmac_response_keys = (known after apply)
      + default_lease_ttl_seconds    = (known after apply)
      + description                  = "KV Version 2 secret engine mount"
      + external_entropy_access      = false
      + force_no_cache               = (known after apply)
      + id                           = (known after apply)
      + max_lease_ttl_seconds        = (known after apply)
      + options                      = {
          + "version" = "2"
        }
      + path                         = "kvv2"
      + seal_wrap                    = (known after apply)
      + type                         = "kv"
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: 
```
👆 (Simply to illustrate that a Terraform apply is successfully evaluating the paths now)


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
