### PR TITLE
Revert field name from insecure_tls to  insecure to fix the connection state loading issue for elasticsearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ BUGS:
 * `vault_pki_external_ca_secret_backend_acme_account`: Provide eab_kid and eab_key values through the ACME account creation request. ([#2851]https://github.com/hashicorp/terraform-provider-vault/pull/2852)
 * `provider/auth_login`: Fix "Missing Region" error when using generic `auth_login` block for AWS authentication without explicit `sts_region` parameter. The provider now properly resolves AWS region from environment variables (`AWS_REGION`, `AWS_DEFAULT_REGION`) and EC2 instance metadata service (IMDS), consistent with `auth_login_aws` behavior. ([#2786](https://github.com/hashicorp/terraform-provider-vault/issues/2786))
 * `provider/auth_aws`: Fix `auth_login_aws` for Vault AWS auth backends configured with `use_sts_region_from_client = true` by generating a standard SigV4-signed `GetCallerIdentity` request with an `Authorization` header, and added support for custom STS endpoints. ([#2841](https://github.com/hashicorp/terraform-provider-vault/pull/2841))
+* `resource_database_secret_backend_connection` : Fixes a regression issue for `resource_database_secret_backend_connection` for elasticsearch. Reverted the field name from insecure_tls to insecure.
 
 ## 5.8.0 (March 12, 2026)
 

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -48,6 +48,7 @@ const (
 	FieldPasswordPolicy                     = "password_policy"
 	FieldLength                             = "length"
 	FieldInsecureTLS                        = "insecure_tls"
+	FieldInsecure                           = "insecure"
 	FieldURL                                = "url"
 	FieldUserAttr                           = "userattr"
 	FieldUserDN                             = "userdn"

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -1515,7 +1515,7 @@ func getElasticsearchConnectionDetailsFromResponse(d *schema.ResourceData, prefi
 		result["tls_server_name"] = v.(string)
 	}
 	if v, ok := data["insecure"]; ok {
-		result["insecure"] = v.(bool)
+		result[consts.FieldInsecureTLS] = v.(bool)
 	}
 	if v, ok := data["username_template"]; ok {
 		result["username_template"] = v.(string)
@@ -1881,7 +1881,7 @@ func setElasticsearchDatabaseConnectionData(d *schema.ResourceData, prefix strin
 		data["tls_server_name"] = v.(string)
 	}
 
-	if v, ok := d.GetOk(prefix + "insecure"); ok {
+	if v, ok := d.GetOk(prefix + consts.FieldInsecureTLS); ok {
 		data["insecure"] = v.(bool)
 	}
 

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -261,7 +261,7 @@ func getDatabaseSchema(typ schema.ValueType) schemaMap {
 						Optional:    true,
 						Description: "This, if set, is used to set the SNI host when connecting via TLS",
 					},
-					consts.FieldInsecureTLS: {
+					consts.FieldInsecure: {
 						Type:        schema.TypeBool,
 						Optional:    true,
 						Default:     false,
@@ -1515,7 +1515,7 @@ func getElasticsearchConnectionDetailsFromResponse(d *schema.ResourceData, prefi
 		result["tls_server_name"] = v.(string)
 	}
 	if v, ok := data["insecure"]; ok {
-		result[consts.FieldInsecureTLS] = v.(bool)
+		result[consts.FieldInsecure] = v.(bool)
 	}
 	if v, ok := data["username_template"]; ok {
 		result["username_template"] = v.(string)
@@ -1881,7 +1881,7 @@ func setElasticsearchDatabaseConnectionData(d *schema.ResourceData, prefix strin
 		data["tls_server_name"] = v.(string)
 	}
 
-	if v, ok := d.GetOk(prefix + consts.FieldInsecureTLS); ok {
+	if v, ok := d.GetOk(prefix + consts.FieldInsecure); ok {
 		data["insecure"] = v.(bool)
 	}
 

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -1515,7 +1515,7 @@ func getElasticsearchConnectionDetailsFromResponse(d *schema.ResourceData, prefi
 		result["tls_server_name"] = v.(string)
 	}
 	if v, ok := data["insecure"]; ok {
-		result[consts.FieldInsecure] = v.(bool)
+		result["insecure"] = v.(bool)
 	}
 	if v, ok := data["username_template"]; ok {
 		result["username_template"] = v.(string)
@@ -1881,7 +1881,7 @@ func setElasticsearchDatabaseConnectionData(d *schema.ResourceData, prefix strin
 		data["tls_server_name"] = v.(string)
 	}
 
-	if v, ok := d.GetOk(prefix + consts.FieldInsecure); ok {
+	if v, ok := d.GetOk(prefix + "insecure"); ok {
 		data["insecure"] = v.(bool)
 	}
 

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -125,7 +125,7 @@ func TestAccDatabaseSecretBackendConnection_cassandra(t *testing.T) {
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.username", username),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.password", password),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.tls", "false"),
-					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.insecure", "false"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.insecure_tls", "false"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.pem_bundle", ""),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.pem_json", ""),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.protocol_version", "4"),
@@ -177,7 +177,7 @@ func TestAccDatabaseSecretBackendConnection_cassandraProtocol(t *testing.T) {
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.username", username),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.password", password),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.tls", "false"),
-					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.insecure", "false"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.insecure_tls", "false"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.pem_bundle", ""),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.pem_json", ""),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.protocol_version", "4"),
@@ -385,7 +385,7 @@ func TestAccDatabaseSecretBackendConnection_couchbase(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceName, "couchbase.0.hosts.#", "1"),
 						resource.TestCheckTypeSetElemAttr(resourceName, "couchbase.0.hosts.*", host),
 						resource.TestCheckResourceAttr(resourceName, "couchbase.0.tls", "false"),
-						resource.TestCheckResourceAttr(resourceName, "couchbase.0.insecure", "false"),
+						resource.TestCheckResourceAttr(resourceName, "couchbase.0.insecure_tls", "false"),
 						resource.TestCheckResourceAttr(resourceName, "couchbase.0.base64_pem", ""),
 					)...,
 				),
@@ -404,7 +404,7 @@ func TestAccDatabaseSecretBackendConnection_couchbase(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceName, "couchbase.0.hosts.#", "1"),
 						resource.TestCheckTypeSetElemAttr(resourceName, "couchbase.0.hosts.*", hostTLS),
 						resource.TestCheckResourceAttr(resourceName, "couchbase.0.tls", "true"),
-						resource.TestCheckResourceAttr(resourceName, "couchbase.0.insecure", "true"),
+						resource.TestCheckResourceAttr(resourceName, "couchbase.0.insecure_tls", "true"),
 						resource.TestCheckResourceAttr(resourceName, "couchbase.0.base64_pem", host1Base64PEM),
 					)...,
 				),
@@ -452,7 +452,7 @@ func TestAccDatabaseSecretBackendConnection_influxdb(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "influxdb.0.username", username),
 					resource.TestCheckResourceAttr(resourceName, "influxdb.0.password", password),
 					resource.TestCheckResourceAttr(resourceName, "influxdb.0.tls", "false"),
-					resource.TestCheckResourceAttr(resourceName, "influxdb.0.insecure", "false"),
+					resource.TestCheckResourceAttr(resourceName, "influxdb.0.insecure_tls", "false"),
 					resource.TestCheckResourceAttr(resourceName, "influxdb.0.pem_bundle", ""),
 					resource.TestCheckResourceAttr(resourceName, "influxdb.0.pem_json", ""),
 					resource.TestCheckResourceAttr(resourceName, "influxdb.0.connect_timeout", "5"),
@@ -1606,7 +1606,7 @@ func TestAccDatabaseSecretBackendConnection_redis(t *testing.T) {
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "redis.0.username", username),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "redis.0.password", password),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "redis.0.tls", "false"),
-					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "redis.0.insecure", "false"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "redis.0.insecure_tls", "false"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, consts.FieldPasswordPolicy, "redis-policy"),
 					testAccCheckSkipStaticRoleImportRotation(testDefaultDatabaseSecretBackendResource, "false"),
 				),
@@ -1678,7 +1678,7 @@ func TestAccDatabaseSecretBackendConnection_redis_externalPlugin(t *testing.T) {
 		resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "redis.0.username", username),
 		resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "redis.0.password", password),
 		resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "redis.0.tls", "false"),
-		resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "redis.0.insecure", "false"),
+		resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "redis.0.insecure_tls", "false"),
 		resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, consts.FieldPasswordPolicy, "redis-policy"),
 		testAccCheckSkipStaticRoleImportRotation(testDefaultDatabaseSecretBackendResource, "false"),
 	}
