### PR TITLE
Regression in v5.7.0 when using token on consul secret backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+BUGS: 
+* `vault_consul_secret_backend`: Fixed validation logic to allow computed token values by correcting the condition that checks for token presence during plan phase. ([#2823](https://github.com/hashicorp/terraform-provider-vault/pull/2823))
+
 ## 5.8.0 (March 12, 2026)
 
 FEATURES:

--- a/vault/resource_consul_secret_backend.go
+++ b/vault/resource_consul_secret_backend.go
@@ -6,13 +6,14 @@ package vault
 import (
 	"context"
 	"fmt"
+	"log"
+	"strings"
+
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
-	"log"
-	"strings"
 )
 
 func consulSecretBackendResource() *schema.Resource {
@@ -384,6 +385,7 @@ func consulSecretsBackendCustomizeDiff(ctx context.Context, diff *schema.Resourc
 		}
 	}
 
+	// check whether mount migration is required
 	f := getMountCustomizeDiffFunc(consts.FieldPath)
 	return f(ctx, diff, meta)
 }

--- a/vault/resource_consul_secret_backend.go
+++ b/vault/resource_consul_secret_backend.go
@@ -6,15 +6,13 @@ package vault
 import (
 	"context"
 	"fmt"
-	"log"
-	"strings"
-
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+	"log"
+	"strings"
 )
 
 func consulSecretBackendResource() *schema.Resource {
@@ -361,34 +359,31 @@ func consulSecretBackendConfigPath(backend string) string {
 }
 
 func consulSecretsBackendCustomizeDiff(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
-	// Check both legacy token and write-only token
 	newToken := diff.Get("token").(string)
-	isTokenValueKnown := diff.NewValueKnown("token")
-
-	// Check if using write-only token
 	newTokenWO := diff.Get(consts.FieldTokenWO).(string)
-	isTokenWOValueKnown := diff.NewValueKnown(consts.FieldTokenWO)
+	newBootstrap := diff.Get("bootstrap").(bool)
 
-	// Determine if any token is provided (legacy or write-only)
-	hasToken := newToken != "" || newTokenWO != ""
-	isAnyTokenKnown := isTokenValueKnown || isTokenWOValueKnown
+	isTokenKnown := diff.NewValueKnown("token")
+	isTokenWOKnown := diff.NewValueKnown(consts.FieldTokenWO)
 
-	// Disallow the following:
-	//   1. Bootstrap is true and any token field is set to something.
-	//   2. Bootstrap is true and no token field is set, but we don't know the final value.
-	//   3. Bootstrap is false, no token field is set, and we know this is the final value.
-	if newBootstrap := diff.Get("bootstrap").(bool); newBootstrap {
-		if hasToken ||
-			(!hasToken && !isAnyTokenKnown) {
-			return fmt.Errorf("field 'bootstrap' must be set to false when 'token' or 'token_wo' is specified")
+	hasTokenValue := newToken != "" || newTokenWO != ""
+	tokenIsDefinitelyEmpty := (isTokenKnown && newToken == "") && (isTokenWOKnown && newTokenWO == "")
+
+	if newBootstrap {
+		// CASE: Bootstrap mode is ON
+		// We disallow a token if it's explicitly provided OR if it's being computed.
+		// If bootstrap is true, the HCL should not contain token/token_wo at all.
+		if hasTokenValue || !isTokenKnown || !isTokenWOKnown {
+			return fmt.Errorf("field 'bootstrap' must be set to false when 'token' or 'token_wo' is specified or computed")
 		}
 	} else {
-		if !hasToken && isAnyTokenKnown {
+		// CASE: Bootstrap mode is OFF (Standard mode)
+		// We require a token. We only throw an error if we are 100% CERTAIN both are empty.
+		if tokenIsDefinitelyEmpty {
 			return fmt.Errorf("field 'bootstrap' must be set to true when neither 'token' nor 'token_wo' is specified")
 		}
 	}
 
-	// check whether mount migration is required
 	f := getMountCustomizeDiffFunc(consts.FieldPath)
 	return f(ctx, diff, meta)
 }

--- a/vault/resource_consul_secret_backend_test.go
+++ b/vault/resource_consul_secret_backend_test.go
@@ -478,6 +478,57 @@ func TestConsulSecretBackend_WriteOnlyConflicts(t *testing.T) {
 	})
 }
 
+func TestConsulSecretBackend_CustomizeDiff(t *testing.T) {
+	t.Parallel()
+	path := acctest.RandomWithPrefix("tf-test-consul-diff")
+	resourceType := "vault_consul_secret_backend"
+	resourceName := resourceType + ".test"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"random": {
+				Source:            "hashicorp/random",
+				VersionConstraint: "~> 3.0",
+			},
+		},
+		PreCheck:     func() { acctestutil.TestAccPreCheck(t) },
+		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeConsul, consts.FieldPath),
+		Steps: []resource.TestStep{
+			{
+				Config: testConsulSecretBackend_staticTokenNoBootstrap(path),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "bootstrap", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "token"),
+				),
+			},
+			{
+				Config: testConsulSecretBackend_tokenWONoBootstrap(path, 1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "bootstrap", "false"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldTokenWOVersion, "1"),
+				),
+			},
+			{
+				Config:      testConsulSecretBackend_bootstrapWithToken(path),
+				ExpectError: regexp.MustCompile("field 'bootstrap' must be set to false when 'token' or 'token_wo' is specified"),
+			},
+			{
+				Config:      testConsulSecretBackend_noTokenNoBootstrap(path),
+				ExpectError: regexp.MustCompile("field 'bootstrap' must be set to true when neither 'token' nor 'token_wo' is specified"),
+			},
+			{
+				// Test Case 5: Computed Token + Bootstrap=false (THE BUG FIX)
+				// This verifies that "Unknown" values do not trigger the error during Plan.
+				// We use PlanOnly to avoid actually connecting to Consul
+				Config:              testConsulSecretBackend_computedTokenNoBootstrap(path),
+				PlanOnly:            true,
+				ExpectNonEmptyPlan:  true,
+			},
+		},
+	})
+}
+
 func testCaptureMountUUID(path string, store *testMountStore) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		mount, err := testGetMount(path)
