### PR TITLE
Add computed version attribute to vault_kv_secret_v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ IMPROVEMENTS:
 
 * `resource/vault_token`: Added deprecation warning to guide users toward the new ephemeral `vault_token` resource for better security and batch token support. ([#2877](https://github.com/hashicorp/terraform-provider-vault/pull/2877))
 * Replaced backend with mount in `vault_aws_access_credentials` resource's documentation and improved descriptions for a few other parameters.([#2911](https://github.com/hashicorp/terraform-provider-vault/pull/2911))
+* `vault_kv_secret_v2`: Added computed `version` attribute, set from the version returned by Vault on the most recent write, so dependent resources can reference the secret version produced within the same apply. Closes [#2562](https://github.com/hashicorp/terraform-provider-vault/issues/2562).
 
 ## 5.9.0 (April 22, 2026)
 

--- a/vault/resource_kv_secret_v2.go
+++ b/vault/resource_kv_secret_v2.go
@@ -43,6 +43,19 @@ func kvSecretV2DisableReadDiff(ctx context.Context, diff *schema.ResourceDiff, m
 		diff.Clear(consts.FieldData)
 		diff.Clear(consts.FieldMetadata)
 	}
+
+	// When the secret data is (re)written, Vault assigns a new version. Mark the
+	// computed version attribute as "known after apply" so the new value is
+	// resolved during the same apply (e.g. for dependent resources and outputs)
+	// rather than lagging until the next refresh. A new resource always writes,
+	// and data_json / data_json_wo (tracked via its version counter) changes
+	// trigger a write as well.
+	if diff.Id() == "" || diff.HasChange(consts.FieldDataJSON) || diff.HasChange(consts.FieldDataJSONWOVersion) {
+		if err := diff.SetNewComputed(consts.FieldVersion); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -143,6 +156,14 @@ func kvSecretV2Resource(name string) *schema.Resource {
 				Description: "Metadata associated with this secret read from Vault.",
 			},
 
+			consts.FieldVersion: {
+				Type:     schema.TypeInt,
+				Computed: true,
+				Description: "Version of the secret. Set from the version returned by " +
+					"Vault on the most recent write, so it reflects the version produced " +
+					"by the current apply.",
+			},
+
 			"delete_all_versions": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -241,11 +262,25 @@ func kvSecretV2Write(ctx context.Context, d *schema.ResourceData, meta interface
 		data[k] = d.Get(k)
 	}
 
-	if _, err := util.RetryWrite(client, path, data, util.DefaultRequestOpts()); err != nil {
+	resp, err := util.RetryWrite(client, path, data, util.DefaultRequestOpts())
+	if err != nil {
 		return diag.FromErr(err)
 	}
 
 	d.SetId(path)
+
+	// The KV-V2 data write response returns the version that Vault assigned to
+	// this write. Set it here so the attribute is populated even when
+	// disable_read is true. When disable_read is false, the kvSecretV2Read call
+	// below refreshes it from the secret's metadata.
+	if resp != nil {
+		if v, ok := resp.Data[consts.FieldVersion]; ok {
+			version, _ := v.(json.Number).Int64()
+			if err := d.Set(consts.FieldVersion, version); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
 
 	// Write custom metadata for secret if provided
 	if _, ok := d.GetOk(consts.FieldCustomMetadata); ok {
@@ -318,6 +353,15 @@ func kvSecretV2Read(_ context.Context, d *schema.ResourceData, meta interface{})
 			if v, ok := metadata.(map[string]interface{}); ok {
 				if err := d.Set(consts.FieldMetadata, serializeDataMapToString(v)); err != nil {
 					return diag.FromErr(err)
+				}
+
+				// Keep the typed version attribute populated on read (e.g.
+				// refresh and import), reusing the metadata already fetched.
+				if rawVersion, ok := v[consts.FieldVersion]; ok {
+					version, _ := rawVersion.(json.Number).Int64()
+					if err := d.Set(consts.FieldVersion, version); err != nil {
+						return diag.FromErr(err)
+					}
 				}
 
 				// Read & Set custom metadata

--- a/vault/resource_kv_secret_v2_test.go
+++ b/vault/resource_kv_secret_v2_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"reflect"
 	"testing"
 
@@ -97,6 +98,7 @@ func TestAccKVSecretV2(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "custom_metadata.0.max_versions", "0"),
 					resource.TestCheckResourceAttr(resourceName, "metadata.%", "5"),
 					resource.TestCheckResourceAttr(resourceName, "metadata.version", "1"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldVersion, "1"),
 					resource.TestCheckResourceAttr(resourceName, "metadata.destroyed", "false"),
 					resource.TestCheckResourceAttr(resourceName, "metadata.deletion_time", ""),
 					resource.TestCheckResourceAttr(resourceName, "metadata.custom_metadata", "null"),
@@ -104,6 +106,14 @@ func TestAccKVSecretV2(t *testing.T) {
 			},
 			{
 				Config: testKVSecretV2Config_updated(mount, name),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						// Updating the secret data must mark version as
+						// "(known after apply)" so the new version is available
+						// to dependent resources within the same apply.
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New(consts.FieldVersion)),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, consts.FieldMount, mount),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldName, name),
@@ -118,6 +128,7 @@ func TestAccKVSecretV2(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "custom_metadata.0.max_versions", "5"),
 					resource.TestCheckResourceAttr(resourceName, "metadata.%", "5"),
 					resource.TestCheckResourceAttr(resourceName, "metadata.version", "2"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldVersion, "2"),
 					resource.TestCheckResourceAttr(resourceName, "metadata.destroyed", "false"),
 					resource.TestCheckResourceAttr(resourceName, "metadata.deletion_time", ""),
 					resource.TestCheckResourceAttr(resourceName, "metadata.custom_metadata", customMetadata),
@@ -179,6 +190,9 @@ func TestAccKVSecretV2_DisableRead(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, consts.FieldName, name),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, fmt.Sprintf("%s/data/%s", mount, name)),
 					resource.TestCheckResourceAttr(resourceName, "disable_read", "true"),
+					// version is populated from the write response even though
+					// reads are disabled.
+					resource.TestCheckResourceAttr(resourceName, consts.FieldVersion, "1"),
 				),
 			},
 			{
@@ -191,6 +205,10 @@ func TestAccKVSecretV2_DisableRead(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, consts.FieldName, name),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, fmt.Sprintf("%s/data/%s", mount, name)),
 					resource.TestCheckResourceAttr(resourceName, "disable_read", "true"),
+					// An external write bumped the secret to version 2, but with
+					// disable_read=true the config is unchanged so Terraform does
+					// not re-write and version stays 1 in state (no drift).
+					resource.TestCheckResourceAttr(resourceName, consts.FieldVersion, "1"),
 				),
 			},
 			{
@@ -203,6 +221,7 @@ func TestAccKVSecretV2_DisableRead(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, consts.FieldName, name),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, fmt.Sprintf("%s/data/%s", mount, name)),
 					resource.TestCheckResourceAttr(resourceName, "disable_read", "true"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldVersion, "1"),
 				),
 			},
 		},
