### PR TITLE
Vault Policy plural and singular data sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 FEATURES:
 * **New Resource**: Add support for RADIUS auth backend: `vault_radius_auth_backend` and `vault_radius_auth_backend_user` resource and `vault_radius_auth_login` ephemeral resource.([#2814](https://github.com/hashicorp/terraform-provider-vault/pull/2814))
+* **New Data Source**: Add plural and singular data sources for Vault Policy (`vault_policy` & `vault_policies`). ([#2896](https://github.com/hashicorp/terraform-provider-vault/pull/2896))
 
 ## 5.9.0 (April 22, 2026)
 

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -276,6 +276,7 @@ const (
 	FieldWrappingAccessor                   = "wrapping_accessor"
 	FieldRoleName                           = "role_name"
 	FieldPolicies                           = "policies"
+	FieldNameFilter                         = "name_filter"
 	FieldNoParent                           = "no_parent"
 	FieldNoDefaultPolicy                    = "no_default_policy"
 	FieldRenewable                          = "renewable"

--- a/internal/provider/fwprovider/provider.go
+++ b/internal/provider/fwprovider/provider.go
@@ -306,6 +306,7 @@ func (p *fwprovider) DataSources(ctx context.Context) []func() datasource.DataSo
 	return []func() datasource.DataSource{
 		pki_external_ca.NewPKIExternalCAOrderChallengeDataSource,
 		sys.NewPluginRuntimesDataSource,
+		sys.NewPolicyDataSource,
 		config.NewSysConfigCORSDataSource,
 	}
 }

--- a/internal/provider/fwprovider/provider.go
+++ b/internal/provider/fwprovider/provider.go
@@ -307,6 +307,7 @@ func (p *fwprovider) DataSources(ctx context.Context) []func() datasource.DataSo
 		pki_external_ca.NewPKIExternalCAOrderChallengeDataSource,
 		sys.NewPluginRuntimesDataSource,
 		sys.NewPolicyDataSource,
+		sys.NewPoliciesDataSource,
 		config.NewSysConfigCORSDataSource,
 	}
 }

--- a/internal/vault/sys/policies_data_source.go
+++ b/internal/vault/sys/policies_data_source.go
@@ -1,0 +1,118 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package sys
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/framework/base"
+	"github.com/hashicorp/terraform-provider-vault/internal/framework/client"
+	"github.com/hashicorp/terraform-provider-vault/internal/framework/errutil"
+)
+
+var _ datasource.DataSource = &policiesDataSource{}
+var _ datasource.DataSourceWithConfigure = &policiesDataSource{}
+
+type policiesDataSourceModel struct {
+	base.BaseModel
+
+	NameFilter types.String `tfsdk:"name_filter"`
+	Policies   types.List   `tfsdk:"policies"`
+}
+
+func NewPoliciesDataSource() datasource.DataSource {
+	return &policiesDataSource{}
+}
+
+type policiesDataSource struct {
+	base.DataSourceWithConfigure
+}
+
+func (d *policiesDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_policies"
+}
+
+func (d *policiesDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Lists ACL policy names from Vault, with optional regex filtering.",
+		Attributes: map[string]schema.Attribute{
+			consts.FieldNameFilter: schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "A regex to filter policy names. Only names matching the pattern are returned.",
+			},
+			consts.FieldPolicies: schema.ListAttribute{
+				ElementType:         types.StringType,
+				Computed:            true,
+				MarkdownDescription: "List of ACL policy names.",
+			},
+			consts.FieldNamespace: schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "Target namespace. (requires Enterprise)",
+			},
+		},
+	}
+}
+
+func (d *policiesDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data policiesDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var filter *regexp.Regexp
+	if !data.NameFilter.IsNull() && !data.NameFilter.IsUnknown() {
+		var err error
+		filter, err = regexp.Compile(data.NameFilter.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Invalid name_filter",
+				"name_filter must be a valid regular expression: "+err.Error(),
+			)
+			return
+		}
+	}
+
+	cli, err := client.GetClient(ctx, d.Meta(), data.Namespace.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(errutil.ClientConfigureErr(err))
+		return
+	}
+
+	vaultResp, err := cli.Logical().ListWithContext(ctx, "sys/policies/acl")
+	if err != nil {
+		resp.Diagnostics.AddError(errutil.VaultReadErr(err))
+		return
+	}
+
+	var names []string
+	if vaultResp != nil {
+		if keys, ok := vaultResp.Data["keys"].([]interface{}); ok {
+			for _, k := range keys {
+				name, ok := k.(string)
+				if !ok {
+					continue
+				}
+				if filter == nil || filter.MatchString(name) {
+					names = append(names, name)
+				}
+			}
+		}
+	}
+
+	policies, diags := types.ListValueFrom(ctx, types.StringType, names)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	data.Policies = policies
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/vault/sys/policies_data_source_test.go
+++ b/internal/vault/sys/policies_data_source_test.go
@@ -1,0 +1,129 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package sys_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-vault/acctestutil"
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/providertest"
+)
+
+func TestAccPoliciesDataSource(t *testing.T) {
+	prefix := acctest.RandomWithPrefix("test-policies")
+	nameA := prefix + "-alpha"
+	nameB := prefix + "-bravo"
+	dataSourceAll := "data.vault_policies.all"
+	dataSourceFiltered := "data.vault_policies.filtered"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
+		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPoliciesDataSourceConfig(nameA, nameB, prefix),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckTypeSetElemAttr(dataSourceAll, consts.FieldPolicies+".*", nameA),
+					resource.TestCheckTypeSetElemAttr(dataSourceAll, consts.FieldPolicies+".*", nameB),
+					resource.TestCheckResourceAttr(dataSourceFiltered, consts.FieldPolicies+".#", "1"),
+					resource.TestCheckTypeSetElemAttr(dataSourceFiltered, consts.FieldPolicies+".*", nameA),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPoliciesDataSource_NS(t *testing.T) {
+	prefix := acctest.RandomWithPrefix("test-policies")
+	nameA := prefix + "-alpha"
+	nameB := prefix + "-bravo"
+	ns := acctest.RandomWithPrefix("ns")
+	dataSourceAll := "data.vault_policies.all"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctestutil.TestAccPreCheck(t)
+			acctestutil.TestEntPreCheck(t)
+		},
+		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPoliciesDataSourceConfigNS(nameA, nameB, ns),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceAll, consts.FieldNamespace, ns),
+					resource.TestCheckTypeSetElemAttr(dataSourceAll, consts.FieldPolicies+".*", nameA),
+					resource.TestCheckTypeSetElemAttr(dataSourceAll, consts.FieldPolicies+".*", nameB),
+				),
+			},
+		},
+	})
+}
+
+func testAccPoliciesDataSourceConfig(nameA, nameB, prefix string) string {
+	return fmt.Sprintf(`
+resource "vault_policy" "alpha" {
+  name   = %q
+  policy = <<-EOT
+    path "secret/*" {
+      capabilities = ["read"]
+    }
+  EOT
+}
+
+resource "vault_policy" "bravo" {
+  name   = %q
+  policy = <<-EOT
+    path "secret/*" {
+      capabilities = ["read"]
+    }
+  EOT
+}
+
+data "vault_policies" "all" {
+  depends_on = [vault_policy.alpha, vault_policy.bravo]
+}
+
+data "vault_policies" "filtered" {
+  name_filter = "%s-alpha$"
+  depends_on  = [vault_policy.alpha, vault_policy.bravo]
+}
+`, nameA, nameB, prefix)
+}
+
+func testAccPoliciesDataSourceConfigNS(nameA, nameB, ns string) string {
+	return fmt.Sprintf(`
+resource "vault_namespace" "test" {
+  path = %q
+}
+
+resource "vault_policy" "alpha" {
+  namespace = vault_namespace.test.path
+  name      = %q
+  policy    = <<-EOT
+    path "secret/*" {
+      capabilities = ["read"]
+    }
+  EOT
+}
+
+resource "vault_policy" "bravo" {
+  namespace = vault_namespace.test.path
+  name      = %q
+  policy    = <<-EOT
+    path "secret/*" {
+      capabilities = ["read"]
+    }
+  EOT
+}
+
+data "vault_policies" "all" {
+  namespace  = vault_namespace.test.path
+  depends_on = [vault_policy.alpha, vault_policy.bravo]
+}
+`, ns, nameA, nameB)
+}

