### PR TITLE
Move test helpers out to common package

### DIFF
--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -16,6 +16,8 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"io"
 	"io/ioutil"
 	"log"
@@ -78,6 +80,66 @@ func SkipTestEnvSet(t *testing.T, envVars ...string) []string {
 func SkipTestEnvUnset(t *testing.T, envVars ...string) []string {
 	t.Helper()
 	return handleTestEnvUnsetF(t, t.Skipf, envVars...)
+}
+
+// SkipIfAPIVersionLT skips of the running vault version is less-than ver.
+func SkipIfAPIVersionLT(t *testing.T, m interface{}, ver *version.Version) {
+	t.Helper()
+	f := func(curVer *version.Version) bool {
+		return curVer.LessThan(ver)
+	}
+	SkipOnAPIVersion(t, m, f, "Vault version < %q", ver)
+}
+
+// SkipIfAPIVersionLTE skips if the running vault version is less-than-or-equal to ver.
+func SkipIfAPIVersionLTE(t *testing.T, m interface{}, ver *version.Version) {
+	t.Helper()
+	f := func(curVer *version.Version) bool {
+		return curVer.LessThanOrEqual(ver)
+	}
+	SkipOnAPIVersion(t, m, f, "Vault version <= %q", ver)
+}
+
+// SkipIfAPIVersionEQ skips if the running vault version is equal to ver.
+func SkipIfAPIVersionEQ(t *testing.T, m interface{}, ver *version.Version) {
+	t.Helper()
+	f := func(curVer *version.Version) bool {
+		return curVer.Equal(ver)
+	}
+	SkipOnAPIVersion(t, m, f, "Vault version == %q", ver)
+}
+
+// SkipIfAPIVersionGT skips if the running vault version is greater-than ver.
+func SkipIfAPIVersionGT(t *testing.T, m interface{}, ver *version.Version) {
+	t.Helper()
+	f := func(curVer *version.Version) bool {
+		return curVer.GreaterThan(ver)
+	}
+	SkipOnAPIVersion(t, m, f, "Vault version > %q", ver)
+}
+
+// SkipIfAPIVersionGTE skips if the running vault version is greater-than-or-equal to ver.
+func SkipIfAPIVersionGTE(t *testing.T, m interface{}, ver *version.Version) {
+	t.Helper()
+	f := func(curVer *version.Version) bool {
+		return curVer.GreaterThanOrEqual(ver)
+	}
+	SkipOnAPIVersion(t, m, f, "Vault version >= %q", ver)
+}
+
+func SkipOnAPIVersion(t *testing.T, m interface{}, cmp func(*version.Version) bool, format string, args ...interface{}) {
+	t.Helper()
+
+	p := m.(*provider.ProviderMeta)
+	curVer := p.GetVaultVersion()
+	if curVer == nil {
+		t.Fatalf("vault version not set on %T", p)
+	}
+
+	t.Logf("Vault server version %q", curVer)
+	if cmp(curVer) {
+		t.Skipf(format, args...)
+	}
 }
 
 // FatalTestEnvUnset fails the test if any of the provided environment variables

--- a/vault/data_source_aws_static_credentials_test.go
+++ b/vault/data_source_aws_static_credentials_test.go
@@ -24,7 +24,7 @@ func TestAccDataSourceAWSStaticCredentials(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion114)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion114)
 
 		},
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),

