### PR TITLE
Add missing docs for field not_before_duration on vault_pki_secret_backend_root_cert

### DIFF
--- a/website/docs/r/pki_secret_backend_root_cert.html.md
+++ b/website/docs/r/pki_secret_backend_root_cert.html.md
@@ -125,6 +125,8 @@ The following arguments are supported:
 * `key_ref` - (Optional) Specifies the key (either default, by name, or by identifier) to use
   for generating this request. Only suitable for `type=existing` requests.
 
+* `not_before_duration` - (Optional) Specifies the duration by which to backdate the NotBefore property.
+
 * `not_after` - (Optional) Set the Not After field of the certificate with specified date value. The value format should be given in UTC format YYYY-MM-ddTHH:MM:SSZ. Supports the Y10K end date for IEEE 802.1AR-2018 standard devices, 9999-12-31T23:59:59Z.
 
 ## Attributes Reference


### PR DESCRIPTION
Add missing documentation for field `not_before_duration` within `vault_pki_secret_backend_root_cert` that was added within https://github.com/hashicorp/terraform-provider-vault/pull/2664/