### PR TITLE
TFVP - Added support for tls_server_name , local_datacenter, socket_keep_alive,consistency and username_template missing configuration parameters for Cassandra database secret engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ IMPROVEMENTS:
 * Add support for `username_template` parameter in `vault_database_secret_backend_connection` and `vault_database_secrets_mount` resource for MongoDB Atlas([#2674](https://github.com/hashicorp/terraform-provider-vault/pull/2674)) 
 * Add support for `username_template` parameter in `vault_database_secret_backend_connection` and `vault_database_secrets_mount` resources for HANADB connections: ([#2671](https://github.com/hashicorp/terraform-provider-vault/pull/2671))
 * Add support for networking allowlist fields (`allowed_ipv4_addresses`, `allowed_ipv6_addresses`, `allowed_ports`, `disable_strict_networking`) in `vault_secrets_sync_vercel_destination` resource. Requires Vault 1.19+. ([#2681](https://github.com/hashicorp/terraform-provider-vault/pull/2681))
+* Add support for `tls_server_name` , `local_datacenter`, `socket_keep_alive`, `consistency` and `username_template`  parameters for Cassandra in `vault_database_secret_backend_connection` resource. ([#2677](https://github.com/hashicorp/terraform-provider-vault/pull/2677))
 
 
 ## 5.6.0 (December 19, 2025)

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -321,6 +321,32 @@ func getDatabaseSchema(typ schema.ValueType) schemaMap {
 						Description: "Whether to skip verification of the server certificate when using TLS.",
 						Default:     false,
 					},
+					"tls_server_name": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "SNI host for TLS connections.",
+					},
+					"local_datacenter": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "Cassandra local datacenter name.",
+					},
+					"socket_keep_alive": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "Enable TCP keepalive for Cassandra connections.",
+						Default:     "0",
+					},
+					"consistency": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "Cassandra consistency level.",
+					},
+					"username_template": {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "Template for dynamic Cassandra usernames.",
+					},
 					"pem_bundle": {
 						Type:        schema.TypeString,
 						Optional:    true,
@@ -1107,6 +1133,23 @@ func setCassandraDatabaseConnectionData(d *schema.ResourceData, prefix string, d
 	if v, ok := d.GetOkExists("cassandra.0.insecure_tls"); ok {
 		data["insecure_tls"] = v.(bool)
 	}
+
+	if v, ok := d.GetOk(prefix + "tls_server_name"); ok {
+		data["tls_server_name"] = v.(string)
+	}
+	if v, ok := d.GetOk(prefix + "local_datacenter"); ok {
+		data["local_datacenter"] = v.(string)
+	}
+	if v, ok := d.GetOkExists(prefix + "socket_keep_alive"); ok {
+		data["socket_keep_alive"] = v.(string)
+	}
+	if v, ok := d.GetOk(prefix + "consistency"); ok {
+		data["consistency"] = v.(string)
+	}
+	if v, ok := d.GetOk(prefix + "username_template"); ok {
+		data["username_template"] = v.(string)
+	}
+
 	if v, ok := d.GetOkExists("cassandra.0.pem_bundle"); ok {
 		data["pem_bundle"] = v.(string)
 	}
@@ -2228,6 +2271,21 @@ func getConnectionDetailsCassandra(d *schema.ResourceData, prefix string, resp *
 		}
 		if v, ok := data["insecure_tls"]; ok {
 			result["insecure_tls"] = v.(bool)
+		}
+		if v, ok := data["tls_server_name"]; ok {
+			result["tls_server_name"] = v.(string)
+		}
+		if v, ok := data["local_datacenter"]; ok {
+			result["local_datacenter"] = v.(string)
+		}
+		if v, ok := data["socket_keep_alive"]; ok {
+			result["socket_keep_alive"] = v.(string)
+		}
+		if v, ok := data["consistency"]; ok {
+			result["consistency"] = v.(string)
+		}
+		if v, ok := data["username_template"]; ok {
+			result["username_template"] = v.(string)
 		}
 		if v, ok := data["pem_bundle"]; ok {
 			result["pem_bundle"] = v.(string)

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -83,6 +84,7 @@ func TestAccDatabaseSecretBackendConnection_postgresql_import(t *testing.T) {
 	})
 }
 
+// TestAccDatabaseSecretBackendConnection_cassandra tests cassandra DB connection for default values
 func TestAccDatabaseSecretBackendConnection_cassandra(t *testing.T) {
 	MaybeSkipDBTests(t, dbEngineCassandra)
 
@@ -121,12 +123,18 @@ func TestAccDatabaseSecretBackendConnection_cassandra(t *testing.T) {
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.protocol_version", "4"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.connect_timeout", "5"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.skip_verification", "false"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.tls_server_name", ""),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.local_datacenter", ""),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.socket_keep_alive", "0"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.consistency", ""),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.username_template", ""),
 				),
 			},
 		},
 	})
 }
 