--- a/vault/data_source_ldap_dynamic_role_credentials_test.go
+++ b/vault/data_source_ldap_dynamic_role_credentials_test.go
@@ -24,7 +24,7 @@ func TestAccDataSourceLDAPDynamicRoleCredentials(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion112)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion112)
 		},
 		Steps: []resource.TestStep{
 			{

--- a/vault/data_source_ldap_static_role_credentials_test.go
+++ b/vault/data_source_ldap_static_role_credentials_test.go
@@ -25,7 +25,7 @@ func TestAccDataSourceLDAPStaticRoleCredentials(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion112)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion112)
 		},
 		Steps: []resource.TestStep{
 			{

--- a/vault/data_source_namespace_test.go
+++ b/vault/data_source_namespace_test.go
@@ -47,7 +47,7 @@ func TestAccDataSourceNamespace(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion112)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion112)
 		},
 		CheckDestroy: testNamespaceDestroy(path),
 		Steps: []resource.TestStep{

--- a/vault/data_source_pki_secret_backend_cert_metadata_test.go
+++ b/vault/data_source_pki_secret_backend_cert_metadata_test.go
@@ -74,7 +74,7 @@ func TestAccDataSourcePKISecretCertMetadata(t *testing.T) {
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion117)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion117)
 		},
 		Steps: []resource.TestStep{
 			{

--- a/vault/data_source_pki_secret_backend_config_cmpv2_test.go
+++ b/vault/data_source_pki_secret_backend_config_cmpv2_test.go
@@ -23,7 +23,7 @@ func TestAccDataSourcePKISecretConfigCMPV2(t *testing.T) {
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion118)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion118)
 		},
 		Steps: []resource.TestStep{
 			{

--- a/vault/data_source_pki_secret_backend_config_est_test.go
+++ b/vault/data_source_pki_secret_backend_config_est_test.go
@@ -23,7 +23,7 @@ func TestAccDataSourcePKISecretConfigEst(t *testing.T) {
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion116)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion116)
 		},
 		Steps: []resource.TestStep{
 			{

--- a/vault/data_source_pki_secret_backend_config_scep_test.go
+++ b/vault/data_source_pki_secret_backend_config_scep_test.go
@@ -23,7 +23,7 @@ func TestAccDataSourcePKISecretConfigScep(t *testing.T) {
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion120)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion120)
 		},
 		Steps: []resource.TestStep{
 			{

--- a/vault/data_source_pki_secret_backend_issuer_test.go
+++ b/vault/data_source_pki_secret_backend_issuer_test.go
@@ -24,7 +24,7 @@ func TestAccDataSourcePKISecretIssuer(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion111)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion111)
 		},
 		Steps: []resource.TestStep{
 			{
@@ -49,7 +49,7 @@ func TestAccDataSourcePKISecretIssuer_verify_disable_fields(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion119)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion119)
 		},
 		Steps: []resource.TestStep{
 			{

--- a/vault/data_source_pki_secret_backend_issuers_test.go
+++ b/vault/data_source_pki_secret_backend_issuers_test.go
@@ -24,7 +24,7 @@ func TestAccDataSourcePKISecretIssuers(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion111)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion111)
 		},
 		Steps: []resource.TestStep{
 			{

--- a/vault/data_source_pki_secret_backend_key_test.go
+++ b/vault/data_source_pki_secret_backend_key_test.go
@@ -24,7 +24,7 @@ func TestAccDataSourcePKISecretKey(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion111)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion111)
 		},
 		Steps: []resource.TestStep{
 			{

--- a/vault/data_source_pki_secret_backend_keys_test.go
+++ b/vault/data_source_pki_secret_backend_keys_test.go
@@ -24,7 +24,7 @@ func TestAccDataSourcePKISecretKeys(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion111)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion111)
 		},
 		Steps: []resource.TestStep{
 			{

--- a/vault/data_source_transit_cmac_test.go
+++ b/vault/data_source_transit_cmac_test.go
@@ -88,7 +88,7 @@ func TestDataSourceTransitCMAC(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion117)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion117)
 		},
 		Steps: []resource.TestStep{
 			{

--- a/vault/resource_aws_auth_backend_client_test.go
+++ b/vault/resource_aws_auth_backend_client_test.go
@@ -112,7 +112,7 @@ func TestAccAWSAuthBackend_wif(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion117)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion117)
 		},
 		CheckDestroy: testAccCheckAWSAuthBackendClientDestroy,
 		Steps: []resource.TestStep{

--- a/vault/resource_aws_auth_backend_sts_role_test.go
+++ b/vault/resource_aws_auth_backend_sts_role_test.go
@@ -30,7 +30,7 @@ func TestAccAWSAuthBackendSTSRole_withExternalID(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion117)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion117)
 		},
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		CheckDestroy:             testAccCheckAWSAuthBackendSTSRoleDestroy,

--- a/vault/resource_aws_secret_backend_static_role_test.go
+++ b/vault/resource_aws_secret_backend_static_role_test.go
@@ -24,7 +24,7 @@ func TestAccAWSSecretBackendStaticRole(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion114)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion114)
 		},
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		Steps: []resource.TestStep{
@@ -50,7 +50,7 @@ func TestAccAWSSecretBackendStaticAssumeRole(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion119)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion119)
 		},
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		Steps: []resource.TestStep{

--- a/vault/resource_aws_secret_backend_test.go
+++ b/vault/resource_aws_secret_backend_test.go
@@ -131,7 +131,7 @@ func TestAccAWSSecretBackend_wif(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion116)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion116)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeAWS, consts.FieldPath),
 		Steps: []resource.TestStep{
@@ -168,7 +168,7 @@ func TestAccAWSSecretBackend_automatedRotation(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion119)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion119)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeAWS, consts.FieldPath),
 		Steps: []resource.TestStep{
@@ -278,7 +278,7 @@ func TestAccAWSSecretBackendRole_MountConfig(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion117)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion117)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeAWS, consts.FieldPath),
 		Steps: []resource.TestStep{

--- a/vault/resource_azure_auth_backend_config_test.go
+++ b/vault/resource_azure_auth_backend_config_test.go
@@ -67,7 +67,7 @@ func TestAccAzureAuthBackend_wif(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion117)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion117)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeAzure, consts.FieldBackend),
 		Steps: []resource.TestStep{

--- a/vault/resource_azure_secret_backend_test.go
+++ b/vault/resource_azure_secret_backend_test.go
@@ -98,7 +98,7 @@ func TestAccAzureSecretBackend_wif(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion117)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion117)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeAzure, consts.FieldPath),
 		Steps: []resource.TestStep{
@@ -138,7 +138,7 @@ func TestAccAzureSecretBackend_MountConfig(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion117)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion117)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeAzure, consts.FieldPath),
 		Steps: []resource.TestStep{
@@ -247,7 +247,7 @@ func TestAccAzureSecretBackendConfig_automatedRotation(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion119)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion119)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeAzure, consts.FieldPath),
 		Steps: []resource.TestStep{

--- a/vault/resource_cert_auth_backend_role_test.go
+++ b/vault/resource_cert_auth_backend_role_test.go
@@ -129,7 +129,7 @@ func TestCertAuthBackend_OCSP(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion113)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion113)
 		},
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		CheckDestroy:             testCertAuthBackendDestroy,

