### PR TITLE
Add test coverage to safeguard PKI resource recreation after provider upgrades when schema changes

### DIFF
--- a/vault/resource_pki_secret_backend_cert_test.go
+++ b/vault/resource_pki_secret_backend_cert_test.go
@@ -146,6 +146,68 @@ func TestPkiSecretBackendCert_basic(t *testing.T) {
 	})
 }
 
+// TestPkiSecretBackendCert_Upgrade verifies upgrades do not force recreation of "vault_pki_secret_backend_cert"
+// and "vault_pki_secret_backend_root_cert" resources.
+// This safeguards against unintended schema changes that would trigger resource replacement.
+func TestPkiSecretBackendCert_Upgrade(t *testing.T) {
+	path := "pki-" + strconv.Itoa(acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		CheckDestroy: testCheckMountDestroyed("vault_mount", consts.MountTypePKI, consts.FieldPath),
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"vault": {
+						VersionConstraint: "5.9.0",
+						Source:            "hashicorp/vault",
+					},
+				},
+				Config: testPkiSecretBackendCertConfig_upgrade(path),
+			},
+			{
+				ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+				Config:                   testPkiSecretBackendCertConfig_upgrade(path),
+				PlanOnly:                 true,
+				ExpectNonEmptyPlan:       false,
+				// Upgrading from v5.9.x to the current provider should be a no-op plan.
+				// If this step fails and the diff is intentional, update the baseline version (preferred) or
+				// expected assertions to reflect the new upgrade contract.
+				// Do not just flip ExpectNonEmptyPlan to true.
+			},
+		},
+	})
+}
+
+// Minimal definition of resources with only required parameters
+func testPkiSecretBackendCertConfig_upgrade(path string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "test" {
+  path  = "%s"
+  type  = "pki"
+}
+
+resource "vault_pki_secret_backend_root_cert" "test" {
+  backend     = vault_mount.test.path
+  type        = "internal"
+  common_name = "RootOrg Root CA"
+}
+
+resource "vault_pki_secret_backend_role" "test" {
+  backend          = vault_mount.test.path
+  name             = "test"
+  allowed_domains  = ["test.my.domain"]
+  allow_subdomains = true
+}
+
+resource "vault_pki_secret_backend_cert" "test" {
+  backend     = vault_mount.test.path
+  name        = vault_pki_secret_backend_role.test.name
+  common_name = "cert.test.my.domain"
+	ttl         = "1h"
+}
+`, path)
+}
+
 func testPkiSecretBackendCertConfig_basic(rootPath, intermediatePath string, withCert bool, certFields certFields) string {
 	fragments := []string{
 		fmt.Sprintf(`

--- a/vault/resource_pki_secret_backend_root_sign_intermediate_test.go
+++ b/vault/resource_pki_secret_backend_root_sign_intermediate_test.go
@@ -632,6 +632,66 @@ func assertCertificateAttributes(res string, notAfter string, expectedSignatureA
 	}
 }
 