@@ -229,6 +248,7 @@ func TestAccKVSecretV2_data_json_wo(t *testing.T) {
 						"foo": "baz",
 					}),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldDataJSONWOVersion, "1"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldVersion, "1"),
 				),
 			},
 			{
@@ -237,6 +257,10 @@ func TestAccKVSecretV2_data_json_wo(t *testing.T) {
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+						// Bumping data_json_wo_version rewrites the secret, so
+						// version must be marked "(known after apply)" and resolved
+						// within the same apply.
+						plancheck.ExpectUnknownValue(resourceName, tfjsonpath.New(consts.FieldVersion)),
 					},
 				},
 				Check: resource.ComposeTestCheckFunc(
@@ -245,6 +269,7 @@ func TestAccKVSecretV2_data_json_wo(t *testing.T) {
 						"foo": "bar",
 					}),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldDataJSONWOVersion, "2"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldVersion, "2"),
 				),
 			},
 			testutil.GetImportTestStep(resourceName, false, nil, consts.FieldDataJSONWO, consts.FieldDataJSONWOVersion,

--- a/website/docs/r/kv_secret_v2.html.md
+++ b/website/docs/r/kv_secret_v2.html.md
@@ -118,6 +118,10 @@ The following attributes are exported in addition to the above:
 
 * `metadata` - Metadata associated with this secret read from Vault.
 
+* `version` - Version of the secret. Set from the version returned by Vault on the
+  most recent write, so it reflects the version produced by the current apply. This can
+  be used to trigger dependent resources when the secret changes.
+
 ## Import
 
 KV-V2 secrets can be imported using the `path`, e.g.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
Expose the KV-V2 secret version so dependent resources can reference the version produced within the same apply. The value is sourced from the data-write response (authoritative for the write) and refreshed from secret metadata on read.

Closes #2562

### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions

Tests ran against Vault CE latest version.

### Output from acceptance testing:

```
❯ make testacc TEST_PATH=./vault/ TESTARGS='-run=TestAccKVSecretV2 -test.v'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -run=TestAccKVSecretV2 -test.v -timeout 30m ./vault/
=== RUN   TestAccKVSecretV2_pathRegex
=== RUN   TestAccKVSecretV2_pathRegex/no_nesting
=== RUN   TestAccKVSecretV2_pathRegex/nested
=== RUN   TestAccKVSecretV2_pathRegex/nested-with-double-data
--- PASS: TestAccKVSecretV2_pathRegex (0.00s)
    --- PASS: TestAccKVSecretV2_pathRegex/no_nesting (0.00s)
    --- PASS: TestAccKVSecretV2_pathRegex/nested (0.00s)
    --- PASS: TestAccKVSecretV2_pathRegex/nested-with-double-data (0.00s)
=== RUN   TestAccKVSecretV2
=== PAUSE TestAccKVSecretV2
=== RUN   TestAccKVSecretV2_DisableRead
=== PAUSE TestAccKVSecretV2_DisableRead
=== RUN   TestAccKVSecretV2_data_json_wo
=== PAUSE TestAccKVSecretV2_data_json_wo
=== RUN   TestAccKVSecretV2_WriteOnlyMigration
=== PAUSE TestAccKVSecretV2_WriteOnlyMigration
=== CONT  TestAccKVSecretV2
=== CONT  TestAccKVSecretV2_data_json_wo
=== CONT  TestAccKVSecretV2_WriteOnlyMigration
=== CONT  TestAccKVSecretV2_DisableRead
--- PASS: TestAccKVSecretV2_data_json_wo (2.50s)
--- PASS: TestAccKVSecretV2_DisableRead (2.59s)
--- PASS: TestAccKVSecretV2 (4.72s)
--- PASS: TestAccKVSecretV2_WriteOnlyMigration (5.50s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/vault	5.537s

```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
