### PR TITLE
Fix vault_pki_secret_backend_crl_config to support setting boolean fields to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ BUGS:
 
 * Fix pki config resources to allow unsetting of fields (to empty fields) ([#2558](https://github.com/hashicorp/terraform-provider-vault/pull/2558))
 * Fix tune auth mounts to allow unsetting of fields (setting fields to empty values) ([#2605](https://github.com/hashicorp/terraform-provider-vault/pull/2605))
+* Fix `vault_pki_secret_backend_crl_config` resource to allow disabling flags previously set to true ([#2615](https://github.com/hashicorp/terraform-provider-vault/pull/2615))
 
 ## 5.3.0 (Sep 4, 2025)
 

--- a/vault/resource_pki_secret_backend_crl_config.go
+++ b/vault/resource_pki_secret_backend_crl_config.go
@@ -131,7 +131,7 @@ func pkiSecretBackendCrlConfigCreate(ctx context.Context, d *schema.ResourceData
 	path := pkiSecretBackendCrlConfigPath(backend)
 	fields := buildConfigCRLFields(meta)
 
-	data := util.GetAPIRequestDataWithSliceOk(d, fields)
+	data := util.GetAPIRequestDataWithSliceOkExists(d, fields)
 	log.Printf("[DEBUG] Creating CRL config on PKI secret backend %q", backend)
 	_, err := client.Logical().Write(path, data)
 	if err != nil {
@@ -188,7 +188,7 @@ func pkiSecretBackendCrlConfigUpdate(ctx context.Context, d *schema.ResourceData
 	path := d.Id()
 	fields := buildConfigCRLFields(meta)
 
-	data := util.GetAPIRequestDataWithSliceOk(d, fields)
+	data := util.GetAPIRequestDataWithSliceOkExists(d, fields)
 	log.Printf("[DEBUG] Updating CRL config on PKI secret path %q", path)
 	_, err := client.Logical().Write(path, data)
 	if err != nil {

--- a/vault/resource_pki_secret_backend_crl_config_test.go
+++ b/vault/resource_pki_secret_backend_crl_config_test.go
@@ -167,6 +167,7 @@ func TestPkiSecretBackendCrlConfig(t *testing.T) {
 			ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 			PreCheck: func() {
 				testutil.TestAccPreCheck(t)
+				testutil.TestEntPreCheck(t)
 				SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion120)
 			},
 			CheckDestroy: testCheckMountDestroyed("vault_mount", consts.MountTypePKI, consts.FieldPath),


### PR DESCRIPTION
### Description

Fix `vault_pki_secret_backend_crl_config` to send fields to the Vault endpoint when they are set to the zero based value. This mainly allows it to now disable options that had been previously set.

Fixes: [2507](https://github.com/hashicorp/terraform-provider-vault/issues/2507)


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [X] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestPkiSecretBackendCrlConfig'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -run=TestPkiSecretBackendCrlConfig -timeout 30m ./...
....
ok      github.com/hashicorp/terraform-provider-vault/vault     6.360s
...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
