### PR TITLE
Fix 'insecure' field mapping between Vault API and database_secret_backend_connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ IMPROVEMENTS:
 
 BUGS: 
 * `vault_consul_secret_backend`: Fixed validation logic to allow computed token values by correcting the condition that checks for token presence during plan phase. ([#2823](https://github.com/hashicorp/terraform-provider-vault/pull/2823))
+* `database_secret_backend_connection`: Fixed loading of `insecure` field from the Vault API ([#2848](https://github.com/hashicorp/terraform-provider-vault/pull/2848))
 
 ## 5.8.0 (March 12, 2026)
 

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -1515,7 +1515,7 @@ func getElasticsearchConnectionDetailsFromResponse(d *schema.ResourceData, prefi
 		result["tls_server_name"] = v.(string)
 	}
 	if v, ok := data["insecure"]; ok {
-		result["insecure"] = v.(bool)
+		result["insecure_tls"] = v.(bool)
 	}
 	if v, ok := data["username_template"]; ok {
 		result["username_template"] = v.(string)
@@ -1882,7 +1882,7 @@ func setElasticsearchDatabaseConnectionData(d *schema.ResourceData, prefix strin
 	}
 
 	if v, ok := d.GetOk(prefix + "insecure"); ok {
-		data["insecure"] = v.(bool)
+		data["insecure_tls"] = v.(bool)
 	}
 
 	if v, ok := d.GetOk(prefix + "username_template"); ok {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->

PR https://github.com/hashicorp/terraform-provider-vault/pull/2748 renamed the `insecure` field to `insecure_tls`, but the code to map from/to the Vault API wasn't updated to use the new field name.

This breaks loading state from existing Vault deployments that have the `insecure` field set, even if it's the default value of `false`.

Tested live on one of our Vault instances, and it fixes the error message referenced in https://github.com/hashicorp/terraform-provider-vault/issues/2847.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2847


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
