### PR TITLE
Spurious diff issue fix for vhost and vhost_topic fields in vault_rabbitmq_secret_backend_role resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,12 @@ IMPROVEMENTS:
 * `vault_pki_secret_backend_config_acme`: Added new fields that control the PKI ACME challenge worker IP ranges that they can connect. ([#2839]https://github.com/hashicorp/terraform-provider-vault/pull/2839)
 * Add support for metadata fields in `azure_access_credentials` and `resource_azure_secret_backend_role` resources. ([#2734](https://github.com/hashicorp/terraform-provider-vault/pull/2734)
 
-BUGS: 
+BUGS:
 * `vault_consul_secret_backend`: Fixed validation logic to allow computed token values by correcting the condition that checks for token presence during plan phase. ([#2823](https://github.com/hashicorp/terraform-provider-vault/pull/2823))
 * `vault_pki_external_ca_secret_backend_acme_account`: Provide eab_kid and eab_key values through the ACME account creation request. ([#2851]https://github.com/hashicorp/terraform-provider-vault/pull/2852)
 * `provider/auth_login`: Fix "Missing Region" error when using generic `auth_login` block for AWS authentication without explicit `sts_region` parameter. The provider now properly resolves AWS region from environment variables (`AWS_REGION`, `AWS_DEFAULT_REGION`) and EC2 instance metadata service (IMDS), consistent with `auth_login_aws` behavior. ([#2786](https://github.com/hashicorp/terraform-provider-vault/issues/2786))
 * `provider/auth_aws`: Fix `auth_login_aws` for Vault AWS auth backends configured with `use_sts_region_from_client = true` by generating a standard SigV4-signed `GetCallerIdentity` request with an `Authorization` header, and added support for custom STS endpoints. ([#2841](https://github.com/hashicorp/terraform-provider-vault/pull/2841))
+* `vault_rabbitmq_secret_backend_role`: Fixed spurious diff issue for `vhost` and `vhost_topic` fields by changing field type from TypeList to TypeSet. ([#2872](https://github.com/hashicorp/terraform-provider-vault/pull/2872))
 
 ## 5.8.0 (March 12, 2026)
 

--- a/vault/resource_rabbitmq_secret_backend_role.go
+++ b/vault/resource_rabbitmq_secret_backend_role.go
@@ -45,7 +45,7 @@ func rabbitMQSecretBackendRoleResource() *schema.Resource {
 				Description: "Specifies a comma-separated RabbitMQ management tags.",
 			},
 			"vhost": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "Specifies a map of virtual hosts to permissions.",
 				Elem: &schema.Resource{
@@ -74,13 +74,13 @@ func rabbitMQSecretBackendRoleResource() *schema.Resource {
 				},
 			},
 			"vhost_topic": {
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 				Optional:    true,
 				Description: "Specifies a map of virtual hosts and exchanges to topic permissions. This option requires RabbitMQ 3.7.0 or later.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"vhost": {
-							Type:        schema.TypeList,
+							Type:        schema.TypeSet,
 							Optional:    true,
 							Description: "Specifies a map of virtual hosts to permissions.",
 							Elem: &schema.Resource{
@@ -125,11 +125,11 @@ func rabbitMQSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) er
 	name := d.Get("name").(string)
 	tags := d.Get("tags").(string)
 
-	vhostsJSON, _, err := expandRabbitMQSecretBackendRoleVhost(d.Get("vhost").([]interface{}), "host")
+	vhostsJSON, _, err := expandRabbitMQSecretBackendRoleVhost(d.Get("vhost").(*schema.Set), "host")
 	if err != nil {
 		return fmt.Errorf("error expanding vhost: %w", err)
 	}
-	vhostTopicsJSON, err := expandRabbitMQSecretBackendRoleVhostTopic(d.Get("vhost_topic").([]interface{}))
+	vhostTopicsJSON, err := expandRabbitMQSecretBackendRoleVhostTopic(d.Get("vhost_topic").(*schema.Set))
 	if err != nil {
 		return fmt.Errorf("error expanding vhost_topic: %w", err)
 	}
@@ -225,7 +225,8 @@ func rabbitMQSecretBackendRoleExists(d *schema.ResourceData, meta interface{}) (
 	return secret != nil, nil
 }
 
-func expandRabbitMQSecretBackendRoleVhost(vhost []interface{}, key string) (string, map[string]interface{}, error) {
+func expandRabbitMQSecretBackendRoleVhost(vhostSet *schema.Set, key string) (string, map[string]interface{}, error) {
+	vhost := vhostSet.List()
 	log.Printf("[DEBUG] Vhosts as list from ResourceData: %+v", vhost)
 
 	vhosts := make(map[string]interface{}, len(vhost))
@@ -258,7 +259,8 @@ func expandRabbitMQSecretBackendRoleVhost(vhost []interface{}, key string) (stri
 	return string(vhostsJSON), vhosts, nil
 }
 
-func expandRabbitMQSecretBackendRoleVhostTopic(vhost []interface{}) (string, error) {
+func expandRabbitMQSecretBackendRoleVhostTopic(vhostSet *schema.Set) (string, error) {
+	vhost := vhostSet.List()
 	log.Printf("[DEBUG] Vhosts as list from ResourceData: %+v", vhost)
 
 	vhosts := make(map[string]interface{}, len(vhost))
@@ -267,7 +269,7 @@ func expandRabbitMQSecretBackendRoleVhostTopic(vhost []interface{}) (string, err
 		vv := host.(map[string]interface{})
 		id := vv["host"].(string)
 
-		_, topics, err := expandRabbitMQSecretBackendRoleVhost(vv["vhost"].([]interface{}), "topic")
+		_, topics, err := expandRabbitMQSecretBackendRoleVhost(vv["vhost"].(*schema.Set), "topic")
 		if err != nil {
 			return "", err
 		}

--- a/vault/resource_rabbitmq_secret_backend_role_test.go
+++ b/vault/resource_rabbitmq_secret_backend_role_test.go
@@ -287,3 +287,192 @@ resource "vault_rabbitmq_secret_backend_role" "test" {
 }
 `, path, connectionUri, username, password, name, testAccRabbitMQSecretBackendRoleTags_updated)
 }
+
+func TestAccRabbitMQSecretBackendRole_multipleVhostsAndTopics(t *testing.T) {
+	backend := acctest.RandomWithPrefix("tf-test-rabbitmq")
+	name := acctest.RandomWithPrefix("tf-test-rabbitmq")
+	resourceName := "vault_rabbitmq_secret_backend_role.test"
+	connectionUri, username, password := testutil.GetTestRMQCreds(t)
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		PreCheck:                 func() { testutil.TestAccPreCheck(t) },
+		CheckDestroy:             testAccRabbitMQSecretBackendRoleCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRabbitMQSecretBackendRoleConfig_multipleVhostsAndTopics(name, backend, connectionUri, username, password),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "backend", backend),
+					resource.TestCheckResourceAttr(resourceName, "tags", "management"),
+					// Verify we have 11 vhost blocks
+					resource.TestCheckResourceAttr(resourceName, "vhost.#", "11"),
+					// Check that specific vhosts are present (TypeSet doesn't guarantee order)
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "vhost.*", map[string]string{
+						"host":      "cosmos",
+						"read":      "^toto$",
+						"write":     "^toto$",
+						"configure": "^toto$",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "vhost.*", map[string]string{
+						"host":      "customer",
+						"read":      "^toto$",
+						"write":     "^toto$",
+						"configure": "^toto$",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "vhost.*", map[string]string{
+						"host":      "ship",
+						"read":      "^toto$",
+						"write":     "^toto$",
+						"configure": "^toto$",
+					}),
+					// Verify we have 3 vhost_topic blocks
+					resource.TestCheckResourceAttr(resourceName, "vhost_topic.#", "3"),
+					// Check vhost_topic hosts are present
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "vhost_topic.*", map[string]string{
+						"host": "/",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "vhost_topic.*", map[string]string{
+						"host": "cosmos",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs(resourceName, "vhost_topic.*", map[string]string{
+						"host": "customers",
+					}),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccRabbitMQSecretBackendRoleConfig_multipleVhostsAndTopics(name, path, connectionUri, username, password string) string {
+	return fmt.Sprintf(`
+resource "vault_rabbitmq_secret_backend" "test" {
+  path = "%s"
+  description = "test description"
+  default_lease_ttl_seconds = 3600
+  max_lease_ttl_seconds = 86400
+  connection_uri = "%s"
+  username = "%s"
+  password = "%s"
+}
+
+resource "vault_rabbitmq_secret_backend_role" "test" {
+  backend = vault_rabbitmq_secret_backend.test.path
+  name = "%s"
+  tags = "management"
+  
+  vhost {
+    host      = "cosmos"
+    read      = "^toto$"
+    write     = "^toto$"
+    configure = "^toto$"
+  }
+  
+  vhost {
+    host      = "customer"
+    read      = "^toto$"
+    write     = "^toto$"
+    configure = "^toto$"
+  }
+  
+  vhost {
+    host      = "demand"
+    read      = "^toto$"
+    write     = "^toto$"
+    configure = "^toto$"
+  }
+  
+  vhost {
+    host      = "ei"
+    read      = "^toto$"
+    write     = "^toto$"
+    configure = "^toto$"
+  }
+  
+  vhost {
+    host      = "es"
+    read      = "^toto$"
+    write     = "^toto$"
+    configure = "^toto$"
+  }
+  
+  vhost {
+    host      = "leg"
+    read      = "^toto$"
+    write     = "^toto$"
+    configure = "^toto$"
+  }
+  
+  vhost {
+    host      = "mulan"
+    read      = "^toto$"
+    write     = "^toto$"
+    configure = "^toto$"
+  }
+  
+  vhost {
+    host      = "mulan_test"
+    read      = "^toto$"
+    write     = "^toto$"
+    configure = "^toto$"
+  }
+  
+  vhost {
+    host      = "op-t"
+    read      = "^toto$"
+    write     = "^toto$"
+    configure = "^toto$"
+  }
+  
+  vhost {
+    host      = "pub"
+    read      = "^toto$"
+    write     = "^toto$"
+    configure = "^toto$"
+  }
+  
+  vhost {
+    host      = "ship"
+    read      = "^toto$"
+    write     = "^toto$"
+    configure = "^toto$"
+  }
+  
+  vhost_topic {
+    host = "/"
+    vhost {
+      topic = "amq.topic"
+      read  = ".*"
+      write = ".*"
+    }
+  }
+
+  vhost_topic {
+    host = "cosmos"
+    vhost {
+      topic = "amq.topic"
+      read  = "^cosmos.*"
+      write = "^cosmos.*"
+    }
+    vhost {
+      topic = "amq.direct"
+      read  = ".*"
+      write = ""
+    }
+  }
+
+  vhost_topic {
+    host = "customers"
+    vhost {
+      topic = "customer.events"
+      read  = ".*"
+      write = "^customer\\..*"
+    }
+  }
+}
+`, path, connectionUri, username, password, name)
+}

--- a/vault/resource_rabbitmq_secret_backend_role_test.go
+++ b/vault/resource_rabbitmq_secret_backend_role_test.go
@@ -366,12 +366,12 @@ resource "vault_rabbitmq_secret_backend_role" "test" {
   tags = "management"
   
   vhost {
-    host      = "cosmos"
+    host      = "demand"
     read      = "^toto$"
     write     = "^toto$"
     configure = "^toto$"
   }
-  
+
   vhost {
     host      = "customer"
     read      = "^toto$"
@@ -380,14 +380,14 @@ resource "vault_rabbitmq_secret_backend_role" "test" {
   }
   
   vhost {
-    host      = "demand"
+    host      = "ei"
     read      = "^toto$"
     write     = "^toto$"
     configure = "^toto$"
   }
-  
+
   vhost {
-    host      = "ei"
+    host      = "cosmos"
     read      = "^toto$"
     write     = "^toto$"
     configure = "^toto$"
@@ -413,6 +413,13 @@ resource "vault_rabbitmq_secret_backend_role" "test" {
     write     = "^toto$"
     configure = "^toto$"
   }
+
+  vhost {
+    host      = "ship"
+    read      = "^toto$"
+    write     = "^toto$"
+    configure = "^toto$"
+  }
   
   vhost {
     host      = "mulan_test"
@@ -434,12 +441,14 @@ resource "vault_rabbitmq_secret_backend_role" "test" {
     write     = "^toto$"
     configure = "^toto$"
   }
-  
-  vhost {
-    host      = "ship"
-    read      = "^toto$"
-    write     = "^toto$"
-    configure = "^toto$"
+
+  vhost_topic {
+    host = "customers"
+    vhost {
+      topic = "customer.events"
+      read  = ".*"
+      write = "^customer\\..*"
+    }
   }
   
   vhost_topic {
@@ -465,14 +474,6 @@ resource "vault_rabbitmq_secret_backend_role" "test" {
     }
   }
 
-  vhost_topic {
-    host = "customers"
-    vhost {
-      topic = "customer.events"
-      read  = ".*"
-      write = "^customer\\..*"
-    }
-  }
 }
 `, path, connectionUri, username, password, name)
 }


### PR DESCRIPTION



### Description
This PR fixes spurious diff issue caused by vhost and vhost_topic fields in vault_rabbitmq_secret_backend_role resource.

Relates OR Closes #952


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
go test -v ./vault -run TestAccRabbitMQSecretBackendRole -count=1
=== RUN   TestAccRabbitMQSecretBackendRole_basic
--- PASS: TestAccRabbitMQSecretBackendRole_basic (2.64s)
=== RUN   TestAccRabbitMQSecretBackendRole_nested
--- PASS: TestAccRabbitMQSecretBackendRole_nested (2.80s)
=== RUN   TestAccRabbitMQSecretBackendRole_topic
--- PASS: TestAccRabbitMQSecretBackendRole_topic (2.55s)
=== RUN   TestAccRabbitMQSecretBackendRole_multipleVhostsAndTopics
--- PASS: TestAccRabbitMQSecretBackendRole_multipleVhostsAndTopics (1.78s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     11.415s
```
### Output from manual testing:
Initial Create:
<img width="1554" height="716" alt="Screenshot 2026-04-10 at 12 16 48 PM" src="https://github.com/user-attachments/assets/f69b9ffd-bc45-4290-afb2-d56cd36fb78a" />

Update Operation:
<img width="1582" height="942" alt="Screenshot 2026-04-10 at 12 18 26 PM" src="https://github.com/user-attachments/assets/49f50507-4d2b-44c1-9839-ddd149acb7c6" />


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
