### PR TITLE
Implement change detection for the write-only field in Alicloud Secret engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ FEATURES:
 
 IMPROVEMENTS:
 
+* `vault_alicloud_secret_backend`: Add `secret_key_wo_version` field to enable Terraform change detection for the write-only `secret_key_wo` field. Incrementing the version triggers an update that sends the new secret key to Vault, enabling secret key rotation without storing sensitive values in state. ([#2874](https://github.com/hashicorp/terraform-provider-vault/pull/2874))
 * `vault_pki_secret_backend_config_acme`: Added new fields that control the PKI ACME challenge worker IP ranges that they can connect. ([#2839]https://github.com/hashicorp/terraform-provider-vault/pull/2839)
 * Add support for metadata fields in `azure_access_credentials` and `resource_azure_secret_backend_role` resources. ([#2734](https://github.com/hashicorp/terraform-provider-vault/pull/2734)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,12 @@ FEATURES:
 * **New Resources**: `vault_rotation_policy` for managing rotation policies. Requires Vault 2.0.0+. ([#2844](https://github.com/hashicorp/terraform-provider-vault/pull/2844))
 * Add support for `vault_quota_config` resource. ([#2837](https://github.com/hashicorp/terraform-provider-vault/pull/2837))
 * **New Resources**: Add support for Vault Key Management secrets engine with resources for managing KMS providers (AWS KMS, Azure Key Vault, GCP Cloud KMS), cryptographic keys, key distribution, replication, and rotation (Vault Enterprise). ([#2802](https://github.com/hashicorp/terraform-provider-vault/pull/2802))
-* **New Resources**: `vault_alicloud_secret_backend`, `vault_alicloud_secret_backend_role`, and ephemeral resource `vault_alicloud_access_credentials` for managing AliCloud secrets engine. ([#2858](https://github.com/hashicorp/terraform-provider-vault/pull/2858))
+* **New Resources**: `vault_alicloud_secret_backend`, `vault_alicloud_secret_backend_role`, and ephemeral resource `vault_alicloud_access_credentials` for managing AliCloud secrets engine. ([#2858](https://github.com/hashicorp/terraform-provider-vault/pull/2858), [#2874](https://github.com/hashicorp/terraform-provider-vault/pull/2874))
 * **New Resource**: `vault_plugin_runtime` for managing plugin runtimes in Vault's plugin runtimes catalog. Requires Vault 1.15 or later.([#2835](https://github.com/hashicorp/terraform-provider-vault/pull/2835/))
 * Add support for CORS configuration: `vault_sys_config_cors` resource and data source for managing and reading Vault's CORS (Cross-Origin Resource Sharing) settings. ([#2849](https://github.com/hashicorp/terraform-provider-vault/pull/2849))
 
 IMPROVEMENTS:
 
-* `vault_alicloud_secret_backend`: Add `secret_key_wo_version` field to enable Terraform change detection for the write-only `secret_key_wo` field. Incrementing the version triggers an update that sends the new secret key to Vault, enabling secret key rotation without storing sensitive values in state. ([#2874](https://github.com/hashicorp/terraform-provider-vault/pull/2874))
 * `vault_pki_secret_backend_config_acme`: Added new fields that control the PKI ACME challenge worker IP ranges that they can connect. ([#2839]https://github.com/hashicorp/terraform-provider-vault/pull/2839)
 * Add support for metadata fields in `azure_access_credentials` and `resource_azure_secret_backend_role` resources. ([#2734](https://github.com/hashicorp/terraform-provider-vault/pull/2734)
 

--- a/internal/vault/secrets/alicloud/alicloud_access_credentials_ephemeral_resource_test.go
+++ b/internal/vault/secrets/alicloud/alicloud_access_credentials_ephemeral_resource_test.go
@@ -47,7 +47,7 @@ func TestAccAliCloudAccessCredentialsEphemeralResource_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			acctestutil.TestAccPreCheck(t)
+			acctestutil.TestEntPreCheck(t)
 		},
 		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
@@ -85,7 +85,7 @@ func TestAccAliCloudAccessCredentialsEphemeralResource_namespace(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			acctestutil.TestAccPreCheck(t)
+			acctestutil.TestEntPreCheck(t)
 		},
 		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
@@ -163,7 +163,7 @@ func TestAccAliCloudAccessCredentialsEphemeralResource_inlinePolicy(t *testing.T
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			acctestutil.TestAccPreCheck(t)
+			acctestutil.TestEntPreCheck(t)
 		},
 		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
@@ -200,7 +200,7 @@ func TestAccAliCloudAccessCredentialsEphemeralResource_remotePolicy(t *testing.T
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			acctestutil.TestAccPreCheck(t)
+			acctestutil.TestEntPreCheck(t)
 		},
 		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){
@@ -236,6 +236,7 @@ resource "vault_alicloud_secret_backend" "test" {
 	mount         = vault_mount.alicloud.path
 	access_key    = "%s"
 	secret_key_wo = "%s"
+	secret_key_wo_version = 1
 }
 `, testAccAliCloudAccessCredentialsEphemeralResourceNamespaceConfig, backend, accessKey, secretKey)
 }
@@ -550,7 +551,7 @@ func TestAccAliCloudAccessCredentialsEphemeralResource_multipleSimultaneous(t *t
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			acctestutil.TestAccPreCheck(t)
+			acctestutil.TestEntPreCheck(t)
 		},
 		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
 		ProtoV6ProviderFactories: map[string]func() (tfprotov6.ProviderServer, error){

--- a/internal/vault/secrets/alicloud/alicloud_secret_backend_resource.go
+++ b/internal/vault/secrets/alicloud/alicloud_secret_backend_resource.go
@@ -41,9 +41,10 @@ type AliCloudSecretBackendResource struct {
 type AliCloudSecretBackendModel struct {
 	base.BaseModel
 
-	Mount       types.String `tfsdk:"mount"`
-	AccessKey   types.String `tfsdk:"access_key"`
-	SecretKeyWO types.String `tfsdk:"secret_key_wo"`
+	Mount              types.String `tfsdk:"mount"`
+	AccessKey          types.String `tfsdk:"access_key"`
+	SecretKeyWO        types.String `tfsdk:"secret_key_wo"`
+	SecretKeyWOVersion types.Int64  `tfsdk:"secret_key_wo_version"`
 }
 
 func (r *AliCloudSecretBackendResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -71,6 +72,10 @@ func (r *AliCloudSecretBackendResource) Schema(_ context.Context, _ resource.Sch
 				Required:            true,
 				Sensitive:           true,
 				WriteOnly:           true,
+			},
+			consts.FieldSecretKeyWOVersion: schema.Int64Attribute{
+				MarkdownDescription: "A version counter for the write-only `secret_key_wo` field. Incrementing this value will trigger an update to the secret key in Vault.",
+				Required:            true,
 			},
 		},
 		MarkdownDescription: "Configures the AliCloud secrets engine credentials. " +

--- a/internal/vault/secrets/alicloud/alicloud_secret_backend_resource_test.go
+++ b/internal/vault/secrets/alicloud/alicloud_secret_backend_resource_test.go
@@ -52,12 +52,13 @@ func TestAliCloudSecretBackend_lifecycle(t *testing.T) {
 				ImportStateVerify:                    true,
 				ImportStateId:                        path,
 				ImportStateVerifyIdentifierAttribute: consts.FieldMount,
+				ImportStateVerifyIgnore:              []string{consts.FieldSecretKeyWO, consts.FieldSecretKeyWOVersion},
 			},
 		},
 	})
 }
 
-// TestAliCloudSecretBackend_writeOnly tests write-only credential pattern with multiple updates
+// TestAliCloudSecretBackend_writeOnly tests write-only credential pattern with version field
 func TestAliCloudSecretBackend_writeOnly(t *testing.T) {
 	path := acctest.RandomWithPrefix("tf-test-alicloud")
 	accessKey, secretKey := getTestAliCloudCreds(t)
@@ -71,46 +72,42 @@ func TestAliCloudSecretBackend_writeOnly(t *testing.T) {
 		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAliCloudSecretBackend_config(path, accessKey, secretKey),
+				Config: testAliCloudSecretBackend_configWithVersion(path, accessKey, secretKey, 1),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, consts.FieldMount, path),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldAccessKey, accessKey),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldSecretKeyWOVersion, "1"),
 					// secret_key_wo is write-only, not in state after Read
 				),
 			},
 			{
-				// Update secret_key_wo to new value
-				Config: testAliCloudSecretBackend_config(path, accessKey, updatedSecretKey),
+				// Update secret_key_wo by incrementing version
+				Config: testAliCloudSecretBackend_configWithVersion(path, accessKey, updatedSecretKey, 2),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, consts.FieldMount, path),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldAccessKey, accessKey),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldSecretKeyWOVersion, "2"),
 					// secret_key_wo is write-only, not in state after Read
 				),
 			},
 			{
-				// Keep same secret_key_wo value
-				Config: testAliCloudSecretBackend_config(path, accessKey, updatedSecretKey),
+				// Keep same secret_key_wo value and version (no update)
+				Config: testAliCloudSecretBackend_configWithVersion(path, accessKey, updatedSecretKey, 2),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, consts.FieldMount, path),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldAccessKey, accessKey),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldSecretKeyWOVersion, "2"),
 					// secret_key_wo is write-only, not in state after Read
 				),
 			},
 			{
-				// Revert secret_key_wo back to original value
-				Config: testAliCloudSecretBackend_config(path, accessKey, secretKey),
+				// Revert secret_key_wo back to original value by incrementing version
+				Config: testAliCloudSecretBackend_configWithVersion(path, accessKey, secretKey, 3),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, consts.FieldMount, path),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldAccessKey, accessKey),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldSecretKeyWOVersion, "3"),
 					// secret_key_wo is write-only, not in state after Read
-				),
-			},
-			{
-				// Keep same secret_key_wo value (original)
-				Config: testAliCloudSecretBackend_config(path, accessKey, secretKey),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, consts.FieldMount, path),
-					resource.TestCheckResourceAttr(resourceName, consts.FieldAccessKey, accessKey),
 				),
 			},
 		},
@@ -301,10 +298,11 @@ resource "vault_mount" "test" {
 }
 
 resource "vault_alicloud_secret_backend" "test" {
-  namespace     = vault_namespace.test.path
-  mount         = vault_mount.test.path
-  access_key    = %q
-  secret_key_wo = %q
+  namespace             = vault_namespace.test.path
+  mount                 = vault_mount.test.path
+  access_key            = %q
+  secret_key_wo         = %q
+  secret_key_wo_version = 1
 }
 `, namespacePath, path, accessKey, secretKey)
 }
@@ -325,11 +323,29 @@ resource "vault_mount" "test" {
 }
 
 resource "vault_alicloud_secret_backend" "test" {
-  mount         = vault_mount.test.path
-  access_key    = %q
-  secret_key_wo = %q
+  mount                 = vault_mount.test.path
+  access_key            = %q
+  secret_key_wo         = %q
+  secret_key_wo_version = 1
 }
 `, path, accessKey, secretKey)
+}
+
+// testAliCloudSecretBackend_configWithVersion returns test configuration with version field
+func testAliCloudSecretBackend_configWithVersion(path, accessKey, secretKey string, version int) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "test" {
+  path = %q
+  type = "alicloud"
+}
+
+resource "vault_alicloud_secret_backend" "test" {
+  mount                  = vault_mount.test.path
+  access_key             = %q
+  secret_key_wo          = %q
+  secret_key_wo_version  = %d
+}
+`, path, accessKey, secretKey, version)
 }
 
 // testAliCloudSecretBackend_missingMountConfig returns config without mount field
@@ -341,8 +357,9 @@ resource "vault_mount" "test" {
 }
 
 resource "vault_alicloud_secret_backend" "test" {
-  access_key    = %q
-  secret_key_wo = %q
+  access_key            = %q
+  secret_key_wo         = %q
+  secret_key_wo_version = 1
 }
 `, accessKey, secretKey)
 }
@@ -356,8 +373,9 @@ resource "vault_mount" "test" {
 }
 
 resource "vault_alicloud_secret_backend" "test" {
-  mount         = vault_mount.test.path
-  secret_key_wo = %q
+  mount                 = vault_mount.test.path
+  secret_key_wo         = %q
+  secret_key_wo_version = 1
 }
 `, path, secretKey)
 }

--- a/internal/vault/secrets/alicloud/alicloud_secret_backend_role_resource.go
+++ b/internal/vault/secrets/alicloud/alicloud_secret_backend_role_resource.go
@@ -32,7 +32,9 @@ import (
 
 const rolesAffix = "role"
 
-var roleIDRegex = regexp.MustCompile(`^(.+)/` + rolesAffix + `/(.+)$`)
+// Match import IDs in the form <mount>/role/<name>, where <name> follows
+// Vault SDK framework.GenericNameRegex("name"): (?P<name>\w(([\w-.]+)?\w)?)
+var roleIDRegex = regexp.MustCompile(`^(.+)/` + rolesAffix + `/(\w(?:[\w-.]*\w)?)$`)
 
 // Ensure the implementation satisfies the expected interfaces
 var _ resource.ResourceWithConfigure = &AliCloudSecretBackendRoleResource{}

--- a/internal/vault/secrets/alicloud/alicloud_secret_backend_role_resource_test.go
+++ b/internal/vault/secrets/alicloud/alicloud_secret_backend_role_resource_test.go
@@ -155,6 +155,40 @@ func TestAccAliCloudSecretBackendRole_maxTtlOnly(t *testing.T) {
 	})
 }
 
+func TestAccAliCloudSecretBackendRole_importState(t *testing.T) {
+	backend := acctest.RandomWithPrefix("tf-test-alicloud")
+	name := acctest.RandomWithPrefix("tf-test-role")
+	accessKey, secretKey := getTestAliCloudCreds(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
+		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAliCloudSecretBackendRoleConfig_minimal(name, backend, accessKey, secretKey),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_alicloud_secret_backend_role.test", consts.FieldName, name),
+					resource.TestCheckResourceAttr("vault_alicloud_secret_backend_role.test", consts.FieldMount, backend),
+					resource.TestCheckResourceAttr("vault_alicloud_secret_backend_role.test", consts.FieldRoleArn, testAccAliCloudSecretBackendRoleRoleARN_basic),
+				),
+			},
+			{
+				ResourceName:                         "vault_alicloud_secret_backend_role.test",
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: consts.FieldMount,
+				ImportStateIdFunc:                    testAccAliCloudSecretBackendRoleImportStateIdFunc("vault_alicloud_secret_backend_role.test"),
+			},
+			{
+				ResourceName:  "vault_alicloud_secret_backend_role.test",
+				ImportState:   true,
+				ImportStateId: fmt.Sprintf("%s/role/%s.", backend, name),
+				ExpectError:   regexp.MustCompile(`Invalid Import ID`),
+			},
+		},
+	})
+}
+
 // TestAccAliCloudSecretBackendRole_validation groups single-step role validation tests.
 func TestAccAliCloudSecretBackendRole_validation(t *testing.T) {
 	accessKey, secretKey := getTestAliCloudCreds(t)

--- a/internal/vault/secrets/alicloud/alicloud_secret_backend_role_resource_test.go
+++ b/internal/vault/secrets/alicloud/alicloud_secret_backend_role_resource_test.go
@@ -103,8 +103,6 @@ func TestAccAliCloudSecretBackendRole_minimal(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_alicloud_secret_backend_role.test", consts.FieldName, name),
 					resource.TestCheckResourceAttr("vault_alicloud_secret_backend_role.test", consts.FieldMount, backend),
 					resource.TestCheckResourceAttr("vault_alicloud_secret_backend_role.test", consts.FieldRoleArn, testAccAliCloudSecretBackendRoleRoleARN_basic),
-					resource.TestCheckResourceAttr("vault_alicloud_secret_backend_role.test", consts.FieldTTL, "0"),
-					resource.TestCheckResourceAttr("vault_alicloud_secret_backend_role.test", consts.FieldMaxTTL, "0"),
 				),
 			},
 		},
@@ -128,7 +126,6 @@ func TestAccAliCloudSecretBackendRole_ttlOnly(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_alicloud_secret_backend_role.test", consts.FieldMount, backend),
 					resource.TestCheckResourceAttr("vault_alicloud_secret_backend_role.test", consts.FieldRoleArn, testAccAliCloudSecretBackendRoleRoleARN_basic),
 					resource.TestCheckResourceAttr("vault_alicloud_secret_backend_role.test", consts.FieldTTL, "1800"),
-					resource.TestCheckResourceAttr("vault_alicloud_secret_backend_role.test", consts.FieldMaxTTL, "0"),
 				),
 			},
 		},
@@ -151,42 +148,7 @@ func TestAccAliCloudSecretBackendRole_maxTtlOnly(t *testing.T) {
 					resource.TestCheckResourceAttr("vault_alicloud_secret_backend_role.test", consts.FieldName, name),
 					resource.TestCheckResourceAttr("vault_alicloud_secret_backend_role.test", consts.FieldMount, backend),
 					resource.TestCheckResourceAttr("vault_alicloud_secret_backend_role.test", consts.FieldRoleArn, testAccAliCloudSecretBackendRoleRoleARN_basic),
-					resource.TestCheckResourceAttr("vault_alicloud_secret_backend_role.test", consts.FieldTTL, "0"),
 					resource.TestCheckResourceAttr("vault_alicloud_secret_backend_role.test", consts.FieldMaxTTL, "7200"),
-				),
-			},
-		},
-	})
-}
-
-// TestAccAliCloudSecretBackendRole_multipleRemotePolicies tests multiple remote policies
-func TestAccAliCloudSecretBackendRole_multipleRemotePolicies(t *testing.T) {
-	backend := acctest.RandomWithPrefix("tf-test-alicloud")
-	name := acctest.RandomWithPrefix("tf-test-role")
-	accessKey, secretKey := getTestAliCloudCreds(t)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccAliCloudSecretBackendRoleConfig_multipleRemotePolicies(name, backend, accessKey, secretKey),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_alicloud_secret_backend_role.test", consts.FieldName, name),
-					resource.TestCheckResourceAttr("vault_alicloud_secret_backend_role.test", consts.FieldMount, backend),
-					resource.TestCheckResourceAttr("vault_alicloud_secret_backend_role.test", consts.FieldRemotePolicies+".#", "3"),
-					resource.TestCheckTypeSetElemNestedAttrs("vault_alicloud_secret_backend_role.test", consts.FieldRemotePolicies+".*", map[string]string{
-						consts.FieldName: "AliyunOSSReadOnlyAccess",
-						consts.FieldType: "System",
-					}),
-					resource.TestCheckTypeSetElemNestedAttrs("vault_alicloud_secret_backend_role.test", consts.FieldRemotePolicies+".*", map[string]string{
-						consts.FieldName: "AliyunECSReadOnlyAccess",
-						consts.FieldType: "System",
-					}),
-					resource.TestCheckTypeSetElemNestedAttrs("vault_alicloud_secret_backend_role.test", consts.FieldRemotePolicies+".*", map[string]string{
-						consts.FieldName: "AliyunRDSReadOnlyAccess",
-						consts.FieldType: "System",
-					}),
 				),
 			},
 		},