+// TestAccDatabaseSecretBackendConnection_cassandraProtocol tests cassandra DB connection when optional fields are ommitted
 func TestAccDatabaseSecretBackendConnection_cassandraProtocol(t *testing.T) {
 	MaybeSkipDBTests(t, dbEngineCassandra)
 
@@ -162,9 +170,142 @@ func TestAccDatabaseSecretBackendConnection_cassandraProtocol(t *testing.T) {
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.insecure_tls", "false"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.pem_bundle", ""),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.pem_json", ""),
-					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.protocol_version", "5"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.protocol_version", "4"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.connect_timeout", "5"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.skip_verification", "false"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.tls_server_name", ""),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.local_datacenter", ""),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.socket_keep_alive", "0"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.consistency", ""),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.username_template", ""),
+				),
+			},
+		},
+	})
+}
+
+// TestAccDatabaseSecretBackendConnection_cassandra_invalidFields tests cassandra DB connection errors when wrong values are provided
+func TestAccDatabaseSecretBackendConnection_cassandra_invalidFields(t *testing.T) {
+	MaybeSkipDBTests(t, dbEngineCassandra)
+
+	values := testutil.SkipTestEnvUnset(t, "CASSANDRA_HOST")
+	host := values[0]
+	username := os.Getenv("CASSANDRA_USERNAME")
+	password := os.Getenv("CASSANDRA_PASSWORD")
+	backend := acctest.RandomWithPrefix("tf-test-db")
+	name := acctest.RandomWithPrefix("db")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		PreCheck:                 func() { testutil.TestAccPreCheck(t) },
+		CheckDestroy:             testAccDatabaseSecretBackendConnectionCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccDatabaseSecretBackendConnectionConfig_cassandra_invalidFields(name, backend, host, username, password, "tls_server_name"),
+				ExpectError: regexp.MustCompile(`(?i)invalid|error|tls_server_name`),
+			},
+			{
+				Config:      testAccDatabaseSecretBackendConnectionConfig_cassandra_invalidFields(name, backend, host, username, password, "local_datacenter"),
+				ExpectError: regexp.MustCompile(`(?i)invalid|error|local_datacenter|required|empty`),
+			},
+			{
+				Config:      testAccDatabaseSecretBackendConnectionConfig_cassandra_invalidFields(name, backend, host, username, password, "socket_keep_alive"),
+				ExpectError: regexp.MustCompile(`(?i)invalid|error|socket_keep_alive|must be|positive`),
+			},
+			{
+				Config:      testAccDatabaseSecretBackendConnectionConfig_cassandra_invalidFields(name, backend, host, username, password, "consistency"),
+				ExpectError: regexp.MustCompile(`(?i)invalid|error|consistency|unsupported`),
+			},
+			{
+				Config:      testAccDatabaseSecretBackendConnectionConfig_cassandra_invalidFields(name, backend, host, username, password, "username_template"),
+				ExpectError: regexp.MustCompile(`(?i)invalid|error|username_template|template`),
+			},
+		},
+	})
+}
+
+// TestAccDatabaseSecretBackendConnection_cassandra_customFields tests cassandra DB connection when tls=true and proper values given to fields
+func TestAccDatabaseSecretBackendConnection_cassandra_customFields(t *testing.T) {
+	MaybeSkipDBTests(t, dbEngineCassandra)
+
+	values := testutil.SkipTestEnvUnset(t, "CASSANDRA_HOST")
+	host := values[0]
+	username := os.Getenv("CASSANDRA_USERNAME")
+	password := os.Getenv("CASSANDRA_PASSWORD")
+
+	// Skip if TLS is not enabled
+	tlsStr := os.Getenv("CASSANDRA_TLS")
+	if tlsStr == "" {
+		tlsStr = "false"
+	}
+	useTLS, err := strconv.ParseBool(tlsStr)
+	if err != nil {
+		t.Fatalf("Invalid CASSANDRA_TLS value: %s", tlsStr)
+	}
+	if !useTLS {
+		t.Skip("Skipping TLS test because CASSANDRA_TLS is not set to true")
+	}
+
+	backend := acctest.RandomWithPrefix("tf-test-db")
+	name := acctest.RandomWithPrefix("db")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		PreCheck:                 func() { testutil.TestAccPreCheck(t) },
+		CheckDestroy:             testAccDatabaseSecretBackendConnectionCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseSecretBackendConnectionConfig_cassandra_customFields(name, backend, host, username, password),
+				Check: testComposeCheckFuncCommonDatabaseSecretBackend(name, backend, dbEngineCassandra.DefaultPluginName(),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.tls_server_name", "cassandra-server"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.local_datacenter", "datacenter1"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.socket_keep_alive", "30"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.consistency", "LOCAL_QUORUM"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.username_template", "vault_{{.RoleName}}_{{.DisplayName}}_{{random 10}}"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccDatabaseSecretBackendConnection_cassandra_customFieldsNoTLS tests cassandra DB connection when tls=false and proper values given to fields
+func TestAccDatabaseSecretBackendConnection_cassandra_customFieldsNoTLS(t *testing.T) {
+	MaybeSkipDBTests(t, dbEngineCassandra)
+
+	values := testutil.SkipTestEnvUnset(t, "CASSANDRA_HOST")
+	host := values[0]
+	username := os.Getenv("CASSANDRA_USERNAME")
+	password := os.Getenv("CASSANDRA_PASSWORD")
+
+	// Skip if TLS is enabled
+	tlsStr := os.Getenv("CASSANDRA_TLS")
+	if tlsStr == "" {
+		tlsStr = "false"
+	}
+	useTLS, err := strconv.ParseBool(tlsStr)
+	if err != nil {
+		t.Fatalf("Invalid CASSANDRA_TLS value: %s", tlsStr)
+	}
+	if useTLS {
+		t.Skip("Skipping non-TLS test because CASSANDRA_TLS is set to true")
+	}
+
+	backend := acctest.RandomWithPrefix("tf-test-db")
+	name := acctest.RandomWithPrefix("db")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		PreCheck:                 func() { testutil.TestAccPreCheck(t) },
+		CheckDestroy:             testAccDatabaseSecretBackendConnectionCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseSecretBackendConnectionConfig_cassandra_customFieldsNoTLS(name, backend, host, username, password),
+				Check: testComposeCheckFuncCommonDatabaseSecretBackend(name, backend, dbEngineCassandra.DefaultPluginName(),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.tls", "false"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.local_datacenter", "datacenter1"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.socket_keep_alive", "30"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.consistency", "LOCAL_QUORUM"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.username_template", "vault_{{.RoleName}}_{{.DisplayName}}_{{random 10}}"),
 				),
 			},
 		},
@@ -1488,27 +1629,33 @@ func testAccDatabaseSecretBackendConnectionCheckDestroy(s *terraform.State) erro
 
 func testAccDatabaseSecretBackendConnectionConfig_cassandra(name, path, host, username, password, timeout string) string {
 	return fmt.Sprintf(`
-resource "vault_mount" "db" {
-  path = "%s"
-  type = "database"
-}
+	resource "vault_mount" "db" {
+		path = "%s"
+		type = "database"
+	}
 
-resource "vault_database_secret_backend_connection" "test" {
-  backend = vault_mount.db.path
-  name = "%s"
-  allowed_roles = ["dev", "prod"]
-  root_rotation_statements = ["FOOBAR"]
+	resource "vault_database_secret_backend_connection" "test" {
+		backend = vault_mount.db.path
+		name = "%s"
+		allowed_roles = ["dev", "prod"]
+		verify_connection = true
+		root_rotation_statements = ["FOOBAR"]
 
-  cassandra {
-    hosts = ["%s"]
-    username = "%s"
-    password = "%s"
-    tls = false
-    protocol_version = 4
-    connect_timeout = %s
-  }
-}
-`, path, name, host, username, password, timeout)
+		cassandra {
+			hosts = ["%s"]
+			username = "%s"
+			password = "%s"
+			tls = false
+			protocol_version = 4
+			connect_timeout = %s
+			tls_server_name = ""
+			local_datacenter = ""
+			socket_keep_alive = 0
+			consistency = ""
+			username_template = ""
+		}
+	}
+	`, path, name, host, username, password, timeout)
 }
 
 func testAccDatabaseSecretBackendConnectionConfig_cassandraProtocol(name, path, host, username, password string) string {
@@ -1522,6 +1669,7 @@ resource "vault_database_secret_backend_connection" "test" {
   backend = vault_mount.db.path
   name = "%s"
   allowed_roles = ["dev", "prod"]
+  verify_connection = true
   root_rotation_statements = ["FOOBAR"]
 
   cassandra {
@@ -1529,10 +1677,127 @@ resource "vault_database_secret_backend_connection" "test" {
     username = "%s"
     password = "%s"
     tls = false
-    protocol_version = 5
+    protocol_version = 4
   }
 }
 `, path, name, host, username, password)
