### PR TITLE
secrets/aws: Add max_retries field to AWS Secret Backend.

### DIFF
--- a/vault/resource_aws_secret_backend.go
+++ b/vault/resource_aws_secret_backend.go
@@ -151,6 +151,12 @@ func awsSecretBackendResource() *schema.Resource {
 				Computed:    true,
 				Description: "The TTL of generated identity tokens in seconds.",
 			},
+			consts.FieldMaxRetries: {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+				Description: "Number of max retries the client should use for recoverable errors.",
+			},
 		},
 	}, false)
 
@@ -262,6 +268,9 @@ func awsSecretBackendCreate(ctx context.Context, d *schema.ResourceData, meta in
 		if v, ok := d.GetOk(consts.FieldIdentityTokenTTL); ok && v != 0 {
 			data[consts.FieldIdentityTokenTTL] = v.(int)
 		}
+		if v, ok := d.GetOk(consts.FieldMaxRetries); ok && v != 0 {
+			data[consts.FieldMaxRetries] = v.(int)
+		}
 	}
 
 	if region != "" {
@@ -367,6 +376,9 @@ func awsSecretBackendRead(ctx context.Context, d *schema.ResourceData, meta inte
 			if err := d.Set(consts.FieldIdentityTokenTTL, resp.Data[consts.FieldIdentityTokenTTL]); err != nil {
 				return diag.Errorf("error reading %s for AWS Secret Backend %q: %q", consts.FieldIdentityTokenTTL, path, err)
 			}
+			if err := d.Set(consts.FieldMaxRetries, resp.Data[consts.FieldMaxRetries]); err != nil {
+				return diag.Errorf("error reading %s for AWS Secret Backend %q: %q", consts.FieldMaxRetries, path, err)
+			}
 		}
 	}
 
@@ -400,7 +412,7 @@ func awsSecretBackendUpdate(ctx context.Context, d *schema.ResourceData, meta in
 	if d.HasChanges(consts.FieldAccessKey,
 		consts.FieldSecretKey, consts.FieldRegion, consts.FieldIAMEndpoint,
 		consts.FieldSTSEndpoint, consts.FieldSTSFallbackEndpoints, consts.FieldSTSRegion, consts.FieldSTSFallbackRegions,
-		consts.FieldIdentityTokenTTL, consts.FieldIdentityTokenAudience, consts.FieldRoleArn,
+		consts.FieldIdentityTokenTTL, consts.FieldIdentityTokenAudience, consts.FieldRoleArn, consts.FieldMaxRetries,
 		consts.FieldRotationSchedule,
 		consts.FieldRotationPeriod,
 		consts.FieldRotationWindow,
@@ -449,6 +461,10 @@ func awsSecretBackendUpdate(ctx context.Context, d *schema.ResourceData, meta in
 			identityTokenTTL := d.Get(consts.FieldIdentityTokenTTL).(int)
 			if identityTokenTTL != 0 {
 				data[consts.FieldIdentityTokenTTL] = identityTokenTTL
+			}
+			maxRetries := d.Get(consts.FieldMaxRetries).(int)
+			if maxRetries != 0 {
+				data[consts.FieldMaxRetries] = maxRetries
 			}
 		}
 

--- a/vault/resource_aws_secret_backend_test.go
+++ b/vault/resource_aws_secret_backend_test.go
@@ -6,7 +6,6 @@ package vault
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"regexp"
 	"testing"
 
@@ -14,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -142,6 +142,7 @@ func TestAccAWSSecretBackend_wif(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, consts.FieldIdentityTokenAudience, "wif-audience"),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldIdentityTokenTTL, "600"),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldRoleArn, "test-role-arn"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldMaxRetries, "3"),
 				),
 			},
 			{
@@ -151,6 +152,7 @@ func TestAccAWSSecretBackend_wif(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, consts.FieldIdentityTokenAudience, "wif-audience-updated"),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldIdentityTokenTTL, "1800"),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldRoleArn, "test-role-arn-updated"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldMaxRetries, "5"),
 				),
 			},
 		},
@@ -436,6 +438,7 @@ resource "vault_aws_secret_backend" "test" {
   identity_token_audience = "wif-audience"
   identity_token_ttl = 600
   role_arn = "test-role-arn"
+  max_retries = 3
 }`, path)
 }
 
@@ -446,6 +449,7 @@ resource "vault_aws_secret_backend" "test" {
   identity_token_audience = "wif-audience-updated"
   identity_token_ttl = 1800
   role_arn = "test-role-arn-updated"
+  max_retries = 5
 }`, path)
 }
 

--- a/website/docs/r/aws_secret_backend.html.md
+++ b/website/docs/r/aws_secret_backend.html.md
@@ -89,6 +89,8 @@ not begin or end with a `/`. Defaults to `aws`.
 
 * `identity_token_ttl` - (Optional) The TTL of generated identity tokens in seconds. Requires Vault 1.16+.
 
+* `max_retries` - (Optional) Number of max retries the client should use for recoverable errors. Requires Vault 1.16+.
+
 * `role_arn` - (Optional) Role ARN to assume for plugin identity token federation. Requires Vault 1.16+.
 
 * `rotation_period` - (Optional) The amount of time in seconds Vault should wait before rotating the root credential. 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
This PR adds support for the [`max_retries` field in the AWS Secret engine](https://developer.hashicorp.com/vault/api-docs/auth/aws#max_retries).

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000


### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSSecretBackend_wif'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -run=TestAccAWSSecretBackend_wif -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/codegen   1.005s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/framework/base   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/framework/client [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/framework/errutil        [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/framework/model  [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/framework/validators     1.318s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  1.725s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/mfa     [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/pki      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/provider 2.401s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/provider/fwprovider      [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/providertest     [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/rotation [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/sync     [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/vault/secrets/ephemeral  2.395s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/vault/sys        1.988s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
ok      github.com/hashicorp/terraform-provider-vault/testutil  3.127s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util      2.444s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util/mountutil    2.876s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/vault     2.801s
...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