@@ -340,14 +302,12 @@ func testAccAliCloudSecretBackendRoleCheck_basic(name, backend string) resource.
 			consts.FieldType: "System",
 		}),
 		resource.TestCheckResourceAttr("vault_alicloud_secret_backend_role.test_remote", consts.FieldTTL, "1800"),
-		resource.TestCheckResourceAttr("vault_alicloud_secret_backend_role.test_remote", consts.FieldMaxTTL, "0"),
 
 		// Role ARN role
 		resource.TestCheckResourceAttr("vault_alicloud_secret_backend_role.test_role_arn", consts.FieldName, fmt.Sprintf("%s-role-arn", name)),
 		resource.TestCheckResourceAttr("vault_alicloud_secret_backend_role.test_role_arn", consts.FieldMount, backend),
 		resource.TestCheckResourceAttr("vault_alicloud_secret_backend_role.test_role_arn", consts.FieldRoleArn, testAccAliCloudSecretBackendRoleRoleARN_basic),
 		resource.TestCheckResourceAttr("vault_alicloud_secret_backend_role.test_role_arn", consts.FieldTTL, "3600"),
-		resource.TestCheckResourceAttr("vault_alicloud_secret_backend_role.test_role_arn", consts.FieldMaxTTL, "0"),
 	)
 }
 
