### PR TITLE
Fix write-only fields silently cleared on unrelated-field updates (k8s-auth, consul, rabbitmq, mongodbatlas)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+BUGS:
+
+* `vault_kubernetes_auth_backend_config`, `vault_consul_secret_backend`, `vault_rabbitmq_secret_backend`, `vault_mongodbatlas_secret_backend`: Fix write-only fields (`token_reviewer_jwt_wo`, `token_wo`/`client_key_wo`, `password_wo`, `private_key_wo`) being silently cleared in Vault (or causing apply errors) when any other field on the resource was updated without bumping the corresponding `*_wo_version`. The provider now always re-sends the configured write-only value on update for these resources, matching the existing behaviour of `vault_jwt_auth_backend.oidc_client_secret_wo`. ([#2900](https://github.com/hashicorp/terraform-provider-vault/issues/2900))
+
 FEATURES:
 
 * **New Resource**: `vault_config_ui_default_auth` - Manages UI default authentication configuration for the Vault GUI login form. Controls which authentication methods are displayed by default and as backup options for specific namespaces. Supports inheritance control for child namespaces. Enterprise-only feature requiring Vault 1.20.0+. ([#2846](https://github.com/hashicorp/terraform-provider-vault/pull/2846))

--- a/vault/resource_consul_secret_backend.go
+++ b/vault/resource_consul_secret_backend.go
@@ -158,25 +158,37 @@ func consulSecretBackendResource() *schema.Resource {
 	return r
 }
 
-// getWriteOnlyOrLegacyValue extracts a field value from either write-only or legacy field.
-// It prioritizes write-only fields when the version field is present and has changed (or is new resource).
-// Falls back to legacy field if write-only is not being used.
-func getWriteOnlyOrLegacyValue(d *schema.ResourceData, woField, woVersionField, legacyField string, isNewOrVersionChanged bool) string {
+// getWriteOnlyOrLegacyValue extracts a field value from either the write-only
+// or the legacy field.
+//
+// It returns the write-only value whenever the corresponding *_wo_version field
+// is present in config, falling back to the legacy field otherwise.
+//
+// NOTE: previously this helper also took an `isNewOrVersionChanged` gate so
+// that the WO value was only re-sent on create or when *_wo_version changed.
+// That was incorrect: the auth/<mount>/config-style endpoints used by this
+// resource (`<backend>/config/access`) are full-replace writes — omitting a
+// field clears it server-side. Combined with the fact that the resource's
+// Update path is invoked whenever any field on the resource changes, the old
+// gate caused the WO value to silently disappear from Vault on plans that
+// touched any other field without bumping *_wo_version. The fix is to
+// re-send the WO value whenever it is configured, regardless of whether the
+// version changed. See https://github.com/hashicorp/terraform-provider-vault/issues/2900.
+func getWriteOnlyOrLegacyValue(d *schema.ResourceData, woField, woVersionField, legacyField string) string {
 	var value string
 
-	// Check if using write-only field
-	if isNewOrVersionChanged {
-		if _, ok := d.GetOk(woVersionField); ok {
-			// Using write-only field - get from raw config
-			p := cty.GetAttrPath(woField)
-			woVal, _ := d.GetRawConfigAt(p)
-			if !woVal.IsNull() {
-				value = woVal.AsString()
-			}
+	// Use the write-only field whenever it is set in config (the version field
+	// is required when the WO field is set, so its presence is a reliable
+	// signal that the user opted into the WO variant).
+	if _, ok := d.GetOk(woVersionField); ok {
+		p := cty.GetAttrPath(woField)
+		woVal, _ := d.GetRawConfigAt(p)
+		if !woVal.IsNull() {
+			value = woVal.AsString()
 		}
 	}
 
-	// Fall back to legacy field if not using write-only
+	// Fall back to the legacy field if WO is not in use.
 	if value == "" {
 		if v, ok := d.GetOk(legacyField); ok {
 			value = v.(string)
@@ -198,13 +210,11 @@ func consulSecretBackendCreate(ctx context.Context, d *schema.ResourceData, meta
 	caCert := d.Get("ca_cert").(string)
 	clientCert := d.Get("client_cert").(string)
 
-	// Handle token: legacy field or write-only field
-	// Only send the token on create or when the write-only version changes
-	token := getWriteOnlyOrLegacyValue(d, consts.FieldTokenWO, consts.FieldTokenWOVersion, consts.FieldToken, d.IsNewResource() || d.HasChange(consts.FieldTokenWOVersion))
-
-	// Handle client_key: legacy field or write-only field
-	// Only send the client_key on create or when the write-only version changes
-	clientKey := getWriteOnlyOrLegacyValue(d, consts.FieldClientKeyWO, consts.FieldClientKeyWOVersion, consts.FieldClientKey, d.IsNewResource() || d.HasChange(consts.FieldClientKeyWOVersion))
+	// Handle token and client_key: prefer the write-only field when configured,
+	// fall back to the legacy field. The values are always re-sent because the
+	// `<backend>/config/access` endpoint is full-replace.
+	token := getWriteOnlyOrLegacyValue(d, consts.FieldTokenWO, consts.FieldTokenWOVersion, consts.FieldToken)
+	clientKey := getWriteOnlyOrLegacyValue(d, consts.FieldClientKeyWO, consts.FieldClientKeyWOVersion, consts.FieldClientKey)
 
 	configPath := consulSecretBackendConfigPath(path)
 
@@ -308,9 +318,11 @@ func consulSecretBackendUpdate(ctx context.Context, d *schema.ResourceData, meta
 		d.HasChange("client_key") || d.HasChange(consts.FieldClientKeyWOVersion) {
 		log.Printf("[DEBUG] Updating Consul configuration at %q", configPath)
 
-		token := getWriteOnlyOrLegacyValue(d, consts.FieldTokenWO, consts.FieldTokenWOVersion, consts.FieldToken, d.HasChange(consts.FieldTokenWOVersion))
-
-		clientKey := getWriteOnlyOrLegacyValue(d, consts.FieldClientKeyWO, consts.FieldClientKeyWOVersion, consts.FieldClientKey, d.HasChange(consts.FieldClientKeyWOVersion))
+		// Always re-resolve token and client_key on update so the WO value is
+		// re-sent even when *_wo_version did not change. The endpoint is
+		// full-replace, so omitting these fields would clear them in Vault.
+		token := getWriteOnlyOrLegacyValue(d, consts.FieldTokenWO, consts.FieldTokenWOVersion, consts.FieldToken)
+		clientKey := getWriteOnlyOrLegacyValue(d, consts.FieldClientKeyWO, consts.FieldClientKeyWOVersion, consts.FieldClientKey)
 
 		data := map[string]interface{}{
 			"address":     d.Get("address").(string),

--- a/vault/resource_consul_secret_backend_test.go
+++ b/vault/resource_consul_secret_backend_test.go
@@ -957,3 +957,73 @@ resource "vault_consul_secret_backend" "test" {
 	 bootstrap = false
 }`, path)
 }
+
+// testConsulSecretBackend_writeOnlyTokenWithDescription is identical to
+// testConsulSecretBackend_writeOnlyToken but allows the caller to vary the
+// `description` field. It is used by
+// TestConsulSecretBackend_WriteOnlyTokenPersistsOnUnrelatedUpdate to exercise
+// the regression case where an unrelated field is updated while
+// token_wo_version stays the same.
+func testConsulSecretBackend_writeOnlyTokenWithDescription(path, description string, version int) string {
+	return fmt.Sprintf(`
+resource "vault_consul_secret_backend" "test" {
+  path                 = "%s"
+  description          = "%s"
+  address              = "127.0.0.1:8500"
+  token_wo             = "test-token-wo-%d"
+  token_wo_version     = %d
+  scheme               = "http"
+}`, path, description, version, version)
+}
+
+// TestConsulSecretBackend_WriteOnlyTokenPersistsOnUnrelatedUpdate is a
+// regression test for the bug where updating an unrelated field on the
+// resource (here `description`) while leaving `token_wo_version` unchanged
+// caused the provider to omit `token` from the Vault `<backend>/config/access`
+// write request, which then cleared (or auto-bootstrapped over) the
+// previously-stored ACL token.
+//
+// See https://github.com/hashicorp/terraform-provider-vault/issues/2900.
+//
+// The Consul `<backend>/config/access` Read endpoint does not return the
+// stored token, so the test cannot directly assert server-side preservation.
+// It instead verifies that the second apply (with the same token_wo_version
+// and only `description` changed) succeeds and that token_wo_version stays
+// at 1 — the silent-clear is then surfaced indirectly by any downstream
+// role/credential operations a user performs against the backend.
+func TestConsulSecretBackend_WriteOnlyTokenPersistsOnUnrelatedUpdate(t *testing.T) {
+	t.Parallel()
+	path := acctest.RandomWithPrefix("tf-test-consul-wo-unrelated")
+	resourceType := "vault_consul_secret_backend"
+	resourceName := resourceType + ".test"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
+		CheckDestroy:             testCheckMountDestroyed(resourceType, consts.MountTypeConsul, consts.FieldPath),
+		Steps: []resource.TestStep{
+			{
+				Config: testConsulSecretBackend_writeOnlyTokenWithDescription(path, "initial", 1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
+					resource.TestCheckResourceAttr(resourceName, "description", "initial"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldTokenWOVersion, "1"),
+					resource.TestCheckNoResourceAttr(resourceName, consts.FieldTokenWO),
+				),
+			},
+			{
+				// Update only `description`; keep token_wo_version at 1.
+				// Before the fix, the provider would resolve token to "" in
+				// the update path and omit it from the request, causing the
+				// Consul plugin endpoint to either replace the stored token
+				// with an auto-bootstrapped ACL token or fail outright.
+				Config: testConsulSecretBackend_writeOnlyTokenWithDescription(path, "updated description", 1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "description", "updated description"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldTokenWOVersion, "1"),
+					resource.TestCheckNoResourceAttr(resourceName, consts.FieldTokenWO),
+				),
+			},
+		},
+	})
+}

--- a/vault/resource_kubernetes_auth_backend_config.go
+++ b/vault/resource_kubernetes_auth_backend_config.go
@@ -318,13 +318,22 @@ func kubernetesAuthBackendConfigUpdate(d *schema.ResourceData, meta interface{})
 		setData(consts.FieldKubernetesCACert, v)
 	}
 
-	// Handle token_reviewer_jwt - check both regular and write-only fields
+	// Handle token_reviewer_jwt - check both regular and write-only fields.
+	//
+	// NOTE: The Vault auth/<mount>/config endpoint is a full-replace write
+	// (see vault-plugin-auth-kubernetes path_config.go::pathConfigWrite),
+	// so omitting token_reviewer_jwt from the request payload clears the
+	// previously-stored value on the server. The JWT is also not returned
+	// by Read, so we cannot detect drift.
+	//
+	// As a result, when token_reviewer_jwt_wo is configured we must always
+	// re-send the value on Update — not only when token_reviewer_jwt_wo_version
+	// changes — otherwise updating any other field on the resource will
+	// silently clear the JWT in Vault and break Kubernetes auth logins.
 	if v, ok := d.GetOk(consts.FieldTokenReviewerJWT); ok {
 		setData(consts.FieldTokenReviewerJWT, v.(string))
-	} else if d.HasChange(consts.FieldTokenReviewerJWTWOVersion) {
-		if tokenWo, _ := d.GetRawConfigAt(cty.GetAttrPath(consts.FieldTokenReviewerJWTWO)); !tokenWo.IsNull() {
-			setData(consts.FieldTokenReviewerJWT, tokenWo.AsString())
-		}
+	} else if tokenWo, _ := d.GetRawConfigAt(cty.GetAttrPath(consts.FieldTokenReviewerJWTWO)); !tokenWo.IsNull() {
+		setData(consts.FieldTokenReviewerJWT, tokenWo.AsString())
 	}
 
 	if v, ok := d.GetOkExists(consts.FieldPEMKeys); ok {

--- a/vault/resource_kubernetes_auth_backend_config_test.go
+++ b/vault/resource_kubernetes_auth_backend_config_test.go
@@ -517,6 +517,128 @@ func TestAccKubernetesAuthBackendConfig_writeOnlyJWT(t *testing.T) {
 	})
 }
 
+// testAccKubernetesAuthBackendConfigConfig_writeOnlyJWTWithIssuer is identical
+// to testAccKubernetesAuthBackendConfigConfig_writeOnlyJWT but allows the
+// caller to vary the `issuer` field. It is used by the regression test for
+// the bug where updating an unrelated field while leaving
+// `token_reviewer_jwt_wo_version` unchanged caused the JWT to be silently
+// cleared in Vault.
+func testAccKubernetesAuthBackendConfigConfig_writeOnlyJWTWithIssuer(backend, jwt string, version int, issuer string) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "kubernetes" {
+  type = "kubernetes"
+  path = "%s"
+}
+
+resource "vault_kubernetes_auth_backend_config" "config" {
+  backend = vault_auth_backend.kubernetes.path
+  kubernetes_host = "http://example.com:443"
+  kubernetes_ca_cert = %q
+  token_reviewer_jwt_wo = %q
+  token_reviewer_jwt_wo_version = %d
+  issuer = %q
+  disable_local_ca_jwt = true
+}
+`, backend, kubernetesCAcert, jwt, version, issuer)
+}
+
+// testAccCheckKubernetesAuthBackendConfigJWTSet verifies that the
+// token_reviewer_jwt is still configured server-side in Vault by reading the
+// resource and asserting that `token_reviewer_jwt_set` is `true`.
+//
+// The Vault auth/<mount>/config endpoint never returns the JWT itself, but it
+// does return a `token_reviewer_jwt_set` boolean; this is the only reliable
+// way to assert that the JWT survived an update from the server's
+// perspective.
+func testAccCheckKubernetesAuthBackendConfigJWTSet(resourceName string, want bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found in state: %s", resourceName)
+		}
+
+		client, err := provider.GetClient(rs.Primary, testProvider.Meta())
+		if err != nil {
+			return err
+		}
+
+		secret, err := client.Logical().Read(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error reading Kubernetes auth backend config %q: %s",
+				rs.Primary.ID, err)
+		}
+		if secret == nil {
+			return fmt.Errorf("Kubernetes auth backend config %q not found", rs.Primary.ID)
+		}
+
+		raw, ok := secret.Data["token_reviewer_jwt_set"]
+		if !ok {
+			return fmt.Errorf("token_reviewer_jwt_set not present in response for %q",
+				rs.Primary.ID)
+		}
+		got, ok := raw.(bool)
+		if !ok {
+			return fmt.Errorf("token_reviewer_jwt_set is not a bool, got %T (%v)", raw, raw)
+		}
+		if got != want {
+			return fmt.Errorf("token_reviewer_jwt_set mismatch for %q: want %t, got %t",
+				rs.Primary.ID, want, got)
+		}
+		return nil
+	}
+}
+
+// TestAccKubernetesAuthBackendConfig_writeOnlyJWTPersistsOnUnrelatedUpdate is a
+// regression test for the bug where updating a non-write-only field on the
+// resource (e.g. `issuer`) while leaving `token_reviewer_jwt_wo_version`
+// unchanged caused the provider to omit `token_reviewer_jwt` from the Vault
+// write request, which in turn cleared the previously-stored JWT in Vault.
+//
+// See https://github.com/hashicorp/terraform-provider-vault/issues/2900.
+func TestAccKubernetesAuthBackendConfig_writeOnlyJWTPersistsOnUnrelatedUpdate(t *testing.T) {
+	backend := acctest.RandomWithPrefix("kubernetes")
+	jwt := kubernetesJWT
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		CheckDestroy:             testAccCheckKubernetesAuthBackendConfigDestroy,
+		Steps: []resource.TestStep{
+			{
+				// Initial create with the write-only JWT and a known issuer.
+				Config: testAccKubernetesAuthBackendConfigConfig_writeOnlyJWTWithIssuer(
+					backend, jwt, 1, "kubernetes/serviceaccount"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						consts.FieldBackend, backend),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						consts.FieldIssuer, "kubernetes/serviceaccount"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						consts.FieldTokenReviewerJWTWOVersion, "1"),
+					testAccCheckKubernetesAuthBackendConfigJWTSet(
+						"vault_kubernetes_auth_backend_config.config", true),
+				),
+			},
+			{
+				// Update only `issuer`, leave token_reviewer_jwt_wo_version at 1.
+				// Before the fix, the provider would omit token_reviewer_jwt
+				// from the write payload and Vault would clear it
+				// (token_reviewer_jwt_set => false).
+				Config: testAccKubernetesAuthBackendConfigConfig_writeOnlyJWTWithIssuer(
+					backend, jwt, 1, "https://kubernetes.default.svc"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						consts.FieldIssuer, "https://kubernetes.default.svc"),
+					resource.TestCheckResourceAttr("vault_kubernetes_auth_backend_config.config",
+						consts.FieldTokenReviewerJWTWOVersion, "1"),
+					testAccCheckKubernetesAuthBackendConfigJWTSet(
+						"vault_kubernetes_auth_backend_config.config", true),
+				),
+			},
+		},
+	})
+}
+
 func testAccKubernetesAuthBackendConfigConfig_full(backend, caCert, jwt, issuer string,
 	disableIssValidation, disableLocalCaJwt, omitCA bool,
 ) string {

--- a/vault/resource_mongodbatlas_secret_backend.go
+++ b/vault/resource_mongodbatlas_secret_backend.go
@@ -80,18 +80,23 @@ func mongodbAtlasSecretBackendCreateUpdate(ctx context.Context, d *schema.Resour
 
 	var privateKey string
 
-	// Check if using write-only field (new resource or version changed)
-	if d.IsNewResource() || d.HasChange(consts.FieldPrivateKeyWOVersion) {
-		if _, ok := d.GetOk(consts.FieldPrivateKeyWOVersion); ok {
-			p := cty.GetAttrPath(consts.FieldPrivateKeyWO)
-			woVal, _ := d.GetRawConfigAt(p)
-			if !woVal.IsNull() {
-				privateKey = woVal.AsString()
-			}
+	// Resolve private_key from either the write-only or legacy field.
+	//
+	// NOTE: The `<mount>/config` endpoint is full-replace and rejects an empty
+	// `private_key`. Previously the WO branch only fired on create or when
+	// `private_key_wo_version` changed, so updating an unrelated field (e.g.
+	// `public_key`) caused the apply to fail with `private_key is empty`.
+	// Always re-resolve from config so the WO value is sent on every update.
+	// See https://github.com/hashicorp/terraform-provider-vault/issues/2900.
+	if _, ok := d.GetOk(consts.FieldPrivateKeyWOVersion); ok {
+		p := cty.GetAttrPath(consts.FieldPrivateKeyWO)
+		woVal, _ := d.GetRawConfigAt(p)
+		if !woVal.IsNull() {
+			privateKey = woVal.AsString()
 		}
 	}
 
-	// Fallback to legacy field if write-only not set
+	// Fallback to legacy field if write-only not set.
 	if privateKey == "" {
 		if v, ok := d.GetOk(consts.FieldPrivateKey); ok {
 			privateKey = v.(string)

--- a/vault/resource_mongodbatlas_secret_backend_test.go
+++ b/vault/resource_mongodbatlas_secret_backend_test.go
@@ -240,3 +240,68 @@ resource "vault_mongodbatlas_secret_backend" "test" {
   public_key  = "%s"
 }`, path, publicKey)
 }
+
+// testAccMongoDBAtlasSecretBackendConfig_writeOnlyWithPublicKey is identical
+// to testAccMongoDBAtlasSecretBackendConfig_writeOnly but takes the public
+// key as a parameter so the regression test can vary it across applies.
+func testAccMongoDBAtlasSecretBackendConfig_writeOnlyWithPublicKey(path, privateKey string, version int, publicKey string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "mongo" {
+	path        = "%s"
+	type        = "mongodbatlas"
+    description = "MongoDB Atlas secret engine mount"
+}
+
+resource "vault_mongodbatlas_secret_backend" "test" {
+  mount                   = vault_mount.mongo.path
+  private_key_wo          = "%s"
+  private_key_wo_version  = %d
+  public_key              = "%s"
+}`, path, privateKey, version, publicKey)
+}
+
+// TestAccMongoDBAtlasSecretBackend_writeOnlyPersistsOnUnrelatedUpdate is a
+// regression test for the bug where updating an unrelated field while
+// private_key_wo_version stays unchanged caused the provider to omit
+// `private_key` from the request to the full-replace `<mount>/config`
+// endpoint. The mongodbatlas plugin rejects an empty private_key with
+// `private_key is empty`, so the bug surfaces as a hard apply failure
+// rather than silent data loss.
+//
+// See https://github.com/hashicorp/terraform-provider-vault/issues/2900.
+func TestAccMongoDBAtlasSecretBackend_writeOnlyPersistsOnUnrelatedUpdate(t *testing.T) {
+	mount := acctest.RandomWithPrefix("tf-test-mongodbatlas-wo-unrelated")
+	resourceType := "vault_mongodbatlas_secret_backend"
+	resourceName := resourceType + ".test"
+	privateKey, publicKey := testutil.GetTestMDBACreds(t)
+	updatedPublicKey := publicKey + "-v2"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
+		CheckDestroy:             testCheckMountDestroyed(resourceType, consts.MountTypeMongoDBAtlas, consts.FieldPath),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMongoDBAtlasSecretBackendConfig_writeOnlyWithPublicKey(
+					mount, privateKey, 1, publicKey),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldMount, mount),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldPrivateKeyWOVersion, "1"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldPublicKey, publicKey),
+				),
+			},
+			{
+				// Update only `public_key`; keep private_key_wo_version at 1.
+				// Before the fix, this apply would fail because the provider
+				// would resolve private_key to "" and the mongodbatlas plugin
+				// would reject the empty private_key.
+				Config: testAccMongoDBAtlasSecretBackendConfig_writeOnlyWithPublicKey(
+					mount, privateKey, 1, updatedPublicKey),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldPublicKey, updatedPublicKey),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldPrivateKeyWOVersion, "1"),
+				),
+			},
+		},
+	})
+}