--- a/vault/resource_config_ui_custom_message_test.go
+++ b/vault/resource_config_ui_custom_message_test.go
@@ -54,7 +54,7 @@ func TestAccConfigUICustomMessage(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion116)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion116)
 		},
 		Steps: []resource.TestStep{
 			{

--- a/vault/resource_consul_secret_backend_role_test.go
+++ b/vault/resource_consul_secret_backend_role_test.go
@@ -75,7 +75,7 @@ func TestConsulSecretBackendRole(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion111)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion111)
 		},
 		CheckDestroy: testAccConsulSecretBackendRoleCheckDestroy,
 		Steps: []resource.TestStep{
@@ -183,7 +183,7 @@ func TestConsulSecretBackendRole_Legacy(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionGTE(t, testProvider.Meta(), provider.VaultVersion111)
+			testutil.SkipIfAPIVersionGTE(t, testProvider.Meta(), provider.VaultVersion111)
 		},
 		CheckDestroy: testAccConsulSecretBackendRoleCheckDestroy,
 		Steps: []resource.TestStep{

--- a/vault/resource_consul_secret_backend_test.go
+++ b/vault/resource_consul_secret_backend_test.go
@@ -148,7 +148,7 @@ func TestConsulSecretBackend_Bootstrap(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion111)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion111)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeConsul, consts.FieldPath),
 		Steps: []resource.TestStep{

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -458,7 +458,7 @@ func TestAccDatabaseSecretBackendConnection_mysql_cloud(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion115)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion115)
 		},
 		CheckDestroy: testAccDatabaseSecretBackendConnectionCheckDestroy,
 		Steps: []resource.TestStep{
@@ -858,7 +858,7 @@ func TestAccDatabaseSecretBackendConnection_postgresql_tls(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion118)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion118)
 		},
 		CheckDestroy: testAccDatabaseSecretBackendConnectionCheckDestroy,
 		Steps: []resource.TestStep{

--- a/vault/resource_database_secret_backend_static_role_test.go
+++ b/vault/resource_database_secret_backend_static_role_test.go
@@ -195,7 +195,7 @@ func TestAccDatabaseSecretBackendStaticRole_rotationSchedule(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion115)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion115)
 		},
 		CheckDestroy: testAccDatabaseSecretBackendStaticRoleCheckDestroy,
 		Steps: []resource.TestStep{
@@ -251,7 +251,7 @@ func TestAccDatabaseSecretBackendStaticRole_Rootless(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion118)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion118)
 		},
 		CheckDestroy: testAccDatabaseSecretBackendStaticRoleCheckDestroy,
 		Steps: []resource.TestStep{
@@ -307,7 +307,7 @@ func TestAccDatabaseSecretBackendStaticRole_SkipImportRotation(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion118)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion118)
 		},
 		CheckDestroy: testAccDatabaseSecretBackendStaticRoleCheckDestroy,
 		Steps: []resource.TestStep{

--- a/vault/resource_database_secrets_mount_test.go
+++ b/vault/resource_database_secrets_mount_test.go
@@ -249,7 +249,7 @@ func TestAccDatabaseSecretsMount_postgresql_automatedRootRotation(t *testing.T) 
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion119)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion119)
 		},
 		CheckDestroy: testAccDatabaseSecretBackendConnectionCheckDestroy,
 		Steps: []resource.TestStep{

--- a/vault/resource_gcp_auth_backend_test.go
+++ b/vault/resource_gcp_auth_backend_test.go
@@ -164,7 +164,7 @@ func TestGCPAuthBackend_WIF(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion117)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion117)
 		},
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		CheckDestroy:             testGCPAuthBackendDestroy,
@@ -304,7 +304,7 @@ func TestAccGCPAuthBackendClient_automatedRotation(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion119)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion119)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeGCP, consts.FieldPath),
 		Steps: []resource.TestStep{

--- a/vault/resource_gcp_secret_backend_test.go
+++ b/vault/resource_gcp_secret_backend_test.go
@@ -122,7 +122,7 @@ func TestAccGCPSecretBackend_automatedRotation(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion119)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion119)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeGCP, consts.FieldPath),
 		Steps: []resource.TestStep{

--- a/vault/resource_gcp_secret_impersonated_account_test.go
+++ b/vault/resource_gcp_secret_impersonated_account_test.go
@@ -38,7 +38,7 @@ func TestGCPSecretImpersonatedAccount(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion113)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion113)
 		},
 		CheckDestroy: testGCPSecretImpersonatedAccountDestroy,
 		Steps: []resource.TestStep{

--- a/vault/resource_kubernetes_auth_backend_config_test.go
+++ b/vault/resource_kubernetes_auth_backend_config_test.go
@@ -362,7 +362,7 @@ func TestAccKubernetesAuthBackendConfig_localCA(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionGTE(t, testProvider.Meta(), vaultVersion193)
+			testutil.SkipIfAPIVersionGTE(t, testProvider.Meta(), vaultVersion193)
 		},
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		CheckDestroy:             testAccCheckKubernetesAuthBackendConfigDestroy,
@@ -506,7 +506,7 @@ func TestAccKubernetesAuthBackendConfig_fullInK8sCluster(t *testing.T) {
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
 			testutil.SkipTestEnvSet(t, envVarTFAccK8sSkipInCluster)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), vaultVersion193)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), vaultVersion193)
 		},
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		CheckDestroy:             testAccCheckKubernetesAuthBackendConfigDestroy,