--- a/internal/vault/sys/policy_data_source.go
+++ b/internal/vault/sys/policy_data_source.go
@@ -1,0 +1,92 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package sys
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/framework/base"
+	"github.com/hashicorp/terraform-provider-vault/internal/framework/client"
+	"github.com/hashicorp/terraform-provider-vault/internal/framework/errutil"
+)
+
+var _ datasource.DataSource = &policyDataSource{}
+var _ datasource.DataSourceWithConfigure = &policyDataSource{}
+
+type policyDataSourceModel struct {
+	base.BaseModel
+
+	Name   types.String `tfsdk:"name"`
+	Policy types.String `tfsdk:"policy"`
+}
+
+func NewPolicyDataSource() datasource.DataSource {
+	return &policyDataSource{}
+}
+
+type policyDataSource struct {
+	base.DataSourceWithConfigure
+}
+
+func (d *policyDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_policy"
+}
+
+func (d *policyDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Reads an ACL policy from Vault.",
+		Attributes: map[string]schema.Attribute{
+			consts.FieldName: schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "Name of the policy.",
+			},
+			consts.FieldPolicy: schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "The policy document.",
+			},
+			consts.FieldNamespace: schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "Target namespace. (requires Enterprise)",
+			},
+		},
+	}
+}
+
+func (d *policyDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data policyDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	cli, err := client.GetClient(ctx, d.Meta(), data.Namespace.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(errutil.ClientConfigureErr(err))
+		return
+	}
+
+	name := data.Name.ValueString()
+
+	vaultResp, err := cli.Logical().ReadWithContext(ctx, fmt.Sprintf("sys/policy/%s", name))
+	if err != nil {
+		resp.Diagnostics.AddError(errutil.VaultReadErr(err))
+		return
+	}
+
+	if vaultResp == nil {
+		resp.Diagnostics.AddError("Policy Not Found", fmt.Sprintf("policy %q does not exist in Vault", name))
+		return
+	}
+
+	rules, _ := vaultResp.Data["rules"].(string)
+	data.Policy = types.StringValue(rules)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}

