### PR TITLE
TFVP Parity - Vault Token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ IMPROVEMENTS:
 
 * `vault_pki_secret_backend_config_acme`: Added new fields that control the PKI ACME challenge worker IP ranges that they can connect. ([#2839]https://github.com/hashicorp/terraform-provider-vault/pull/2839)
 
+* `vault_token`: Added support for `type` and `entity_alias` fields to enable batch/service token type specification and entity alias association with token roles. ([#2855](https://github.com/hashicorp/terraform-provider-vault/pull/2855))
+
 BUGS: 
 * `vault_consul_secret_backend`: Fixed validation logic to allow computed token values by correcting the condition that checks for token presence during plan phase. ([#2823](https://github.com/hashicorp/terraform-provider-vault/pull/2823))
 

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -262,6 +262,7 @@ const (
 	FieldProviderConfig                     = "provider_config"
 	FieldNamespaceInState                   = "namespace_in_state"
 	FieldIdentityGroupIDs                   = "identity_group_ids"
+	FieldEntityAlias                        = "entity_alias"
 	FieldIdentityEntityIDs                  = "identity_entity_ids"
 	FieldWrappingAccessor                   = "wrapping_accessor"
 	FieldRoleName                           = "role_name"

--- a/vault/resource_token.go
+++ b/vault/resource_token.go
@@ -229,11 +229,11 @@ func tokenCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if v, ok := d.GetOk(consts.FieldMetadata); ok {
-		metadata := make(map[string]string)
+		d := make(map[string]string)
 		for k, val := range v.(map[string]interface{}) {
-			metadata[k] = val.(string)
+			d[k] = val.(string)
 		}
-		createRequest.Metadata = metadata
+		createRequest.Metadata = d
 	}
 
 	if v, ok := d.GetOk(consts.FieldType); ok {

--- a/vault/resource_token.go
+++ b/vault/resource_token.go
@@ -292,7 +292,7 @@ func tokenCreate(d *schema.ResourceData, meta interface{}) error {
 		log.Printf("[DEBUG] Created token accessor %q", accessor)
 	}
 
-	// Batch tokens do not have accessors; use client token as ID
+	// Batch tokens do not have accessors; use Request ID instead
 
 	if accessor == "" && !wrapped && resp.Auth.ClientToken != "" && strings.HasPrefix(resp.Auth.ClientToken, "hvb.") {
 		accessor = resp.RequestID
@@ -382,9 +382,6 @@ func tokenRead(d *schema.ResourceData, meta interface{}) error {
 
 	if tokenType, ok := resp.Data["type"].(string); ok {
 		d.Set(consts.FieldType, tokenType)
-	}
-	if entityAlias, ok := resp.Data["entity_alias"].(string); ok {
-		d.Set(consts.FieldEntityAlias, entityAlias)
 	}
 
 	// Renewal logic

--- a/vault/resource_token.go
+++ b/vault/resource_token.go
@@ -159,6 +159,19 @@ func tokenResource() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			consts.FieldType: {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+				Description: "The token type. Can be 'batch' or 'service'.",
+			},
+			consts.FieldEntityAlias: {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Name of the entity alias to associate with during token creation.",
+			},
 		},
 	}
 }
@@ -216,11 +229,19 @@ func tokenCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if v, ok := d.GetOk(consts.FieldMetadata); ok {
-		d := make(map[string]string)
+		metadata := make(map[string]string)
 		for k, val := range v.(map[string]interface{}) {
-			d[k] = val.(string)
+			metadata[k] = val.(string)
 		}
-		createRequest.Metadata = d
+		createRequest.Metadata = metadata
+	}
+
+	if v, ok := d.GetOk(consts.FieldType); ok {
+		createRequest.Type = v.(string)
+	}
+
+	if v, ok := d.GetOk(consts.FieldEntityAlias); ok {
+		createRequest.EntityAlias = v.(string)
 	}
 
 	if v, ok := d.GetOk(consts.FieldWrappingTTL); ok {
@@ -271,13 +292,24 @@ func tokenCreate(d *schema.ResourceData, meta interface{}) error {
 		log.Printf("[DEBUG] Created token accessor %q", accessor)
 	}
 
+	// Batch tokens do not have accessors; use client token as ID
+
+	if accessor == "" && !wrapped && resp.Auth.ClientToken != "" && strings.HasPrefix(resp.Auth.ClientToken, "hvb.") {
+		accessor = resp.RequestID
+		d.Set(consts.FieldType, "batch")
+	}
+
+	if accessor == "" {
+		return fmt.Errorf("Vault returned an empty accessor and no client token")
+	}
+
 	if wrapped {
 		d.Set(consts.FieldWrappedToken, resp.WrapInfo.Token)
 		d.Set(consts.FieldWrappingAccessor, resp.WrapInfo.Accessor)
 	} else {
 		d.Set(consts.FieldClientToken, resp.Auth.ClientToken)
 	}
-
+	// resp
 	d.SetId(accessor)
 
 	return tokenRead(d, meta)
@@ -287,6 +319,12 @@ func tokenRead(d *schema.ResourceData, meta interface{}) error {
 	client, e := provider.GetClient(d, meta)
 	if e != nil {
 		return e
+	}
+
+	// Batch tokens cannot be looked up via API
+	if strings.HasPrefix(d.Id(), "hvb.") || d.Get(consts.FieldType).(string) == "batch" {
+		d.Set(consts.FieldType, "batch")
+		return nil
 	}
 
 	id := d.Get(consts.FieldClientToken).(string)
@@ -342,6 +380,14 @@ func tokenRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set(consts.FieldMetadata, resp.Data["meta"])
 
+	if tokenType, ok := resp.Data["type"].(string); ok {
+		d.Set(consts.FieldType, tokenType)
+	}
+	if entityAlias, ok := resp.Data["entity_alias"].(string); ok {
+		d.Set(consts.FieldEntityAlias, entityAlias)
+	}
+
+	// Renewal logic
 	if d.Get(consts.FieldRenewable).(bool) && tokenCheckLease(d) {
 		if id == "" {
 			log.Printf("[DEBUG] Lease for token access %q cannot be renewed as it's been encrypted.", accessor)
@@ -380,6 +426,9 @@ func tokenUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func tokenDelete(d *schema.ResourceData, meta interface{}) error {
+	if strings.HasPrefix(d.Id(), "hvb.") || d.Get(consts.FieldType).(string) == "batch" {
+		return nil
+	}
 	client, e := provider.GetClient(d, meta)
 	if e != nil {
 		return e
@@ -398,6 +447,9 @@ func tokenDelete(d *schema.ResourceData, meta interface{}) error {
 }
 
 func tokenExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	if strings.HasPrefix(d.Id(), "hvb.") || d.Get(consts.FieldType).(string) == "batch" {
+		return true, nil
+	}
 	client, e := provider.GetClient(d, meta)
 	if e != nil {
 		return false, e

--- a/vault/resource_token_test.go
+++ b/vault/resource_token_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
+	"github.com/hashicorp/terraform-provider-vault/acctestutil"
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
-	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
 func testResourceTokenCheckDestroy(s *terraform.State) error {
@@ -41,7 +41,7 @@ func TestResourceToken_basic(t *testing.T) {
 	resourceName := "vault_token.test"
 	resource.Test(t, resource.TestCase{
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
-		PreCheck:                 func() { testutil.TestAccPreCheck(t) },
+		PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
 		CheckDestroy:             testResourceTokenCheckDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -62,7 +62,7 @@ func TestResourceToken_import(t *testing.T) {
 	resourceName := "vault_token.test"
 	resource.Test(t, resource.TestCase{
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
-		PreCheck:                 func() { testutil.TestAccPreCheck(t) },
+		PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
 		CheckDestroy:             testResourceTokenCheckDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -105,7 +105,7 @@ func TestResourceToken_full(t *testing.T) {
 	resourceName := "vault_token.test"
 	resource.Test(t, resource.TestCase{
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
-		PreCheck:                 func() { testutil.TestAccPreCheck(t) },
+		PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
 		CheckDestroy:             testResourceTokenCheckDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -159,7 +159,7 @@ resource "vault_token" "test" {
 func TestResourceToken_lookup(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
-		PreCheck:                 func() { testutil.TestAccPreCheck(t) },
+		PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
 		CheckDestroy:             testResourceTokenCheckDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -192,7 +192,7 @@ func TestResourceToken_expire(t *testing.T) {
 	t.Skip("skipping, because it's flaky in CI and there's a long time.Sleep call")
 	resource.Test(t, resource.TestCase{
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
-		PreCheck:                 func() { testutil.TestAccPreCheck(t) },
+		PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
 		CheckDestroy:             testResourceTokenCheckDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -264,7 +264,7 @@ func TestResourceToken_renew(t *testing.T) {
 	}
 	resource.Test(t, resource.TestCase{
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
-		PreCheck:                 func() { testutil.TestAccPreCheck(t) },
+		PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
 		CheckDestroy:             testResourceTokenCheckDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -470,4 +470,172 @@ func testResourceTokenWaitRenewMinLeaseTime(n string) resource.TestCheckFunc {
 
 		return nil
 	}
+}
+
+func TestResourceToken_withType(t *testing.T) {
+	resourceName := "vault_token.test"
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
+		CheckDestroy:             testResourceTokenCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceTokenConfig_withType("service"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "policies.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldType, "service"),
+					resource.TestCheckResourceAttrSet(resourceName, consts.FieldClientToken),
+				),
+			},
+		},
+	})
+}
+
+func TestResourceToken_withTypeBatch(t *testing.T) {
+	resourceName := "vault_token.test"
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
+		CheckDestroy:             testResourceTokenCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceTokenConfig_withType("batch"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "policies.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldType, "batch"),
+					resource.TestCheckResourceAttrSet(resourceName, consts.FieldClientToken),
+				),
+			},
+		},
+	})
+}
+
+func testResourceTokenConfig_withType(tokenType string) string {
+	return fmt.Sprintf(`
+resource "vault_policy" "test" {
+  name   = "test"
+  policy = <<EOT
+path "secret/*" { capabilities = [ "list" ] }
+EOT
+}
+
+resource "vault_token" "test" {
+  policies = [vault_policy.test.name]
+  type     = "%s"
+}
+`, tokenType)
+}
+
+func TestResourceToken_withEntityAlias(t *testing.T) {
+	resourceName := "vault_token.test"
+	roleName := "test-role"
+	entityName := "test-entity"
+	aliasName := "test-alias"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
+		CheckDestroy:             testResourceTokenCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceTokenConfig_withEntityAlias(roleName, entityName, aliasName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "policies.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldRoleName, roleName),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldEntityAlias, aliasName),
+					resource.TestCheckResourceAttrSet(resourceName, consts.FieldClientToken),
+				),
+			},
+		},
+	})
+}
+
+func testResourceTokenConfig_withEntityAlias(roleName, entityName, aliasName string) string {
+	return fmt.Sprintf(`
+resource "vault_policy" "test" {
+  name   = "test"
+  policy = <<EOT
+path "secret/*" { capabilities = [ "list" ] }
+EOT
+}
+
+resource "vault_auth_backend" "test" {
+  type = "userpass"
+  path = "userpass-test"
+}
+
+resource "vault_identity_entity" "test" {
+  name = "%s"
+}
+
+resource "vault_identity_entity_alias" "test" {
+  name           = "%s"
+  mount_accessor = vault_auth_backend.test.accessor
+  canonical_id   = vault_identity_entity.test.id
+}
+
+resource "vault_token_auth_backend_role" "test" {
+  role_name              = "%s"
+  allowed_policies       = [vault_policy.test.name]
+  allowed_entity_aliases = [vault_identity_entity_alias.test.name]
+}
+
+resource "vault_token" "test" {
+  policies     = [vault_policy.test.name]
+  role_name    = vault_token_auth_backend_role.test.role_name
+  entity_alias = vault_identity_entity_alias.test.name
+}
+`, entityName, aliasName, roleName)
+}
+
+func TestResourceToken_batchTokenAutoDetectionViaRole(t *testing.T) {
+	resourceName := "vault_token.test"
+	roleName := "batch-vault-role"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
+		CheckDestroy:             testResourceTokenCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceTokenConfig_batchTokenAutoDetectionViaRole(roleName),
+				Check: resource.ComposeTestCheckFunc(
+					// Verify the token was actually created
+					resource.TestCheckResourceAttrSet(resourceName, consts.FieldClientToken),
+
+					// Even though Vault issued a batch token (hvb...), the provider
+					// didn't explicitly update the 'type' field in the state during Create.
+					resource.TestCheckResourceAttr(resourceName, consts.FieldType, "batch"),
+				),
+			},
+			{
+				// Trigger a refresh to see if the provider tries to
+				// perform a LookupAccessor (which it shouldn't for batch)
+				Config:   testResourceTokenConfig_batchTokenAutoDetectionViaRole(roleName),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func testResourceTokenConfig_batchTokenAutoDetectionViaRole(roleName string) string {
+	return fmt.Sprintf(`
+resource "vault_policy" "test" {
+  name   = "test"
+  policy = "path \"secret/*\" { capabilities = [\"read\"] }"
+}
+
+resource "vault_token_auth_backend_role" "batch" {
+  role_name        = "%s"
+  token_type       = "batch"
+  orphan           = true   # Batch tokens must be orphans
+  renewable        = false  # Batch tokens cannot be renewable
+  allowed_policies = [vault_policy.test.name]
+}
+
+resource "vault_token" "test" {
+  role_name = vault_token_auth_backend_role.batch.role_name
+  # No 'type' specified here, forcing the provider to auto-detect it from the role
+}
+`, roleName)
 }

--- a/vault/resource_token_test.go
+++ b/vault/resource_token_test.go
@@ -58,34 +58,6 @@ func TestResourceToken_basic(t *testing.T) {
 	})
 }
 
-func TestResourceToken_import(t *testing.T) {
-	resourceName := "vault_token.test"
-	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
-		PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
-		CheckDestroy:             testResourceTokenCheckDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testResourceTokenConfig_basic(),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "policies.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, consts.FieldTTL, "60s"),
-					resource.TestCheckResourceAttrSet(resourceName, consts.FieldLeaseDuration),
-					resource.TestCheckResourceAttrSet(resourceName, consts.FieldLeaseStarted),
-					resource.TestCheckResourceAttrSet(resourceName, consts.FieldClientToken),
-				),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
-				// the API can't serve these fields, so ignore them
-				ImportStateVerifyIgnore: []string{consts.FieldTTL, consts.FieldLeaseDuration, consts.FieldLeaseStarted, consts.FieldClientToken},
-			},
-		},
-	})
-}
-
 func testResourceTokenConfig_basic() string {
 	return `
 resource "vault_policy" "test" {
@@ -99,6 +71,82 @@ resource "vault_token" "test" {
 	policies = [ vault_policy.test.name ]
 	ttl = "60s"
 }`
+}
+
+func TestResourceToken_import(t *testing.T) {
+	resourceName := "vault_token.test"
+	roleName := "test-role-import"
+	entityName := "test-entity-import"
+	aliasName := "test-alias-import"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
+		CheckDestroy:             testResourceTokenCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceTokenConfig_import(roleName, entityName, aliasName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "policies.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldTTL, "60s"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldType, "service"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldRoleName, roleName),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldEntityAlias, aliasName),
+					resource.TestCheckResourceAttrSet(resourceName, consts.FieldLeaseDuration),
+					resource.TestCheckResourceAttrSet(resourceName, consts.FieldLeaseStarted),
+					resource.TestCheckResourceAttrSet(resourceName, consts.FieldClientToken),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+
+				// the API can't serve these fields, so ignore them
+				ImportStateVerifyIgnore: []string{consts.FieldTTL, consts.FieldLeaseDuration, consts.FieldLeaseStarted, consts.FieldClientToken, consts.FieldRoleName, consts.FieldEntityAlias},
+			},
+		},
+	})
+}
+
+func testResourceTokenConfig_import(roleName, entityName, aliasName string) string {
+	return fmt.Sprintf(`
+resource "vault_policy" "test" {
+  name = "test"
+  policy = <<EOT
+path "secret/*" { capabilities = [ "list" ] }
+EOT
+}
+
+resource "vault_auth_backend" "test" {
+  type = "userpass"
+  path = "userpass-test-import"
+}
+
+resource "vault_identity_entity" "test" {
+  name = "%s"
+}
+
+resource "vault_identity_entity_alias" "test" {
+  name           = "%s"
+  mount_accessor = vault_auth_backend.test.accessor
+  canonical_id   = vault_identity_entity.test.id
+}
+
+resource "vault_token_auth_backend_role" "test" {
+  role_name              = "%s"
+  allowed_policies       = [vault_policy.test.name]
+  allowed_entity_aliases = [vault_identity_entity_alias.test.name]
+}
+
+resource "vault_token" "test" {
+  policies     = [vault_policy.test.name]
+  ttl          = "60s"
+  type         = "service"
+  role_name    = vault_token_auth_backend_role.test.role_name
+  entity_alias = vault_identity_entity_alias.test.name
+}
+`, entityName, aliasName, roleName)
 }
 
 func TestResourceToken_full(t *testing.T) {
@@ -487,6 +535,13 @@ func TestResourceToken_withType(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, consts.FieldClientToken),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// the API can't serve these fields, so ignore them
+				ImportStateVerifyIgnore: []string{consts.FieldTTL, consts.FieldLeaseDuration, consts.FieldLeaseStarted, consts.FieldClientToken, consts.FieldEntityAlias},
+			},
 		},
 	})
 }
@@ -506,6 +561,10 @@ func TestResourceToken_withTypeBatch(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, consts.FieldClientToken),
 				),
 			},
+			// Note: Batch tokens cannot be imported via accessor because they don't have accessors.
+			// The resource uses RequestID as the ID for batch tokens, but ImportStatePassthrough
+			// doesn't work for batch tokens since they can't be looked up by the ID we store.
+			// This is a known limitation - batch tokens are not importable.
 		},
 	})
 }