--- a/vault/resource_rabbitmq_secret_backend.go
+++ b/vault/resource_rabbitmq_secret_backend.go
@@ -198,11 +198,19 @@ func rabbitMQSecretBackendUpdate(ctx context.Context, d *schema.ResourceData, me
 	if d.HasChanges(consts.FieldConnectionURI, consts.FieldUsername, consts.FieldPassword, consts.FieldPasswordWOVersion, consts.FieldVerifyConnection, consts.FieldUsernameTemplate, consts.FieldPasswordPolicy) {
 		log.Printf("[DEBUG] Updating connection credentials at %q", path+"/config/connection")
 
-		// Handle password and password_wo
+		// Handle password and password_wo.
+		//
+		// NOTE: The `<mount>/config/connection` endpoint is full-replace and
+		// rejects an empty `password`. Previously this branch only re-sent the
+		// WO value when `password_wo_version` changed, so any other field
+		// change (e.g. `connection_uri`, `username`, `verify_connection`)
+		// caused the apply to fail with `missing password`. Re-resolve the
+		// password from config on every update so the WO value is always sent.
+		// See https://github.com/hashicorp/terraform-provider-vault/issues/2900.
 		var password string
 		if v, ok := d.GetOk(consts.FieldPassword); ok {
 			password = v.(string)
-		} else if d.HasChange(consts.FieldPasswordWOVersion) {
+		} else {
 			woVal := d.GetRawConfig().GetAttr(consts.FieldPasswordWO)
 			if !woVal.IsNull() {
 				password = woVal.AsString()

--- a/vault/resource_rabbitmq_secret_backend_test.go
+++ b/vault/resource_rabbitmq_secret_backend_test.go
@@ -247,3 +247,65 @@ resource "vault_rabbitmq_secret_backend" "test" {
 		},
 	})
 }
+
+// testAccRabbitMQSecretBackendConfig_passwordWOWithDescription is identical
+// to testAccRabbitMQSecretBackendConfig_passwordWO but allows the caller to
+// vary the `description` field. It is used by the regression test for the
+// bug where updating an unrelated field while leaving password_wo_version
+// unchanged caused the apply to fail with a "missing password" error from
+// the rabbitmq plugin endpoint.
+func testAccRabbitMQSecretBackendConfig_passwordWOWithDescription(path, description, connectionUri, username, password string, version int) string {
+	return fmt.Sprintf(`
+resource "vault_rabbitmq_secret_backend" "test" {
+  path                = "%s"
+  description         = "%s"
+  connection_uri      = "%s"
+  username            = "%s"
+  password_wo         = "%s"
+  password_wo_version = %d
+}`, path, description, connectionUri, username, password, version)
+}
+
+// TestAccRabbitMQSecretBackend_passwordWOPersistsOnUnrelatedUpdate is a
+// regression test for the bug where updating an unrelated field while
+// password_wo_version stays unchanged caused the provider to omit `password`
+// from the request to the full-replace `<mount>/config/connection` endpoint.
+// The rabbitmq plugin rejects an empty password with `missing password`, so
+// the bug surfaces as a hard apply failure rather than silent data loss.
+//
+// See https://github.com/hashicorp/terraform-provider-vault/issues/2900.
+func TestAccRabbitMQSecretBackend_passwordWOPersistsOnUnrelatedUpdate(t *testing.T) {
+	path := acctest.RandomWithPrefix("tf-test-rabbitmq-wo-unrelated")
+	connectionUri, username, password := testutil.GetTestRMQCreds(t)
+	resourceType := "vault_rabbitmq_secret_backend"
+	resourceName := resourceType + ".test"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		PreCheck:                 func() { testutil.TestAccPreCheck(t) },
+		CheckDestroy:             testCheckMountDestroyed(resourceType, consts.MountTypeRabbitMQ, consts.FieldPath),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRabbitMQSecretBackendConfig_passwordWOWithDescription(
+					path, "initial", connectionUri, username, password, 1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldDescription, "initial"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldPasswordWOVersion, "1"),
+				),
+			},
+			{
+				// Update only `description`; keep password_wo_version at 1.
+				// Before the fix, this apply would fail because the provider
+				// would resolve password to "" and the rabbitmq plugin would
+				// reject the empty password.
+				Config: testAccRabbitMQSecretBackendConfig_passwordWOWithDescription(
+					path, "updated", connectionUri, username, password, 1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldDescription, "updated"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldPasswordWOVersion, "1"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

### Description

The write-only (`*_wo` / `*_wo_version`) field support added in v5.7.0+ has a bug in several resources: the Update path only re-sends the WO value when `*_wo_version` itself changes, so an Update triggered by any other field on the resource omits the WO value from the API request. For resources whose Vault endpoint is full-replace, omitting the field clears or corrupts the stored value server-side.

This PR fixes four resources to always re-send the configured WO value on Update, matching the existing pattern used by `vault_jwt_auth_backend.oidc_client_secret_wo` (#2714):

| Resource | WO field(s) | Failure mode before fix |
|---|---|---|
| `vault_kubernetes_auth_backend_config` | `token_reviewer_jwt_wo` | **Silent clear** of `token_reviewer_jwt`; subsequent K8s auth logins fail with permission denied because the TokenReview call goes out without a bearer. |
| `vault_consul_secret_backend` | `token_wo`, `client_key_wo` | **Silent clear** of `client_key` and replacement of the configured ACL `token` with an auto-bootstrapped one (or hard failure). |
| `vault_rabbitmq_secret_backend` | `password_wo` | Apply fails with `missing password` from the rabbitmq plugin. |
| `vault_mongodbatlas_secret_backend` | `private_key_wo` | Apply fails with `private_key is empty` from the mongodbatlas plugin. |

The kubernetes-auth case is the most user-visible because Vault never returns the JWT, so the failure is silent on the Terraform side and only surfaces later when pods try to log in.

A full audit of every `*_wo_version`-using resource is in the linked issue. About 16 other resources have the same buggy provider gate but happen to be safe today because their Vault endpoint is merge/patch (only overwrites fields explicitly present in the request). Those aren't touched here, but adopting the always-send pattern across the provider would make WO support robust against future plugin endpoint changes. Three Vault Enterprise `secrets_sync_*_destination` resources have the same gate and unknown endpoint behaviour; maintainers with Enterprise visibility should confirm whether they need the same fix.

### Reproduction (kubernetes case)

```hcl
resource "vault_kubernetes_auth_backend_config" "config" {
  backend                       = vault_auth_backend.kubernetes.path
  kubernetes_host               = "https://kube.example.com:6443"
  kubernetes_ca_cert            = file("ca-v1.pem")
  token_reviewer_jwt_wo         = var.reviewer_jwt
  token_reviewer_jwt_wo_version = 1
  disable_local_ca_jwt          = true
}
```

1. `terraform apply` → resource created, k8s auth works.
2. Rotate the cluster CA: change `kubernetes_ca_cert`, leave `token_reviewer_jwt_wo_version` at `1`.
3. `terraform apply` → succeeds with no warning.
4. `vault read auth/<mount>/config` shows `token_reviewer_jwt_set: false`.
5. `vault login -method=kubernetes role=...` → 403 from the TokenReview API.

### Tests added

Each fixed resource gets a regression acceptance test that updates an unrelated field while keeping `*_wo_version` constant and asserts the apply succeeds:

- `TestAccKubernetesAuthBackendConfig_writeOnlyJWTPersistsOnUnrelatedUpdate` — additionally verifies server-side `token_reviewer_jwt_set: true` via a custom CheckFunc that reads `auth/<mount>/config`.
- `TestConsulSecretBackend_WriteOnlyTokenPersistsOnUnrelatedUpdate`
- `TestAccRabbitMQSecretBackend_passwordWOPersistsOnUnrelatedUpdate`
- `TestAccMongoDBAtlasSecretBackend_writeOnlyPersistsOnUnrelatedUpdate`

The Consul/RabbitMQ/MongoDB Atlas tests rely on "apply succeeds" as the regression signal because their endpoints don't expose a server-side flag analogous to `token_reviewer_jwt_set`. Pre-fix, the rabbitmq and mongodbatlas tests would fail at the second step due to the plugin's empty-value validation; the consul test would either fail or silently regenerate the token (which downstream credential-issuing operations would then surface).

Closes #2900

### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions

### Output from acceptance testing:

```
(Acceptance tests not run by submitter — these tests require a live Vault + Consul/RabbitMQ/MongoDB Atlas cluster. Compile and gofmt verified locally.)
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

  Revert plan: this PR can be safely reverted by reverting the single commit. The change makes the provider re-send WO values that were already in the user's config, so reverting restores the previous (buggy) behaviour without data loss beyond what the original bug already caused.

- [x] If applicable, I've documented the impact of any changes to security controls.

  This PR does not change security controls. The fix prevents previously-configured credentials from being silently cleared from Vault on unrelated-field updates, which is a user-availability fix rather than a security control change. The WO field model itself (values not stored in state) is unchanged.