--- a/vault/resource_ldap_auth_backend_test.go
+++ b/vault/resource_ldap_auth_backend_test.go
@@ -130,7 +130,7 @@ func TestLDAPAuthBackend_automatedRotation(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion119)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion119)
 		},
 		Steps: []resource.TestStep{
 			{

--- a/vault/resource_ldap_secret_backend_dynamic_role_test.go
+++ b/vault/resource_ldap_secret_backend_dynamic_role_test.go
@@ -38,7 +38,7 @@ func TestAccLDAPSecretBackendDynamicRole(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion112)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion112)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeLDAP, consts.FieldMount),
 		Steps: []resource.TestStep{

--- a/vault/resource_ldap_secret_backend_library_set_test.go
+++ b/vault/resource_ldap_secret_backend_library_set_test.go
@@ -25,7 +25,7 @@ func TestAccLDAPSecretBackendLibrarySet(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion112)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion112)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeLDAP, consts.FieldMount),
 		Steps: []resource.TestStep{

--- a/vault/resource_ldap_secret_backend_static_role_test.go
+++ b/vault/resource_ldap_secret_backend_static_role_test.go
@@ -32,7 +32,7 @@ func TestAccLDAPSecretBackendStaticRole(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion112)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion112)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeLDAP, consts.FieldMount),
 		Steps: []resource.TestStep{

--- a/vault/resource_ldap_secret_backend_test.go
+++ b/vault/resource_ldap_secret_backend_test.go
@@ -133,7 +133,7 @@ func TestLDAPSecretBackend_SchemaAD(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion112)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion112)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeLDAP, consts.FieldPath),
 		Steps: []resource.TestStep{
@@ -213,7 +213,7 @@ func TestLDAPSecretBackend_automatedRotation(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion119)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion119)
 		}, PreventPostDestroyRefresh: true,
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeLDAP, consts.FieldPath),
 		Steps: []resource.TestStep{

--- a/vault/resource_mount_test.go
+++ b/vault/resource_mount_test.go
@@ -359,7 +359,7 @@ func TestResourceMount_IDTokenKey(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion117)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion117)
 		},
 		Steps: []resource.TestStep{
 			{

--- a/vault/resource_pki_secret_backend_acme_eab_test.go
+++ b/vault/resource_pki_secret_backend_acme_eab_test.go
@@ -26,7 +26,7 @@ func TestAccPKISecretBackendAcmeEab(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion114)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion114)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypePKI, consts.FieldBackend),
 		Steps: []resource.TestStep{

--- a/vault/resource_pki_secret_backend_config_acme_test.go
+++ b/vault/resource_pki_secret_backend_config_acme_test.go
@@ -25,7 +25,7 @@ func TestPkiSecretBackendConfigACME_basic(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion114)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion114)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypePKI, consts.FieldBackend),
 		Steps: []resource.TestStep{
@@ -77,7 +77,7 @@ func TestPkiSecretBackendConfigACME_basic(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion117)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion117)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypePKI, consts.FieldBackend),
 		Steps: []resource.TestStep{

--- a/vault/resource_pki_secret_backend_config_auto_tidy_test.go
+++ b/vault/resource_pki_secret_backend_config_auto_tidy_test.go
@@ -324,7 +324,7 @@ func TestAccPKISecretBackendConfigAutoTidy_ent(t *testing.T) {
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion117)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion117)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypePKI, consts.FieldBackend),
 		Steps: []resource.TestStep{

--- a/vault/resource_pki_secret_backend_config_cluster_test.go
+++ b/vault/resource_pki_secret_backend_config_cluster_test.go
@@ -28,7 +28,7 @@ func TestPkiSecretBackendConfigCluster_basic(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion113)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion113)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypePKI, consts.FieldBackend),
 		Steps: []resource.TestStep{

--- a/vault/resource_pki_secret_backend_config_cmpv2_test.go
+++ b/vault/resource_pki_secret_backend_config_cmpv2_test.go
@@ -29,7 +29,7 @@ func TestAccPKISecretBackendConfigCMPV2_Empty(t *testing.T) {
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion118)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion118)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypePKI, consts.FieldBackend),
 		Steps: []resource.TestStep{
@@ -72,7 +72,7 @@ func TestAccPKISecretBackendConfigCMPV2_AllFields_Pre1185(t *testing.T) {
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion118)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion118)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypePKI, consts.FieldBackend),
 		Steps: []resource.TestStep{
@@ -123,7 +123,7 @@ func TestAccPKISecretBackendConfigCMPV2_AllFields(t *testing.T) {
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion1185)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion1185)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypePKI, consts.FieldBackend),
 		Steps: []resource.TestStep{
@@ -189,7 +189,7 @@ func TestAccPKISecretBackendConfigCMPV2_ChangeFields(t *testing.T) {
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion118)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion118)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypePKI, consts.FieldBackend),
 		Steps: []resource.TestStep{

--- a/vault/resource_pki_secret_backend_config_est_test.go
+++ b/vault/resource_pki_secret_backend_config_est_test.go
@@ -31,7 +31,7 @@ func TestAccPKISecretBackendConfigEst_Empty(t *testing.T) {
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion116)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion116)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypePKI, consts.FieldBackend),
 		Steps: []resource.TestStep{
@@ -81,7 +81,7 @@ func TestAccPKISecretBackendConfigEst_Blank(t *testing.T) {
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion116)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion116)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypePKI, consts.FieldBackend),
 		Steps: []resource.TestStep{
@@ -131,7 +131,7 @@ func TestAccPKISecretBackendConfigEst_AllFields(t *testing.T) {
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion116)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion116)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypePKI, consts.FieldBackend),
 		Steps: []resource.TestStep{
@@ -206,7 +206,7 @@ func TestAccPKISecretBackendConfigEst_ChangeFields(t *testing.T) {
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion116)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion116)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypePKI, consts.FieldBackend),
 		Steps: []resource.TestStep{

--- a/vault/resource_pki_secret_backend_config_issuers_test.go
+++ b/vault/resource_pki_secret_backend_config_issuers_test.go
@@ -27,7 +27,7 @@ func TestAccPKISecretBackendConfigIssuers_basic(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion111)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion111)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypePKI, consts.FieldBackend),
 		Steps: []resource.TestStep{

--- a/vault/resource_pki_secret_backend_config_scep_test.go
+++ b/vault/resource_pki_secret_backend_config_scep_test.go
@@ -29,7 +29,7 @@ func TestAccPKISecretBackendConfigScep_Empty(t *testing.T) {
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion120)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion120)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypePKI, consts.FieldBackend),
 		Steps: []resource.TestStep{

--- a/vault/resource_pki_secret_backend_crl_config_test.go
+++ b/vault/resource_pki_secret_backend_crl_config_test.go
@@ -94,7 +94,7 @@ func TestPkiSecretBackendCrlConfig(t *testing.T) {
 	t.Run("vault-1.11-and-below", func(t *testing.T) {
 		setupCRLConfigTest(t, func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionGTE(t, testProvider.Meta(), provider.VaultVersion112)
+			testutil.SkipIfAPIVersionGTE(t, testProvider.Meta(), provider.VaultVersion112)
 		},
 			"ocsp_disable",
 			"ocsp_expiry",
@@ -113,8 +113,8 @@ func TestPkiSecretBackendCrlConfig(t *testing.T) {
 	t.Run("vault-1.12", func(t *testing.T) {
 		setupCRLConfigTest(t, func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionGTE(t, testProvider.Meta(), provider.VaultVersion113)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion112)
+			testutil.SkipIfAPIVersionGTE(t, testProvider.Meta(), provider.VaultVersion113)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion112)
 		},
 			"cross_cluster_revocation",
 			"unified_crl",
@@ -127,8 +127,8 @@ func TestPkiSecretBackendCrlConfig(t *testing.T) {
 	t.Run("vault-1.13-to-1.18", func(t *testing.T) {
 		setupCRLConfigTest(t, func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion113)
-			SkipIfAPIVersionGTE(t, testProvider.Meta(), provider.VaultVersion119)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion113)
+			testutil.SkipIfAPIVersionGTE(t, testProvider.Meta(), provider.VaultVersion119)
 		},
 			"max_crl_entries",
 		)
@@ -138,7 +138,7 @@ func TestPkiSecretBackendCrlConfig(t *testing.T) {
 	t.Run("vault-1.19-and-above", func(t *testing.T) {
 		setupCRLConfigTest(t, func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion119)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion119)
 		},
 		)
 	})
@@ -168,7 +168,7 @@ func TestPkiSecretBackendCrlConfig(t *testing.T) {
 			PreCheck: func() {
 				testutil.TestAccPreCheck(t)
 				testutil.TestEntPreCheck(t)
-				SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion120)
+				testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion120)
 			},
 			CheckDestroy: testCheckMountDestroyed("vault_mount", consts.MountTypePKI, consts.FieldPath),
 			Steps:        steps,

--- a/vault/resource_pki_secret_backend_intermediate_cert_request_test.go
+++ b/vault/resource_pki_secret_backend_intermediate_cert_request_test.go
@@ -268,7 +268,7 @@ func TestPkiSecretBackendIntermediateCertificate_multiIssuer(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion111)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion111)
 		},
 		CheckDestroy: testCheckMountDestroyed("vault_mount", consts.MountTypePKI, consts.FieldPath),
 		Steps: []resource.TestStep{

--- a/vault/resource_pki_secret_backend_intermediate_set_signed_test.go
+++ b/vault/resource_pki_secret_backend_intermediate_set_signed_test.go
@@ -46,7 +46,7 @@ func TestPkiSecretBackendIntermediateSetSigned_multiIssuers(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion111)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion111)
 		},
 		CheckDestroy: testCheckMountDestroyed("vault_mount", consts.MountTypePKI, consts.FieldPath),
 		Steps: []resource.TestStep{

--- a/vault/resource_pki_secret_backend_issuer_test.go
+++ b/vault/resource_pki_secret_backend_issuer_test.go
@@ -28,7 +28,7 @@ func TestAccPKISecretBackendIssuer_basic(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion111)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion111)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypePKI, consts.FieldBackend),
 		Steps: []resource.TestStep{
@@ -102,7 +102,7 @@ func TestAccPKISecretBackendIssuer_verify_disable_fields(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion119)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion119)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypePKI, consts.FieldBackend),
 		Steps: []resource.TestStep{

--- a/vault/resource_pki_secret_backend_key_test.go
+++ b/vault/resource_pki_secret_backend_key_test.go
@@ -35,7 +35,7 @@ func TestAccPKISecretBackendKey_basic(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion111)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion111)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypePKI, consts.FieldBackend),
 		Steps: []resource.TestStep{

--- a/vault/resource_pki_secret_backend_root_cert_test.go
+++ b/vault/resource_pki_secret_backend_root_cert_test.go
@@ -123,7 +123,7 @@ func TestPkiSecretBackendRootCertificate_name_constraints(t *testing.T) {
 	}
 
 	testPkiSecretBackendRootCertificate(t, path, config, resourceName, checks, func(t *testing.T) {
-		SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion119)
+		testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion119)
 	})
 }
 
