### PR TITLE
Fix jwt_auth_backend provider_config values not being converted to strings in Read

### DIFF
--- a/vault/resource_jwt_auth_backend.go
+++ b/vault/resource_jwt_auth_backend.go
@@ -348,6 +348,18 @@ func jwtAuthBackendRead(ctx context.Context, d *schema.ResourceData, meta interf
 			continue
 		}
 
+		// provider_config values need to be converted back to strings because
+		// the schema defines it as TypeMap with string Elem, but the Vault API
+		// returns typed values (bool, int). This fixes perpetual diff issues.
+		if configOption == consts.FieldProviderConfig {
+			if providerConfig, ok := config.Data[configOption].(map[string]interface{}); ok {
+				d.Set(configOption, convertProviderConfigValuesToStrings(providerConfig))
+			} else {
+				d.Set(configOption, config.Data[configOption])
+			}
+			continue
+		}
+
 		d.Set(configOption, config.Data[configOption])
 	}
 
@@ -394,6 +406,21 @@ func convertProviderConfigValues(input map[string]interface{}) (map[string]inter
 		}
 	}
 	return newConfig, nil
+}
+
+// convertProviderConfigValuesToStrings converts provider_config values from the API
+// response (which may be bool, int, or string) back to strings for state storage.
+// This is necessary because the schema defines provider_config as TypeMap with
+// string Elem, but the Vault API returns typed values.
+func convertProviderConfigValuesToStrings(input map[string]interface{}) map[string]interface{} {
+	if input == nil {
+		return nil
+	}
+	result := make(map[string]interface{})
+	for k, v := range input {
+		result[k] = fmt.Sprintf("%v", v)
+	}
+	return result
 }
 
 func jwtAuthBackendUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {


### PR DESCRIPTION
## Description

Fixes #1172

When reading `provider_config` from the Vault API, the response contains typed values (bool, int) for fields like `fetch_groups`, `fetch_user_info`, and `groups_recurse_max_depth`. However, the schema defines `provider_config` as `TypeMap` with string `Elem`. This mismatch causes Terraform to detect perpetual diffs since the state stores bool/int while the config has strings.

## Root Cause

In the `jwtAuthBackendRead` function, `provider_config` values are set directly from the API response:

```go
d.Set(configOption, config.Data[configOption])
```

When `fetch_groups=true` is sent, the API returns it as boolean `true`, but the schema expects string `"true"`.

## Solution

1. Add `convertProviderConfigValuesToStrings` function to convert API response values back to strings using `fmt.Sprintf`
2. Use this function in `jwtAuthBackendRead` specifically for the `provider_config` field

## Changes

```go
// In Read function
if configOption == consts.FieldProviderConfig {
    if providerConfig, ok := config.Data[configOption].(map[string]interface{}); ok {
        d.Set(configOption, convertProviderConfigValuesToStrings(providerConfig))
    } else {
        d.Set(configOption, config.Data[configOption])
    }
    continue
}

// New helper function
func convertProviderConfigValuesToStrings(input map[string]interface{}) map[string]interface{} {
    if input == nil {
        return nil
    }
    result := make(map[string]interface{})
    for k, v := range input {
        result[k] = fmt.Sprintf("%v", v)
    }
    return result
}
```

## Testing

- When `provider_config` contains bool values in API response, they are converted to strings
- When `provider_config` contains int values in API response, they are converted to strings
- String values remain as strings
- Subsequent `terraform plan` shows no changes