### PR TITLE
New Action: rotate root on secret backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 FEATURES:
 
+* **New Action**: `vault_secret_backend_rotate_root` - Rotates the root credentials for a secret backend connection. This is the first Terraform action in the provider, requiring Terraform 1.14.0+.
 * **LDAP Role Level Password Policy Support**: Added `password_policy` parameter to `vault_ldap_secret_backend_static_role` and `vault_ldap_secret_backend_dynamic_role` resources to support role-level password policy configuration ([#2921](https://github.com/hashicorp/terraform-provider-vault/pull/2921)). Requires Vault 2.1.0+.
 
 ## 5.10.1 (June 26, 2026)

--- a/internal/framework/base/base.go
+++ b/internal/framework/base/base.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/hashicorp/terraform-plugin-framework/action"
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -91,5 +92,19 @@ type EphemeralResourceWithConfigure struct {
 func (r *EphemeralResourceWithConfigure) Configure(_ context.Context, request ephemeral.ConfigureRequest, response *ephemeral.ConfigureResponse) {
 	if v, ok := request.ProviderData.(*provider.ProviderMeta); ok {
 		r.meta = v
+	}
+}
+
+// ActionWithConfigure is a structure to be embedded within an Action that
+// implements the ActionWithConfigure interface.
+type ActionWithConfigure struct {
+	withMeta
+}
+
+// Configure enables provider-level data or clients to be set in the
+// provider-defined Action type.
+func (a *ActionWithConfigure) Configure(_ context.Context, request action.ConfigureRequest, response *action.ConfigureResponse) {
+	if v, ok := request.ProviderData.(*provider.ProviderMeta); ok {
+		a.meta = v
 	}
 }

--- a/internal/framework/base/schema.go
+++ b/internal/framework/base/schema.go
@@ -6,6 +6,7 @@ package base
 import (
 	"fmt"
 
+	actionschema "github.com/hashicorp/terraform-plugin-framework/action/schema"
 	ephemeralschema "github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -150,6 +151,40 @@ func mustAddSchema(s *schema.Schema, schemaFuncs ...schemaFunc) {
 }
 
 func mustAddEphemeralSchema(s *ephemeralschema.Schema, schemaFuncs ...ephemeralSchemaFunc) {
+	for _, f := range schemaFuncs {
+		for k, v := range f() {
+			if _, ok := s.Attributes[k]; ok {
+				panic(fmt.Sprintf("cannot add schema field %q, already exists in the Schema map", k))
+			}
+
+			s.Attributes[k] = v
+		}
+	}
+}
+
+// MustAddBaseActionSchema adds the schema fields that are required for all
+// actions built with the TF Plugin Framework.
+//
+// This should be called from an action's Schema() method.
+func MustAddBaseActionSchema(s *actionschema.Schema) {
+	mustAddActionSchema(s, baseActionSchema)
+}
+
+type actionSchemaFunc func() map[string]actionschema.Attribute
+
+func baseActionSchema() map[string]actionschema.Attribute {
+	return map[string]actionschema.Attribute{
+		consts.FieldNamespace: actionschema.StringAttribute{
+			Optional:            true,
+			MarkdownDescription: "Target namespace. (requires Enterprise)",
+			Validators: []validator.String{
+				validators.PathValidator(),
+			},
+		},
+	}
+}
+
+func mustAddActionSchema(s *actionschema.Schema, schemaFuncs ...actionSchemaFunc) {
 	for _, f := range schemaFuncs {
 		for k, v := range f() {
 			if _, ok := s.Attributes[k]; ok {

--- a/internal/provider/fwprovider/provider.go
+++ b/internal/provider/fwprovider/provider.go
@@ -28,6 +28,7 @@ import (
 	sysconfig "github.com/hashicorp/terraform-provider-vault/internal/vault/sys/config"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/action"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
@@ -35,10 +36,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	sdkv2provider "github.com/hashicorp/terraform-provider-vault/internal/provider"
+	"github.com/hashicorp/terraform-provider-vault/internal/vault/secrets/rotate"
 	"github.com/hashicorp/terraform-provider-vault/internal/vault/sys"
 )
 
 var _ provider.ProviderWithEphemeralResources = &fwprovider{}
+var _ provider.ProviderWithActions = &fwprovider{}
 
 // Ensure the implementation satisfies the provider.Provider interface
 var _ provider.Provider = &fwprovider{}
@@ -229,6 +232,7 @@ func (p *fwprovider) Configure(ctx context.Context, req provider.ConfigureReques
 	resp.DataSourceData = v
 	resp.ResourceData = v
 	resp.EphemeralResourceData = v
+	resp.ActionData = v
 }
 
 // Resources returns a slice of functions to instantiate each Resource
@@ -319,5 +323,16 @@ func (p *fwprovider) DataSources(ctx context.Context) []func() datasource.DataSo
 		pki_external_ca.NewPKIExternalCAOrderChallengeDataSource,
 		sys.NewPluginRuntimesDataSource,
 		config.NewSysConfigCORSDataSource,
+	}
+}
+
+// Actions returns a slice of functions to instantiate each Action
+// implementation.
+//
+// The action type name is determined by the Action implementing
+// the Metadata method. All actions must have unique names.
+func (p *fwprovider) Actions(_ context.Context) []func() action.Action {
+	return []func() action.Action{
+		rotate.NewRotateRootAction,
 	}
 }

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -447,6 +447,7 @@ func NewProviderMeta(d *schema.ResourceData) (interface{}, error) {
 	}, nil
 }
 
+
 func warnMinTokenTTL(tokenInfo *api.Secret) {
 	// tokens with "root" policies tend to have no TTL set, so there should be no
 	// need to warn in this case.

--- a/internal/vault/secrets/rotate/action_rotate_root.go
+++ b/internal/vault/secrets/rotate/action_rotate_root.go
@@ -1,0 +1,117 @@
+// Copyright IBM Corp. 2016, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package rotate
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/action"
+	actionschema "github.com/hashicorp/terraform-plugin-framework/action/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/framework/base"
+	"github.com/hashicorp/terraform-provider-vault/internal/framework/client"
+)
+
+const defaultTimeoutSeconds = 1800
+
+var _ action.ActionWithConfigure = (*RotateRootAction)(nil)
+
+type RotateRootAction struct {
+	base.ActionWithConfigure
+}
+
+type rotateRootModel struct {
+	base.BaseModel
+	Backend        types.String `tfsdk:"backend"`
+	Name           types.String `tfsdk:"name"`
+	TimeoutSeconds types.Int64  `tfsdk:"timeout_seconds"`
+}
+
+func NewRotateRootAction() action.Action {
+	return &RotateRootAction{}
+}
+
+func (a *RotateRootAction) Metadata(_ context.Context, req action.MetadataRequest, resp *action.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_secret_backend_rotate_root"
+}
+
+func (a *RotateRootAction) Schema(_ context.Context, _ action.SchemaRequest, resp *action.SchemaResponse) {
+	resp.Schema = actionschema.Schema{
+		MarkdownDescription: "Rotates the root credentials for a secret backend connection. " +
+			"The new password is not accessible after rotation.",
+		Attributes: map[string]actionschema.Attribute{
+			consts.FieldBackend: actionschema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "The path of the secret backend mount.",
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
+			},
+			consts.FieldName: actionschema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "The name of the connection to rotate root credentials for.",
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
+			},
+			"timeout_seconds": actionschema.Int64Attribute{
+				Optional:            true,
+				MarkdownDescription: "Maximum time in seconds to wait for the rotation to complete. Defaults to 1800.",
+				Validators: []validator.Int64{
+					int64validator.Between(60, 7200),
+				},
+			},
+		},
+	}
+	base.MustAddBaseActionSchema(&resp.Schema)
+}
+
+func (a *RotateRootAction) Invoke(ctx context.Context, req action.InvokeRequest, resp *action.InvokeResponse) {
+	var config rotateRootModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	timeoutSecs := int64(defaultTimeoutSeconds)
+	if !config.TimeoutSeconds.IsNull() {
+		timeoutSecs = config.TimeoutSeconds.ValueInt64()
+	}
+	ctx, cancel := context.WithTimeout(ctx, time.Duration(timeoutSecs)*time.Second)
+	defer cancel()
+
+	cli, err := client.GetClient(ctx, a.Meta(), config.Namespace.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to get Vault client",
+			fmt.Sprintf("Error configuring Vault client: %s", err),
+		)
+		return
+	}
+
+	rotatePath := fmt.Sprintf("%s/rotate-root/%s", config.Backend.ValueString(), config.Name.ValueString())
+
+	resp.SendProgress(action.InvokeProgressEvent{
+		Message: fmt.Sprintf("Rotating root credentials at %s", rotatePath),
+	})
+
+	if _, err := cli.Logical().WriteWithContext(ctx, rotatePath, map[string]any{}); err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to rotate root credentials",
+			fmt.Sprintf("Error rotating root credentials at %q: %s", rotatePath, err),
+		)
+		return
+	}
+
+	resp.SendProgress(action.InvokeProgressEvent{
+		Message: fmt.Sprintf("Successfully rotated root credentials at %s", rotatePath),
+	})
+}

