### PR TITLE
provider now checks for FieldSetNamespaceFromToken being true before prepending token namespace

### DIFF
--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -369,7 +369,6 @@ func (p *ProviderMeta) setClient() error {
 		// namespace paths are properly honoured.
 		setTokenFromNamespace := GetResourceDataBool(d, consts.FieldSetNamespaceFromToken, "VAULT_SET_NAMESPACE_FROM_TOKEN", true)
 		if setTokenFromNamespace {
-			// namespace = tokenNamespace
 			if err := d.Set(consts.FieldNamespace, namespace); err != nil {
 				return err
 			}

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -109,7 +109,9 @@ func (p *ProviderMeta) GetNSClient(ns string) (*api.Client, error) {
 	}
 
 	if root, ok := p.resourceData.GetOk(consts.FieldNamespace); ok && root.(string) != "" {
-		ns = fmt.Sprintf("%s/%s", root, ns)
+		if GetResourceDataBool(p.resourceData, consts.FieldSetNamespaceFromToken, "VAULT_SET_NAMESPACE_FROM_TOKEN", true) {
+			ns = fmt.Sprintf("%s/%s", root, ns)
+		}
 	}
 
 	if p.clientCache == nil {
@@ -367,6 +369,7 @@ func (p *ProviderMeta) setClient() error {
 		// namespace paths are properly honoured.
 		setTokenFromNamespace := GetResourceDataBool(d, consts.FieldSetNamespaceFromToken, "VAULT_SET_NAMESPACE_FROM_TOKEN", true)
 		if setTokenFromNamespace {
+			// namespace = tokenNamespace
 			if err := d.Set(consts.FieldNamespace, namespace); err != nil {
 				return err
 			}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
The provider now makes sure that `set_namespace_from_token` is set to true before prepending the namespace of the token to the request, honoring the setting without disturbing existing functionality.


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->


### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ go test -v ./internal/provider/ -run 'TestProviderMeta_GetNSClient' -count=1

=== RUN   TestProviderMeta_GetNSClient
=== RUN   TestProviderMeta_GetNSClient/no-resource-data
=== RUN   TestProviderMeta_GetNSClient/basic-no-root-ns
=== RUN   TestProviderMeta_GetNSClient/basic-root-ns
=== RUN   TestProviderMeta_GetNSClient/basic-root-ns-trimmed
--- PASS: TestProviderMeta_GetNSClient (0.00s)
    --- PASS: TestProviderMeta_GetNSClient/no-resource-data (0.00s)
    --- PASS: TestProviderMeta_GetNSClient/basic-no-root-ns (0.00s)
    --- PASS: TestProviderMeta_GetNSClient/basic-root-ns (0.00s)
    --- PASS: TestProviderMeta_GetNSClient/basic-root-ns-trimmed (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/internal/provider 0.487s

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