@@ -764,4 +815,53 @@ resource "vault_consul_secret_backend" "test" {
   client_cert              = "FAKE-CLIENT-CERT-MATERIAL"
   client_key_wo_version    = 1
 }`, path, token)
+}
+
+
+func testConsulSecretBackend_staticTokenNoBootstrap(path string) string {
+	return fmt.Sprintf(`
+resource "vault_consul_secret_backend" "test" {
+  path    = "%s"
+  address = "127.0.0.1:8500"
+  token   = "some-static-token"
+}`, path)
+}
+
+func testConsulSecretBackend_computedTokenNoBootstrap(path string) string {
+	return fmt.Sprintf(`
+resource "random_uuid" "token" {}
+
+resource "vault_consul_secret_backend" "test" {
+  path    = "%s"
+  address = "127.0.0.1:8500"
+  token   = random_uuid.token.result
+}`, path)
+}
+
+func testConsulSecretBackend_noTokenNoBootstrap(path string) string {
+	return fmt.Sprintf(`
+resource "vault_consul_secret_backend" "test" {
+  path      = "%s"
+  address   = "127.0.0.1:8500"
+}`, path)
+}
+
+func testConsulSecretBackend_bootstrapWithToken(path string) string {
+	return fmt.Sprintf(`
+resource "vault_consul_secret_backend" "test" {
+	 path      = "%s"
+	 address   = "127.0.0.1:8500"
+	 token     = "static-token"
+	 bootstrap = true
+}`, path)
+}
+
+func testConsulSecretBackend_tokenWONoBootstrap(path string, version int) string {
+	return fmt.Sprintf(`
+resource "vault_consul_secret_backend" "test" {
+  path                 = "%s"
+  address              = "127.0.0.1:8500"
+  token_wo             = "test-token-wo-%d"
+  token_wo_version     = %d
+}`, path, version, version)
 }

--- a/vault/resource_consul_secret_backend_test.go
+++ b/vault/resource_consul_secret_backend_test.go
@@ -518,19 +518,60 @@ func TestConsulSecretBackend_CustomizeDiff(t *testing.T) {
 				ExpectError: regexp.MustCompile("field 'bootstrap' must be set to true when neither 'token' nor 'token_wo' is specified"),
 			},
 			{
-				// Test Case 5: Computed Token + Bootstrap=false (THE BUG FIX)
-				// This verifies that "Unknown" values do not trigger the error during Plan.
-				// We use PlanOnly to avoid actually connecting to Consul
+				Config:      testConsulSecretBackend_emptyTokenNoBootstrap(path),
+				ExpectError: regexp.MustCompile("field 'bootstrap' must be set to true when neither 'token' nor 'token_wo' is specified"),
+			},
+			{
 				Config:             testConsulSecretBackend_computedTokenNoBootstrap(path),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
 			},
 			{
-				// Test Case 6: Bootstrap=true with Computed Token (should fail)
-				// This verifies that bootstrap=true is rejected when any token field is present,
-				// even if it's a computed value
 				Config:      testConsulSecretBackend_bootstrapWithComputedToken(path),
 				ExpectError: regexp.MustCompile("field 'bootstrap' must be set to false when 'token' or 'token_wo' is specified"),
+			},
+		},
+	})
+}
+
+func TestConsulSecretBackend_ComputedTokenWithConsul(t *testing.T) {
+	t.Parallel()
+	acctestutil.SkipTestAcc(t)
+
+	path := acctest.RandomWithPrefix("tf-test-consul-computed")
+	resourceType := "vault_consul_secret_backend"
+	resourceName := resourceType + ".test"
+
+	// Set up Consul with ACLs enabled (OSS, not Enterprise)
+	cleanup, consulConfig := testutil.PrepareTestContainer(t, "1.12.3", false, true)
+	t.Cleanup(cleanup)
+	consulAddr := consulConfig.Address()
+	consulToken := consulConfig.Token
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"consul": {
+				Source:            "hashicorp/consul",
+				VersionConstraint: "~> 2.0",
+			},
+		},
+		PreCheck: func() {
+			testutil.TestAccPreCheck(t)
+			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion111)
+		},
+		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeConsul, consts.FieldPath),
+		Steps: []resource.TestStep{
+			{
+				// Test with computed token from Consul provider
+				// This validates that computed values work end-to-end with real Consul
+				Config: testConsulSecretBackend_computedTokenFromConsul(path, consulAddr, consulToken),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
+					resource.TestCheckResourceAttr(resourceName, "address", consulAddr),
+					resource.TestCheckResourceAttr(resourceName, "bootstrap", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "token"),
+				),
 			},
 		},
 	})
@@ -852,6 +893,29 @@ resource "vault_consul_secret_backend" "test" {
 }`, path)
 }
 