@@ -298,7 +298,7 @@ func TestPkiSecretBackendRootCertificate_multiIssuer(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion111)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion111)
 		},
 		CheckDestroy: testCheckMountDestroyed("vault_mount", consts.MountTypePKI, consts.FieldPath),
 		Steps: []resource.TestStep{
@@ -341,7 +341,7 @@ func TestAccPKISecretBackendRootCert_multipleRootCerts(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion111)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion111)
 		},
 		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypePKI, consts.FieldBackend),
 		Steps: []resource.TestStep{

--- a/vault/resource_pki_secret_backend_root_sign_intermediate_test.go
+++ b/vault/resource_pki_secret_backend_root_sign_intermediate_test.go
@@ -314,7 +314,7 @@ func TestPkiSecretBackendRootSignIntermediate_name_constraints_pem_bundle(t *tes
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion119)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion119)
 		},
 		CheckDestroy: testCheckMountDestroyed("vault_mount", consts.MountTypePKI, consts.FieldPath),
 		Steps: []resource.TestStep{

--- a/vault/resource_plugin_pinned_version_test.go
+++ b/vault/resource_plugin_pinned_version_test.go
@@ -33,7 +33,7 @@ func TestPluginPinnedVersion(t *testing.T) {
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
 			testutil.SkipTestEnvUnset(t, envPluginCommand)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion116)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion116)
 		},
 		Steps: []resource.TestStep{
 			{

--- a/vault/resource_plugin_test.go
+++ b/vault/resource_plugin_test.go
@@ -47,7 +47,7 @@ func TestPlugin(t *testing.T) {
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
 			testutil.SkipTestEnvUnset(t, envPluginCommand)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion112)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion112)
 		},
 		Steps: []resource.TestStep{
 			{

--- a/vault/resource_quota_lease_count_test.go
+++ b/vault/resource_quota_lease_count_test.go
@@ -67,7 +67,7 @@ func TestQuotaLeaseCountRoot(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionGTE(t, testProvider.Meta(), provider.VaultVersion116)
+			testutil.SkipIfAPIVersionGTE(t, testProvider.Meta(), provider.VaultVersion116)
 		},
 		CheckDestroy: testQuotaLeaseCountCheckDestroy([]string{leaseCount, newLeaseCount}),
 		Steps: []resource.TestStep{
@@ -96,7 +96,7 @@ func TestQuotaLeaseCountWithRole(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion112)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion112)
 		},
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			testQuotaLeaseCountCheckDestroy([]string{leaseCount, newLeaseCount}),
@@ -138,7 +138,7 @@ func TestQuotaLeaseCountInheritable(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion115)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion115)
 		},
 		CheckDestroy: testQuotaLeaseCountCheckDestroy([]string{leaseCount, newLeaseCount}),
 		Steps: []resource.TestStep{
@@ -196,7 +196,7 @@ func TestQuotaLeaseCountWithRoleInheritable(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion115)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion115)
 		},
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			testQuotaLeaseCountCheckDestroy([]string{leaseCount, newLeaseCount}),

