### PR TITLE
move root_password_ttl field from azure_secret_backend_role to azure_secret_backend

### DIFF
--- a/website/docs/r/azure_secret_backend.html.md
+++ b/website/docs/r/azure_secret_backend.html.md
@@ -77,6 +77,8 @@ The following arguments are supported:
 - `identity_token_ttl` - (Optional) The TTL of generated identity tokens in seconds. Requires Vault 1.17+.
   *Available only for Vault Enterprise*
 
+- `root_password_ttl` - (Optional) Specifies the TTL of the root password when rotate-root generates a new client secret. Requires Vault 1.15+.
+
 - `rotation_period` - (Optional) The amount of time in seconds Vault should wait before rotating the root credential.
   A zero value tells Vault not to rotate the root credential. The minimum rotation period is 10 seconds. Requires Vault Enterprise 1.19+.
   *Available only for Vault Enterprise*

--- a/website/docs/r/azure_secret_backend_role.html.md
+++ b/website/docs/r/azure_secret_backend_role.html.md
@@ -77,7 +77,6 @@ The following arguments are supported:
 * `sign_in_audience` - (Optional) Specifies the security principal types that are allowed to sign in to the application.
   Valid values are: AzureADMyOrg, AzureADMultipleOrgs, AzureADandPersonalMicrosoftAccount, PersonalMicrosoftAccount. Requires Vault 1.16+.
 * `tags` - (Optional) - A list of Azure tags to attach to an application. Requires Vault 1.16+.
-* `root_password_ttl` - (Optional) Specifies the TTL of the root password when rotate-root generates a new client secret. Requires Vault 1.15+.
 
 ## Attributes Reference
 


### PR DESCRIPTION

### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
This PR fixes the Azure resource docs by moving the `root_password_ttl` field from `azure_secret_backend_role` to `azure_secret_backend`

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000


### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

N/A


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