@@ -376,14 +336,12 @@ func testAccAliCloudSecretBackendRoleCheck_updated(name, backend string) resourc
 			consts.FieldType: "System",
 		}),
 		resource.TestCheckResourceAttr("vault_alicloud_secret_backend_role.test_remote", consts.FieldTTL, "3600"),
-		resource.TestCheckResourceAttr("vault_alicloud_secret_backend_role.test_remote", consts.FieldMaxTTL, "0"),
 
 		// Role ARN role - updated
 		resource.TestCheckResourceAttr("vault_alicloud_secret_backend_role.test_role_arn", consts.FieldName, fmt.Sprintf("%s-role-arn", name)),
 		resource.TestCheckResourceAttr("vault_alicloud_secret_backend_role.test_role_arn", consts.FieldMount, backend),
 		resource.TestCheckResourceAttr("vault_alicloud_secret_backend_role.test_role_arn", consts.FieldRoleArn, testAccAliCloudSecretBackendRoleRoleARN_updated),
 		resource.TestCheckResourceAttr("vault_alicloud_secret_backend_role.test_role_arn", consts.FieldTTL, "7200"),
-		resource.TestCheckResourceAttr("vault_alicloud_secret_backend_role.test_role_arn", consts.FieldMaxTTL, "0"),
 	)
 }
 
