### PR TITLE
docs(ephemeral): add missing namespace attribute to ephemeral resources

### DIFF
--- a/website/docs/ephemeral-resources/database_secret.html.md
+++ b/website/docs/ephemeral-resources/database_secret.html.md
@@ -143,6 +143,12 @@ ephemeral "vault_database_secret" "db_cert_credentials" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace of the target resource.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's
+  configured [namespace](/docs/providers/vault/index.html#namespace).
+  *Available only for Vault Enterprise*.
+
 * `mount` - (Required) Mount path for the DB engine in Vault without trailing or leading slashes.
 
 * `mount_id` - (Optional) If value is set, will defer provisioning the ephemeral resource until

--- a/website/docs/ephemeral-resources/kv_secret_v2.html.md
+++ b/website/docs/ephemeral-resources/kv_secret_v2.html.md
@@ -57,6 +57,12 @@ resource "vault_database_secret_backend_connection" "postgres" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace of the target resource.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's
+  configured [namespace](/docs/providers/vault/index.html#namespace).
+  *Available only for Vault Enterprise*.
+
 * `mount` - (Required) Mount path for the KVV2 engine in Vault without trailing or leading slashes.
 
 * `mount_id` - (Optional) If value is set, will defer provisioning the ephemeral resource until

--- a/website/docs/ephemeral-resources/spiffe_secret_backend_mintjwt.html.md
+++ b/website/docs/ephemeral-resources/spiffe_secret_backend_mintjwt.html.md
@@ -49,6 +49,13 @@ ephemeral "vault_spiffe_secret_backend_mintjwt" "token" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace of the target resource.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's
+  configured [namespace](/docs/providers/vault/index.html#namespace).
+  *Available only for Vault Enterprise*.
+
+
 * `mount` - (Required) The SPIFFE secret backend the resource belongs to.
 
 * `name`  - (Required) The name of the SPIFFE role to use to mint the JWT token.

--- a/website/docs/ephemeral-resources/terraform_token.html.md
+++ b/website/docs/ephemeral-resources/terraform_token.html.md
@@ -60,6 +60,12 @@ ephemeral "vault_terraform_token" "tf_token" {
 
 The following arguments are supported:
 
+* `namespace` - (Optional) The namespace of the target resource.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's
+  configured [namespace](/docs/providers/vault/index.html#namespace).
+  *Available only for Vault Enterprise*.
+
 * `role_name` - (Required) Name of the terraform role without trailing or leading slashes.
 * `mount` - (Optional) Mount path for the TF engine in Vault without trailing or leading slashes. Defaults to `terraform`
 * `mount_id` - (Optional) ID of the mount path. This argument is only helpful if you're calling the ephemeral resource in the same terraform run as the dependencies are created. It should be omitted if your role is created in other runs.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
I realised some ephemeral resources do not have the `namespace` attribute documented. Which they all should have as ephemeral resources extend the [`BaseModel`](https://github.com/FalcoSuessgott/terraform-provider-vault/blob/main/internal/framework/base/schema.go#L40), which includes a `namespace` field.

<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
