### PR TITLE
Add enable_self_enrollment to vault_identity_mfa_totp resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ FEATURES:
 * **LDAP Role Level Password Policy Support**: Added `password_policy` parameter to `vault_ldap_secret_backend_static_role` and `vault_ldap_secret_backend_dynamic_role` resources to support role-level password policy configuration ([#2921](https://github.com/hashicorp/terraform-provider-vault/pull/2921)). Requires Vault 2.1.0+.
 * **Terraform Secret Engine Root Rotation Support**: Add support for automated root token rotation via the `rotation_period`, `rotation_schedule`, `rotation_window`, and `disable_automated_rotation` fields, and add `explicit_max_ttl` to bound the lifetime of the rotated root token. Requires Vault 2.1.0+. ([#2958](https://github.com/hashicorp/terraform-provider-vault/issues/2958))
 * Add support for Kerberos auth backend: `vault_kerberos_auth_backend_config`, `vault_kerberos_auth_backend_ldap_config`, and `vault_kerberos_auth_backend_group` resources, and `vault_kerberos_auth_backend_login` ephemeral resource for Kerberos authentication. ([#2819](https://github.com/hashicorp/terraform-provider-vault/pull/2819))
+* `resource/vault_identity_mfa_totp`: Add support for the `enable_self_enrollment` field, allowing users to control whether end users can self-enroll in the TOTP MFA method. Requires Vault Enterpise. ([#2919](https://github.com/hashicorp/terraform-provider-vault/pull/2920))
 
 IMPROVEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 5.12.0 (Unreleased)
 
+FEATURES:
+
+* `resource/vault_identity_mfa_totp`: Add support for the `enable_self_enrollment` field, allowing users to control whether end users can self-enroll in the TOTP MFA method. Requires Vault Enterpise. ([#2919](https://github.com/hashicorp/terraform-provider-vault/pull/2920))
+
 IMPROVEMENTS:
 
 * `vault_ldap_auth_backend`: emit a warning when the auth mount or its config is not found during refresh, so users see an actionable message in `terraform plan` output rather than a silent state removal. ([#2997](https://github.com/hashicorp/terraform-provider-vault/pull/2997))

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -242,6 +242,7 @@ const (
 	FieldAlgorithm                          = "algorithm"
 	FieldDigits                             = "digits"
 	FieldSkew                               = "skew"
+	FieldEnableSelfEnrollment               = "enable_self_enrollment"
 	FieldMaxValidationAttempts              = "max_validation_attempts"
 	FieldOrgName                            = "org_name"
 	FieldAPIToken                           = "api_token"

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -243,6 +243,7 @@ const (
 	FieldAlgorithm                          = "algorithm"
 	FieldDigits                             = "digits"
 	FieldSkew                               = "skew"
+	FieldEnableSelfEnrollment               = "enable_self_enrollment"
 	FieldMaxValidationAttempts              = "max_validation_attempts"
 	FieldOrgName                            = "org_name"
 	FieldAPIToken                           = "api_token"

--- a/internal/identity/mfa/totp.go
+++ b/internal/identity/mfa/totp.go
@@ -71,6 +71,12 @@ var (
 			Description: `The number of delay periods that are allowed when validating a TOTP token. ` +
 				`This value can either be 0 or 1.`,
 		},
+		consts.FieldEnableSelfEnrollment: {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: `If true, allows users to enroll themselves in this MFA method. Vault Enterprise only.`,
+		},
 		consts.FieldMaxValidationAttempts: {
 			Type:        schema.TypeInt,
 			Optional:    true,

--- a/vault/resource_identity_mfa_totp_test.go
+++ b/vault/resource_identity_mfa_totp_test.go
@@ -122,3 +122,51 @@ resource "%s" "test" {
 		},
 	})
 }
+
+func TestIdentityMFATOTPEnterpriseEnableSelfEnrollment(t *testing.T) {
+	t.Parallel()
+	testutil.SkipTestAccEnt(t)
+
+	resourceName := mfa.ResourceNameTOTP + ".test"
+
+	checksCommon := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttrSet(resourceName, consts.FieldUUID),
+		resource.TestCheckResourceAttrSet(resourceName, consts.FieldMethodID),
+		resource.TestCheckResourceAttr(resourceName, consts.FieldNamespaceID, "root"),
+		resource.TestCheckResourceAttr(resourceName, consts.FieldType, mfa.MethodTypeTOTP),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testutil.TestAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "%s" "test" {
+  issuer                 = "issuer1"
+  enable_self_enrollment = true
+}
+`, mfa.ResourceNameTOTP),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					append(checksCommon,
+						resource.TestCheckResourceAttr(resourceName, consts.FieldIssuer, "issuer1"),
+						resource.TestCheckResourceAttr(resourceName, consts.FieldEnableSelfEnrollment, "true"),
+					)...),
+			},
+			{
+				Config: fmt.Sprintf(`
+resource "%s" "test" {
+  issuer                 = "issuer1"
+  enable_self_enrollment = false
+}
+`, mfa.ResourceNameTOTP),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					append(checksCommon,
+						resource.TestCheckResourceAttr(resourceName, consts.FieldIssuer, "issuer1"),
+						resource.TestCheckResourceAttr(resourceName, consts.FieldEnableSelfEnrollment, "false"),
+					)...),
+			},
+			testutil.GetImportTestStep(resourceName, false, nil),
+		},
+	})
+}


### PR DESCRIPTION
Note: This is my first contribution to this repository so please be nice.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

### Description
Add support for enable_self_enrollment to the vault_identity_mfa_totp resource, allowing control over whether users can self-enroll in the TOTP MFA method.

Enterprise only feature.

Closes #2919 


### Checklist
- [X] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc-ent TESTARGS='-run=TestIdentityMFATOTPEnterpriseEnableSelfEnrollment -v'
make testacc TF_ACC_ENTERPRISE=1
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -run=TestIdentityMFATOTPEnterpriseEnableSelfEnrollment -v -timeout 30m ./...

=== RUN   TestIdentityMFATOTPEnterpriseEnableSelfEnrollment
=== PAUSE TestIdentityMFATOTPEnterpriseEnableSelfEnrollment
=== CONT  TestIdentityMFATOTPEnterpriseEnableSelfEnrollment
--- PASS: TestIdentityMFATOTPEnterpriseEnableSelfEnrollment (2.79s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     2.829s
```

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