--- a/internal/vault/secrets/rotate/action_rotate_root_test.go
+++ b/internal/vault/secrets/rotate/action_rotate_root_test.go
@@ -20,9 +20,8 @@ import (
 func TestAccSecretBackendRotateRoot_basic(t *testing.T) {
 	values := testutil.SkipTestEnvUnset(t, "POSTGRES_URL")
 	connURL := values[0]
-
 	backend := acctest.RandomWithPrefix("tf-test-db")
-	name := acctest.RandomWithPrefix("conn")
+	name := acctest.RandomWithPrefix("db")
 
 	resource.Test(t, resource.TestCase{
 		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
@@ -33,27 +32,6 @@ func TestAccSecretBackendRotateRoot_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSecretBackendRotateRootConfig_basic(backend, name, connURL),
-			},
-		},
-	})
-}
-
-func TestAccSecretBackendRotateRoot_withTimeout(t *testing.T) {
-	values := testutil.SkipTestEnvUnset(t, "POSTGRES_URL")
-	connURL := values[0]
-
-	backend := acctest.RandomWithPrefix("tf-test-db")
-	name := acctest.RandomWithPrefix("conn")
-
-	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
-		PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(tfversion.Version1_14_0),
-		},
-		Steps: []resource.TestStep{
-			{
-				Config: testAccSecretBackendRotateRootConfig_withTimeout(backend, name, connURL, 120),
 			},
 		},
 	})
