### PR TITLE
VAULT-39756: Add support for allowed_sts_header_values associated with /auth/aws/config/client endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ FEATURES:
 
 * New parameters for `vault_terraform_cloud_secret_role` to support multi-team tokens, by @drewmullen ([#2498](https://github.com/hashicorp/terraform-provider-vault/pull/2498))
 
+* Add support for `allowed_sts_header_values` parameter in `vault_aws_auth_backend_client` resource to specify additional headers allowed in STS requests
+
 BUGS:
 
 * Fix pki config resources to allow unsetting of fields (to empty fields) ([#2558](https://github.com/hashicorp/terraform-provider-vault/pull/2558))

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -439,6 +439,7 @@ const (
 	FieldEC2Endpoint                    = "ec2_endpoint"
 	FieldSTSRegion                      = "sts_region"
 	FieldSTSFallbackRegions             = "sts_fallback_regions"
+	FieldAllowedSTSHeaderValues         = "allowed_sts_header_values"
 	FieldIAMServerIDHeaderValue         = "iam_server_id_header_value"
 	FieldListingVisibility              = "listing_visibility"
 	FieldPassthroughRequestHeaders      = "passthrough_request_headers"

--- a/vault/resource_aws_auth_backend_client.go
+++ b/vault/resource_aws_auth_backend_client.go
@@ -6,6 +6,7 @@ package vault
 import (
 	"context"
 	"log"
+	"net/textproto"
 	"regexp"
 	"strings"
 
@@ -82,6 +83,20 @@ func awsAuthBackendClientResource() *schema.Resource {
 				Computed:    true,
 				Description: "If set, will override sts_region and use the region from the client request's header",
 			},
+			consts.FieldAllowedSTSHeaderValues: {
+				Type:        schema.TypeSet,
+				Optional:    true,
+				Description: "List of additional headers that are allowed to be in STS request headers.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+					StateFunc: func(v interface{}) string {
+						original := strings.TrimSpace(v.(string))
+						// Canonicalize header names for consistent state storage
+						canonical := textproto.CanonicalMIMEHeaderKey(original)
+						return canonical
+					},
+				},
+			},
 			consts.FieldIAMServerIDHeaderValue: {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -132,6 +147,25 @@ func awsAuthBackendWrite(ctx context.Context, d *schema.ResourceData, meta inter
 	stsEndpoint := d.Get(consts.FieldSTSEndpoint).(string)
 	stsRegion := d.Get(consts.FieldSTSRegion).(string)
 	stsRegionFromClient := d.Get(useSTSRegionFromClient).(bool)
+	allowedSTSHeaderValuesSet := d.Get(consts.FieldAllowedSTSHeaderValues).(*schema.Set)
+	var allowedSTSHeaderValuesList []string
+	if allowedSTSHeaderValuesSet.Len() > 0 {
+		// Convert TypeSet to slice for Vault API
+		// Need explicit deduplication because TypeSet may not handle StateFunc canonicalization properly
+		allowedSTSHeaderValuesList = make([]string, 0, allowedSTSHeaderValuesSet.Len())
+		seenHeaders := make(map[string]bool) // Track duplicates after canonicalization
+
+		for _, v := range allowedSTSHeaderValuesSet.List() {
+			header := strings.TrimSpace(v.(string))
+			canonical := textproto.CanonicalMIMEHeaderKey(header)
+
+			// Only add if we haven't seen this canonical form before
+			if !seenHeaders[canonical] {
+				allowedSTSHeaderValuesList = append(allowedSTSHeaderValuesList, canonical)
+				seenHeaders[canonical] = true
+			}
+		}
+	}
 	identityTokenAud := d.Get(consts.FieldIdentityTokenAudience).(string)
 	roleArn := d.Get(consts.FieldRoleArn).(string)
 	identityTokenTTL := d.Get(consts.FieldIdentityTokenTTL).(int)
@@ -145,6 +179,7 @@ func awsAuthBackendWrite(ctx context.Context, d *schema.ResourceData, meta inter
 		consts.FieldIAMEndpoint:            iamEndpoint,
 		consts.FieldSTSEndpoint:            stsEndpoint,
 		consts.FieldSTSRegion:              stsRegion,
+		consts.FieldAllowedSTSHeaderValues: allowedSTSHeaderValuesList,
 		consts.FieldIAMServerIDHeaderValue: iamServerIDHeaderValue,
 		consts.FieldMaxRetries:             maxRetries,
 	}
@@ -229,6 +264,32 @@ func awsAuthBackendRead(ctx context.Context, d *schema.ResourceData, meta interf
 			if err := d.Set(k, v); err != nil {
 				return diag.FromErr(err)
 			}
+		}
+	}
+	// Handle allowed_sts_header_values conversion from Vault's slice to set
+	if headersInterface, ok := secret.Data[consts.FieldAllowedSTSHeaderValues]; ok {
+		if headersList, ok := headersInterface.([]interface{}); ok && len(headersList) > 0 {
+			// Convert interface{} slice to string slice
+			headers := make([]string, len(headersList))
+			for i, header := range headersList {
+				if headerStr, ok := header.(string); ok {
+					// Vault already canonicalizes these, no need to do it again
+					headers[i] = strings.TrimSpace(headerStr)
+				}
+			}
+			if err := d.Set(consts.FieldAllowedSTSHeaderValues, headers); err != nil {
+				return diag.FromErr(err)
+			}
+		} else {
+			// Empty or nil headers
+			if err := d.Set(consts.FieldAllowedSTSHeaderValues, []string{}); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	} else {
+		// Field not present in response
+		if err := d.Set(consts.FieldAllowedSTSHeaderValues, []string{}); err != nil {
+			return diag.FromErr(err)
 		}
 	}
 	if provider.IsAPISupported(meta, provider.VaultVersion115) {

--- a/website/docs/r/aws_auth_backend_client.html.md
+++ b/website/docs/r/aws_auth_backend_client.html.md
@@ -52,6 +52,10 @@ resource "vault_aws_auth_backend_client" "example" {
   secret_key        = "INSERT_AWS_SECRET_KEY"
   rotation_schedule = "0 * * * SAT"
   rotation_window   = 3600
+  allowed_sts_header_values = [
+    "X-Custom-Header",
+    "X-Another-Header"
+  ]
 }
 ```
 
@@ -106,6 +110,10 @@ The following arguments are supported:
 
 * `max_retries` - (Optional) Number of max retries the client should use for recoverable errors. 
     The default `-1` falls back to the AWS SDK's default behavior.
+
+* `allowed_sts_header_values` - (Optional) List of additional headers that are allowed to be in STS request headers.
+    The headers are automatically canonicalized (e.g., `content-type` becomes `Content-Type`). Duplicate values are automatically
+    removed. This can be useful when you need to allow specific headers in STS requests for IAM-based authentication.
 
 * `rotation_period` - (Optional) The amount of time in seconds Vault should wait before rotating the root credential.
     A zero value tells Vault not to rotate the root credential. The minimum rotation period is 10 seconds. Requires Vault Enterprise 1.19+.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
Added support for allowed_sts_header_values for the [/auth/aws/config/client](https://developer.hashicorp.com/vault/api-docs/auth/aws#configure-client) endpoint in the [vault_aws_auth_backend_client](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/aws_auth_backend_client) resource.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes [VAULT-39756](https://hashicorp.atlassian.net/browse/VAULT-39756)


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccAWSAuthBackendClient_allowedSTSHeaderValues'
$ make testacc TESTARGS='-run=TestAccAWSAuthBackendClient_allowedSTSHeaderValues_canonicalization'
$ make testacc TESTARGS='-run=TestAccAWSAuthBackendClient_allowedSTSHeaderValues_duplicateHandling'
...
```

<img width="1038" height="236" alt="image" src="https://github.com/user-attachments/assets/c484146d-7dbf-4a7b-88db-73abeb652478" />

<img width="798" height="127" alt="image" src="https://github.com/user-attachments/assets/ecfcf0f5-606a-471d-8fdf-b86aeae2bbf2" />

Manual Testing with additional allowed headers in the config

Terraform Config
<img width="808" height="236" alt="image" src="https://github.com/user-attachments/assets/40a37802-752a-4d18-848e-0c1ef4907123" />

Terraform and Vault outputs
<img width="651" height="76" alt="image" src="https://github.com/user-attachments/assets/46124cae-14fe-47c3-869f-465568af76fd" />

<img width="774" height="923" alt="image" src="https://github.com/user-attachments/assets/391f61d1-ec2f-4e06-acd4-f689df25854c" />

<img width="1069" height="413" alt="image" src="https://github.com/user-attachments/assets/d7b66733-0891-491f-b51b-f159d2919a63" />

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.


[VAULT-39756]: https://hashicorp.atlassian.net/browse/VAULT-39756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