--- a/vault/resource_quota_rate_limit_test.go
+++ b/vault/resource_quota_rate_limit_test.go
@@ -82,7 +82,7 @@ func TestQuotaRateLimitWithRole(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion112)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion112)
 		},
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			testQuotaRateLimitCheckDestroy([]string{rateLimit}),
@@ -127,7 +127,7 @@ func TestQuotaRateLimitInheritable(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion115)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion115)
 		},
 		CheckDestroy: testQuotaRateLimitCheckDestroy([]string{rateLimit, newRateLimit}),
 		Steps: []resource.TestStep{
@@ -180,7 +180,7 @@ func TestQuotaRateLimitWithNamespaceInheritable(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion115)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion115)
 		},
 		CheckDestroy: testQuotaRateLimitCheckDestroy([]string{rateLimit, newRateLimit}),
 		Steps: []resource.TestStep{
@@ -249,7 +249,7 @@ resource "vault_quota_rate_limit" "foobar" {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion120)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion120)
 		},
 		CheckDestroy: testQuotaRateLimitCheckDestroy([]string{rateLimit, newRateLimit}),
 		Steps: []resource.TestStep{

--- a/vault/resource_saml_auth_backend_role_test.go
+++ b/vault/resource_saml_auth_backend_role_test.go
@@ -26,7 +26,7 @@ func TestAccSAMLAuthBackendRole_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion115)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion115)
 		},
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		CheckDestroy:             testCheckMountDestroyed(resourceType, consts.MountTypeSAML, consts.FieldPath),