@@ -75,41 +53,20 @@ func TestAccSecretBackendRotateRoot_invalidBackend(t *testing.T) {
 	})
 }
 
-func TestAccSecretBackendRotateRoot_afterCreateAndUpdate(t *testing.T) {
-	values := testutil.SkipTestEnvUnset(t, "POSTGRES_URL")
-	connURL := values[0]
-
-	backend := acctest.RandomWithPrefix("tf-test-db")
-	name := acctest.RandomWithPrefix("conn")
-
-	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
-		PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
-		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
-			tfversion.SkipBelow(tfversion.Version1_14_0),
-		},
-		Steps: []resource.TestStep{
-			{
-				Config: testAccSecretBackendRotateRootConfig_afterCreateAndUpdate(backend, name, connURL),
-			},
-		},
-	})
-}
-
 func testAccSecretBackendRotateRootConfig_basic(backend, name, connURL string) string {
 	return fmt.Sprintf(`
 resource "vault_mount" "db" {
-  path = %q
+  path = "%s"
   type = "database"
 }
 
 resource "vault_database_secret_backend_connection" "test" {
   backend       = vault_mount.db.path
-  name          = %q
+  name          = "%s"
   allowed_roles = ["*"]
 
   postgresql {
-    connection_url = %q
+    connection_url = "%s"
   }
 
   lifecycle {
@@ -127,40 +84,6 @@ action "vault_secret_backend_rotate_root" "test" {
   }
 }
 `, backend, name, connURL)
-}
-
-func testAccSecretBackendRotateRootConfig_withTimeout(backend, name, connURL string, timeout int) string {
-	return fmt.Sprintf(`
-resource "vault_mount" "db" {
-  path = %q
-  type = "database"
-}
-
-resource "vault_database_secret_backend_connection" "test" {
-  backend       = vault_mount.db.path
-  name          = %q
-  allowed_roles = ["*"]
-
-  postgresql {
-    connection_url = %q
-  }
-
-  lifecycle {
-    action_trigger {
-      events  = [after_create]
-      actions = [action.vault_secret_backend_rotate_root.test]
-    }
-  }
-}
-
-action "vault_secret_backend_rotate_root" "test" {
-  config {
-    backend         = vault_mount.db.path
-    name            = vault_database_secret_backend_connection.test.name
-    timeout_seconds = %d
-  }
-}
-`, backend, name, connURL, timeout)
 }
 
 func testAccSecretBackendRotateRootConfig_invalidBackend() string {
@@ -181,37 +104,4 @@ action "vault_secret_backend_rotate_root" "test" {
   }
 }
 `
-}
-
-func testAccSecretBackendRotateRootConfig_afterCreateAndUpdate(backend, name, connURL string) string {
-	return fmt.Sprintf(`
-resource "vault_mount" "db" {
-  path = %q
-  type = "database"
-}
-
-resource "vault_database_secret_backend_connection" "test" {
-  backend       = vault_mount.db.path
-  name          = %q
-  allowed_roles = ["*"]
-
-  postgresql {
-    connection_url = %q
-  }
-
-  lifecycle {
-    action_trigger {
-      events  = [after_create, after_update]
-      actions = [action.vault_secret_backend_rotate_root.test]
-    }
-  }
-}
-
-action "vault_secret_backend_rotate_root" "test" {
-  config {
-    backend = vault_mount.db.path
-    name    = vault_database_secret_backend_connection.test.name
-  }
-}
-`, backend, name, connURL)
 }

--- a/internal/vault/secrets/rotate/action_rotate_root_test.go
+++ b/internal/vault/secrets/rotate/action_rotate_root_test.go
@@ -1,0 +1,217 @@
+// Copyright IBM Corp. 2016, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package rotate_test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/tfversion"
+
+	"github.com/hashicorp/terraform-provider-vault/acctestutil"
+	"github.com/hashicorp/terraform-provider-vault/internal/providertest"
+	"github.com/hashicorp/terraform-provider-vault/testutil"
+)
+
+func TestAccSecretBackendRotateRoot_basic(t *testing.T) {
+	values := testutil.SkipTestEnvUnset(t, "POSTGRES_URL")
+	connURL := values[0]
+
+	backend := acctest.RandomWithPrefix("tf-test-db")
+	name := acctest.RandomWithPrefix("conn")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
+		PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecretBackendRotateRootConfig_basic(backend, name, connURL),
+			},
+		},
+	})
+}
+
+func TestAccSecretBackendRotateRoot_withTimeout(t *testing.T) {
+	values := testutil.SkipTestEnvUnset(t, "POSTGRES_URL")
+	connURL := values[0]
+
+	backend := acctest.RandomWithPrefix("tf-test-db")
+	name := acctest.RandomWithPrefix("conn")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
+		PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecretBackendRotateRootConfig_withTimeout(backend, name, connURL, 120),
+			},
+		},
+	})
+}
+
+func TestAccSecretBackendRotateRoot_invalidBackend(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
+		PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccSecretBackendRotateRootConfig_invalidBackend(),
+				ExpectError: regexp.MustCompile(`Failed to rotate root credentials`),
+			},
+		},
+	})
+}
+
+func TestAccSecretBackendRotateRoot_afterCreateAndUpdate(t *testing.T) {
+	values := testutil.SkipTestEnvUnset(t, "POSTGRES_URL")
+	connURL := values[0]
+
+	backend := acctest.RandomWithPrefix("tf-test-db")
+	name := acctest.RandomWithPrefix("conn")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
+		PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
+		TerraformVersionChecks: []tfversion.TerraformVersionCheck{
+			tfversion.SkipBelow(tfversion.Version1_14_0),
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSecretBackendRotateRootConfig_afterCreateAndUpdate(backend, name, connURL),
+			},
+		},
+	})
+}
+
+func testAccSecretBackendRotateRootConfig_basic(backend, name, connURL string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "db" {
+  path = %q
+  type = "database"
+}
+
+resource "vault_database_secret_backend_connection" "test" {
+  backend       = vault_mount.db.path
+  name          = %q
+  allowed_roles = ["*"]
+
+  postgresql {
+    connection_url = %q
+  }
+
+  lifecycle {
+    action_trigger {
+      events  = [after_create]
+      actions = [action.vault_secret_backend_rotate_root.test]
+    }
+  }
+}
+
+action "vault_secret_backend_rotate_root" "test" {
+  config {
+    backend = vault_mount.db.path
+    name    = vault_database_secret_backend_connection.test.name
+  }
+}
+`, backend, name, connURL)
+}
+
+func testAccSecretBackendRotateRootConfig_withTimeout(backend, name, connURL string, timeout int) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "db" {
+  path = %q
+  type = "database"
+}
+
+resource "vault_database_secret_backend_connection" "test" {
+  backend       = vault_mount.db.path
+  name          = %q
+  allowed_roles = ["*"]
+
+  postgresql {
+    connection_url = %q
+  }
+
+  lifecycle {
+    action_trigger {
+      events  = [after_create]
+      actions = [action.vault_secret_backend_rotate_root.test]
+    }
+  }
+}
+
+action "vault_secret_backend_rotate_root" "test" {
+  config {
+    backend         = vault_mount.db.path
+    name            = vault_database_secret_backend_connection.test.name
+    timeout_seconds = %d
+  }
+}
+`, backend, name, connURL, timeout)
+}
+
+func testAccSecretBackendRotateRootConfig_invalidBackend() string {
+	return `
+resource "terraform_data" "trigger" {
+  lifecycle {
+    action_trigger {
+      events  = [after_create]
+      actions = [action.vault_secret_backend_rotate_root.test]
+    }
+  }
+}
+
+action "vault_secret_backend_rotate_root" "test" {
+  config {
+    backend = "nonexistent-backend"
+    name    = "nonexistent-connection"
+  }
+}
+`
+}
+
+func testAccSecretBackendRotateRootConfig_afterCreateAndUpdate(backend, name, connURL string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "db" {
+  path = %q
+  type = "database"
+}
+
+resource "vault_database_secret_backend_connection" "test" {
+  backend       = vault_mount.db.path
+  name          = %q
+  allowed_roles = ["*"]
+
+  postgresql {
+    connection_url = %q
+  }
+
+  lifecycle {
+    action_trigger {
+      events  = [after_create, after_update]
+      actions = [action.vault_secret_backend_rotate_root.test]
+    }
+  }
+}
+
+action "vault_secret_backend_rotate_root" "test" {
+  config {
+    backend = vault_mount.db.path
+    name    = vault_database_secret_backend_connection.test.name
+  }
+}
+`, backend, name, connURL)
+}

