### PR TITLE
Add canonical_arn to allowed values of iam_alias

### DIFF
--- a/vault/resource_aws_auth_backend_config_identity.go
+++ b/vault/resource_aws_auth_backend_config_identity.go
@@ -36,7 +36,7 @@ func awsAuthBackendConfigIdentityResource() *schema.Resource {
 				Optional:     true,
 				Default:      "role_id",
 				Description:  "How to generate the identity alias when using the iam auth method.",
-				ValidateFunc: validation.StringInSlice([]string{"role_id", "unique_id", "full_arn"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"role_id", "unique_id", "full_arn", "canonical_arn"}, false),
 			},
 			consts.FieldIAMMetadata: {
 				Type:        schema.TypeSet,

--- a/vault/resource_aws_auth_backend_config_identity_test.go
+++ b/vault/resource_aws_auth_backend_config_identity_test.go
@@ -49,6 +49,15 @@ func TestAccAwsAuthBackendConfigIdentity(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, consts.FieldEC2Metadata+".#", "0"),
 				),
 			},
+			{
+				Config: testAccAwsAuthBackendConfigIdentity_canonicalArn(backend),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldBackend, backend),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldIAMAlias, "canonical_arn"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldIAMMetadata+".#", "1"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldIAMMetadata+".0", "client_arn"),
+				),
+			},
 			testutil.GetImportTestStep(resourceName, false, nil),
 		},
 	})
@@ -103,5 +112,20 @@ resource "vault_aws_auth_backend_config_identity" "config" {
   backend = vault_auth_backend.aws.path
   iam_alias = "full_arn"
   iam_metadata = ["client_user_id"]
+}`, backend)
+}
+func testAccAwsAuthBackendConfigIdentity_canonicalArn(backend string) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "aws" {
+  path = "%s"
+  type = "aws"
+  description = "Test auth backend for AWS backend config"
+}
+
+resource "vault_aws_auth_backend_config_identity" "config" {
+  backend = vault_auth_backend.aws.path
+  iam_alias = "canonical_arn"
+  iam_metadata = ["client_arn"]
+  canonical_arn = true
 }`, backend)
 }

--- a/website/docs/r/aws_auth_backend_config_identity.html.md
+++ b/website/docs/r/aws_auth_backend_config_identity.html.md
@@ -39,7 +39,7 @@ The following arguments are supported:
 	mounted at.  Defaults to `aws`.
 
 * `iam_alias` - (Optional) How to generate the identity alias when using the iam auth method. Valid choices are
-  `role_id`, `unique_id`, and `full_arn`. Defaults to `role_id`
+  `role_id`, `unique_id`, `canonical_arn` and `full_arn`. Defaults to `role_id`
 
 * `iam_metadata` - (Optional) The metadata to include on the token returned by the `login` endpoint. This metadata will be
   added to both audit logs, and on the `iam_alias`


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
As per doc here: https://developer.hashicorp.com/vault/api-docs/auth/aws#parameters-2 iam_alias accepts 4 values

- role_id
- unique_id
- canonical_arn
- full_arn

Only 3 are allowed in this provider, and this change fixes that



<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2359 


### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