+}
+
+func testAccDatabaseSecretBackendConnectionConfig_cassandra_invalidFields(name, backend, host, username, password, invalidField string) string {
+	// Base configuration with valid values
+	config := fmt.Sprintf(`
+
+resource "vault_mount" "db" {
+  path = "%s"
+  type = "database"
+}
+
+resource "vault_database_secret_backend_connection" "test" {
+  name    = "%s"
+  backend = vault_mount.db.path
+  plugin_name = "cassandra-database-plugin"
+  allowed_roles = ["dev", "prod"]
+  verify_connection = true
+
+  cassandra {
+    hosts              = ["%s"]
+    port               = 9042
+    username           = "%s"
+    password           = "%s"
+    connect_timeout    = 30`, backend, name, host, username, password)
+
+	// Add the specific invalid field based on the parameter
+	switch invalidField {
+	case "tls_server_name":
+		config += `
+    tls                = true
+    tls_server_name    = "!!invalid!!"
+    insecure_tls       = true`
+	case "local_datacenter":
+		config += `
+    local_datacenter   = ""`
+	case "socket_keep_alive":
+		config += `
+    socket_keep_alive  = -1`
+	case "consistency":
+		config += `
+    consistency        = "INVALID"`
+	case "username_template":
+		config += `
+    username_template  = "{{.Invalid}}"`
+	}
+
+	config += `
+  }
+}
+`
+	return config
+}
+
+func testAccDatabaseSecretBackendConnectionConfig_cassandra_customFields(name, backend, host, username, password string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "db" {
+  path = "%s"
+  type = "database"
+}
+
+resource "vault_database_secret_backend_connection" "test" {
+  name    = "%s"
+  backend = vault_mount.db.path
+  plugin_name = "cassandra-database-plugin"
+  allowed_roles = ["dev", "prod"]
+  verify_connection = true
+
+  cassandra {
+    hosts              = ["%s"]
+    port               = 9042
+    username           = "%s"
+    password           = "%s"
+    protocol_version   = 4
+    tls                = true
+    tls_server_name    = "cassandra-server"
+    local_datacenter   = "datacenter1"
+    socket_keep_alive  = 30
+    consistency        = "LOCAL_QUORUM"
+    username_template  = "vault_{{.RoleName}}_{{.DisplayName}}_{{random 10}}"
+    insecure_tls       = true
+    connect_timeout    = 30
+  }
+}
+`, backend, name, host, username, password)
+}
+
+func testAccDatabaseSecretBackendConnectionConfig_cassandra_customFieldsNoTLS(name, backend, host, username, password string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "db" {
+  path = "%s"
+  type = "database"
+}
+
+resource "vault_database_secret_backend_connection" "test" {
+  name    = "%s"
+  backend = vault_mount.db.path
+  plugin_name = "cassandra-database-plugin"
+  allowed_roles = ["dev", "prod"]
+  verify_connection = true
+
+  cassandra {
+    hosts              = ["%s"]
+    port               = 9042
+    username           = "%s"
+    password           = "%s"
+    protocol_version   = 4
+    tls                = false
+    tls_server_name    = "cassandra-server"
+    local_datacenter   = "datacenter1"
+    socket_keep_alive  = 30
+    consistency        = "LOCAL_QUORUM"
+    username_template  = "vault_{{.RoleName}}_{{.DisplayName}}_{{random 10}}"
+    insecure_tls       = false
+    connect_timeout    = 30
+  }
+}
+`, backend, name, host, username, password)
 }
 
 func testAccDatabaseSecretBackendConnectionConfig_import(name, path, connURL, userTempl string) string {

--- a/vault/resource_database_secrets_mount_test.go
+++ b/vault/resource_database_secrets_mount_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -605,6 +606,261 @@ resource "vault_database_secret_backend_role" "test" {
   ]
 }
 `, path, fmt.Sprintf(config, pluginName, name, publicKey, privateKey, projectID, usernameTemplate))
+
+	return result
+}
+
+// TestAccDatabaseSecretsMount_cassandra tests basic Cassandra configuration
+// with TLS setting from environment variable
+func TestAccDatabaseSecretsMount_cassandra(t *testing.T) {
+	MaybeSkipDBTests(t, dbEngineCassandra)
+
+	values := testutil.SkipTestEnvUnset(t, "CASSANDRA_HOST")
+	host := values[0]
+
+	username := os.Getenv("CASSANDRA_USERNAME")
+	password := os.Getenv("CASSANDRA_PASSWORD")
+	// Get TLS setting from environment, default to false if not set
+	tlsStr := os.Getenv("CASSANDRA_TLS")
+	if tlsStr == "" {
+		tlsStr = "false"
+	}
+	useTLS, err := strconv.ParseBool(tlsStr)
+	if err != nil {
+		t.Fatalf("Invalid CASSANDRA_TLS value: %s", tlsStr)
+	}
+
+	backend := acctest.RandomWithPrefix("tf-test-db")
+	pluginName := dbEngineCassandra.DefaultPluginName()
+	name := acctest.RandomWithPrefix("db")
+
+	importIgnoreKeys := []string{
+		"engine_count",
+		"cassandra.0.verify_connection",
+		"cassandra.0.password",
+	}
+	resourceType := "vault_database_secrets_mount"
+	resourceName := resourceType + ".db"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		PreCheck:                 func() { testutil.TestAccPreCheck(t) },
+		CheckDestroy:             testCheckMountDestroyed(resourceType, consts.MountTypeDatabase, consts.FieldPath),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseSecretsMount_cassandra(name, backend, pluginName, host, username, password, useTLS),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "cassandra.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.allowed_roles.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.allowed_roles.0", "dev"),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.allowed_roles.1", "prod"),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.hosts.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.hosts.0", host),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.port", "9042"),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.username", username),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.name", name),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.tls", strconv.FormatBool(useTLS)),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.protocol_version", "4"),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.connect_timeout", "5"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: importIgnoreKeys,
+			},
+		},
+	})
+}
+
+// TestAccDatabaseSecretsMount_cassandra_customFields tests Cassandra with all custom fields when TLS is enabled
+func TestAccDatabaseSecretsMount_cassandra_customFields(t *testing.T) {
+	MaybeSkipDBTests(t, dbEngineCassandra)
+
+	values := testutil.SkipTestEnvUnset(t, "CASSANDRA_HOST")
+	host := values[0]
+	username := os.Getenv("CASSANDRA_USERNAME")
+	password := os.Getenv("CASSANDRA_PASSWORD")
+
+	// Skip if TLS is not enabled
+	tlsStr := os.Getenv("CASSANDRA_TLS")
+	if tlsStr == "" {
+		tlsStr = "false"
+	}
+	useTLS, err := strconv.ParseBool(tlsStr)
+	if err != nil {
+		t.Fatalf("Invalid CASSANDRA_TLS value: %s", tlsStr)
+	}
+	if !useTLS {
+		t.Skip("Skipping TLS test because CASSANDRA_TLS is not set to true")
+	}
+
+	backend := acctest.RandomWithPrefix("tf-test-db")
+	pluginName := dbEngineCassandra.DefaultPluginName()
+	name := acctest.RandomWithPrefix("db")
+
+	resourceType := "vault_database_secrets_mount"
+	resourceName := resourceType + ".db"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		PreCheck:                 func() { testutil.TestAccPreCheck(t) },
+		CheckDestroy:             testCheckMountDestroyed(resourceType, consts.MountTypeDatabase, consts.FieldPath),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseSecretsMount_cassandra_customFields(name, backend, pluginName, host, username, password, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "cassandra.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.name", name),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.tls", "true"),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.tls_server_name", "cassandra-server"),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.insecure_tls", "true"),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.local_datacenter", "datacenter1"),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.socket_keep_alive", "30"),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.consistency", "LOCAL_QUORUM"),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.username_template", "vault_{{.RoleName}}_{{.DisplayName}}_{{random 10}}"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccDatabaseSecretsMount_cassandra_customFieldsNoTLS tests Cassandra with all custom fields when TLS is disabled
+func TestAccDatabaseSecretsMount_cassandra_customFieldsNoTLS(t *testing.T) {
+	MaybeSkipDBTests(t, dbEngineCassandra)
+
+	values := testutil.SkipTestEnvUnset(t, "CASSANDRA_HOST")
+	host := values[0]
+	username := os.Getenv("CASSANDRA_USERNAME")
+	password := os.Getenv("CASSANDRA_PASSWORD")
+
+	// Skip if TLS is enabled
+	tlsStr := os.Getenv("CASSANDRA_TLS")
+	if tlsStr == "" {
+		tlsStr = "false"
+	}
+	useTLS, err := strconv.ParseBool(tlsStr)
+	if err != nil {
+		t.Fatalf("Invalid CASSANDRA_TLS value: %s", tlsStr)
+	}
+	if useTLS {
+		t.Skip("Skipping non-TLS test because CASSANDRA_TLS is set to true")
+	}
+
+	backend := acctest.RandomWithPrefix("tf-test-db")
+	pluginName := dbEngineCassandra.DefaultPluginName()
+	name := acctest.RandomWithPrefix("db")
+
+	resourceType := "vault_database_secrets_mount"
+	resourceName := resourceType + ".db"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		PreCheck:                 func() { testutil.TestAccPreCheck(t) },
+		CheckDestroy:             testCheckMountDestroyed(resourceType, consts.MountTypeDatabase, consts.FieldPath),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseSecretsMount_cassandra_customFields(name, backend, pluginName, host, username, password, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "cassandra.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.name", name),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.tls", "false"),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.local_datacenter", "datacenter1"),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.socket_keep_alive", "30"),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.consistency", "LOCAL_QUORUM"),
+					resource.TestCheckResourceAttr(resourceName, "cassandra.0.username_template", "vault_{{.RoleName}}_{{.DisplayName}}_{{random 10}}"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatabaseSecretsMount_cassandra(name, path, pluginName, host, username, password string, useTLS bool) string {
+	tlsFields := ""
+	if useTLS {
+		tlsFields = `
+    insecure_tls      = true`
+	}
+
+	config := fmt.Sprintf(`
+  cassandra {
+    allowed_roles     = ["dev", "prod"]
+    plugin_name       = "%s"
+    name              = "%s"
+    hosts             = ["%s"]
+    port              = 9042
+    username          = "%s"
+    password          = "%s"
+    tls               = %t%s
+    protocol_version  = 4
+    connect_timeout   = 5
+    verify_connection = true
+  }`, pluginName, name, host, username, password, useTLS, tlsFields)
+
+	result := fmt.Sprintf(`
+resource "vault_database_secrets_mount" "db" {
+  path = "%s"
+%s
+}
+
+resource "vault_database_secret_backend_role" "test" {
+  backend = vault_database_secrets_mount.db.path
+  name    = "dev"
+  db_name = vault_database_secrets_mount.db.cassandra[0].name
+  creation_statements = [
+    "CREATE USER '{{name}}' WITH PASSWORD '{{password}}' NOSUPERUSER;",
+    "GRANT SELECT ON ALL KEYSPACES TO '{{name}}';",
+  ]
+}
+`, path, config)
+
+	return result
+}
+
+func testAccDatabaseSecretsMount_cassandra_customFields(name, path, pluginName, host, username, password string, useTLS bool) string {
+	tlsFields := ""
+	if useTLS {
+		tlsFields = `
+    tls_server_name     = "cassandra-server"
+    insecure_tls        = true`
+	}
+
+	config := fmt.Sprintf(`
+  cassandra {
+    allowed_roles       = ["dev", "prod"]
+    plugin_name         = "%s"
+    name                = "%s"
+    hosts               = ["%s"]
+    port                = 9042
+    username            = "%s"
+    password            = "%s"
+    tls                 = %t%s
+    local_datacenter    = "datacenter1"
+    socket_keep_alive   = 30
+    consistency         = "LOCAL_QUORUM"
+    username_template   = "vault_{{.RoleName}}_{{.DisplayName}}_{{random 10}}"
+    protocol_version    = 4
+    connect_timeout     = 30
+    verify_connection   = true
+  }`, pluginName, name, host, username, password, useTLS, tlsFields)
+
+	result := fmt.Sprintf(`
+resource "vault_database_secrets_mount" "db" {
+  path = "%s"
+%s
+}
+
+resource "vault_database_secret_backend_role" "test" {
+  backend = vault_database_secrets_mount.db.path
+  name    = "dev"
+  db_name = vault_database_secrets_mount.db.cassandra[0].name
+  creation_statements = [
+    "CREATE USER '{{name}}' WITH PASSWORD '{{password}}' NOSUPERUSER;",
+    "GRANT SELECT ON ALL KEYSPACES TO '{{name}}';",
+  ]
+}
+`, path, config)
 
 	return result
 }

--- a/website/docs/r/database_secret_backend_connection.md
+++ b/website/docs/r/database_secret_backend_connection.md
@@ -180,6 +180,17 @@ Exactly one of the nested blocks of configuration options must be supplied.
 
 * `password_wo_version` - (Optional)  The version of the `password_wo`. For more info see [updating write-only attributes](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/guides/using_write_only_attributes.html#updating-write-only-attributes).
 
+* `username_template` - (Optional)  Template describing how dynamic usernames are generated.
+
+* `tls_server_name` - (Optional) Specifies the name to use as the SNI host when connecting to the Cassandra server via TLS.
+
+* `local_datacenter` - (Optional) If set, enables host selection policy which will prioritize and use hosts which are in the local datacenter before hosts in all other datacenters.
+
+* `socket_keep_alive` - (Optional) The keep-alive period for an active network connection. If zero, keep-alives are not enabled.
+
+* `consistency` - (Optional)  Specifies the consistency option to use. See the gocql definition for valid options.
+
+
 ### Couchbase Configuration Options
 
 * `hosts` - (Required) A set of Couchbase URIs to connect to. Must use `couchbases://` scheme if `tls` is `true`.