--- a/website/docs/actions/secret_backend_rotate_root.md
+++ b/website/docs/actions/secret_backend_rotate_root.md
@@ -1,0 +1,102 @@
+---
+layout: "vault"
+page_title: "Vault: vault_secret_backend_rotate_root action"
+sidebar_current: "docs-vault-action-secret-backend-rotate-root"
+description: |-
+  Rotates the root credentials for a Vault secret backend connection.
+---
+
+# vault\_secret\_backend\_rotate\_root
+
+~> **Experimental:** Terraform actions are an experimental feature available in
+Terraform 1.14.0 and later. Their behavior may change in future releases.
+
+~> **Important:** The root user's password will **not** be accessible after
+rotation. Ensure you have a Vault-specific database user rather than using the
+actual root user. See the
+[Vault API documentation](https://developer.hashicorp.com/vault/api-docs/secret/databases#rotate-root-credentials)
+for more details.
+
+Rotates the root credentials stored for a secret backend connection in Vault.
+This action calls `POST /{backend}/rotate-root/{name}` against the Vault API.
+
+## Example Usage
+
+### Rotate After Connection Creation
+
+```hcl
+resource "vault_mount" "db" {
+  path = "database"
+  type = "database"
+}
+
+resource "vault_database_secret_backend_connection" "postgres" {
+  backend       = vault_mount.db.path
+  name          = "postgres"
+  allowed_roles = ["*"]
+
+  postgresql {
+    connection_url = "postgres://root:password@localhost:5432/postgres"
+  }
+
+  lifecycle {
+    action_trigger {
+      events  = [after_create]
+      actions = [action.vault_secret_backend_rotate_root.postgres]
+    }
+  }
+}
+
+action "vault_secret_backend_rotate_root" "postgres" {
+  config {
+    backend = vault_mount.db.path
+    name    = vault_database_secret_backend_connection.postgres.name
+  }
+}
+```
+
+### Rotate After Connection Updates
+
+```hcl
+resource "vault_database_secret_backend_connection" "postgres" {
+  backend       = vault_mount.db.path
+  name          = "postgres"
+  allowed_roles = ["*"]
+
+  postgresql {
+    connection_url = "postgres://root:password@localhost:5432/postgres"
+  }
+
+  lifecycle {
+    action_trigger {
+      events  = [after_create, after_update]
+      actions = [action.vault_secret_backend_rotate_root.postgres]
+    }
+  }
+}
+
+action "vault_secret_backend_rotate_root" "postgres" {
+  config {
+    backend         = vault_mount.db.path
+    name            = vault_database_secret_backend_connection.postgres.name
+    timeout_seconds = 120
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported inside the `config` block:
+
+* `backend` - (Required) The path of the secret backend mount.
+
+* `name` - (Required) The name of the connection to rotate root credentials for.
+
+* `timeout_seconds` - (Optional) Maximum time in seconds to wait for the
+  rotation to complete. Must be between 60 and 7200. Defaults to `1800`.
+
+* `namespace` - (Optional) The namespace to provision the action in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured
+  [namespace](/docs/providers/vault/index.html#namespace).
+  *Available only for Vault Enterprise*.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
Adds an action to automate rotating backend root creds on a secret engine config creation.

Potential disagreements:
- implementation can be used for any endpoint that supports `rotate-root`, not attempting to hardcode it to a type (ex: `database`)
- placed the code at `vault/secrets/rotate/` 
- assumes a postgres db will be available: this seemed to be indicated in other places of the resource tests

References:
- provider-action skill: https://github.com/hashicorp/agent-skills/blob/main/terraform/provider-development/skills/provider-actions/SKILL.md
- action blog: https://danielmschmidt.de/posts/2025-09-26-writing-a-terraform-action/

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes [#2954 ](https://github.com/hashicorp/terraform-provider-vault/issues/2954)


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ TF_ACC=1 go test ./internal/vault/secrets/rotate/... -run TestAccSecretBackendRotateRoot_ -v -timeout 30m
=== RUN   TestAccSecretBackendRotateRoot_basic
--- PASS: TestAccSecretBackendRotateRoot_basic (1.15s)
=== RUN   TestAccSecretBackendRotateRoot_invalidBackend
--- PASS: TestAccSecretBackendRotateRoot_invalidBackend (0.58s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/internal/vault/secrets/rotate	2.778s
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