+func testConsulSecretBackend_computedTokenFromConsul(path, consulAddr, consulToken string) string {
+	return fmt.Sprintf(`
+# Configure Consul provider with bootstrap token
+provider "consul" {
+  address = "%s"
+  token   = "%s"
+}
+
+# Generate a management token from Consul
+resource "consul_acl_token" "test" {
+  description = "Test token for Vault"
+  policies    = ["global-management"]
+}
+
+# Use the computed token in Vault Consul backend
+resource "vault_consul_secret_backend" "test" {
+  path        = "%s"
+  address     = "%s"
+  token       = consul_acl_token.test.accessor_id
+  bootstrap   = false
+}`, consulAddr, consulToken, path, consulAddr)
+}
+
 func testConsulSecretBackend_bootstrapWithToken(path string) string {
 	return fmt.Sprintf(`
 resource "vault_consul_secret_backend" "test" {
@@ -877,9 +941,19 @@ resource "vault_consul_secret_backend" "test" {
 func testConsulSecretBackend_tokenWONoBootstrap(path string, version int) string {
 	return fmt.Sprintf(`
 resource "vault_consul_secret_backend" "test" {
-  path                 = "%s"
-  address              = "127.0.0.1:8500"
-  token_wo             = "test-token-wo-%d"
-  token_wo_version     = %d
+	 path                 = "%s"
+	 address              = "127.0.0.1:8500"
+	 token_wo             = "test-token-wo-%d"
+	 token_wo_version     = %d
 }`, path, version, version)
+}
+
+func testConsulSecretBackend_emptyTokenNoBootstrap(path string) string {
+	return fmt.Sprintf(`
+resource "vault_consul_secret_backend" "test" {
+	 path      = "%s"
+	 address   = "127.0.0.1:8500"
+	 token     = ""
+	 bootstrap = false
+}`, path)
 }

--- a/vault/resource_consul_secret_backend_test.go
+++ b/vault/resource_consul_secret_backend_test.go
@@ -521,9 +521,9 @@ func TestConsulSecretBackend_CustomizeDiff(t *testing.T) {
 				// Test Case 5: Computed Token + Bootstrap=false (THE BUG FIX)
 				// This verifies that "Unknown" values do not trigger the error during Plan.
 				// We use PlanOnly to avoid actually connecting to Consul
-				Config:              testConsulSecretBackend_computedTokenNoBootstrap(path),
-				PlanOnly:            true,
-				ExpectNonEmptyPlan:  true,
+				Config:             testConsulSecretBackend_computedTokenNoBootstrap(path),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -816,7 +816,6 @@ resource "vault_consul_secret_backend" "test" {
   client_key_wo_version    = 1
 }`, path, token)
 }