--- a/website/docs/r/token.html.md
+++ b/website/docs/r/token.html.md
@@ -45,6 +45,31 @@ resource "vault_token" "example" {
 }
 ```
 
+### Batch Token Example
+
+```hcl
+resource "vault_token" "batch" {
+  policies = ["policy1"]
+  
+  type = "batch"
+  ttl  = "1h"
+}
+```
+
+### Token with Entity Alias
+
+```hcl
+resource "vault_token" "with_entity" {
+  role_name = "app"
+  
+  policies     = ["policy1"]
+  entity_alias = "my-entity-alias"
+  
+  renewable = true
+  ttl       = "24h"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -79,6 +104,10 @@ The following arguments are supported:
 * `renew_increment` - (Optional) The renew increment. This is specified in seconds
 
 * `metadata` - (Optional) Metadata to be set on this token
+
+* `type` - (Optional) The type of token to create. Can be `service` or `batch`. Service tokens are persisted and support renewal and revocation. Batch tokens are lightweight, non-renewable, and non-revocable. If not specified, defaults to `service`.
+
+* `entity_alias` - (Optional) Name of the entity alias to associate with during token creation. The entity alias must already exist and be associated with an entity. This allows the token to inherit the entity's policies and metadata.
 
 ## Attributes Reference
 

--- a/website/docs/r/token.html.md
+++ b/website/docs/r/token.html.md
@@ -105,7 +105,7 @@ The following arguments are supported:
 
 * `metadata` - (Optional) Metadata to be set on this token
 
-* `type` - (Optional) The type of token to create. Can be `service` or `batch`. Service tokens are persisted and support renewal and revocation. Batch tokens are lightweight, non-renewable, and non-revocable. If not specified, defaults to `service`.
+* `type` - (Optional) The token type. Can be "batch" or "service". Defaults to the type specified by the role configuration named by role_name. Service tokens are persisted and support renewal and revocation. Batch tokens are lightweight, non-renewable, and non-revocable. 
 
 * `entity_alias` - (Optional) Name of the entity alias to associate with during token creation. The entity alias must already exist and be associated with an entity. This allows the token to inherit the entity's policies and metadata.
 


### PR DESCRIPTION


<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Added the following fields to vault_token:
  - type
  - entity_alias

Also added support for batch tokens.
Tested across versions 1.15.0 - 1.21.0


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
% go test -v -count=1 -run TestResourceToken ./vault
=== RUN   TestResourceToken_basic
--- PASS: TestResourceToken_basic (1.09s)
=== RUN   TestResourceToken_import
--- PASS: TestResourceToken_import (1.41s)
=== RUN   TestResourceToken_full
--- PASS: TestResourceToken_full (0.99s)
=== RUN   TestResourceToken_lookup
--- PASS: TestResourceToken_lookup (1.09s)
=== RUN   TestResourceToken_expire
--- PASS: TestResourceToken_expire (8.14s)
=== RUN   TestResourceToken_renew
--- PASS: TestResourceToken_renew (9.39s)
=== RUN   TestResourceToken_withType
--- PASS: TestResourceToken_withType (1.09s)
=== RUN   TestResourceToken_withTypeBatch
--- PASS: TestResourceToken_withTypeBatch (0.87s)
=== RUN   TestResourceToken_withEntityAlias
--- PASS: TestResourceToken_withEntityAlias (1.55s)
=== RUN   TestResourceToken_batchTokenAutoDetectionViaRole
--- PASS: TestResourceToken_batchTokenAutoDetectionViaRole (1.33s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     27.696s
...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
