### PR TITLE
feat(token): add entity_alias field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 CHANGES:
 
 * `vault_ldap_auth_backend`: Set `deny_null_bind` to `true` by default if not provided in configuration ([#2622](https://github.com/hashicorp/terraform-provider-vault/pull/2622))
+* `vault_token`: Add support for `entity_alias` argument ([#2662](https://github.com/hashicorp/terraform-provider-vault/pull/2662))
 
 FEATURES:
 

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -209,6 +209,7 @@ const (
 	FieldPolicies                       = "policies"
 	FieldNoParent                       = "no_parent"
 	FieldNoDefaultPolicy                = "no_default_policy"
+	FieldEntityAlias                    = "entity_alias"
 	FieldRenewable                      = "renewable"
 	FieldExplicitMaxTTL                 = "explicit_max_ttl"
 	FieldPersistApp                     = "persist_app"

--- a/vault/resource_token.go
+++ b/vault/resource_token.go
@@ -159,6 +159,12 @@ func tokenResource() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			consts.FieldEntityAlias: {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Entity alias to associate with the token.",
+			},
 		},
 	}
 }
@@ -221,6 +227,10 @@ func tokenCreate(d *schema.ResourceData, meta interface{}) error {
 			d[k] = val.(string)
 		}
 		createRequest.Metadata = d
+	}
+
+	if v, ok := d.GetOk(consts.FieldEntityAlias); ok {
+		createRequest.EntityAlias = v.(string)
 	}
 
 	if v, ok := d.GetOk(consts.FieldWrappingTTL); ok {
@@ -341,6 +351,10 @@ func tokenRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set(consts.FieldLeaseDuration, int(expireTime.Sub(issueTime).Seconds()))
 
 	d.Set(consts.FieldMetadata, resp.Data["meta"])
+
+	if v, ok := resp.Data[consts.FieldEntityAlias]; ok {
+		d.Set(consts.FieldEntityAlias, v)
+	}
 
 	if d.Get(consts.FieldRenewable).(bool) && tokenCheckLease(d) {
 		if id == "" {

--- a/vault/resource_token_test.go
+++ b/vault/resource_token_test.go
@@ -334,6 +334,38 @@ resource "vault_token" "test" {
 	return config
 }
 
+func TestResourceToken_entityAlias(t *testing.T) {
+	resourceName := "vault_token.test"
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		PreCheck:                 func() { testutil.TestAccPreCheck(t) },
+		CheckDestroy:             testResourceTokenCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceTokenConfig_entityAlias(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldEntityAlias, "test-alias"),
+				),
+			},
+		},
+	})
+}
+
+func testResourceTokenConfig_entityAlias() string {
+	return `
+resource "vault_policy" "test" {
+  name   = "test"
+  policy = <<EOT
+path "secret/*" { capabilities = [ "list" ] }
+EOT
+}
+
+resource "vault_token" "test" {
+  policies     = [vault_policy.test.name]
+  entity_alias = "test-alias"
+}`
+}
+
 func testResourceTokenLookup(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
The PR allows to set entity-alias when creating Token.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2541


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'
?       github.com/hashicorp/terraform-provider-vault/internal/framework/model  [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/framework/token  [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/framework/validators     0.019s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  0.020s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/mfa     [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/pki      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/provider 0.025s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/provider/fwprovider      [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/providertest     [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/rotation [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/sync     [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/vault/auth/spiffe        0.041s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/vault/secrets/azure      0.035s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/vault/secrets/ephemeral  0.033s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/vault/sys        0.031s [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
ok      github.com/hashicorp/terraform-provider-vault/testutil  0.015s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util      0.020s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util/mountutil    0.015s [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/vault     0.020s [no tests to run]
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
