### PR TITLE
ci: declare permissions on actionlint, go-checks, jira

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -3,6 +3,10 @@ on:
   push:
     paths:
     - '.github/**'
+
+permissions:
+  contents: read
+
 jobs:
   actionlint:
     # using `main` as the ref will keep your workflow up-to-date

--- a/.github/workflows/go-checks.yaml
+++ b/.github/workflows/go-checks.yaml
@@ -4,6 +4,10 @@ on:
     paths-ignore:
       - 'website/**'
       - 'CHANGELOG.md'
+
+permissions:
+  contents: read
+
 jobs:
   go-checks:
     # using `main` as the ref will keep your workflow up-to-date

--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -6,6 +6,13 @@ on:
     types: [opened, closed, reopened]
   issue_comment: # Also triggers when commenting on a PR from the conversation view
     types: [created]
+
+# Reusable Jira sync only reads issue/PR metadata; writes go to Jira.
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
 jobs:
   sync:
     uses: hashicorp/vault-workflows-common/.github/workflows/jira.yaml@main


### PR DESCRIPTION
Adds explicit caller-side `permissions:` blocks to the three workflows that delegate to `hashicorp/vault-workflows-common` reusables. Caller scopes:

- `actionlint.yaml` — `contents: read`. Lints `.github/**` workflows.
- `go-checks.yaml` — `contents: read`. Go static analysis on source.
- `jira.yaml` — `contents: read` + `issues: read` + `pull-requests: read`. Mirrors issue/PR/comment metadata to Jira; the writes happen through `JIRA_SYNC_API_TOKEN`, not the GitHub token.

YAML validated locally with `yaml.safe_load`.