--- a/website/docs/r/database_secrets_mount.md
+++ b/website/docs/r/database_secrets_mount.md
@@ -213,6 +213,16 @@ Supported list of database secrets engines that can be configured:
 
 * `password_wo_version` - (Optional)  The version of the `password_wo`. For more info see [updating write-only attributes](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/guides/using_write_only_attributes.html#updating-write-only-attributes).
 
+* `username_template` - (Optional)  Template describing how dynamic usernames are generated.
+
+* `tls_server_name` - (Optional) Specifies the name to use as the SNI host when connecting to the Cassandra server via TLS.
+
+* `local_datacenter` - (Optional) If set, enables host selection policy which will prioritize and use hosts which are in the local datacenter before hosts in all other datacenters.
+
+* `socket_keep_alive` - (Optional) The keep-alive period for an active network connection. If zero, keep-alives are not enabled.
+
+* `consistency` - (Optional)  Specifies the consistency option to use. See the gocql definition for valid options.
+
 ### Couchbase Configuration Options
 
 * `hosts` - (Required) A set of Couchbase URIs to connect to. Must use `couchbases://` scheme if `tls` is `true`.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
TFVP - Add missing configuration parameters for Cassandra


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000


### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

<img width="1047" height="596" alt="Screenshot 2025-12-03 at 7 44 26 PM" src="https://github.com/user-attachments/assets/7f124ba6-c9b3-4e7f-928b-efce0f7f58bd" />

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