-
 
 func testConsulSecretBackend_staticTokenNoBootstrap(path string) string {
 	return fmt.Sprintf(`

--- a/vault/resource_consul_secret_backend_test.go
+++ b/vault/resource_consul_secret_backend_test.go
@@ -525,6 +525,13 @@ func TestConsulSecretBackend_CustomizeDiff(t *testing.T) {
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
 			},
+			{
+				// Test Case 6: Bootstrap=true with Computed Token (should fail)
+				// This verifies that bootstrap=true is rejected when any token field is present,
+				// even if it's a computed value
+				Config:      testConsulSecretBackend_bootstrapWithComputedToken(path),
+				ExpectError: regexp.MustCompile("field 'bootstrap' must be set to false when 'token' or 'token_wo' is specified"),
+			},
 		},
 	})
 }
@@ -852,6 +859,18 @@ resource "vault_consul_secret_backend" "test" {
 	 address   = "127.0.0.1:8500"
 	 token     = "static-token"
 	 bootstrap = true
+}`, path)
+}
+
+func testConsulSecretBackend_bootstrapWithComputedToken(path string) string {
+	return fmt.Sprintf(`
+resource "random_uuid" "token" {}
+
+resource "vault_consul_secret_backend" "test" {
+  path      = "%s"
+  address   = "127.0.0.1:8500"
+  token     = random_uuid.token.result
+  bootstrap = true
 }`, path)
 }
 

