### PR TITLE
fix(kvv2): correctly trim suffix from vault_kv_secret_backend_v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 FEATURES:
 
+* `vault_kv_secret_backend_v2`: Fixed kvSecretBackendV2Read to correctly strip the `/config` suffix
 * `vault_config_control_group`: Added initial implementation for `vault_config_control_group` resource in sys/config/control-group. ([#2840](https://github.com/hashicorp/terraform-provider-vault/pull/2840))
 * **New Resource**: `vault_config_ui_header` - Manages custom HTTP headers for the Vault UI. Supports security headers (CSP, HSTS, X-Frame-Options), CORS configuration, and custom organizational headers. Requires Vault 1.16.0+. ([#2842](https://github.com/hashicorp/terraform-provider-vault/pull/2842))
 * **New Resource**: Add support for RADIUS auth backend: `vault_radius_auth_backend` and `vault_radius_auth_backend_user` resource and `vault_radius_auth_login` ephemeral resource.([#2814](https://github.com/hashicorp/terraform-provider-vault/pull/2814))

--- a/vault/resource_kv_secret_backend_v2.go
+++ b/vault/resource_kv_secret_backend_v2.go
@@ -112,7 +112,7 @@ func kvSecretBackendV2Read(_ context.Context, d *schema.ResourceData, meta inter
 
 	if _, ok := d.GetOk(consts.FieldMount); !ok {
 		// ensure that mount is set on import
-		if err := d.Set(consts.FieldMount, strings.TrimRight(path, "/config")); err != nil {
+		if err := d.Set(consts.FieldMount, strings.TrimSuffix(path, "/config")); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/vault/resource_kv_secret_backend_v2_test.go
+++ b/vault/resource_kv_secret_backend_v2_test.go
@@ -51,6 +51,42 @@ func TestAccKVSecretBackendV2(t *testing.T) {
 	})
 }
 
+func TestAccKVSecretBackendV2Suffix(t *testing.T) {
+	t.Parallel()
+	resourceName := "vault_kv_secret_backend_v2.test"
+	mount := acctest.RandomWithPrefix("tf-kvv2-config")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		PreCheck:                 func() { testutil.TestAccPreCheck(t) },
+		Steps: []resource.TestStep{
+			{
+				Config: testKVSecretBackendV2Config(mount, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldMount, mount),
+					resource.TestCheckResourceAttr(resourceName, "max_versions", "5"),
+					resource.TestCheckResourceAttr(resourceName, "delete_version_after", "3700"),
+					resource.TestCheckResourceAttr(resourceName, "cas_required", "true"),
+				),
+			},
+			{
+				Config: testKVSecretBackendV2Config(mount, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldMount, mount),
+					resource.TestCheckResourceAttr(resourceName, "max_versions", "7"),
+					resource.TestCheckResourceAttr(resourceName, "delete_version_after", "87550"),
+					resource.TestCheckResourceAttr(resourceName, "cas_required", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestKVV2SecretNameFromPath(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
The `vault_kv_secret_backend_v2` resource attempts to remove `/config` from the `mount` attribute, this operation is performed using `strings.TrimRight()`, which would end up stripping any trailing characters that are in the set of `/, c, o, n, f, i, g`.  This PR switches to correctly use `strings.TrimSuffix()`

This bug leads to wrong imported KVv2 backend in Terraforms state

I reckon the same bug will also happen in `vault_pki_secret_backend_crl_config` (https://github.com/hashicorp/terraform-provider-vault/blob/main/vault/resource_pki_secret_backend_crl_config.go#L168)

Reproduce:

```sh
> vault server -dev -dev-listen-address=0.0.0.0:8200 -dev-root-token-id=root
> vault secrets enable -path=my-secrets-ending-on-c -version=2 kv
> terraform init
> terraform import vault_kv_secret_backend_v2.example my-secrets-ending-on-c
>terraform state show vault_kv_secret_backend_v2.example
# vault_kv_secret_backend_v2.example:
resource "vault_kv_secret_backend_v2" "example" {
    cas_required = false
    id           = "my-secrets-ending-on-c"
    max_versions = 0
    mount        = "my-secrets-ending-on-" # wrong mount, missing c, wrongly stripped by the resource during import
}
```
<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccKVSecretBackendV2Suffix'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -run=TestAccKVSecretBackendV2Suffix -timeout 30m ./...
?       github.com/hashicorp/terraform-provider-vault   [no test files]
?       github.com/hashicorp/terraform-provider-vault/acctestutil       [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/coverage      [no test files]
?       github.com/hashicorp/terraform-provider-vault/cmd/generate      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/codegen   (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/helper    [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/consts   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/framework/base   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/framework/client [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/framework/errutil        [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/framework/model  [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/framework/rotation       [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/framework/token  [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/framework/validators     (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/identity/entity  (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/group   [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/identity/mfa     [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/pki      [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/provider (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/internal/provider/fwprovider      [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/providertest     [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/rotation [no test files]
?       github.com/hashicorp/terraform-provider-vault/internal/sync     [no test files]
ok      github.com/hashicorp/terraform-provider-vault/internal/vault/auth/cloudfoundry  (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/vault/auth/ephemeral     (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/vault/auth/radius        (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/vault/auth/spiffe        (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/vault/auth/userpass      (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/vault/generic    (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/vault/keymgmt    (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/vault/secrets/alicloud   (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/vault/secrets/azure      (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/vault/secrets/ephemeral  (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/vault/secrets/kmip       (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/vault/secrets/os (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/vault/secrets/pki-external-ca    (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/vault/secrets/spiffe     (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/vault/sys        (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/internal/vault/sys/config (cached) [no tests to run]
?       github.com/hashicorp/terraform-provider-vault/schema    [no test files]
ok      github.com/hashicorp/terraform-provider-vault/testutil  (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util      (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/util/mountutil    (cached) [no tests to run]
ok      github.com/hashicorp/terraform-provider-vault/vault     2.483s
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
