### PR TITLE
secrets/aws: Add support for session_token for STS credentials

### DIFF
--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -580,6 +580,7 @@ const (
 	FieldAudience                             = "audience"
 	FieldTokenMaxTTL                          = "token_max_ttl"
 	FieldTokenPeriod                          = "token_period"
+	FieldSessionToken                         = "session_token"
 
 	/*
 		ephemeral resource constants and write-only attributes

--- a/website/docs/d/aws_access_credentials.html.md
+++ b/website/docs/d/aws_access_credentials.html.md
@@ -100,7 +100,9 @@ In addition to the arguments above, the following attributes are exported:
 
 * `secret_key` - The AWS Secret Key returned by Vault.
 
-* `security_token` - The STS token returned by Vault, if any.
+* `session_token` - The STS token returned by Vault, if any. Requires Vault 1.16+.
+
+* `security_token` - **Deprecated** The STS token returned by Vault, if any. Please use `session_token` instead.
 
 * `lease_id` - The lease identifier assigned by Vault.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->

This PR adds support for the `session_token` attribute when retrieving STS credentials from the AWS secret backend which appears in Vault responses since 1.16. It's noted that the original `security_token` attribute will disappear in a future version of Vault so I have marked it as deprecated.

This

### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccDataSourceAWSAccessCredentials'
=== RUN   TestAccDataSourceAWSAccessCredentials_basic
2026/01/07 15:08:09 [INFO] Using Vault token with the following policies: root
--- PASS: TestAccDataSourceAWSAccessCredentials_basic (127.78s)
=== RUN   TestAccDataSourceAWSAccessCredentials_sts
=== RUN   TestAccDataSourceAWSAccessCredentials_sts/sts_without_role_arn
=== RUN   TestAccDataSourceAWSAccessCredentials_sts/sts_with_role_arn
--- PASS: TestAccDataSourceAWSAccessCredentials_sts (15.25s)
    --- PASS: TestAccDataSourceAWSAccessCredentials_sts/sts_without_role_arn (7.79s)
    --- PASS: TestAccDataSourceAWSAccessCredentials_sts/sts_with_role_arn (7.46s)
=== RUN   TestAccDataSourceAWSAccessCredentials_sts_ttl
--- PASS: TestAccDataSourceAWSAccessCredentials_sts_ttl (9.63s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     153.296s
...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
