### PR TITLE
Only require one of key_id and key_label for pkcs managed keys

### DIFF
--- a/vault/resource_managed_keys_test.go
+++ b/vault/resource_managed_keys_test.go
@@ -184,12 +184,15 @@ func TestManagedKeysPKCS(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		Steps: []resource.TestStep{
 			{
+				Config:      testManagedKeysConfig_pkcs_nokeyidorlabel(name, library, slot, pin),
+				ExpectError: regexp.MustCompile("at least one of key_id or key_label must be provided"),
+			},
+			{
 				Config: testManagedKeysConfig_pkcs(name, library, slot, pin),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "pkcs.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "pkcs.0.library", library),
 					resource.TestCheckResourceAttr(resourceName, "pkcs.0.key_label", "kms-intermediate"),
-					resource.TestCheckResourceAttr(resourceName, "pkcs.0.key_id", "kms-intermediate"),
 					resource.TestCheckResourceAttr(resourceName, "pkcs.0.key_bits", "4096"),
 					resource.TestCheckResourceAttr(resourceName, "pkcs.0.slot", slot),
 					resource.TestCheckResourceAttr(resourceName, "pkcs.0.pin", pin),
@@ -252,7 +255,21 @@ resource "vault_managed_keys" "test" {
     name               = "%s"
     library            = "%s"
     key_label          = "kms-intermediate"
-    key_id             = "kms-intermediate"
+    key_bits           = "4096"
+    slot               = "%s"
+    pin                = "%s"
+    mechanism          = "0x0001"
+  }
+}
+`, name, library, slot, pin)
+}
+
+func testManagedKeysConfig_pkcs_nokeyidorlabel(name, library, slot, pin string) string {
+	return fmt.Sprintf(`
+resource "vault_managed_keys" "test" {
+  pkcs {
+    name               = "%s"
+    library            = "%s"
     key_bits           = "4096"
     slot               = "%s"
     pin                = "%s"


### PR DESCRIPTION
Make key_id/key_label optional and add a check to ensure at least one is present during applies.  Can't use atleastoneof unfortunately, given our schema, see https://github.com/hashicorp/terraform-plugin-sdk/issues/470.  It can be done with the newer [framework](https://developer.hashicorp.com/terraform/plugin/framework), but that requires a big migration.  I experimented with this in https://github.com/hashicorp/terraform-provider-vault/pull/2708, but I feel that's too big a change relative to the benefit. 

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000


### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
