### PR TITLE
provider now checks for FieldSetNamespaceFromToken being true before prepending token namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ FEATURES:
 
 * **LDAP Role Level Password Policy Support**: Added `password_policy` parameter to `vault_ldap_secret_backend_static_role` and `vault_ldap_secret_backend_dynamic_role` resources to support role-level password policy configuration ([#2921](https://github.com/hashicorp/terraform-provider-vault/pull/2921)). Requires Vault 2.1.0+.
 
-IMPROVEMENTS:
+BUG FIXES:
 
-* Fixed the token namespace being set as the provider namespace, even when `set_namespace_from_token` was `false`.
+* Fixed the token namespace being set as the provider namespace, even when `set_namespace_from_token` was `false`. ([#2926](https://github.com/hashicorp/terraform-provider-vault/pull/2926/))
 
 ## 5.10.1 (June 26, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ FEATURES:
 
 * **LDAP Role Level Password Policy Support**: Added `password_policy` parameter to `vault_ldap_secret_backend_static_role` and `vault_ldap_secret_backend_dynamic_role` resources to support role-level password policy configuration ([#2921](https://github.com/hashicorp/terraform-provider-vault/pull/2921)). Requires Vault 2.1.0+.
 
+IMPROVEMENTS:
+
+* Fixed the token namespace being set as the provider namespace, even when `set_namespace_from_token` was `false`.
+
 ## 5.10.1 (June 26, 2026)
 
 BREAKING CHANGES: 

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -371,7 +371,6 @@ func (p *ProviderMeta) setClient() error {
 		// namespace paths are properly honoured.
 		setTokenFromNamespace := GetResourceDataBool(d, consts.FieldSetNamespaceFromToken, "VAULT_SET_NAMESPACE_FROM_TOKEN", true)
 		if setTokenFromNamespace {
-			// namespace = tokenNamespace
 			if err := d.Set(consts.FieldNamespace, namespace); err != nil {
 				return err
 			}

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -111,7 +111,9 @@ func (p *ProviderMeta) GetNSClient(ns string) (*api.Client, error) {
 	}
 
 	if root, ok := p.resourceData.GetOk(consts.FieldNamespace); ok && root.(string) != "" {
-		ns = fmt.Sprintf("%s/%s", root, ns)
+		if GetResourceDataBool(p.resourceData, consts.FieldSetNamespaceFromToken, "VAULT_SET_NAMESPACE_FROM_TOKEN", true) {
+			ns = fmt.Sprintf("%s/%s", root, ns)
+		}
 	}
 
 	if p.clientCache == nil {
@@ -369,6 +371,7 @@ func (p *ProviderMeta) setClient() error {
 		// namespace paths are properly honoured.
 		setTokenFromNamespace := GetResourceDataBool(d, consts.FieldSetNamespaceFromToken, "VAULT_SET_NAMESPACE_FROM_TOKEN", true)
 		if setTokenFromNamespace {
+			// namespace = tokenNamespace
 			if err := d.Set(consts.FieldNamespace, namespace); err != nil {
 				return err
 			}

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -375,11 +375,13 @@ func (p *ProviderMeta) setClient() error {
 	}
 
 	if namespace != "" {
-		// This block now only executes when the namespace was explicitly
-		// configured on the provider (not derived from the token).
+		// This block executes when the namespace was explicitly
+		// configured on the provider (not derived from the token)
+		// or when the namespace was not configured on the provider but was derived from the token
 		if err := d.Set(consts.FieldNamespace, namespace); err != nil {
 			return fmt.Errorf("failed to set namespace on provider: %w", err)
 		}
+		log.Printf("[DEBUG] Setting namespace on client to %q", namespace)
 		client.SetNamespace(namespace)
 	}
 

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -364,21 +364,13 @@ func (p *ProviderMeta) setClient() error {
 			"configuration's namespace to be %q, before executing terraform. "+
 			"Future releases may not support this type of configuration.", tokenNamespace)
 
-		namespace = tokenNamespace
-		// set the namespace on the provider to ensure that all child
-		// namespace paths are properly honoured.
+		setNamespaceFromToken := GetResourceDataBool(d, consts.FieldSetNamespaceFromToken, "VAULT_SET_NAMESPACE_FROM_TOKEN", true)
 
-		setTokenFromNamespace := GetResourceDataBool(d, consts.FieldSetNamespaceFromToken, "VAULT_SET_NAMESPACE_FROM_TOKEN", true)
-
-		if setTokenFromNamespace {
+		if setNamespaceFromToken {
+			namespace = tokenNamespace
 			if err := d.Set(consts.FieldNamespace, namespace); err != nil {
 				return err
 			}
-		} else {
-			// When set_namespace_from_token=false, do NOT propagate the token's
-			// namespace to ResourceData or the client. Reset namespace so the
-			// subsequent block is skipped entirely.
-			namespace = ""
 		}
 	}
 

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -368,9 +368,6 @@ func (p *ProviderMeta) setClient() error {
 
 		if setNamespaceFromToken {
 			namespace = tokenNamespace
-			if err := d.Set(consts.FieldNamespace, namespace); err != nil {
-				return err
-			}
 		}
 	}
 

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -363,11 +363,11 @@ func (p *ProviderMeta) setClient() error {
 			"using namespaced auth tokens. You may want to update your provider "+
 			"configuration's namespace to be %q, before executing terraform. "+
 			"Future releases may not support this type of configuration.", tokenNamespace)
-		
+
 		namespace = tokenNamespace
 		// set the namespace on the provider to ensure that all child
 		// namespace paths are properly honoured.
-		
+
 		setTokenFromNamespace := GetResourceDataBool(d, consts.FieldSetNamespaceFromToken, "VAULT_SET_NAMESPACE_FROM_TOKEN", true)
 
 		if setTokenFromNamespace {

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -355,12 +355,19 @@ func (p *ProviderMeta) setClient() error {
 	}
 
 	if namespace == "" && tokenNamespace != "" {
+		// set the provider namespace to the token's namespace
+		// this is here to ensure that do not break any configurations that are relying on the
+		// token's namespace being used during resource provisioning.
+		// In the future we should drop support for this behaviour.
 		log.Printf("[WARN] The provider namespace should be set whenever "+
 			"using namespaced auth tokens. You may want to update your provider "+
 			"configuration's namespace to be %q, before executing terraform. "+
 			"Future releases may not support this type of configuration.", tokenNamespace)
+		
 		namespace = tokenNamespace
-
+		// set the namespace on the provider to ensure that all child
+		// namespace paths are properly honoured.
+		
 		setTokenFromNamespace := GetResourceDataBool(d, consts.FieldSetNamespaceFromToken, "VAULT_SET_NAMESPACE_FROM_TOKEN", true)
 
 		if setTokenFromNamespace {

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -111,9 +111,7 @@ func (p *ProviderMeta) GetNSClient(ns string) (*api.Client, error) {
 	}
 
 	if root, ok := p.resourceData.GetOk(consts.FieldNamespace); ok && root.(string) != "" {
-		if GetResourceDataBool(p.resourceData, consts.FieldSetNamespaceFromToken, "VAULT_SET_NAMESPACE_FROM_TOKEN", true) {
-			ns = fmt.Sprintf("%s/%s", root, ns)
-		}
+		ns = fmt.Sprintf("%s/%s", root, ns)
 	}
 
 	if p.clientCache == nil {
@@ -357,36 +355,32 @@ func (p *ProviderMeta) setClient() error {
 	}
 
 	if namespace == "" && tokenNamespace != "" {
-		// set the provider namespace to the token's namespace
-		// this is here to ensure that do not break any configurations that are relying on the
-		// token's namespace being used during resource provisioning.
-		// In the future we should drop support for this behaviour.
 		log.Printf("[WARN] The provider namespace should be set whenever "+
 			"using namespaced auth tokens. You may want to update your provider "+
 			"configuration's namespace to be %q, before executing terraform. "+
 			"Future releases may not support this type of configuration.", tokenNamespace)
-
 		namespace = tokenNamespace
-		// set the namespace on the provider to ensure that all child
-		// namespace paths are properly honoured.
+
 		setTokenFromNamespace := GetResourceDataBool(d, consts.FieldSetNamespaceFromToken, "VAULT_SET_NAMESPACE_FROM_TOKEN", true)
+
 		if setTokenFromNamespace {
 			if err := d.Set(consts.FieldNamespace, namespace); err != nil {
 				return err
 			}
+		} else {
+			// When set_namespace_from_token=false, do NOT propagate the token's
+			// namespace to ResourceData or the client. Reset namespace so the
+			// subsequent block is skipped entirely.
+			namespace = ""
 		}
 	}
 
 	if namespace != "" {
-		// set the namespace on the provider to ensure that all child
-		// namespace paths are properly honoured.
-		log.Printf("[DEBUG] Setting namespace on provider to %q", namespace)
+		// This block now only executes when the namespace was explicitly
+		// configured on the provider (not derived from the token).
 		if err := d.Set(consts.FieldNamespace, namespace); err != nil {
 			return fmt.Errorf("failed to set namespace on provider: %w", err)
 		}
-
-		// set the namespace on the parent client
-		log.Printf("[DEBUG] Setting namespace on client to %q", namespace)
 		client.SetNamespace(namespace)
 	}
 

--- a/vault/provider_test.go
+++ b/vault/provider_test.go
@@ -282,75 +282,144 @@ func TestAccNamespaceProviderConfigure(t *testing.T) {
 	})
 }
 
-// TestAccNamespaceProviderConfigure_setNamespaceFromTokenFalse verifies that when
-// set_namespace_from_token = false, the provider namespace is NOT prepended to resource
-// namespace paths. The provider is configured with namespace = parentNS and
-// set_namespace_from_token = false. A resource sets namespace = childNS, where childNS
-// exists at root only (not under parentNS). If the fix is absent, GetNSClient prepends
-// parentNS, resolving to parentNS/childNS which does not exist, causing a 404.
-func TestAccNamespaceProviderConfigure_setNamespaceFromTokenFalse(t *testing.T) {
+// TestAccNamespaceProviderConfigure_setNamespaceFromToken verifies that
+// set_namespace_from_token controls whether a namespace derived from the auth
+// token is prepended to a resource's namespace.
+//
+// The flag only has an effect when the provider namespace (and VAULT_NAMESPACE)
+// are unset and the token is scoped to a namespace — the
+// `namespace == "" && tokenNamespace != ""` branch in
+// internal/provider/meta.go setClient. When the flag is honored (false) the
+// token namespace is NOT adopted as the provider root, so GetNSClient does not
+// prepend it to a resource's namespace; when true, it is.
+//
+// The flag is read via GetResourceDataBool, which depends on RawConfig.
+// RawConfig is only populated when the provider is configured from real HCL
+// through the plugin protocol, so the provider block is embedded in the test
+// config string and the assertion inspects the configured ProviderMeta. A
+// hand-built ResourceData leaves RawConfig null and the flag would silently
+// fall back to its default of true.
+func TestAccNamespaceProviderConfigure_setNamespaceFromToken(t *testing.T) {
 	acctestutil.SkipTestAccEnt(t)
 	acctestutil.SkipTestAcc(t)
 
-	client := testProvider.Meta().(*provider.ProviderMeta).MustGetClient()
+	rootClient := testProvider.Meta().(*provider.ProviderMeta).MustGetClient()
 
-	// Create a parent namespace. The provider will be configured with this namespace.
-	parentNS := acctest.RandomWithPrefix("test-ns-parent")
-	if _, err := client.Logical().Write(consts.SysNamespaceRoot+parentNS, nil); err != nil {
-		t.Fatalf("failed to create parent namespace %q: %s", parentNS, err)
+	// Create the namespace that the auth token will be scoped to. It needs no
+	// child namespaces: the assertion only inspects the namespace GetNSClient
+	// resolves locally, so teardown is a single-level delete.
+	tokenNS := acctest.RandomWithPrefix("test-ns-token")
+	if _, err := rootClient.Logical().Write(consts.SysNamespaceRoot+tokenNS, nil); err != nil {
+		t.Fatalf("failed to create token namespace %q: %s", tokenNS, err)
 	}
 	t.Cleanup(func() {
-		if _, err := client.Logical().Delete(consts.SysNamespaceRoot + parentNS); err != nil {
-			t.Errorf("failed to delete parent namespace %q: %s", parentNS, err)
+		if _, err := rootClient.Logical().Delete(consts.SysNamespaceRoot + tokenNS); err != nil {
+			t.Errorf("failed to delete token namespace %q: %s", tokenNS, err)
 		}
 	})
 
-	// Create a child namespace at root only — not under parentNS. This is intentional:
-	// with set_namespace_from_token = false the resource namespace = childNS must resolve
-	// directly to the root-level childNS. If the code incorrectly prepends parentNS it
-	// targets parentNS/childNS, which does not exist, and the apply fails.
-	childNS := acctest.RandomWithPrefix("test-ns-child")
-	if _, err := client.Logical().Write(consts.SysNamespaceRoot+childNS, nil); err != nil {
-		t.Fatalf("failed to create child namespace %q: %s", childNS, err)
+	// A root-derived client bound to tokenNS, used to provision the policy and
+	// token that live inside it.
+	nsClient, err := rootClient.Clone()
+	if err != nil {
+		t.Fatalf("failed to clone client: %s", err)
 	}
-	t.Cleanup(func() {
-		if _, err := client.Logical().Delete(consts.SysNamespaceRoot + childNS); err != nil {
-			t.Errorf("failed to delete child namespace %q: %s", childNS, err)
-		}
+	nsClient.SetNamespace(tokenNS)
+
+	// Grant the token permission to create the limited child token that
+	// setClient mints during provider configuration.
+	const tokenPolicy = `path "auth/token/create" { capabilities = ["create", "update", "sudo"] }`
+	if err := nsClient.Sys().PutPolicy("token-create", tokenPolicy); err != nil {
+		t.Fatalf("failed to create policy in %q: %s", tokenNS, err)
+	}
+
+	// Mint a token scoped to tokenNS. Its namespace_path is what setClient
+	// inspects to derive the provider namespace.
+	secret, err := nsClient.Auth().Token().Create(&api.TokenCreateRequest{
+		Policies: []string{"token-create"},
+		TTL:      "1h",
 	})
+	if err != nil {
+		t.Fatalf("failed to create namespaced token: %s", err)
+	}
+	nsToken := secret.Auth.ClientToken
 
-	grandchildNS := acctest.RandomWithPrefix("test-ns-grandchild")
+	// The resource namespace whose resolution we assert.
+	const childNS = "child"
 
-	// The provider block in HCL sets namespace = parentNS and set_namespace_from_token = false.
-	// resource.Test re-configures the provider from HCL, so these values must be embedded in
-	// the config string — not set on nsProviderData before the test — to survive re-configure.
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
-		Steps: []resource.TestStep{
-			{
-				Config: testNamespaceConfigWithProviderNS(parentNS, childNS, grandchildNS),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_namespace.grandchild", consts.FieldPath, grandchildNS),
-					resource.TestCheckResourceAttr("vault_namespace.grandchild", consts.FieldNamespace, childNS),
-				),
-			},
+	tests := []struct {
+		name                  string
+		setNamespaceFromToken bool
+		// wantNS is the namespace GetNSClient should apply to a resource that
+		// sets namespace = childNS, once the provider has derived its root from
+		// the token.
+		wantNS string
+	}{
+		{
+			name:                  "false_does_not_prepend_token_namespace",
+			setNamespaceFromToken: false,
+			wantNS:                childNS,
 		},
-	})
+		{
+			name:                  "true_prepends_token_namespace",
+			setNamespaceFromToken: true,
+			wantNS:                tokenNS + "/" + childNS,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resource.Test(t, resource.TestCase{
+				PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
+				ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+				Steps: []resource.TestStep{
+					{
+						Config: testNamespaceFromTokenConfig(nsToken, tt.setNamespaceFromToken),
+						Check:  checkResolvedNamespaceFromToken(childNS, tt.wantNS),
+					},
+				},
+			})
+		})
+	}
 }
 
-func testNamespaceConfigWithProviderNS(providerNS, resourceNS, path string) string {
+// checkResolvedNamespaceFromToken asserts that the configured provider resolves
+// resourceNS to wantNS. It inspects the namespace GetNSClient applies to a
+// cloned client, which is where the token namespace is (or is not) prepended.
+func checkResolvedNamespaceFromToken(resourceNS, wantNS string) resource.TestCheckFunc {
+	return func(*terraform.State) error {
+		pm, ok := testProvider.Meta().(*provider.ProviderMeta)
+		if !ok {
+			return fmt.Errorf("provider meta is %T, want *provider.ProviderMeta", testProvider.Meta())
+		}
+
+		c, err := pm.GetNSClient(resourceNS)
+		if err != nil {
+			return fmt.Errorf("GetNSClient(%q) failed: %w", resourceNS, err)
+		}
+
+		if got := c.Namespace(); got != wantNS {
+			return fmt.Errorf("resolved namespace for %q = %q, want %q", resourceNS, got, wantNS)
+		}
+		return nil
+	}
+}
+
+// testNamespaceFromTokenConfig configures the provider with a namespaced token
+// and NO namespace, so the namespace is derived from the token and governed by
+// set_namespace_from_token. The data source only serves to trigger provider
+// configuration.
+func testNamespaceFromTokenConfig(token string, setNamespaceFromToken bool) string {
 	return fmt.Sprintf(`
 provider "vault" {
-  namespace                = %q
-  set_namespace_from_token = false
+  token                    = %q
+  set_namespace_from_token = %t
 }
 
-resource "vault_namespace" "grandchild" {
-  namespace = %q
-  path      = %q
+data "vault_generic_secret" "test" {
+  path = "/auth/token/lookup-self"
 }
-`, providerNS, resourceNS, path)
+`, token, setNamespaceFromToken)
 }
 
 func testResourceApproleConfig_basic() string {

--- a/vault/provider_test.go
+++ b/vault/provider_test.go
@@ -283,17 +283,18 @@ func TestAccNamespaceProviderConfigure(t *testing.T) {
 }
 
 // TestAccNamespaceProviderConfigure_setNamespaceFromTokenFalse verifies that when
-// set_namespace_from_token = false, the provider namespace is NOT prepended to child
-// namespace paths passed to GetNSClient. Without the fix, a resource with namespace = "child"
-// inside a provider configured with namespace = "parent" would resolve to "parent/child",
-// which is incorrect when set_namespace_from_token is explicitly false.
+// set_namespace_from_token = false, the provider namespace is NOT prepended to resource
+// namespace paths. The provider is configured with namespace = parentNS and
+// set_namespace_from_token = false. A resource sets namespace = childNS, where childNS
+// exists at root only (not under parentNS). If the fix is absent, GetNSClient prepends
+// parentNS, resolving to parentNS/childNS which does not exist, causing a 404.
 func TestAccNamespaceProviderConfigure_setNamespaceFromTokenFalse(t *testing.T) {
 	acctestutil.SkipTestAccEnt(t)
 	acctestutil.SkipTestAcc(t)
 
 	client := testProvider.Meta().(*provider.ProviderMeta).MustGetClient()
 
-	// Create a parent namespace.
+	// Create a parent namespace. The provider will be configured with this namespace.
 	parentNS := acctest.RandomWithPrefix("test-ns-parent")
 	if _, err := client.Logical().Write(consts.SysNamespaceRoot+parentNS, nil); err != nil {
 		t.Fatalf("failed to create parent namespace %q: %s", parentNS, err)
@@ -304,9 +305,10 @@ func TestAccNamespaceProviderConfigure_setNamespaceFromTokenFalse(t *testing.T) 
 		}
 	})
 
-	// Create a child namespace at root. This is intentional: when
-	// set_namespace_from_token = false, namespace=childNS should resolve directly
-	// to childNS. If code incorrectly prepends parentNS, apply should fail.
+	// Create a child namespace at root only — not under parentNS. This is intentional:
+	// with set_namespace_from_token = false the resource namespace = childNS must resolve
+	// directly to the root-level childNS. If the code incorrectly prepends parentNS it
+	// targets parentNS/childNS, which does not exist, and the apply fails.
 	childNS := acctest.RandomWithPrefix("test-ns-child")
 	if _, err := client.Logical().Write(consts.SysNamespaceRoot+childNS, nil); err != nil {
 		t.Fatalf("failed to create child namespace %q: %s", childNS, err)
@@ -317,36 +319,17 @@ func TestAccNamespaceProviderConfigure_setNamespaceFromTokenFalse(t *testing.T) 
 		}
 	})
 
-	// Configure a provider scoped to the parent namespace with set_namespace_from_token = false.
-	// The child resource sets namespace = childNS. With set_namespace_from_token = false the
-	// provider must NOT prepend parentNS, so the resolved namespace on the client must be
-	// exactly childNS (not "parentNS/childNS").
-	nsProvider := Provider()
-	nsProviderResource := &schema.Resource{
-		Schema: nsProvider.Schema,
-	}
-	nsProviderData := nsProviderResource.TestResourceData()
-	nsProviderData.Set(consts.FieldNamespace, parentNS)
-	nsProviderData.Set(consts.FieldToken, os.Getenv(api.EnvVaultToken))
-	nsProviderData.Set(consts.FieldSetNamespaceFromToken, false)
-	if _, err := provider.NewProviderMeta(nsProviderData); err != nil {
-		t.Fatal(err)
-	}
-
 	grandchildNS := acctest.RandomWithPrefix("test-ns-grandchild")
 
+	// The provider block in HCL sets namespace = parentNS and set_namespace_from_token = false.
+	// resource.Test re-configures the provider from HCL, so these values must be embedded in
+	// the config string — not set on nsProviderData before the test — to survive re-configure.
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() { acctestutil.TestAccPreCheck(t) },
-		Providers: map[string]*schema.Provider{
-			"vault": nsProvider,
-		},
+		PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		Steps: []resource.TestStep{
 			{
-				// The resource sets namespace = childNS. With set_namespace_from_token = false the
-				// provider must resolve the client namespace to childNS only, not parentNS/childNS.
-				// If namespace were incorrectly prepended the Write would target
-				// "parentNS/childNS/grandchildNS" which does not exist and would fail.
-				Config: testNamespaceConfigWithProviderNS(childNS, grandchildNS),
+				Config: testNamespaceConfigWithProviderNS(parentNS, childNS, grandchildNS),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("vault_namespace.grandchild", consts.FieldPath, grandchildNS),
 					resource.TestCheckResourceAttr("vault_namespace.grandchild", consts.FieldNamespace, childNS),
@@ -356,13 +339,18 @@ func TestAccNamespaceProviderConfigure_setNamespaceFromTokenFalse(t *testing.T) 
 	})
 }
 
-func testNamespaceConfigWithProviderNS(providerNS, path string) string {
+func testNamespaceConfigWithProviderNS(providerNS, resourceNS, path string) string {
 	return fmt.Sprintf(`
+provider "vault" {
+  namespace                = %q
+  set_namespace_from_token = false
+}
+
 resource "vault_namespace" "grandchild" {
   namespace = %q
   path      = %q
 }
-`, providerNS, path)
+`, providerNS, resourceNS, path)
 }
 
 func testResourceApproleConfig_basic() string {

--- a/vault/provider_test.go
+++ b/vault/provider_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/vault/api"
 	"github.com/mitchellh/go-homedir"
 
+	"github.com/hashicorp/terraform-provider-vault/acctestutil"
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
@@ -279,6 +280,89 @@ func TestAccNamespaceProviderConfigure(t *testing.T) {
 			},
 		},
 	})
+}
+
+// TestAccNamespaceProviderConfigure_setNamespaceFromTokenFalse verifies that when
+// set_namespace_from_token = false, the provider namespace is NOT prepended to child
+// namespace paths passed to GetNSClient. Without the fix, a resource with namespace = "child"
+// inside a provider configured with namespace = "parent" would resolve to "parent/child",
+// which is incorrect when set_namespace_from_token is explicitly false.
+func TestAccNamespaceProviderConfigure_setNamespaceFromTokenFalse(t *testing.T) {
+	acctestutil.SkipTestAccEnt(t)
+	acctestutil.SkipTestAcc(t)
+
+	client := testProvider.Meta().(*provider.ProviderMeta).MustGetClient()
+
+	// Create a parent namespace.
+	parentNS := acctest.RandomWithPrefix("test-ns-parent")
+	if _, err := client.Logical().Write(consts.SysNamespaceRoot+parentNS, nil); err != nil {
+		t.Fatalf("failed to create parent namespace %q: %s", parentNS, err)
+	}
+	t.Cleanup(func() {
+		if _, err := client.Logical().Delete(consts.SysNamespaceRoot + parentNS); err != nil {
+			t.Errorf("failed to delete parent namespace %q: %s", parentNS, err)
+		}
+	})
+
+	// Create a child namespace at root. This is intentional: when
+	// set_namespace_from_token = false, namespace=childNS should resolve directly
+	// to childNS. If code incorrectly prepends parentNS, apply should fail.
+	childNS := acctest.RandomWithPrefix("test-ns-child")
+	if _, err := client.Logical().Write(consts.SysNamespaceRoot+childNS, nil); err != nil {
+		t.Fatalf("failed to create child namespace %q: %s", childNS, err)
+	}
+	t.Cleanup(func() {
+		if _, err := client.Logical().Delete(consts.SysNamespaceRoot + childNS); err != nil {
+			t.Errorf("failed to delete child namespace %q: %s", childNS, err)
+		}
+	})
+
+	// Configure a provider scoped to the parent namespace with set_namespace_from_token = false.
+	// The child resource sets namespace = childNS. With set_namespace_from_token = false the
+	// provider must NOT prepend parentNS, so the resolved namespace on the client must be
+	// exactly childNS (not "parentNS/childNS").
+	nsProvider := Provider()
+	nsProviderResource := &schema.Resource{
+		Schema: nsProvider.Schema,
+	}
+	nsProviderData := nsProviderResource.TestResourceData()
+	nsProviderData.Set(consts.FieldNamespace, parentNS)
+	nsProviderData.Set(consts.FieldToken, os.Getenv(api.EnvVaultToken))
+	nsProviderData.Set(consts.FieldSetNamespaceFromToken, false)
+	if _, err := provider.NewProviderMeta(nsProviderData); err != nil {
+		t.Fatal(err)
+	}
+
+	grandchildNS := acctest.RandomWithPrefix("test-ns-grandchild")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { acctestutil.TestAccPreCheck(t) },
+		Providers: map[string]*schema.Provider{
+			"vault": nsProvider,
+		},
+		Steps: []resource.TestStep{
+			{
+				// The resource sets namespace = childNS. With set_namespace_from_token = false the
+				// provider must resolve the client namespace to childNS only, not parentNS/childNS.
+				// If namespace were incorrectly prepended the Write would target
+				// "parentNS/childNS/grandchildNS" which does not exist and would fail.
+				Config: testNamespaceConfigWithProviderNS(childNS, grandchildNS),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("vault_namespace.grandchild", consts.FieldPath, grandchildNS),
+					resource.TestCheckResourceAttr("vault_namespace.grandchild", consts.FieldNamespace, childNS),
+				),
+			},
+		},
+	})
+}
+
+func testNamespaceConfigWithProviderNS(providerNS, path string) string {
+	return fmt.Sprintf(`
+resource "vault_namespace" "grandchild" {
+  namespace = %q
+  path      = %q
+}
+`, providerNS, path)
 }
 
 func testResourceApproleConfig_basic() string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
The provider now makes sure that set_namespace_from_token is set to true before prepending the namespace of the token to the request, honoring the setting without disturbing existing functionality.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->



### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
go test -v ./vault -run 'TestAccNamespaceProviderConfigure_setNamespaceFromToken' -count=1
=== RUN   TestAccNamespaceProviderConfigure_setNamespaceFromToken
2026/06/25 15:28:53 [INFO] Using Vault token with the following policies: root
=== RUN   TestAccNamespaceProviderConfigure_setNamespaceFromToken/false_does_not_prepend_token_namespace
=== RUN   TestAccNamespaceProviderConfigure_setNamespaceFromToken/true_prepends_token_namespace
--- PASS: TestAccNamespaceProviderConfigure_setNamespaceFromToken (1.87s)
    --- PASS: TestAccNamespaceProviderConfigure_setNamespaceFromToken/false_does_not_prepend_token_namespace (1.07s)
    --- PASS: TestAccNamespaceProviderConfigure_setNamespaceFromToken/true_prepends_token_namespace (0.79s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     2.908s
```

### Output from exisitng unit tests for GetNSClient:

```
$ go test -v ./internal/provider/ -run 'TestProviderMeta_GetNSClient' -count=1

=== RUN   TestProviderMeta_GetNSClient
=== RUN   TestProviderMeta_GetNSClient/no-resource-data
=== RUN   TestProviderMeta_GetNSClient/basic-no-root-ns
=== RUN   TestProviderMeta_GetNSClient/basic-root-ns
=== RUN   TestProviderMeta_GetNSClient/basic-root-ns-trimmed
--- PASS: TestProviderMeta_GetNSClient (0.00s)
    --- PASS: TestProviderMeta_GetNSClient/no-resource-data (0.00s)
    --- PASS: TestProviderMeta_GetNSClient/basic-no-root-ns (0.00s)
    --- PASS: TestProviderMeta_GetNSClient/basic-root-ns (0.00s)
    --- PASS: TestProviderMeta_GetNSClient/basic-root-ns-trimmed (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/internal/provider 0.487s
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