--- a/vault/resource_saml_auth_backend_test.go
+++ b/vault/resource_saml_auth_backend_test.go
@@ -24,7 +24,7 @@ func TestAccSAMLAuthBackend_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion115)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion115)
 		},
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		CheckDestroy:             testCheckMountDestroyed(resourceType, consts.MountTypeSAML, consts.FieldPath),

--- a/vault/resource_scep_auth_backend_role_test.go
+++ b/vault/resource_scep_auth_backend_role_test.go
@@ -22,7 +22,7 @@ func TestScepAuthBackendRolesResource_static_challenge(t *testing.T) {
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion120)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion120)
 		},
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		CheckDestroy:             testScepAuthBackendDestroy,

--- a/vault/resource_secrets_sync_association_test.go
+++ b/vault/resource_secrets_sync_association_test.go
@@ -36,7 +36,7 @@ func TestSecretsSyncAssociation_gh(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion115)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion115)
 		}, PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{

--- a/vault/resource_secrets_sync_aws_destination_test.go
+++ b/vault/resource_secrets_sync_aws_destination_test.go
@@ -32,7 +32,7 @@ func TestAWSSecretsSyncDestination(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion116)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion116)
 		},
 		Steps: []resource.TestStep{
 			{

--- a/vault/resource_secrets_sync_azure_destination_test.go
+++ b/vault/resource_secrets_sync_azure_destination_test.go
@@ -36,7 +36,7 @@ func TestAzureSecretsSyncDestination(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion115)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion115)
 		}, PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{

--- a/vault/resource_secrets_sync_config_test.go
+++ b/vault/resource_secrets_sync_config_test.go
@@ -22,7 +22,7 @@ func TestSecretsSyncConfig(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestEntPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion116)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion116)
 		}, PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{
@@ -52,7 +52,7 @@ func TestSecretsSyncConfig(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion115)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion115)
 		}, PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{

--- a/vault/resource_secrets_sync_gh_destination_test.go
+++ b/vault/resource_secrets_sync_gh_destination_test.go
@@ -37,7 +37,7 @@ func TestGithubSecretsSyncDestination(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion116)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion116)
 		}, PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{

--- a/vault/resource_secrets_sync_github_apps_test.go
+++ b/vault/resource_secrets_sync_github_apps_test.go
@@ -33,7 +33,7 @@ func TestGithubAppsSecretsSync(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion116)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion116)
 		}, PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{

--- a/vault/resource_secrets_sync_vercel_destination_test.go
+++ b/vault/resource_secrets_sync_vercel_destination_test.go
@@ -31,7 +31,7 @@ func TestVercelSecretsSyncDestination(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion116)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion116)
 		}, PreventPostDestroyRefresh: true,
 		Steps: []resource.TestStep{
 			{

--- a/vault/resource_ssh_secret_backend_ca_test.go
+++ b/vault/resource_ssh_secret_backend_ca_test.go
@@ -110,7 +110,7 @@ func TestAccSSHSecretBackendCA_managedKeys(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion120)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion120)
 		},
 		CheckDestroy: testAccCheckSSHSecretBackendCADestroy,
 		Steps: []resource.TestStep{

--- a/vault/resource_ssh_secret_backend_role_test.go
+++ b/vault/resource_ssh_secret_backend_role_test.go
@@ -164,7 +164,7 @@ func TestAccSSHSecretBackendRole_template(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion112)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion112)
 		},
 		CheckDestroy: testAccSSHSecretBackendRoleCheckDestroy,
 		Steps: []resource.TestStep{

--- a/vault/resource_terraform_cloud_secret_role_test.go
+++ b/vault/resource_terraform_cloud_secret_role_test.go
@@ -82,7 +82,7 @@ func TestTerraformCloudSecretRole_options(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion120)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion120)
 		},
 		CheckDestroy: testAccTerraformCloudSecretRoleCheckDestroy,
 		Steps: []resource.TestStep{

--- a/vault/resource_transit_secret_backend_key_test.go
+++ b/vault/resource_transit_secret_backend_key_test.go
@@ -155,7 +155,7 @@ func TestTransitSecretBackendKey_hmac(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			testutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion112)
+			testutil.SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion112)
 		},
 		CheckDestroy: testTransitSecretBackendKeyCheckDestroy,
 		Steps: []resource.TestStep{

--- a/vault/testhelpers_test.go
+++ b/vault/testhelpers_test.go
@@ -5,12 +5,9 @@ package vault
 
 import (
 	"fmt"
-	"regexp"
-	"testing"
-
-	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"regexp"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
@@ -74,65 +71,5 @@ func testCheckMountDestroyed(resourceType, mountType, pathField string) resource
 		}
 
 		return nil
-	}
-}
-
-// SkipIfAPIVersionLT skips of the running vault version is less-than ver.
-func SkipIfAPIVersionLT(t *testing.T, m interface{}, ver *version.Version) {
-	t.Helper()
-	f := func(curVer *version.Version) bool {
-		return curVer.LessThan(ver)
-	}
-	SkipOnAPIVersion(t, m, f, "Vault version < %q", ver)
-}
-
-// SkipIfAPIVersionLTE skips if the running vault version is less-than-or-equal to ver.
-func SkipIfAPIVersionLTE(t *testing.T, m interface{}, ver *version.Version) {
-	t.Helper()
-	f := func(curVer *version.Version) bool {
-		return curVer.LessThanOrEqual(ver)
-	}
-	SkipOnAPIVersion(t, m, f, "Vault version <= %q", ver)
-}
-
-// SkipIfAPIVersionEQ skips if the running vault version is equal to ver.
-func SkipIfAPIVersionEQ(t *testing.T, m interface{}, ver *version.Version) {
-	t.Helper()
-	f := func(curVer *version.Version) bool {
-		return curVer.Equal(ver)
-	}
-	SkipOnAPIVersion(t, m, f, "Vault version == %q", ver)
-}
-
-// SkipIfAPIVersionGT skips if the running vault version is greater-than ver.
-func SkipIfAPIVersionGT(t *testing.T, m interface{}, ver *version.Version) {
-	t.Helper()
-	f := func(curVer *version.Version) bool {
-		return curVer.GreaterThan(ver)
-	}
-	SkipOnAPIVersion(t, m, f, "Vault version > %q", ver)
-}
-
-// SkipIfAPIVersionGTE skips if the running vault version is greater-than-or-equal to ver.
-func SkipIfAPIVersionGTE(t *testing.T, m interface{}, ver *version.Version) {
-	t.Helper()
-	f := func(curVer *version.Version) bool {
-		return curVer.GreaterThanOrEqual(ver)
-	}
-	SkipOnAPIVersion(t, m, f, "Vault version >= %q", ver)
-}
-
-func SkipOnAPIVersion(t *testing.T, m interface{}, cmp func(*version.Version) bool, format string, args ...interface{}) {
-	t.Helper()
-
-	p := m.(*provider.ProviderMeta)
-	curVer := p.GetVaultVersion()
-	if curVer == nil {
-		t.Fatalf("vault version not set on %T", p)
-	}
-
-	t.Logf("Vault server version %q", curVer)
-	if cmp(curVer) {
-		t.Skipf(format, args...)
 	}
 }


### PR DESCRIPTION
### Description
Moves test helpers that are common to both SDKv2 and new Framework resources out of the `vault/` subpackage and into the common `testutil` package. 

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
