### PR TITLE
VAULT-39750 Added parameters : request_timeout, dereference_aliases, enable_samaccountname_login, anonymous_group_search to LDAP Auth Method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ FEATURES:
 
 * Add support for `allowed_sts_header_values` parameter in `vault_aws_auth_backend_client` resource to specify additional headers allowed in STS requests
 
+* Add support for `request_timeout`, `dereference_aliases`,`enable_samaccountname_login` and `anonymous_group_search` parameters in `vault_ldap_auth_backend` resource.
+
 BUGS:
 
 * Fix pki config resources to allow unsetting of fields (to empty fields) ([#2558](https://github.com/hashicorp/terraform-provider-vault/pull/2558))

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -543,7 +543,9 @@ const (
 	FieldDestroyed                            = "destroyed"
 	FieldDeleteAllVersions                    = "delete_all_versions"
 	FieldForceNoCache                         = "force_no_cache"
-
+	FieldDereferenceAliases                   = "dereference_aliases"
+	FieldEnableSamaccountnameLogin            = "enable_samaccountname_login"
+	FieldAnonymousGroupSearch                 = "anonymous_group_search"
 	/*
 		ephemeral resource constants and write-only attributes
 	*/

--- a/vault/resource_ldap_auth_backend_test.go
+++ b/vault/resource_ldap_auth_backend_test.go
@@ -10,14 +10,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
-	"github.com/hashicorp/vault/api"
-
-	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
+	"github.com/hashicorp/vault/api"
 )
 
 func TestLDAPAuthBackend_basic(t *testing.T) {
@@ -402,26 +402,30 @@ func testLDAPAuthBackendCheck_attrs(resourceName string, name string) resource.T
 		}
 
 		attrs := map[string]string{
-			"url":                  "url",
-			"starttls":             "starttls",
-			"case_sensitive_names": "case_sensitive_names",
-			"tls_min_version":      "tls_min_version",
-			"tls_max_version":      "tls_max_version",
-			"insecure_tls":         "insecure_tls",
-			"certificate":          "certificate",
-			"binddn":               "binddn",
-			"userdn":               "userdn",
-			"userattr":             "userattr",
-			"userfilter":           "userfilter",
-			"discoverdn":           "discoverdn",
-			"deny_null_bind":       "deny_null_bind",
-			"upndomain":            "upndomain",
-			"groupfilter":          "groupfilter",
-			"username_as_alias":    "username_as_alias",
-			"groupdn":              "groupdn",
-			"groupattr":            "groupattr",
-			"use_token_groups":     "use_token_groups",
-			"connection_timeout":   "connection_timeout",
+			"url":                         "url",
+			"starttls":                    "starttls",
+			"case_sensitive_names":        "case_sensitive_names",
+			"tls_min_version":             "tls_min_version",
+			"tls_max_version":             "tls_max_version",
+			"insecure_tls":                "insecure_tls",
+			"certificate":                 "certificate",
+			"binddn":                      "binddn",
+			"userdn":                      "userdn",
+			"userattr":                    "userattr",
+			"userfilter":                  "userfilter",
+			"discoverdn":                  "discoverdn",
+			"deny_null_bind":              "deny_null_bind",
+			"upndomain":                   "upndomain",
+			"groupfilter":                 "groupfilter",
+			"username_as_alias":           "username_as_alias",
+			"groupdn":                     "groupdn",
+			"groupattr":                   "groupattr",
+			"use_token_groups":            "use_token_groups",
+			"connection_timeout":          "connection_timeout",
+			"request_timeout":             "request_timeout",
+			"dereference_aliases":         "dereference_aliases",
+			"enable_samaccountname_login": "enable_samaccountname_login",
+			"anonymous_group_search":      "anonymous_group_search",
 		}
 
 		isVaultVersion111 := provider.IsAPISupported(testProvider.Meta(), provider.VaultVersion111)
@@ -479,6 +483,10 @@ resource "vault_ldap_auth_backend" "test" {
     username_as_alias      = true
     use_token_groups       = %s
     connection_timeout     = 30
+	request_timeout        = 60
+    dereference_aliases    = "always"
+    enable_samaccountname_login = true
+    anonymous_group_search = false
 }
 `, path, local, use_token_groups)
 }
@@ -575,7 +583,11 @@ pIth9roSSN2mcYxH5P7uVIFm7jJ3tI4ExQdtJkPed/GK1DC7l2VGOi+TtCdm004r
 MvQzNd87hRypUZ9Hyx2C9RljNDHHjgwYwWv9JOT0xEOS4ZAaPfvTf20=
 -----END RSA PRIVATE KEY-----
 EOT
-    use_token_groups = %s
+    request_timeout        = 60
+    dereference_aliases    = "always"
+    enable_samaccountname_login = true
+    anonymous_group_search = false
+	use_token_groups = %s
 }
 `, path, local, use_token_groups)
 }
