### PR TITLE
add length based id generation

### DIFF
--- a/vault/resource_secrets_sync_association.go
+++ b/vault/resource_secrets_sync_association.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strconv"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -117,9 +119,11 @@ func secretsSyncAssociationWrite(ctx context.Context, d *schema.ResourceData, me
 	}
 	log.Printf("[DEBUG] Wrote association to %q", path)
 
-	// ex: gh/dest/gh-dest-1/mount/kv/secret/token
-	// unique. each destination should only have one association for a particular accessor and secret
-	id := fmt.Sprintf("%s/dest/%s/mount/%s/secret/%s", destType, name, mount, secretName)
+	// Length-based ID format: {len1},{len2},{len3},{len4}:{destType}:{name}:{mount}:{secretName}
+	// Example: 7,8,2,5:aws-kms:my-mount:kv:token
+	id := fmt.Sprintf("%d,%d,%d,%d:%s:%s:%s:%s",
+		len(destType), len(name), len(mount), len(secretName),
+		destType, name, mount, secretName)
 	d.SetId(id)
 
 	return secretsSyncAssociationRead(ctx, d, meta)
@@ -289,7 +293,78 @@ func getSyncAssociationModelFromResponse(resp *api.Secret) (*syncAssociationMode
 	return model, nil
 }
 
