### PR TITLE
Update Azure Static Secrets to use new import endpoint (#2756) (#2884)

### DIFF
--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -687,6 +687,7 @@ const (
 	FieldAudience                             = "audience"
 	FieldTokenMaxTTL                          = "token_max_ttl"
 	FieldTokenPeriod                          = "token_period"
+	FieldDeferInitialCreds                    = "defer_initial_creds"
 	FieldTokenExplicitMaxTTL                  = "token_explicit_max_ttl"
 	FieldTokenNoDefaultPolicy                 = "token_no_default_policy"
 	FieldTokenDefaultAudiences                = "token_default_audiences"

--- a/internal/vault/secrets/azure/azure_static_role_resource.go
+++ b/internal/vault/secrets/azure/azure_static_role_resource.go
@@ -10,10 +10,12 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -55,6 +57,7 @@ type AzureStaticRoleModel struct {
 	ClientSecret        types.String `tfsdk:"client_secret"`
 	Expiration          types.String `tfsdk:"expiration"`
 	SkipImportRotation  types.Bool   `tfsdk:"skip_import_rotation"`
+	DeferInitialCreds   types.Bool   `tfsdk:"defer_initial_creds"`
 }
 
 // AzureStaticRoleAPIModel describes the Vault API data model.
@@ -87,7 +90,7 @@ func (r *AzureSecretsStaticRoleResource) Schema(_ context.Context, _ resource.Sc
 				Required:            true,
 			},
 			consts.FieldTTL: schema.Int64Attribute{
-				MarkdownDescription: "Timespan of 1 year (31536000) or more during which the role credentials are valid.",
+				MarkdownDescription: "Timespan of 1 month or more during which the role credentials are valid.",
 				Optional:            true,
 				Computed:            true,
 			},
@@ -95,6 +98,8 @@ func (r *AzureSecretsStaticRoleResource) Schema(_ context.Context, _ resource.Sc
 				MarkdownDescription: "A map of string key/value pairs that will be stored as metadata on the secret.",
 				ElementType:         types.StringType,
 				Optional:            true,
+				Computed:            true,
+				Default:             mapdefault.StaticValue(types.MapValueMust(types.StringType, map[string]attr.Value{})),
 			},
 			consts.FieldSecretID: schema.StringAttribute{
 				MarkdownDescription: "The secret ID of the Azure password credential you want to import.",
@@ -104,13 +109,20 @@ func (r *AzureSecretsStaticRoleResource) Schema(_ context.Context, _ resource.Sc
 				MarkdownDescription: "The plaintext secret value of the credential you want to import.",
 				Optional:            true,
 				Sensitive:           true,
+				WriteOnly:           true, // Prevents the value from being shown in state
 			},
 			consts.FieldExpiration: schema.StringAttribute{
 				MarkdownDescription: "A future expiration time for the imported credential, in RFC3339 format.",
 				Optional:            true,
+				DeprecationMessage: "This field is deprecated and will be removed in a future release. " +
+					"Vault will always read the expiration from Azure.",
 			},
 			consts.FieldSkipImportRotation: schema.BoolAttribute{
 				MarkdownDescription: "If true, skip rotation of the client secret on import.",
+				Optional:            true,
+			},
+			consts.FieldDeferInitialCreds: schema.BoolAttribute{
+				MarkdownDescription: "If true, the initial creation of credentials will be deferred until first static-creds read.",
 				Optional:            true,
 			},
 		},
@@ -123,7 +135,13 @@ func (r *AzureSecretsStaticRoleResource) Schema(_ context.Context, _ resource.Sc
 //
 // https://developer.hashicorp.com/terraform/plugin/framework/resources/create
 func (r *AzureSecretsStaticRoleResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var data AzureStaticRoleModel
+	var (
+		path         string
+		vaultRequest map[string]any
+		diags        diag.Diagnostics
+		data         AzureStaticRoleModel
+	)
+
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -137,9 +155,19 @@ func (r *AzureSecretsStaticRoleResource) Create(ctx context.Context, req resourc
 
 	backend := data.Backend.ValueString()
 	role := data.Role.ValueString()
-	path := fmt.Sprintf("%s/%s/%s", backend, staticRolesAffix, role)
 
-	vaultRequest, diags := buildVaultRequestFromModel(ctx, &data, true)
+	// if secretID is set, it's an import create operation using import endpoint
+	// otherwise, it's a standard create operation
+	if !data.SecretID.IsNull() && data.SecretID.ValueString() != "" {
+		// <backend>/static-roles/<role>/import
+		path = fmt.Sprintf("%s/%s/%s/import", backend, staticRolesAffix, role)
+		vaultRequest, diags = buildVaultRequestForImportCreate(ctx, &data)
+	} else {
+		// <backend>/static-roles/<role>
+		path = fmt.Sprintf("%s/%s/%s", backend, staticRolesAffix, role)
+		vaultRequest, diags = buildVaultRequestFromModel(ctx, &data)
+	}
+
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -229,7 +257,7 @@ func (r *AzureSecretsStaticRoleResource) Update(ctx context.Context, req resourc
 	role := data.Role.ValueString()
 	path := fmt.Sprintf("%s/%s/%s", backend, staticRolesAffix, role)
 
-	vaultRequest, diags := buildVaultRequestFromModel(ctx, &data, false)
+	vaultRequest, diags := buildVaultRequestFromModel(ctx, &data)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -244,23 +272,11 @@ func (r *AzureSecretsStaticRoleResource) Update(ctx context.Context, req resourc
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func buildVaultRequestFromModel(ctx context.Context, data *AzureStaticRoleModel, includeSkipImport bool) (map[string]any, diag.Diagnostics) {
+func buildVaultRequestFromModel(ctx context.Context, data *AzureStaticRoleModel) (map[string]any, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	vaultRequest := map[string]any{
 		consts.FieldApplicationObjectID: data.ApplicationObjectID.ValueString(),
-	}
-
-	fieldMap := map[string]any{
-		consts.FieldSecretID:     data.SecretID.ValueString(),
-		consts.FieldClientSecret: data.ClientSecret.ValueString(),
-		consts.FieldExpiration:   data.Expiration.ValueString(),
-	}
-
-	for k, v := range fieldMap {
-		if s, ok := v.(string); ok && s != "" {
-			vaultRequest[k] = s
-		}
 	}
 
 	if !data.TTL.IsNull() {
@@ -276,12 +292,48 @@ func buildVaultRequestFromModel(ctx context.Context, data *AzureStaticRoleModel,
 		vaultRequest[consts.FieldMetadata] = meta
 	}
 
-	// only include on create and only when true
-	if includeSkipImport && data.SkipImportRotation.ValueBool() {
-		vaultRequest[consts.FieldSkipImportRotation] = true
+	// Prefer defer_initial_creds if true
+	deferInitial := !data.DeferInitialCreds.IsNull() && data.DeferInitialCreds.ValueBool()
+	// Legacy alias (back comp) skip_import_rotation == true means defer_initial_creds == true
+	legacyAlias := !data.SkipImportRotation.IsNull() && data.SkipImportRotation.ValueBool()
+
+	if deferInitial || legacyAlias {
+		vaultRequest[consts.FieldDeferInitialCreds] = true
 	}
 
 	return vaultRequest, diags
+}
+
+func buildVaultRequestForImportCreate(ctx context.Context, data *AzureStaticRoleModel) (map[string]any, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	req := map[string]any{
+		consts.FieldApplicationObjectID: data.ApplicationObjectID.ValueString(),
+		consts.FieldSecretID:            data.SecretID.ValueString(),
+	}
+
+	if !data.ClientSecret.IsNull() && data.ClientSecret.ValueString() != "" {
+		req[consts.FieldClientSecret] = data.ClientSecret.ValueString()
+	}
+
+	if !data.TTL.IsNull() {
+		req[consts.FieldTTL] = data.TTL.ValueInt64()
+	}
+
+	if !data.Metadata.IsNull() && !data.Metadata.IsUnknown() {
+		var meta map[string]string
+		if mdDiags := data.Metadata.ElementsAs(ctx, &meta, false); mdDiags.HasError() {
+			diags.Append(mdDiags...)
+			return nil, diags
+		}
+		req[consts.FieldMetadata] = meta
+	}
+
+	if !data.SkipImportRotation.IsNull() && data.SkipImportRotation.ValueBool() {
+		req[consts.FieldSkipImportRotation] = true
+	}
+
+	return req, diags
 }
 
 func (r *AzureSecretsStaticRoleResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/website/docs/r/azure_secret_backend_static_role.html.md
+++ b/website/docs/r/azure_secret_backend_static_role.html.md
@@ -59,17 +59,19 @@ The following arguments are supported:
 * `application_object_id` - (Required) The Azure AD Application Object ID associated with the existing application whose
   credentials Vault will manage.
 * `ttl` – (Optional) Duration that defines the validity period of the managed credential. Defaults to 2 years. Must be
-  at least 1 year.
+  at least 1 month.
   Accepts an integer number of seconds (31536000). Defaults to the system/engine default TTL time.
 * `metadata` – (Optional) A map of string key-value pairs that are stored alongside the role and returned with generated
   credentials.
 * `secret_id` - (Optional) When importing an existing credential, specifies the Azure secret’s key ID.
 * `client_secret` - (Optional, Sensitive) When importing an existing credential, provides the existing client secret
   value.
-* `expiration` - (Optional) - Expiration timestamp (UTC, RFC3339 format) of the existing credential being imported. If
-  not set, Vault uses the value provided by Azure.
+* `expiration` - (Optional) **Deprecated** - Expiration timestamp (UTC, RFC3339 format) of the existing credential being imported. 
+  Vault reads expiration from Azure.
 * `skip_import_rotation` - (Optional, Bool) - If true, Vault will import the provided credential without performing
   rotation. Valid only during creation. Defaults to `false`.
+* `defer_initial_creds` - (Optional, Bool) - If true, the initial credential generation will be deferred until the
+  first read of credentials from this role. Defaults to `false`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
* Update Azure Static Secrets to use new import endpoint

* update ttl change

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000


### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