@@ -633,4 +645,28 @@ resource "vault_ldap_auth_backend" "test" {
 	}
 }
 `, path)
+}
+func TestFieldRequestTimeoutValidation(t *testing.T) {
+	tests := []struct {
+		value    int
+		expected bool
+	}{
+		{10, true},
+		{0, true},
+		{-5, false},
+	}
+	validateFunc := func(val interface{}, key string) (warns []string, errs []error) {
+		v := val.(int)
+		if v < 0 {
+			errs = append(errs, fmt.Errorf("%q must be a non-negative integer, got: %d", key, v))
+		}
+		return
+	}
+	for _, test := range tests {
+		_, errs := validateFunc(test.value, "request_timeout")
+
+		if (len(errs) == 0) != test.expected {
+			t.Errorf("Validation for value %d failed. Expected valid: %v, got errors: %v", test.value, test.expected, errs)
+		}
+	}
 }

--- a/website/docs/r/ldap_auth_backend.html.md
+++ b/website/docs/r/ldap_auth_backend.html.md
@@ -24,6 +24,10 @@ resource "vault_ldap_auth_backend" "ldap" {
     groupfilter       = "(&(objectClass=group)(member:1.2.840.113556.1.4.1941:={{.UserDN}}))"
     rotation_schedule = "0 * * * SAT"
     rotation_window   = 3600
+    request_timeout               = 30
+    dereference_aliases           = "always"
+    enable_samaccountname_login   = false
+    anonymous_group_search        = false
 }
 ```
 
@@ -137,6 +141,14 @@ The `tune` block is used to tune the auth backend:
 ### Common Token Arguments
 
 These arguments are common across several Authentication Token resources since Vault 1.2.
+
+* `request_timeout` - Timeout, in seconds, for the connection when making requests against the server before returning back an error.
+
+* `dereference_aliases` - When aliases should be dereferenced on search operations. Accepted values are 'never', 'finding', 'searching', 'always'. Defaults to 'never'.
+
+* `enable_samaccountname_login` - (Optional) Lets Active Directory LDAP users log in using sAMAccountName or userPrincipalName when the upndomain parameter is set.
+
+* `anonymous_group_search` - Use anonymous binds when performing LDAP group searches (note: even when true, the initial credentials will still be used for the initial connection test).
 
 * `token_ttl` - (Optional) The incremental lifetime for generated tokens in number of seconds.
   Its current value will be referenced at renewal time.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
Added support for The [vault_ldap_auth_backend](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/resources/ldap_auth_backend) resource associated with the [/auth/ldap/config](https://developer.hashicorp.com/vault/api-docs/auth/ldap#configure-ldap) endpoint needs to support the following missing fields:

- request_timeout
- dereference_aliases
- enable_samaccountname_login
- anonymous_group_search

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes [VAULT-39750](https://hashicorp.atlassian.net/browse/VAULT-39750)


### Checklist
- [Y] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [Y] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestFieldRequestTimeoutValidation'
...
```
<img width="1305" height="72" alt="Screenshot 2025-10-17 at 3 45 32 PM" src="https://github.com/user-attachments/assets/afd79483-a0c9-4ffd-b785-3a0757e1cf40" />


Terraform Config : 
<img width="487" height="357" alt="Terraform Resource for LDAP Auth" src="https://github.com/user-attachments/assets/d2b42e2e-47f2-443c-a725-4706c026526e" />

Vault Output : 
<img width="590" height="611" alt="After applying changes " src="https://github.com/user-attachments/assets/f69083b4-8476-405c-b755-e68016412eda" />


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.


[VAULT-39750]: https://hashicorp.atlassian.net/browse/VAULT-39750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