+// TestPkiSecretBackendRootSignIntermediate_Upgrade verifies upgrades do not force recreation of "vault_pki_secret_backend_root_sign_intermediate" resources.
+// This safeguards against unintended schema changes that would trigger resource replacement.
+func TestPkiSecretBackendRootSignIntermediate_Upgrade(t *testing.T) {
+	path := "pki-" + strconv.Itoa(acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		CheckDestroy: testCheckMountDestroyed("vault_mount", consts.MountTypePKI, consts.FieldPath),
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"vault": {
+						VersionConstraint: "5.9.0",
+						Source:            "hashicorp/vault",
+					},
+				},
+				Config: testPkiSecretBackendRootSignIntermediateConfig_upgrade(path),
+			},
+			{
+				ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+				Config:                   testPkiSecretBackendRootSignIntermediateConfig_upgrade(path),
+				PlanOnly:                 true,
+				ExpectNonEmptyPlan:       false,
+				// Upgrading from v5.9.x to the current provider should be a no-op plan.
+				// If this step fails and the diff is intentional, update the baseline version (preferred) or
+				// expected assertions to reflect the new upgrade contract.
+				// Do not just flip ExpectNonEmptyPlan to true.
+			},
+		},
+	})
+}
+
+// Minimal definition of resources with only required parameters
+func testPkiSecretBackendRootSignIntermediateConfig_upgrade(path string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "test" {
+  path  = "%s"
+  type  = "pki"
+}
+
+resource "vault_pki_secret_backend_root_cert" "test" {
+  backend     = vault_mount.test.path
+  type        = "internal"
+	common_name = "RootOrg Root CA"
+}
+
+resource "vault_pki_secret_backend_intermediate_cert_request" "test" {
+  depends_on  = [vault_pki_secret_backend_root_cert.test]
+  backend     = vault_mount.test.path
+	common_name = "SubOrg Intermediate CA"
+  type        = "internal"
+}
+
+resource "vault_pki_secret_backend_root_sign_intermediate" "test" {
+  backend     = vault_mount.test.path
+  csr         = vault_pki_secret_backend_intermediate_cert_request.test.csr
+	common_name = "SubOrg Intermediate CA"
+}
+`, path)
+}
+
 func testPkiSecretBackendRootSignIntermediateConfig_basic(rootPath, path string, revoke bool, extra ...string) string {
 	config := fmt.Sprintf(`
 resource "vault_mount" "test-root" {

--- a/vault/resource_pki_secret_backend_sign_test.go
+++ b/vault/resource_pki_secret_backend_sign_test.go
@@ -70,6 +70,97 @@ func TestPkiSecretBackendSign_basic(t *testing.T) {
 	})
 }
 