@@ -400,6 +358,7 @@ resource "vault_alicloud_secret_backend" "test" {
   mount         = vault_mount.test.path
   access_key    = %q
   secret_key_wo = %q
+  secret_key_wo_version = 1
 }
 
 resource "vault_alicloud_secret_backend_role" "test_inline" {
@@ -447,6 +406,7 @@ resource "vault_alicloud_secret_backend" "test" {
   mount         = vault_mount.test.path
   access_key    = %q
   secret_key_wo = %q
+  secret_key_wo_version = 1
 }
 
 resource "vault_alicloud_secret_backend_role" "test_inline" {
@@ -499,6 +459,7 @@ resource "vault_alicloud_secret_backend" "test" {
   mount         = vault_mount.test.path
   access_key    = %q
   secret_key_wo = %q
+  secret_key_wo_version = 1
 }
 
 resource "vault_alicloud_secret_backend_role" "test" {
@@ -532,6 +493,7 @@ resource "vault_alicloud_secret_backend" "test" {
   mount         = vault_mount.test.path
   access_key    = %q
   secret_key_wo = %q
+  secret_key_wo_version = 1
 }
 
 resource "vault_alicloud_secret_backend_role" "test" {
@@ -553,6 +515,7 @@ resource "vault_alicloud_secret_backend" "test" {
   mount         = vault_mount.test.path
   access_key    = %q
   secret_key_wo = %q
+  secret_key_wo_version = 1
 }
 
 resource "vault_alicloud_secret_backend_role" "test" {
@@ -575,6 +538,7 @@ resource "vault_alicloud_secret_backend" "test" {
   mount         = vault_mount.test.path
   access_key    = %q
   secret_key_wo = %q
+  secret_key_wo_version = 1
 }
 
 resource "vault_alicloud_secret_backend_role" "test" {
@@ -584,44 +548,6 @@ resource "vault_alicloud_secret_backend_role" "test" {
   max_ttl  = 7200
 }
 `, backend, accessKey, secretKey, name, testAccAliCloudSecretBackendRoleRoleARN_basic)
-}
-
-func testAccAliCloudSecretBackendRoleConfig_multipleRemotePolicies(name, backend, accessKey, secretKey string) string {
-	return fmt.Sprintf(`
-resource "vault_mount" "test" {
-  path = %q
-  type = "alicloud"
-}
-
-resource "vault_alicloud_secret_backend" "test" {
-  mount         = vault_mount.test.path
-  access_key    = %q
-  secret_key_wo = %q
-}
-
-resource "vault_alicloud_secret_backend_role" "test" {
-  mount = vault_mount.test.path
-  name  = %q
-
-  remote_policies {
-    name = "AliyunOSSReadOnlyAccess"
-    type = "System"
-  }
-
-  remote_policies {
-    name = "AliyunECSReadOnlyAccess"
-    type = "System"
-  }
-
-  remote_policies {
-    name = "AliyunRDSReadOnlyAccess"
-    type = "System"
-  }
-
-  ttl     = 3600
-  max_ttl = 7200
-}
-`, backend, accessKey, secretKey, name)
 }
 
 func testAccAliCloudSecretBackendRoleConfig_missingName(backend, accessKey, secretKey string) string {
@@ -635,6 +561,7 @@ resource "vault_alicloud_secret_backend" "test" {
   mount         = vault_mount.test.path
   access_key    = %q
   secret_key_wo = %q
+  secret_key_wo_version = 1
 }
 
 resource "vault_alicloud_secret_backend_role" "test" {
@@ -664,6 +591,7 @@ resource "vault_alicloud_secret_backend" "test" {
   mount         = vault_mount.test.path
   access_key    = %q
   secret_key_wo = %q
+  secret_key_wo_version = 1
 }
 
 resource "vault_alicloud_secret_backend_role" "test" {
@@ -685,6 +613,7 @@ resource "vault_alicloud_secret_backend" "test" {
   mount         = vault_mount.test.path
   access_key    = %q
   secret_key_wo = %q
+  secret_key_wo_version = 1
 }
 
 resource "vault_alicloud_secret_backend_role" "test" {
@@ -706,6 +635,7 @@ resource "vault_alicloud_secret_backend" "test" {
   mount         = vault_mount.test.path
   access_key    = %q
   secret_key_wo = %q
+  secret_key_wo_version = 1
 }
 
 resource "vault_alicloud_secret_backend_role" "test" {
@@ -729,6 +659,7 @@ resource "vault_alicloud_secret_backend" "test" {
   mount         = vault_mount.test.path
   access_key    = %q
   secret_key_wo = %q
+  secret_key_wo_version = 1
 }
 
 resource "vault_alicloud_secret_backend_role" "test" {
@@ -754,6 +685,7 @@ resource "vault_alicloud_secret_backend" "test" {
   mount         = vault_mount.test.path
   access_key    = %q
   secret_key_wo = %q
+  secret_key_wo_version = 1
 }
 
 resource "vault_alicloud_secret_backend_role" "test" {
@@ -780,6 +712,7 @@ resource "vault_alicloud_secret_backend" "test" {
   mount         = vault_mount.test.path
   access_key    = %q
   secret_key_wo = %q
+  secret_key_wo_version = 1
 }
 
 resource "vault_alicloud_secret_backend_role" "test" {
@@ -816,6 +749,7 @@ resource "vault_alicloud_secret_backend" "test" {
   mount         = vault_mount.test.path
   access_key    = %q
   secret_key_wo = %q
+  secret_key_wo_version = 1
 }
 
 resource "vault_alicloud_secret_backend_role" "test" {
@@ -846,6 +780,7 @@ resource "vault_alicloud_secret_backend" "test" {
   mount         = vault_mount.test.path
   access_key    = %q
   secret_key_wo = %q
+  secret_key_wo_version = 1
 }
 
 resource "vault_alicloud_secret_backend_role" "test" {

--- a/website/docs/r/alicloud_secret_backend.html.md
+++ b/website/docs/r/alicloud_secret_backend.html.md
@@ -30,9 +30,10 @@ resource "vault_mount" "alicloud" {
 }
 
 resource "vault_alicloud_secret_backend" "alicloud" {
-  mount         = vault_mount.alicloud.path
-  access_key    = var.alicloud_access_key
-  secret_key_wo = var.alicloud_secret_key
+  mount                 = vault_mount.alicloud.path
+  access_key            = var.alicloud_access_key
+  secret_key_wo         = var.alicloud_secret_key
+  secret_key_wo_version = 1
 }
 
 variable "alicloud_access_key" {
@@ -57,6 +58,8 @@ The following arguments are supported:
 * `access_key` - (Required, Sensitive) The AliCloud Access Key ID with permissions to manage RAM users and policies.
   This credential is used by Vault to create and manage dynamic AliCloud credentials.
 
+* `secret_key_wo_version` - (Required) A version counter for the write-only `secret_key_wo` field. Incrementing this value will trigger an update to the secret key in Vault. This is required to enable Terraform to detect changes to the write-only field.
+
 ## Attributes Reference
 
 In addition to the arguments above, the following attributes are exported:
@@ -72,9 +75,37 @@ The following attributes are write-only and will never be read back from Vault o
 
 ## Understanding the Write-Only Pattern
 
-The `secret_key_wo` field is write-only and required. It will not be stored in Terraform state or read back from Vault, so Terraform sends it to Vault on each apply.
+The `secret_key_wo` field is write-only and required. It will not be stored in Terraform state or read back from Vault.
 
-If you change `secret_key_wo` in your configuration, Terraform will send the new value to Vault on the next apply.
+### How to Update the Secret Key
+
+Because `secret_key_wo` is write-only, Terraform cannot detect changes to it directly. To update the secret key:
+
+1. Change the `secret_key_wo` value in your configuration
+2. Increment the `secret_key_wo_version` value
+3. Run `terraform apply`
+
+Example:
+
+```hcl
+# Initial configuration
+resource "vault_alicloud_secret_backend" "alicloud" {
+  mount                 = vault_mount.alicloud.path
+  access_key            = var.alicloud_access_key
+  secret_key_wo         = var.alicloud_secret_key
+  secret_key_wo_version = 1
+}
+
+# To rotate the secret key, update both fields:
+resource "vault_alicloud_secret_backend" "alicloud" {
+  mount                 = vault_mount.alicloud.path
+  access_key            = var.alicloud_access_key
+  secret_key_wo         = var.new_alicloud_secret_key  # New secret key
+  secret_key_wo_version = 2                             # Increment version
+}
+```
+
+The `secret_key_wo_version` field enables Terraform to detect when you want to update the secret key. When the version changes, Terraform will call the update operation and send the new `secret_key_wo` value to Vault.
 
 
 ## Import
@@ -82,11 +113,7 @@ If you change `secret_key_wo` in your configuration, Terraform will send the new
 AliCloud secrets engines can be imported using the `mount` path, e.g.
 
 ```
-<<<<<<< HEAD
-$ terraform import vault_alicloud_secret_backend.alicloud alicloud/config
-=======
 $ terraform import vault_alicloud_secret_backend.alicloud alicloud
->>>>>>> 47bc91c0 (AliCloud Secret Engine Resources Initial Implementation (#2809))
 ```
 
 ~> **Note:** When importing, the `secret_key_wo` field will not be populated as it is 


### PR DESCRIPTION

### Description
 Implemented secret_key_wo_version field to enable Terraform change detection for the write-only secret_key_wo field in the AliCloud secrets engine backend resource(vault_alicloud_secret_backend).

### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:
<img width="1141" height="605" alt="Screenshot 2026-04-09 at 1 15 29 PM" src="https://github.com/user-attachments/assets/8e736eef-cbf5-4a46-a207-939ade58606e" />
<img width="764" height="292" alt="Screenshot 2026-04-09 at 9 39 52 AM" src="https://github.com/user-attachments/assets/75a4b3c1-c95a-4837-8bff-7b0a5da11dcc" />

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