--- a/vault/resource_consul_secret_backend_test.go
+++ b/vault/resource_consul_secret_backend_test.go
@@ -537,12 +537,12 @@ func TestConsulSecretBackend_CustomizeDiff(t *testing.T) {
 func TestConsulSecretBackend_ComputedTokenWithConsul(t *testing.T) {
 	t.Parallel()
 	acctestutil.SkipTestAcc(t)
+	testutil.SkipTestEnvSet(t, "CONSUL_HTTP_ADDR")
 
 	path := acctest.RandomWithPrefix("tf-test-consul-computed")
 	resourceType := "vault_consul_secret_backend"
 	resourceName := resourceType + ".test"
 
-	// Set up Consul with ACLs enabled (OSS, not Enterprise)
 	cleanup, consulConfig := testutil.PrepareTestContainer(t, "1.12.3", false, true)
 	t.Cleanup(cleanup)
 	consulAddr := consulConfig.Address()


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Fixes a bug in `vault_consul_secret_backend` that incorrectly rejected computed token values (e.g., random_uuid.result). The conditional checks in the `consulSecretsBackendCustomizeDiff` function were incorrectly rejecting computed tokens when the bootstrap field was not present. This change corrects the validation logic to properly handle computed values during the plan phase while still catching all invalid field combinations. Added comprehensive test cases to verify both valid and invalid field configurations.

tested on 1.15.0+ent - 1.21.0+ent

Closes #2772

### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
# if CONSUL_HTTP_ADDR env is set , "TestConsulSecretBackend_Bootstrap" is skipped.

% go test -v -run TestConsulSecretBackend ./vault -count=1 
=== RUN   TestConsulSecretBackendRole
=== PAUSE TestConsulSecretBackendRole
=== RUN   TestConsulSecretBackendRole_Legacy
    resource_consul_secret_backend_role_test.go:186: Vault server version "1.21.0+ent"
    resource_consul_secret_backend_role_test.go:186: Vault version >= "1.11.0"
--- SKIP: TestConsulSecretBackendRole_Legacy (0.09s)
=== RUN   TestConsulSecretBackendRoleNameFromPath
--- PASS: TestConsulSecretBackendRoleNameFromPath (0.00s)
=== RUN   TestConsulSecretBackendRoleBackendFromPath
--- PASS: TestConsulSecretBackendRoleBackendFromPath (0.00s)
=== RUN   TestConsulSecretBackend
=== PAUSE TestConsulSecretBackend
=== RUN   TestConsulSecretBackend_Bootstrap
=== PAUSE TestConsulSecretBackend_Bootstrap
=== RUN   TestConsulSecretBackend_remount
=== PAUSE TestConsulSecretBackend_remount
=== RUN   TestConsulSecretBackend_WriteOnlyToken
=== PAUSE TestConsulSecretBackend_WriteOnlyToken
=== RUN   TestConsulSecretBackend_WriteOnlyClientKey
=== PAUSE TestConsulSecretBackend_WriteOnlyClientKey
=== RUN   TestConsulSecretBackend_WriteOnlyBoth
=== PAUSE TestConsulSecretBackend_WriteOnlyBoth
=== RUN   TestConsulSecretBackend_LegacyFields
=== PAUSE TestConsulSecretBackend_LegacyFields
=== RUN   TestConsulSecretBackend_WriteOnlyConflicts
=== PAUSE TestConsulSecretBackend_WriteOnlyConflicts
=== RUN   TestConsulSecretBackend_CustomizeDiff
=== PAUSE TestConsulSecretBackend_CustomizeDiff
=== RUN   TestConsulSecretBackend_ComputedTokenWithConsul
=== PAUSE TestConsulSecretBackend_ComputedTokenWithConsul
=== CONT  TestConsulSecretBackendRole
=== CONT  TestConsulSecretBackend_WriteOnlyBoth
=== CONT  TestConsulSecretBackend_remount
=== CONT  TestConsulSecretBackend_Bootstrap
=== CONT  TestConsulSecretBackend
=== CONT  TestConsulSecretBackend_WriteOnlyClientKey
=== CONT  TestConsulSecretBackend_CustomizeDiff
=== CONT  TestConsulSecretBackend_ComputedTokenWithConsul
=== CONT  TestConsulSecretBackend_WriteOnlyConflicts
=== CONT  TestConsulSecretBackend_WriteOnlyToken
=== CONT  TestConsulSecretBackend_LegacyFields
=== NAME  TestConsulSecretBackendRole
    resource_consul_secret_backend_role_test.go:78: Vault server version "1.21.0+ent"
--- PASS: TestConsulSecretBackend_WriteOnlyConflicts (0.72s)
--- PASS: TestConsulSecretBackend_LegacyFields (2.03s)
=== NAME  TestConsulSecretBackend_Bootstrap
    resource_consul_secret_backend_test.go:152: Vault server version "1.21.0+ent"
--- PASS: TestConsulSecretBackend_WriteOnlyClientKey (3.91s)
--- PASS: TestConsulSecretBackend_WriteOnlyBoth (3.92s)
--- PASS: TestConsulSecretBackend_WriteOnlyToken (4.01s)
=== NAME  TestConsulSecretBackend_ComputedTokenWithConsul
    resource_consul_secret_backend_test.go:561: Vault server version "1.21.0+ent"
--- PASS: TestConsulSecretBackend_remount (6.80s)
--- PASS: TestConsulSecretBackend_CustomizeDiff (8.42s)
--- PASS: TestConsulSecretBackend (9.73s)
--- PASS: TestConsulSecretBackendRole (9.87s)
--- PASS: TestConsulSecretBackend_ComputedTokenWithConsul (11.19s)
--- PASS: TestConsulSecretBackend_Bootstrap (11.79s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     12.584s
...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