@@ -1990,7 +1990,7 @@ resource "vault_database_secret_backend_connection" "test" {
 		config += `
     tls                = true
     tls_server_name    = "!!invalid!!"
-    insecure       = true`
+    insecure_tls       = true`
 	case "local_datacenter":
 		config += `
     local_datacenter   = ""`
@@ -2038,7 +2038,7 @@ resource "vault_database_secret_backend_connection" "test" {
     socket_keep_alive  = 30
     consistency        = "LOCAL_QUORUM"
     username_template  = "vault_{{.RoleName}}_{{.DisplayName}}_{{random 10}}"
-    insecure       = true
+    insecure_tls       = true
     connect_timeout    = 30
   }
 }
@@ -2071,7 +2071,7 @@ resource "vault_database_secret_backend_connection" "test" {
     socket_keep_alive  = 30
     consistency        = "LOCAL_QUORUM"
     username_template  = "vault_{{.RoleName}}_{{.DisplayName}}_{{random 10}}"
-    insecure       = false
+    insecure_tls       = false
     connect_timeout    = 30
   }
 }
@@ -2138,7 +2138,7 @@ func testAccDatabaseSecretBackendConnectionConfig_couchbase(name, path, host1, u
 	if base64PEM != "" {
 		tlsConfig = fmt.Sprintf(`
     tls          = true
-    insecure = true
+    insecure_tls = true
     base64_pem   = "%s"
 `, base64PEM)
 	}
@@ -2213,7 +2213,7 @@ resource "vault_database_secret_backend_connection" "test" {
     url = "%s"
     username = "%s"
     password = "%s"
-		insecure= true
+	insecure = true
 	username_template = %q
 	tls_server_name = "test"
   }

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -1429,7 +1429,7 @@ func TestAccDatabaseSecretBackendConnection_elasticsearch(t *testing.T) {
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "elasticsearch.0.url", connURL),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "elasticsearch.0.username", username),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "elasticsearch.0.password", password),
-					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "elasticsearch.0.insecure", "false"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "elasticsearch.0.insecure_tls", "false"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, consts.FieldPasswordPolicy, "elastic-policy"),
 					testAccCheckSkipStaticRoleImportRotation(testDefaultDatabaseSecretBackendResource, "false"),
 				),
@@ -1451,7 +1451,7 @@ func TestAccDatabaseSecretBackendConnection_elasticsearch(t *testing.T) {
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "elasticsearch.0.url", connURL),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "elasticsearch.0.username", username),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "elasticsearch.0.password", password),
-					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "elasticsearch.0.insecure", "true"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "elasticsearch.0.insecure_tls", "true"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "elasticsearch.0.username_template", "test"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "elasticsearch.0.tls_server_name", "test"),
 				),
@@ -2207,12 +2207,13 @@ resource "vault_database_secret_backend_connection" "test" {
   name = "%s"
   allowed_roles = ["dev", "prod"]
   root_rotation_statements = ["FOOBAR"]
+	password_policy = "elastic-policy"
 
   elasticsearch {
     url = "%s"
     username = "%s"
     password = "%s"
-	insecure = true
+		insecure_tls = true
 	username_template = %q
 	tls_server_name = "test"
   }

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -125,7 +125,7 @@ func TestAccDatabaseSecretBackendConnection_cassandra(t *testing.T) {
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.username", username),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.password", password),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.tls", "false"),
-					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.insecure_tls", "false"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.insecure", "false"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.pem_bundle", ""),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.pem_json", ""),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.protocol_version", "4"),
@@ -177,7 +177,7 @@ func TestAccDatabaseSecretBackendConnection_cassandraProtocol(t *testing.T) {
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.username", username),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.password", password),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.tls", "false"),
-					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.insecure_tls", "false"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.insecure", "false"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.pem_bundle", ""),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.pem_json", ""),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.protocol_version", "4"),
@@ -385,7 +385,7 @@ func TestAccDatabaseSecretBackendConnection_couchbase(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceName, "couchbase.0.hosts.#", "1"),
 						resource.TestCheckTypeSetElemAttr(resourceName, "couchbase.0.hosts.*", host),
 						resource.TestCheckResourceAttr(resourceName, "couchbase.0.tls", "false"),
-						resource.TestCheckResourceAttr(resourceName, "couchbase.0.insecure_tls", "false"),
+						resource.TestCheckResourceAttr(resourceName, "couchbase.0.insecure", "false"),
 						resource.TestCheckResourceAttr(resourceName, "couchbase.0.base64_pem", ""),
 					)...,
 				),
@@ -404,7 +404,7 @@ func TestAccDatabaseSecretBackendConnection_couchbase(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceName, "couchbase.0.hosts.#", "1"),
 						resource.TestCheckTypeSetElemAttr(resourceName, "couchbase.0.hosts.*", hostTLS),
 						resource.TestCheckResourceAttr(resourceName, "couchbase.0.tls", "true"),
-						resource.TestCheckResourceAttr(resourceName, "couchbase.0.insecure_tls", "true"),
+						resource.TestCheckResourceAttr(resourceName, "couchbase.0.insecure", "true"),
 						resource.TestCheckResourceAttr(resourceName, "couchbase.0.base64_pem", host1Base64PEM),
 					)...,
 				),
@@ -452,7 +452,7 @@ func TestAccDatabaseSecretBackendConnection_influxdb(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "influxdb.0.username", username),
 					resource.TestCheckResourceAttr(resourceName, "influxdb.0.password", password),
 					resource.TestCheckResourceAttr(resourceName, "influxdb.0.tls", "false"),
-					resource.TestCheckResourceAttr(resourceName, "influxdb.0.insecure_tls", "false"),
+					resource.TestCheckResourceAttr(resourceName, "influxdb.0.insecure", "false"),
 					resource.TestCheckResourceAttr(resourceName, "influxdb.0.pem_bundle", ""),
 					resource.TestCheckResourceAttr(resourceName, "influxdb.0.pem_json", ""),
 					resource.TestCheckResourceAttr(resourceName, "influxdb.0.connect_timeout", "5"),
@@ -1429,7 +1429,7 @@ func TestAccDatabaseSecretBackendConnection_elasticsearch(t *testing.T) {
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "elasticsearch.0.url", connURL),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "elasticsearch.0.username", username),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "elasticsearch.0.password", password),
-					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "elasticsearch.0.insecure_tls", "false"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "elasticsearch.0.insecure", "false"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, consts.FieldPasswordPolicy, "elastic-policy"),
 					testAccCheckSkipStaticRoleImportRotation(testDefaultDatabaseSecretBackendResource, "false"),
 				),
@@ -1451,7 +1451,7 @@ func TestAccDatabaseSecretBackendConnection_elasticsearch(t *testing.T) {
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "elasticsearch.0.url", connURL),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "elasticsearch.0.username", username),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "elasticsearch.0.password", password),
-					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "elasticsearch.0.insecure_tls", "true"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "elasticsearch.0.insecure", "true"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "elasticsearch.0.username_template", "test"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "elasticsearch.0.tls_server_name", "test"),
 				),
@@ -1606,7 +1606,7 @@ func TestAccDatabaseSecretBackendConnection_redis(t *testing.T) {
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "redis.0.username", username),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "redis.0.password", password),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "redis.0.tls", "false"),
-					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "redis.0.insecure_tls", "false"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "redis.0.insecure", "false"),
 					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, consts.FieldPasswordPolicy, "redis-policy"),
 					testAccCheckSkipStaticRoleImportRotation(testDefaultDatabaseSecretBackendResource, "false"),
 				),
@@ -1678,7 +1678,7 @@ func TestAccDatabaseSecretBackendConnection_redis_externalPlugin(t *testing.T) {
 		resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "redis.0.username", username),
 		resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "redis.0.password", password),
 		resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "redis.0.tls", "false"),
-		resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "redis.0.insecure_tls", "false"),
+		resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "redis.0.insecure", "false"),
 		resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, consts.FieldPasswordPolicy, "redis-policy"),
 		testAccCheckSkipStaticRoleImportRotation(testDefaultDatabaseSecretBackendResource, "false"),
 	}
@@ -1990,7 +1990,7 @@ resource "vault_database_secret_backend_connection" "test" {
 		config += `
     tls                = true
     tls_server_name    = "!!invalid!!"
-    insecure_tls       = true`
+    insecure       = true`
 	case "local_datacenter":
 		config += `
     local_datacenter   = ""`
@@ -2038,7 +2038,7 @@ resource "vault_database_secret_backend_connection" "test" {
     socket_keep_alive  = 30
     consistency        = "LOCAL_QUORUM"
     username_template  = "vault_{{.RoleName}}_{{.DisplayName}}_{{random 10}}"
-    insecure_tls       = true
+    insecure       = true
     connect_timeout    = 30
   }
 }
@@ -2071,7 +2071,7 @@ resource "vault_database_secret_backend_connection" "test" {
     socket_keep_alive  = 30
     consistency        = "LOCAL_QUORUM"
     username_template  = "vault_{{.RoleName}}_{{.DisplayName}}_{{random 10}}"
-    insecure_tls       = false
+    insecure       = false
     connect_timeout    = 30
   }
 }
@@ -2138,7 +2138,7 @@ func testAccDatabaseSecretBackendConnectionConfig_couchbase(name, path, host1, u
 	if base64PEM != "" {
 		tlsConfig = fmt.Sprintf(`
     tls          = true
-    insecure_tls = true
+    insecure = true
     base64_pem   = "%s"
 `, base64PEM)
 	}
@@ -2213,7 +2213,7 @@ resource "vault_database_secret_backend_connection" "test" {
     url = "%s"
     username = "%s"
     password = "%s"
-		insecure_tls = true
+		insecure= true
 	username_template = %q
 	tls_server_name = "test"
   }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #2847


### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
<img width="784" height="173" alt="Screenshot 2026-04-09 at 12 28 08 AM" src="https://github.com/user-attachments/assets/21bf8163-8e5e-40dc-8539-90caa05c5013" />


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