--- a/internal/vault/sys/policy_data_source_test.go
+++ b/internal/vault/sys/policy_data_source_test.go
@@ -1,0 +1,100 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package sys_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-provider-vault/acctestutil"
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/providertest"
+)
+
+func TestAccPolicyDataSource(t *testing.T) {
+	name := acctest.RandomWithPrefix("test-policy")
+	dataSourceName := "data.vault_policy.test"
+	resourceName := "vault_policy.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
+		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPolicyDataSourceConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, consts.FieldName, name),
+					resource.TestCheckResourceAttrPair(dataSourceName, consts.FieldPolicy, resourceName, consts.FieldPolicy),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPolicyDataSource_NS(t *testing.T) {
+	name := acctest.RandomWithPrefix("test-policy")
+	ns := acctest.RandomWithPrefix("ns")
+	dataSourceName := "data.vault_policy.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctestutil.TestAccPreCheck(t)
+			acctestutil.TestEntPreCheck(t)
+		},
+		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPolicyDataSourceConfigNS(name, ns),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, consts.FieldName, name),
+					resource.TestCheckResourceAttr(dataSourceName, consts.FieldNamespace, ns),
+				),
+			},
+		},
+	})
+}
+
+func testAccPolicyDataSourceConfig(name string) string {
+	return fmt.Sprintf(`
+resource "vault_policy" "test" {
+  name   = %q
+  policy = <<-EOT
+    path "secret/*" {
+      capabilities = ["read"]
+    }
+  EOT
+}
+
+data "vault_policy" "test" {
+  name       = vault_policy.test.name
+  depends_on = [vault_policy.test]
+}
+`, name)
+}
+
+func testAccPolicyDataSourceConfigNS(name, ns string) string {
+	return fmt.Sprintf(`
+resource "vault_namespace" "test" {
+  path = %q
+}
+
+resource "vault_policy" "test" {
+  namespace = vault_namespace.test.path
+  name      = %q
+  policy    = <<-EOT
+    path "secret/*" {
+      capabilities = ["read"]
+    }
+  EOT
+}
+
+data "vault_policy" "test" {
+  namespace  = vault_namespace.test.path
+  name       = vault_policy.test.name
+  depends_on = [vault_policy.test]
+}
+`, ns, name)
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
Adds data sources for singular and plural vault policy lookups

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #1516


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
% TF_ACC_ENTERPRISE=1 TF_ACC=1 go test ./internal/vault/sys/ -run "TestAccPolic(ies|y)DataSource" -v
=== RUN   TestAccPoliciesDataSource
--- PASS: TestAccPoliciesDataSource (2.62s)
=== RUN   TestAccPoliciesDataSource_NS
--- PASS: TestAccPoliciesDataSource_NS (3.77s)
=== RUN   TestAccPolicyDataSource
--- PASS: TestAccPolicyDataSource (2.67s)
=== RUN   TestAccPolicyDataSource_NS
--- PASS: TestAccPolicyDataSource_NS (3.60s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/internal/vault/sys        13.626s
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