+// isLengthBasedIDFormat checks if ID uses length-based format (starts with digit).
+func isLengthBasedIDFormat(id string) bool {
+	return len(id) > 0 && id[0] >= '0' && id[0] <= '9'
+}
+
+// parseLengthBasedID parses length-based ID format.
+// Format: {len1},{len2},{len3},{len4}:{destType}:{name}:{mount}:{secretName}
+// Returns: [destType, name, mount, secretName]
+func parseLengthBasedID(id string) ([]string, error) {
+	// Find the first colon that separates lengths from values
+	colonIdx := strings.Index(id, ":")
+	if colonIdx == -1 {
+		return nil, fmt.Errorf("invalid length-based ID format: expected format {len1},{len2},{len3},{len4}:{values}")
+	}
+
+	lengthsPart := id[:colonIdx]
+	valuesPart := id[colonIdx+1:] // Skip the first colon
+
+	// Parse the lengths
+	lengthStrs := strings.Split(lengthsPart, ",")
+	if len(lengthStrs) != 4 {
+		return nil, fmt.Errorf("invalid length-based ID format: expected 4 length values, got %d", len(lengthStrs))
+	}
+
+	lengths := make([]int, 4)
+	for i, lenStr := range lengthStrs {
+		length, err := strconv.Atoi(lenStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid length value at position %d: %s", i, err)
+		}
+		if length < 0 {
+			return nil, fmt.Errorf("invalid length value at position %d: length cannot be negative", i)
+		}
+		lengths[i] = length
+	}
+
+	// Extract values using the lengths, skipping colon separators
+	fields := make([]string, 4)
+	pos := 0
+	for i := 0; i < 4; i++ {
+		// Skip colon separator before each field (except the first)
+		if i > 0 {
+			if pos >= len(valuesPart) || valuesPart[pos] != ':' {
+				return nil, fmt.Errorf("invalid length-based ID format: expected ':' separator at position %d", pos)
+			}
+			pos++ // Skip the colon
+		}
+
+		if pos+lengths[i] > len(valuesPart) {
+			return nil, fmt.Errorf("invalid length-based ID format: length %d at position %d exceeds remaining string length", lengths[i], i)
+		}
+
+		fields[i] = valuesPart[pos : pos+lengths[i]]
+		pos += lengths[i]
+	}
+
+	// Verify we've consumed the entire values part
+	if pos != len(valuesPart) {
+		return nil, fmt.Errorf("invalid length-based ID format: unexpected trailing data after parsing all fields")
+	}
+
+	return fields, nil
+}
+
+// syncAssociationFieldsFromID parses ID and returns [destType, name, mount, secretName].
+// Supports both old and new formats for backward compatibility.
 func syncAssociationFieldsFromID(id string) ([]string, error) {
+	if isLengthBasedIDFormat(id) {
+		return parseLengthBasedID(id)
+	}
+
+	// Old format fallback
 	if !syncAssociationFieldsFromIDRegex.MatchString(id) {
 		return nil, fmt.Errorf("regex did not match")
 	}

--- a/vault/resource_secrets_sync_association_test.go
+++ b/vault/resource_secrets_sync_association_test.go
@@ -93,3 +93,260 @@ resource "vault_secrets_sync_association" "test" {
 
 	return ret
 }
+
+// TestSyncAssociationFieldsFromID_NewFormat tests the new length-based ID format
+func TestSyncAssociationFieldsFromID_NewFormat(t *testing.T) {
+	tests := []struct {
+		name      string
+		id        string
+		want      []string
+		wantError bool
+	}{
+		{
+			name: "basic new format",
+			id:   "7,8,2,5:aws-kms:my-mount:kv:token",
+			want: []string{"aws-kms", "my-mount", "kv", "token"},
+		},
+		{
+			name: "values with keywords",
+			id:   "6,11,2,6:gh-app:dest-secret:kv:secret",
+			want: []string{"gh-app", "dest-secret", "kv", "secret"},
+		},
+		{
+			name: "values with mount keyword",
+			id:   "3,8,2,10:aws:my-mount:kv:mount-test",
+			want: []string{"aws", "my-mount", "kv", "mount-test"},
+		},
+		{
+			name: "values with colons",
+			id:   "10,12,5,16:aws:kms:v2:dest:name:v2:kv/v2:secret:name:test",
+			want: []string{"aws:kms:v2", "dest:name:v2", "kv/v2", "secret:name:test"},
+		},
+		{
+			name: "empty field values",
+			id:   "0,0,0,0::::",
+			want: []string{"", "", "", ""},
+		},
+		{
+			name: "single character values",
+			id:   "1,1,1,1:a:b:c:d",
+			want: []string{"a", "b", "c", "d"},
+		},
+		{
+			name: "long values",
+			id:   "19,29,15,26:very-long-dest-type:this-is-a-very-long-dest-name:long-mount-path:very-long-secret-name-here",
+			want: []string{"very-long-dest-type", "this-is-a-very-long-dest-name", "long-mount-path", "very-long-secret-name-here"},
+		},
+		{
+			name:      "invalid format - missing colon",
+			id:        "7,8,2,5aws-kms:my-mount:kv:token",
+			wantError: true,
+		},
+		{
+			name:      "invalid format - wrong number of lengths",
+			id:        "7,8,2:aws-kms:my-mount:kv:token",
+			wantError: true,
+		},
+		{
+			name:      "invalid format - non-numeric length",
+			id:        "7,abc,2,5:aws-kms:my-mount:kv:token",
+			wantError: true,
+		},
+		{
+			name:      "invalid format - negative length",
+			id:        "7,-8,2,5:aws-kms:my-mount:kv:token",
+			wantError: true,
+		},
+		{
+			name:      "invalid format - missing separator between values",
+			id:        "7,8,2,5:aws-kmsmy-mount:kv:token",
+			wantError: true,
+		},
+		{
+			name:      "invalid format - trailing data",
+			id:        "7,8,2,5:aws-kms:my-mount:kv:token:extra",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := syncAssociationFieldsFromID(tt.id)
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("syncAssociationFieldsFromID() expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("syncAssociationFieldsFromID() unexpected error: %v", err)
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Errorf("syncAssociationFieldsFromID() got %d fields, want %d", len(got), len(tt.want))
+				return
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("syncAssociationFieldsFromID() field[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestSyncAssociationFieldsFromID_OldFormat tests backward compatibility with old format
+func TestSyncAssociationFieldsFromID_OldFormat(t *testing.T) {
+	tests := []struct {
+		name      string
+		id        string
+		want      []string
+		wantError bool
+	}{
+		{
+			name: "basic old format",
+			id:   "aws-kms/dest/my-dest/mount/kv/secret/token",
+			want: []string{"aws-kms", "my-dest", "kv", "token"},
+		},
+		{
+			name: "old format with hyphens",
+			id:   "gh-app/dest/gh-dest-1/mount/kv-v2/secret/my-token",
+			want: []string{"gh-app", "gh-dest-1", "kv-v2", "my-token"},
+		},
+		{
+			name:      "old format - invalid regex",
+			id:        "aws-kms/dest/my-dest/mount/kv",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := syncAssociationFieldsFromID(tt.id)
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("syncAssociationFieldsFromID() expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("syncAssociationFieldsFromID() unexpected error: %v", err)
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Errorf("syncAssociationFieldsFromID() got %d fields, want %d", len(got), len(tt.want))
+				return
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("syncAssociationFieldsFromID() field[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestIsLengthBasedIDFormat tests the format detection helper
+func TestIsLengthBasedIDFormat(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		want bool
+	}{
+		{
+			name: "length-based format - starts with digit",
+			id:   "7,8,2,5:aws-kms:my-mount:kv:token",
+			want: true,
+		},
+		{
+			name: "old format - starts with letter",
+			id:   "aws-kms/dest/my-dest/mount/kv/secret/token",
+			want: false,
+		},
+		{
+			name: "empty string",
+			id:   "",
+			want: false,
+		},
+		{
+			name: "starts with zero",
+			id:   "0,0,0,0::::",
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isLengthBasedIDFormat(tt.id)
+			if got != tt.want {
+				t.Errorf("isLengthBasedIDFormat() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseLengthBasedID tests the length-based ID parser directly
+func TestParseLengthBasedID(t *testing.T) {
+	tests := []struct {
+		name      string
+		id        string
+		want      []string
+		wantError bool
+	}{
+		{
+			name: "valid format",
+			id:   "7,8,2,5:aws-kms:my-mount:kv:token",
+			want: []string{"aws-kms", "my-mount", "kv", "token"},
+		},
+		{
+			name: "with special characters",
+			id:   "10,15,5,12:aws-kms-v2:dest_with-chars:kv/v2:secret@name!",
+			want: []string{"aws-kms-v2", "dest_with-chars", "kv/v2", "secret@name!"},
+		},
+		{
+			name: "with colons in values",
+			id:   "10,12,5,16:aws:kms:v2:dest:name:v2:kv/v2:secret:name:test",
+			want: []string{"aws:kms:v2", "dest:name:v2", "kv/v2", "secret:name:test"},
+		},
+		{
+			name:      "missing colon separator",
+			id:        "7,8,2,5aws-kms:my-mount:kv:token",
+			wantError: true,
+		},
+		{
+			name:      "too many length values",
+			id:        "7,8,2,5,6:aws-kms:my-mount:kv:token",
+			wantError: true,
+		},
+		{
+			name:      "too few length values",
+			id:        "7,8,2:aws-kms:my-mount:kv:token",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseLengthBasedID(tt.id)
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("parseLengthBasedID() expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("parseLengthBasedID() unexpected error: %v", err)
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Errorf("parseLengthBasedID() got %d fields, want %d", len(got), len(tt.want))
+				return
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("parseLengthBasedID() field[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description
Bug: https://hashicorp.atlassian.net/browse/VAULT-31541

Fix ID parsing for secrets_sync_association resource

### Problem
The current ID format for vault_secrets_sync_association uses regex-based parsing with keyword delimiters:

`{destType}/dest/{name}/mount/{mount}/secret/{secretName}
`
This fails when field values contain the keywords "dest", "mount", or "secret". For example:

name = "my/mount" → ID becomes aws-kms/dest/my/mount/mount/kv/secret/token
Regex incorrectly parses "my/" as part of destType instead of name

### Solution
Implemented length-based ID format that uses explicit field lengths for parsing:

```
{len1},{len2},{len3},{len4}:{destType}:{name}:{mount}:{secretName}
Example: 7,8,2,5:aws-kms:my-mount:kv:token
```

The parser uses the length values to extract fields, making it immune to keyword collisions and special characters (including colons in field values).

### Changes

- Updated ID generation in secretsSyncAssociationWrite()
- Added isLengthBasedIDFormat() for format detection (checks if ID starts with digit)
- Added parseLengthBasedID() for parsing new format
- Updated syncAssociationFieldsFromID() to support both formats

### Backward Compatibility
Fully backward compatible - old format IDs continue to work

Automatic format detection: digit = new format, letter = old format
No state migration required
Existing resources unaffected

