### PR TITLE
fix(auth_login_aws): assume aws_role_arn only once for non-web-identity credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,14 @@ FEATURES:
 * Add support for `pkcs12_bundle` and `jks_bundle` formats in `vault_pki_secret_backend_cert`, `vault_pki_secret_backend_root_cert`, `vault_pki_secret_backend_root_sign_intermediate`, and `vault_pki_secret_backend_sign` ([#2908](https://github.com/hashicorp/terraform-provider-vault/pull/2908)). Requires Vault 2.1+.
 * `vault_policy`: Added `allow_overwrite` to optionally prevent overwriting Vault policies.([#2895](https://github.com/hashicorp/terraform-provider-vault/pull/2895))
 
-IMPROVEMENTS: 
+IMPROVEMENTS:
 
 * `resource/vault_token`: Added deprecation warning to guide users toward the new ephemeral `vault_token` resource for better security and batch token support. ([#2877](https://github.com/hashicorp/terraform-provider-vault/pull/2877))
 * Replaced backend with mount in `vault_aws_access_credentials` resource's documentation and improved descriptions for a few other parameters.([#2911](https://github.com/hashicorp/terraform-provider-vault/pull/2911))
+
+BUG FIXES:
+
+* `provider`: Fix `auth_login_aws` assuming `aws_role_arn` twice when credentials are sourced from a profile or other non-web-identity chain, which caused the target role to assume itself and fail for roles that do not permit self-assumption. ([#2923](https://github.com/hashicorp/terraform-provider-vault/pull/2923))
 
 ## 5.9.0 (April 22, 2026)
 

--- a/internal/provider/auth_aws.go
+++ b/internal/provider/auth_aws.go
@@ -478,10 +478,11 @@ func (l *AuthLoginAWS) getCredentialsConfig(logger hclog.Logger) (*awsutil.Crede
 	if v, ok := l.params[consts.FieldAWSRegion].(string); ok && v != "" {
 		opts = append(opts, awsutil.WithRegion(v))
 	}
-	if v, ok := l.params[consts.FieldAWSRoleARN].(string); ok && v != "" {
+	_, manualAssume := l.manualAssumeRoleARN()
+	if v, ok := l.params[consts.FieldAWSRoleARN].(string); ok && v != "" && !manualAssume {
 		opts = append(opts, awsutil.WithRoleArn(v))
 	}
-	if v, ok := l.params[consts.FieldAWSRoleSessionName].(string); ok && v != "" {
+	if v, ok := l.params[consts.FieldAWSRoleSessionName].(string); ok && v != "" && !manualAssume {
 		opts = append(opts, awsutil.WithRoleSessionName(v))
 	}
 	if v, ok := l.params[consts.FieldAWSWebIdentityTokenFile].(string); ok && v != "" {

--- a/internal/provider/auth_aws_test.go
+++ b/internal/provider/auth_aws_test.go
@@ -404,12 +404,12 @@ func TestAuthLoginAWS_getCredentialsConfig(t *testing.T) {
 				},
 			},
 			logger: hclog.NewNullLogger(),
+			// Non-web-identity creds: aws_role_arn is assumed manually in
+			// getLoginData, so it is not also passed to the SDK here (#2922).
 			want: &awsutil.CredentialsConfig{
-				Region:          "us-east-1",
-				AccessKey:       "key-id",
-				SecretKey:       "secret-key",
-				RoleARN:         "arn:aws:iam::123456789012:role/test-role",
-				RoleSessionName: "test-session",
+				Region:    "us-east-1",
+				AccessKey: "key-id",
+				SecretKey: "secret-key",
 			},
 			wantErr: false,
 		},
@@ -431,7 +431,6 @@ func TestAuthLoginAWS_getCredentialsConfig(t *testing.T) {
 				AccessKey:    "key-id",
 				SecretKey:    "secret-key",
 				SessionToken: "session-token",
-				RoleARN:      "arn:aws:iam::123456789012:role/test-role",
 			},
 			wantErr: false,
 		},
@@ -585,25 +584,28 @@ func TestAuthLoginAWS_RoleAssumption(t *testing.T) {
 		expectSessionName    string
 	}{
 		{
-			name: "with-role-arn-and-session-name",
+			// Web identity (IRSA): the SDK assumes the role, so the role ARN
+			// must be passed through in the credentials config.
+			name: "web-identity-with-role-arn-and-session-name",
 			params: map[string]interface{}{
-				consts.FieldAWSAccessKeyID:     "key-id",
-				consts.FieldAWSSecretAccessKey: "secret-key",
-				consts.FieldAWSRoleARN:         "arn:aws:iam::123456789012:role/test-role",
-				consts.FieldAWSRoleSessionName: "custom-session",
+				consts.FieldAWSRoleARN:              "arn:aws:iam::123456789012:role/test-role",
+				consts.FieldAWSRoleSessionName:      "custom-session",
+				consts.FieldAWSWebIdentityTokenFile: "/var/run/secrets/eks.amazonaws.com/serviceaccount/token",
 			},
 			expectRoleAssumption: true,
 			expectSessionName:    "custom-session",
 		},
 		{
-			name: "with-role-arn-default-session-name",
+			// Non-web-identity creds: the role is assumed manually in
+			// getLoginData, so the SDK config must NOT carry the role ARN
+			// (otherwise it is assumed twice; #2922).
+			name: "non-web-identity-role-arn-assumed-manually",
 			params: map[string]interface{}{
 				consts.FieldAWSAccessKeyID:     "key-id",
 				consts.FieldAWSSecretAccessKey: "secret-key",
 				consts.FieldAWSRoleARN:         "arn:aws:iam::123456789012:role/test-role",
 			},
-			expectRoleAssumption: true,
-			expectSessionName:    "", // Session name is not set in config when not provided
+			expectRoleAssumption: false,
 		},
 		{
 			name: "without-role-arn",


### PR DESCRIPTION
Fixes `auth_login_aws` assuming `aws_role_arn` twice when credentials are sourced from a profile or another non-web-identity chain. `getCredentialsConfig` handed `aws_role_arn` to the AWS SDK while `getLoginData` independently ran a manual STS `AssumeRole`, so the target role had to assume itself — which fails for cross-account roles that disallow self-assumption. Regression from the v5.7.0 awsutil/v2 migration.

## Fix

Gate `WithRoleArn`/`WithRoleSessionName` in `getCredentialsConfig` behind `!manualAssumeRoleARN()`. Non-web-identity sources defer to the existing manual `AssumeRole` (assumed once). Web-identity (IRSA) is unchanged — the SDK credential chain assumes the role, so `aws_role_arn` stays set.

## Testing

Updated the two `TestAuthLoginAWS_getCredentialsConfig` cases that asserted the old double-assume behavior, and adjusted `TestAuthLoginAWS_RoleAssumption` to cover both paths: web-identity (role ARN passed to the SDK) and non-web-identity (role ARN deferred to the manual assume). `gofmt`/`go vet` clean; all AWS auth unit tests pass. Verified against a live cross-account role.


Closes #2922

### Checklist
- [X] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [X] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
