### PR TITLE
Allow Unsetting String and Array Values to Auth Mount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ FEATURES:
 BUGS:
 
 * Fix pki config resources to allow unsetting of fields (to empty fields) ([#2558](https://github.com/hashicorp/terraform-provider-vault/pull/2558))
+* Fix tune auth mounts to allow unsetting of fields (setting fields to empty values) ([#2605](https://github.com/hashicorp/terraform-provider-vault/pull/2605))
 
 ## 5.3.0 (Sep 4, 2025)
 

--- a/vault/resource_mount.go
+++ b/vault/resource_mount.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -287,23 +288,22 @@ func updateMount(ctx context.Context, d *schema.ResourceData, meta interface{}, 
 		return err
 	}
 
-	config := api.MountConfigInput{
-		DefaultLeaseTTL: fmt.Sprintf("%ds", d.Get(consts.FieldDefaultLeaseTTL)),
-		MaxLeaseTTL:     fmt.Sprintf("%ds", d.Get(consts.FieldMaxLeaseTTL)),
-		Options:         mountOptions(d),
+	mapConfig := map[string]interface{}{
+		"default_lease_ttl": fmt.Sprintf("%ds", d.Get(consts.FieldDefaultLeaseTTL)),
+		"max_lease_ttl":     fmt.Sprintf("%ds", d.Get(consts.FieldMaxLeaseTTL)),
+		"options":           mountOptions(d),
 	}
 
 	if d.HasChange(consts.FieldAuditNonHMACRequestKeys) {
-		config.AuditNonHMACRequestKeys = expandStringSlice(d.Get(consts.FieldAuditNonHMACRequestKeys).([]interface{}))
+		mapConfig[consts.FieldAuditNonHMACRequestKeys] = expandStringSlice(d.Get(consts.FieldAuditNonHMACRequestKeys).([]interface{}))
 	}
 
 	if d.HasChange(consts.FieldAuditNonHMACResponseKeys) {
-		config.AuditNonHMACResponseKeys = expandStringSlice(d.Get(consts.FieldAuditNonHMACResponseKeys).([]interface{}))
+		mapConfig[consts.FieldAuditNonHMACResponseKeys] = expandStringSlice(d.Get(consts.FieldAuditNonHMACResponseKeys).([]interface{}))
 	}
 
 	if d.HasChange(consts.FieldDescription) {
-		description := fmt.Sprintf("%s", d.Get(consts.FieldDescription))
-		config.Description = &description
+		mapConfig[consts.FieldDescription] = d.Get(consts.FieldDescription).(string)
 	}
 
 	path := d.Id()
@@ -325,33 +325,33 @@ func updateMount(ctx context.Context, d *schema.ResourceData, meta interface{}, 
 	}
 
 	if d.HasChange(consts.FieldAllowedManagedKeys) {
-		config.AllowedManagedKeys = expandStringSlice(d.Get(consts.FieldAllowedManagedKeys).(*schema.Set).List())
+		mapConfig[consts.FieldAllowedManagedKeys] = expandStringSlice(d.Get(consts.FieldAllowedManagedKeys).(*schema.Set).List())
 	}
 
 	if d.HasChange(consts.FieldPassthroughRequestHeaders) {
-		config.PassthroughRequestHeaders = expandStringSlice(d.Get(consts.FieldPassthroughRequestHeaders).([]interface{}))
+		mapConfig[consts.FieldPassthroughRequestHeaders] = expandStringSlice(d.Get(consts.FieldPassthroughRequestHeaders).([]interface{}))
 	}
 
 	if d.HasChange(consts.FieldAllowedResponseHeaders) {
-		config.AllowedResponseHeaders = expandStringSlice(d.Get(consts.FieldAllowedResponseHeaders).([]interface{}))
+		mapConfig[consts.FieldAllowedResponseHeaders] = d.Get(consts.FieldAllowedResponseHeaders).([]interface{})
 	}
 
 	if d.HasChange(consts.FieldDelegatedAuthAccessors) {
-		config.DelegatedAuthAccessors = expandStringSlice(d.Get(consts.FieldDelegatedAuthAccessors).([]interface{}))
+		mapConfig[consts.FieldDelegatedAuthAccessors] = expandStringSlice(d.Get(consts.FieldDelegatedAuthAccessors).([]interface{}))
 	}
 
 	if d.HasChange(consts.FieldListingVisibility) {
-		config.ListingVisibility = d.Get(consts.FieldListingVisibility).(string)
+		mapConfig[consts.FieldListingVisibility] = d.Get(consts.FieldListingVisibility).(string)
 	}
 
 	if d.HasChange(consts.FieldPluginVersion) {
-		config.PluginVersion = d.Get(consts.FieldPluginVersion).(string)
+		mapConfig[consts.FieldPluginVersion] = d.Get(consts.FieldPluginVersion).(string)
 	}
 
 	useAPIVer116Ent := provider.IsAPISupported(meta, provider.VaultVersion116) && provider.IsEnterpriseSupported(meta)
 	if useAPIVer116Ent {
 		if d.HasChange(consts.FieldIdentityTokenKey) {
-			config.IdentityTokenKey = d.Get(consts.FieldIdentityTokenKey).(string)
+			mapConfig[consts.FieldIdentityTokenKey] = d.Get(consts.FieldIdentityTokenKey)
 		}
 	}
 
@@ -360,7 +360,7 @@ func updateMount(ctx context.Context, d *schema.ResourceData, meta interface{}, 
 	// TODO: remove this work-around once VAULT-5521 is fixed
 	var tries int
 	for {
-		if err := client.Sys().TuneMountWithContext(ctx, path, config); err != nil {
+		if err := tuneMountWithMap(client, ctx, path, mapConfig); err != nil {
 			if tries > 10 {
 				return fmt.Errorf("error updating Vault: %s", err)
 			}
@@ -510,4 +510,17 @@ func mountOptions(d *schema.ResourceData) map[string]string {
 		}
 	}
 	return options
+}
+
+func tuneMountWithMap(c *api.Client, ctx context.Context, path string, config map[string]interface{}) error {
+	r := c.NewRequest(http.MethodPost, fmt.Sprintf("/v1/sys/mounts/%s/tune", path))
+	if err := r.SetJSONBody(config); err != nil {
+		return err
+	}
+
+	resp, err := c.RawRequestWithContext(ctx, r)
+	if err != nil {
+		return err
+	}
+	return resp.Body.Close()
 }

--- a/vault/resource_mount.go
+++ b/vault/resource_mount.go
@@ -366,7 +366,7 @@ func updateMount(ctx context.Context, d *schema.ResourceData, meta interface{}, 
 		// Prior to 1.21.0, 1.20.4, 1.19.10, 1.18.15 and 1.16.26 fields can not be set to their empty values in the
 		// Vault Client.  Using the new function that fixes this in the client would create a backwards compatibility
 		// issue, so instead we make a raw HTTP request here, using the Vault API directly.
-		if err := tuneMountWithMap(client, ctx, path, mapConfig); err != nil {
+		if err := tuneMountWithMap(ctx, client, path, mapConfig); err != nil {
 			if tries > 10 {
 				return fmt.Errorf("error updating Vault: %s", err)
 			}
@@ -518,7 +518,7 @@ func mountOptions(d *schema.ResourceData) map[string]string {
 	return options
 }
 
-func tuneMountWithMap(c *api.Client, ctx context.Context, path string, config map[string]interface{}) error {
+func tuneMountWithMap(ctx context.Context, c *api.Client, path string, config map[string]interface{}) error {
 	r := c.NewRequest(http.MethodPost, fmt.Sprintf("/v1/sys/mounts/%s/tune", path))
 	if err := r.SetJSONBody(config); err != nil {
 		return err

--- a/vault/resource_mount_test.go
+++ b/vault/resource_mount_test.go
@@ -172,6 +172,9 @@ func TestResourceMount_AuditNonHMACRequestKeys(t *testing.T) {
 	})
 }
 
+// TestResourceMount_AllowedResponseHeaders_Removal checks that after the allowed response headers were set on an
+// vault auth mount, that if the headers were removed from the configuration, then the vault field would be updated
+// accordingly.  This is a regression test. VAULT-34426
 func TestResourceMount_AllowedResponseHeaders_Removal(t *testing.T) {
 	resourcePath := "vault_mount.lol"
 	path := "example-" + acctest.RandString(10)

--- a/vault/resource_mount_test.go
+++ b/vault/resource_mount_test.go
@@ -356,7 +356,7 @@ func TestResourceMount_IDTokenKey(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion116)
+			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion117)
 		},
 		Steps: []resource.TestStep{
 			{

--- a/vault/resource_mount_test.go
+++ b/vault/resource_mount_test.go
@@ -223,6 +223,8 @@ func TestResourceMount_AllowedResponseHeaders_Removal(t *testing.T) {
 	})
 }
 
+// TestResourceMount_AllowedResponseHeaders_EmptySlice checks that after the allowed response headers were set on an
+// vault auth mount, that the headers could be set back to being an empty slice.  This is a regression test. VAULT-34426
 func TestResourceMount_AllowedResponseHeaders_EmptySlice(t *testing.T) {
 	resourcePath := "vault_mount.lol"
 	path := "example-" + acctest.RandString(10)

--- a/vault/resource_mount_test.go
+++ b/vault/resource_mount_test.go
@@ -373,10 +373,9 @@ func TestResourceMount_IDTokenKey(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "allowed_response_headers.0", "header1"),
 					resource.TestCheckResourceAttr(resourceName, "allowed_response_headers.1", "header2"),
 					resource.TestCheckResourceAttr(resourceName, "listing_visibility", "hidden"),
-					// @TODO add these back in when Vault 1.16.3 is released
-					// resource.TestCheckResourceAttr(resourceName, "delegated_auth_accessors.#", "2"),
-					// resource.TestCheckResourceAttr(resourceName, "delegated_auth_accessors.0", "header1"),
-					// resource.TestCheckResourceAttr(resourceName, "delegated_auth_accessors.1", "header2"),
+					resource.TestCheckResourceAttr(resourceName, "delegated_auth_accessors.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "delegated_auth_accessors.0", "header1"),
+					resource.TestCheckResourceAttr(resourceName, "delegated_auth_accessors.1", "header2"),
 				),
 			},
 			{
@@ -394,17 +393,13 @@ func TestResourceMount_IDTokenKey(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "allowed_response_headers.2", "header3"),
 					resource.TestCheckResourceAttr(resourceName, "listing_visibility", "unauth"),
 					resource.TestCheckResourceAttr(resourceName, "identity_token_key", "my-key"),
-					// @TODO add these back in when Vault 1.16.3 is released
-					// resource.TestCheckResourceAttr(resourceName, "delegated_auth_accessors.#", "3"),
-					// resource.TestCheckResourceAttr(resourceName, "delegated_auth_accessors.0", "header1"),
-					// resource.TestCheckResourceAttr(resourceName, "delegated_auth_accessors.1", "header2"),
-					// resource.TestCheckResourceAttr(resourceName, "delegated_auth_accessors.2", "header3"),
+					resource.TestCheckResourceAttr(resourceName, "delegated_auth_accessors.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "delegated_auth_accessors.0", "header1"),
+					resource.TestCheckResourceAttr(resourceName, "delegated_auth_accessors.1", "header2"),
+					resource.TestCheckResourceAttr(resourceName, "delegated_auth_accessors.2", "header3"),
 				),
 			},
-			// @TODO remove ignore_fields once Vault 1.16.3 is released
-			testutil.GetImportTestStep(resourceName, false, nil,
-				"delegated_auth_accessors",
-			),
+			testutil.GetImportTestStep(resourceName, false, nil),
 		},
 	})
 }


### PR DESCRIPTION
### Description
This changes the implementation to the tuneable auth parameters to use JSON rather than a struct.  This way which parameters were actually changed / set is transmitted to vault.  This means that instead of ignoring nil/zero/empty values, those values explictly exist, and fields can therefore be unset (that is set to nil/zero/empty value).

This is an updated implementation of this PR, to avoid changes that wouldn't be backwards compatible: https://github.com/hashicorp/terraform-provider-vault/pull/2532

There is a vault change that enables the same sort of "unset" behavior for these fields from the command line, but that change is independent (that is, neither of these changes are reliant on the other to function):

ENT: https://github.com/hashicorp/vault-enterprise/pull/9383
CE: https://github.com/hashicorp/vault/pull/31555

### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
=== RUN   TestResourceMount_AllowedResponseHeaders_EmptySlice
--- PASS: TestResourceMount_AllowedResponseHeaders_EmptySlice (3.81s)
PASS

Process finished with the exit code 0
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
-- It's sufficient to just revert this PR

- [x] If applicable, I've documented the impact of any changes to security controls.
-- No change to security controls, these values were already accessible /unsettable through the API

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