+// TestPkiSecretBackendSign_Upgrade verifies upgrades do not force recreation of "vault_pki_secret_backend_sign" resources.
+// This safeguards against unintended schema changes that would trigger resource replacement.
+func TestPkiSecretBackendSign_Upgrade(t *testing.T) {
+	path := "pki-" + strconv.Itoa(acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		CheckDestroy: testCheckMountDestroyed("vault_mount", consts.MountTypePKI, consts.FieldPath),
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"vault": {
+						VersionConstraint: "5.9.0",
+						Source:            "hashicorp/vault",
+					},
+				},
+				Config: testPkiSecretBackendSignConfig_upgrade(path),
+			},
+			{
+				ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+				Config:                   testPkiSecretBackendSignConfig_upgrade(path),
+				PlanOnly:                 true,
+				ExpectNonEmptyPlan:       false,
+				// Upgrading from v5.9.x to the current provider should be a no-op plan.
+				// If this step fails and the diff is intentional, update the baseline version (preferred) or
+				// expected assertions to reflect the new upgrade contract.
+				// Do not just flip ExpectNonEmptyPlan to true.
+			},
+		},
+	})
+}
+
+// Minimal definition of resources with only required parameters
+func testPkiSecretBackendSignConfig_upgrade(path string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "test" {
+  path                      = "%s"
+  type                      = "pki"
+  description               = "test root"
+}
+
+resource "vault_pki_secret_backend_root_cert" "test" {
+  backend     = vault_mount.test.path
+  type        = "internal"
+  common_name = "my.domain"
+}
+
+resource "vault_pki_secret_backend_role" "test" {
+  backend          = vault_mount.test.path
+  name             = "test"
+  allowed_domains  = ["test.my.domain"]
+  allow_subdomains = true
+}
+
+resource "vault_pki_secret_backend_sign" "test" {
+  backend     = vault_mount.test.path
+  name        = vault_pki_secret_backend_role.test.name
+	ttl         = "1h"
+  csr         = <<EOT
+-----BEGIN CERTIFICATE REQUEST-----
+MIIEqDCCApACAQAwYzELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUx
+ITAfBgNVBAoMGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDEcMBoGA1UEAwwTY2Vy
+dC50ZXN0Lm15LmRvbWFpbjCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIB
+AJupYCQ8UVCWII1Zof1c6YcSSaM9hEaDU78cfKP5RoSeH10BvrWRfT+mzCONVpNP
+CW9Iabtvk6hm0ot6ilnndEyVJbc0g7hdDLBX5BM25D+DGZGJRKUz1V+uBrWmXtIt
+Vonj7JTDTe7ViH0GDsB7CvqXFGXO2a2cDYBchLkL6vQiFPshxvUsLtwxuy/qdYgy
+X6ya+AUoZcoQGy1XxNjfH6cPtWSWQGEp1oPR6vL9hU3laTZb3C+VV4jZem+he8/0
+V+qV6fLG92WTXm2hmf8nrtUqqJ+C7mW/RJod+TviviBadIX0OHXW7k5HVsZood01
+te8vMRUNJNiZfa9EMIK5oncbQn0LcM3Wo9VrjpL7jREb/4HCS2gswYGv7hzk9cCS
+kVY4rDucchKbApuI3kfzmO7GFOF5eiSkYZpY/czNn7VVM3WCu6dpOX4+3rhgrZQw
+kY14L930DaLVRUgve/zKVP2D2GHdEOs+MbV7s96UgigT9pXly/yHPj+1sSYqmnaD
+5b7jSeJusmzO/nrwXVGLsnezR87VzHl9Ux9g5s6zh+R+PrZuVxYsLvoUpaasH47O
+gIcBzSb/6pSGZKAUizmYsHsR1k88dAvsQ+FsUDaNokdi9VndEB4QPmiFmjyLV+0I
+1TFoXop4sW11NPz1YCq+IxnYrEaIN3PyhY0GvBJDFY1/AgMBAAGgADANBgkqhkiG
+9w0BAQsFAAOCAgEActuqnqS8Y9UF7e08w7tR3FPzGecWreuvxILrlFEZJxiLPFqL
+It7uJvtypCVQvz6UQzKdBYO7tMpRaWViB8DrWzXNZjLMrg+QHcpveg8C0Ett4scG
+fnvLk6fTDFYrnGvwHTqiHos5i0y3bFLyS1BGwSpdLAykGtvC+VM8mRyw/Y7CPcKN
+77kebY/9xduW1g2uxWLr0x90RuQDv9psPojT+59tRLGSp5Kt0IeD3QtnAZEFE4aN
+vt+Pd69eg3BgZ8ZeDgoqAw3yppvOkpAFiE5pw2qPZaM4SRphl4d2Lek2zNIMyZqv
+do5zh356HOgXtDaSg0POnRGrN/Ua+LMCRTg6GEPUnx9uQb/zt8Zu0hIexDGyykp1
+OGqtWlv/Nc8UYuS38v0BeB6bMPeoqQUjkqs8nHlAEFn0KlgYdtDC+7SdQx6wS4te
+dBKRNDfC4lS3jYJgs55jHqonZgkpSi3bamlxpfpW0ukGBcmq91wRe4bOw/4uD/vf
+UwqMWOdCYcU3mdYNjTWy22ORW3SGFQxMBwpUEURCSoeqWr6aJeQ7KAYkx1PrB5T8
+OTEc13lWf+B0PU9UJuGTsmpIuImPDVd0EVDayr3mT5dDbqTVDbe8ppf2IswABmf0
+o3DybUeUmknYjl109rdSf+76nuREICHatxXgN3xCMFuBaN4WLO+ksd6Y1Ys=
+-----END CERTIFICATE REQUEST-----
+EOT
+  common_name = "cert.test.my.domain"
+}
+`, path)
+}
+
 func testPkiSecretBackendSignConfig_basic(rootPath, intermediatePath, extraConfig string) string {
 	return fmt.Sprintf(`
 resource "vault_mount" "test-root" {


### PR DESCRIPTION
Add test coverage so we don't accidentally recreate the following PKI resources in the future:
`vault_pki_secret_backend_cert`
`vault_pki_secret_backend_root_cert`
`vault_pki_secret_backend_root_sign_intermediate`
`vault_pki_secret_backend_sign`

(The following are tested indirectly since they're required for mount setup and cert issuance)
`vault_pki_secret_backend_role`
`vault_mount`

Coverage is added in response to this issue: #2941

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->



### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
