### PR TITLE
TFVP support for Terraform root rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 FEATURES:
 
 * **LDAP Role Level Password Policy Support**: Added `password_policy` parameter to `vault_ldap_secret_backend_static_role` and `vault_ldap_secret_backend_dynamic_role` resources to support role-level password policy configuration ([#2921](https://github.com/hashicorp/terraform-provider-vault/pull/2921)). Requires Vault 2.1.0+.
+* ** Terraform Secret Engine Root Rotation Support**: Add support for automated root token rotation via the `rotation_period`, `rotation_schedule`, `rotation_window`, and `disable_automated_rotation` fields, and add `explicit_max_ttl` to bound the lifetime of the rotated root token. Requires Vault 2.1.0+. ([#2958](https://github.com/hashicorp/terraform-provider-vault/issues/2958))
 
 ## 5.10.1 (June 26, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 FEATURES:
 
 * **LDAP Role Level Password Policy Support**: Added `password_policy` parameter to `vault_ldap_secret_backend_static_role` and `vault_ldap_secret_backend_dynamic_role` resources to support role-level password policy configuration ([#2921](https://github.com/hashicorp/terraform-provider-vault/pull/2921)). Requires Vault 2.1.0+.
-* ** Terraform Secret Engine Root Rotation Support**: Add support for automated root token rotation via the `rotation_period`, `rotation_schedule`, `rotation_window`, and `disable_automated_rotation` fields, and add `explicit_max_ttl` to bound the lifetime of the rotated root token. Requires Vault 2.1.0+. ([#2958](https://github.com/hashicorp/terraform-provider-vault/issues/2958))
+* **Terraform Secret Engine Root Rotation Support**: Add support for automated root token rotation via the `rotation_period`, `rotation_schedule`, `rotation_window`, and `disable_automated_rotation` fields, and add `explicit_max_ttl` to bound the lifetime of the rotated root token. Requires Vault 2.1.0+. ([#2958](https://github.com/hashicorp/terraform-provider-vault/issues/2958))
 
 ## 5.10.1 (June 26, 2026)
 

--- a/vault/resource_terraform_cloud_secret_backend.go
+++ b/vault/resource_terraform_cloud_secret_backend.go
@@ -279,9 +279,13 @@ func terraformCloudSecretBackendUpdate(ctx context.Context, d *schema.ResourceDa
 	if d.HasChange(consts.FieldAddress) || d.HasChange(consts.FieldBasePath) ||
 		explicitMaxTTLChanged || rotationFieldsChanged {
 		log.Printf("[DEBUG] Updating Terraform Cloud configuration at %q", configPath)
-		data := map[string]interface{}{
-			consts.FieldAddress:  d.Get(consts.FieldAddress).(string),
-			consts.FieldBasePath: d.Get(consts.FieldBasePath).(string),
+		data := map[string]interface{}{}
+
+		if d.HasChange(consts.FieldAddress) {
+			data[consts.FieldAddress] = d.Get(consts.FieldAddress).(string)
+		}
+		if d.HasChange(consts.FieldBasePath) {
+			data[consts.FieldBasePath] = d.Get(consts.FieldBasePath).(string)
 		}
 
 		if explicitMaxTTLChanged {
@@ -295,11 +299,15 @@ func terraformCloudSecretBackendUpdate(ctx context.Context, d *schema.ResourceDa
 			return diag.Errorf("Error configuring Terraform Cloud configuration for %q: %s", backend, err)
 		}
 		log.Printf("[DEBUG] Updated Terraform Cloud configuration at %q", configPath)
-		if err := d.Set(consts.FieldAddress, data[consts.FieldAddress]); err != nil {
-			return diag.FromErr(err)
+		if d.HasChange(consts.FieldAddress) {
+			if err := d.Set(consts.FieldAddress, data[consts.FieldAddress]); err != nil {
+				return diag.FromErr(err)
+			}
 		}
-		if err := d.Set(consts.FieldBasePath, data[consts.FieldBasePath]); err != nil {
-			return diag.FromErr(err)
+		if d.HasChange(consts.FieldBasePath) {
+			if err := d.Set(consts.FieldBasePath, data[consts.FieldBasePath]); err != nil {
+				return diag.FromErr(err)
+			}
 		}
 	}
 

--- a/vault/resource_terraform_cloud_secret_backend.go
+++ b/vault/resource_terraform_cloud_secret_backend.go
@@ -215,6 +215,11 @@ func terraformCloudSecretBackendRead(ctx context.Context, d *schema.ResourceData
 	if err != nil {
 		return diag.Errorf("error reading from Vault: %s", err)
 	}
+	if secret == nil {
+		log.Printf("[WARN] No Terraform Cloud config found at %q, removing from state", configPath)
+		d.SetId("")
+		return nil
+	}
 
 	if v, ok := secret.Data[consts.FieldAddress]; ok {
 		if err := d.Set(consts.FieldAddress, v); err != nil {

--- a/vault/resource_terraform_cloud_secret_backend.go
+++ b/vault/resource_terraform_cloud_secret_backend.go
@@ -14,8 +14,13 @@ import (
 
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+	automatedrotationutil "github.com/hashicorp/terraform-provider-vault/internal/rotation"
 	"github.com/hashicorp/terraform-provider-vault/util"
 )
+
+// tfseRotationVersion is the minimum Vault version that supports root-token
+// rotation configuration on the Terraform secrets engine.
+var tfseRotationVersion = provider.VaultVersion210
 
 func terraformCloudSecretBackendResource() *schema.Resource {
 	r := provider.MustAddMountMigrationSchema(&schema.Resource{
@@ -91,6 +96,15 @@ func terraformCloudSecretBackendResource() *schema.Resource {
 				Default:     "0",
 				Description: "Maximum possible lease duration for secrets in seconds",
 			},
+			consts.FieldExplicitMaxTTL: {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+				Description: "The maximum lifetime, in seconds, set on the root token in " +
+					"Terraform Cloud or Enterprise when Vault rotates it. Acts as an upper-bound " +
+					"safety net; Vault manages the root token lifecycle. The default (0) omits the " +
+					"expiration so Terraform applies its default token expiry.",
+			},
 		},
 	}, false)
 
@@ -103,6 +117,11 @@ func terraformCloudSecretBackendResource() *schema.Resource {
 		consts.FieldMaxLeaseTTLSeconds,
 	))
 
+	// Add common automated root rotation schema to the resource. Automated
+	// rotation requires Vault Enterprise; the on-demand rotate-root endpoint and
+	// explicit_max_ttl work in both editions.
+	provider.MustAddSchema(r, provider.GetAutomatedRootRotationSchema())
+
 	return r
 }
 
@@ -111,6 +130,9 @@ func terraformCloudSecretBackendCreate(ctx context.Context, d *schema.ResourceDa
 	if e != nil {
 		return diag.FromErr(e)
 	}
+
+	useRotationFields := provider.IsAPISupported(meta, tfseRotationVersion)
+	isEnterprise := provider.IsEnterpriseSupported(meta)
 
 	backend := d.Get(consts.FieldBackend).(string)
 	address := d.Get(consts.FieldAddress).(string)
@@ -148,6 +170,20 @@ func terraformCloudSecretBackendCreate(ctx context.Context, d *schema.ResourceDa
 		data[consts.FieldToken] = token
 	}
 
+	if useRotationFields {
+		// explicit_max_ttl applies to both manual and automated rotation and is
+		// not Enterprise-gated.
+		if v, ok := d.GetOk(consts.FieldExplicitMaxTTL); ok {
+			data[consts.FieldExplicitMaxTTL] = v.(int)
+		}
+
+		// Automated root rotation relies on the Rotation Manager, which requires
+		// Vault Enterprise.
+		if isEnterprise {
+			automatedrotationutil.ParseAutomatedRotationFields(d, data)
+		}
+	}
+
 	if _, err := client.Logical().WriteWithContext(ctx, configPath, data); err != nil {
 		return diag.Errorf("Error writing Terraform Cloud configuration for %q: %s", backend, err)
 	}
@@ -180,11 +216,29 @@ func terraformCloudSecretBackendRead(ctx context.Context, d *schema.ResourceData
 		return diag.Errorf("error reading from Vault: %s", err)
 	}
 
-	if err := d.Set("address", secret.Data["address"].(string)); err != nil {
-		return diag.FromErr(err)
+	if v, ok := secret.Data[consts.FieldAddress]; ok {
+		if err := d.Set(consts.FieldAddress, v); err != nil {
+			return diag.FromErr(err)
+		}
 	}
-	if err := d.Set("base_path", secret.Data["base_path"].(string)); err != nil {
-		return diag.FromErr(err)
+	if v, ok := secret.Data[consts.FieldBasePath]; ok {
+		if err := d.Set(consts.FieldBasePath, v); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if provider.IsAPISupported(meta, tfseRotationVersion) {
+		if v, ok := secret.Data[consts.FieldExplicitMaxTTL]; ok {
+			if err := d.Set(consts.FieldExplicitMaxTTL, v); err != nil {
+				return diag.FromErr(err)
+			}
+		}
+
+		if provider.IsEnterpriseSupported(meta) {
+			if err := automatedrotationutil.PopulateAutomatedRotationFields(d, secret, configPath); err != nil {
+				return diag.FromErr(err)
+			}
+		}
 	}
 
 	return nil
@@ -209,20 +263,37 @@ func terraformCloudSecretBackendUpdate(ctx context.Context, d *schema.ResourceDa
 
 	configPath := terraformCloudSecretBackendConfigPath(backend)
 
-	if d.HasChange(consts.FieldAddress) || d.HasChange(consts.FieldBasePath) {
+	useRotationFields := provider.IsAPISupported(meta, tfseRotationVersion)
+	isEnterprise := provider.IsEnterpriseSupported(meta)
+
+	rotationFieldsChanged := useRotationFields && isEnterprise &&
+		d.HasChanges(consts.FieldRotationSchedule, consts.FieldRotationPeriod,
+			consts.FieldRotationWindow, consts.FieldDisableAutomatedRotation)
+	explicitMaxTTLChanged := useRotationFields && d.HasChange(consts.FieldExplicitMaxTTL)
+
+	if d.HasChange(consts.FieldAddress) || d.HasChange(consts.FieldBasePath) ||
+		explicitMaxTTLChanged || rotationFieldsChanged {
 		log.Printf("[DEBUG] Updating Terraform Cloud configuration at %q", configPath)
 		data := map[string]interface{}{
 			consts.FieldAddress:  d.Get(consts.FieldAddress).(string),
 			consts.FieldBasePath: d.Get(consts.FieldBasePath).(string),
 		}
+
+		if explicitMaxTTLChanged {
+			data[consts.FieldExplicitMaxTTL] = d.Get(consts.FieldExplicitMaxTTL).(int)
+		}
+		if rotationFieldsChanged {
+			automatedrotationutil.ParseAutomatedRotationFields(d, data)
+		}
+
 		if _, err := client.Logical().WriteWithContext(ctx, configPath, data); err != nil {
 			return diag.Errorf("Error configuring Terraform Cloud configuration for %q: %s", backend, err)
 		}
 		log.Printf("[DEBUG] Updated Terraform Cloud configuration at %q", configPath)
-		if err := d.Set("address", data["address"]); err != nil {
+		if err := d.Set(consts.FieldAddress, data[consts.FieldAddress]); err != nil {
 			return diag.FromErr(err)
 		}
-		if err := d.Set("base_path", data["base_path"]); err != nil {
+		if err := d.Set(consts.FieldBasePath, data[consts.FieldBasePath]); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/vault/resource_terraform_cloud_secret_backend.go
+++ b/vault/resource_terraform_cloud_secret_backend.go
@@ -18,10 +18,6 @@ import (
 	"github.com/hashicorp/terraform-provider-vault/util"
 )
 
-// tfseRotationVersion is the minimum Vault version that supports root-token
-// rotation configuration on the Terraform secrets engine.
-var tfseRotationVersion = provider.VaultVersion210
-
 func terraformCloudSecretBackendResource() *schema.Resource {
 	r := provider.MustAddMountMigrationSchema(&schema.Resource{
 		CreateContext: terraformCloudSecretBackendCreate,
@@ -131,7 +127,7 @@ func terraformCloudSecretBackendCreate(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(e)
 	}
 
-	useRotationFields := provider.IsAPISupported(meta, tfseRotationVersion)
+	useRotationFields := provider.IsAPISupported(meta, provider.VaultVersion210)
 	isEnterprise := provider.IsEnterpriseSupported(meta)
 
 	backend := d.Get(consts.FieldBackend).(string)
@@ -232,7 +228,7 @@ func terraformCloudSecretBackendRead(ctx context.Context, d *schema.ResourceData
 		}
 	}
 
-	if provider.IsAPISupported(meta, tfseRotationVersion) {
+	if provider.IsAPISupported(meta, provider.VaultVersion210) {
 		if v, ok := secret.Data[consts.FieldExplicitMaxTTL]; ok {
 			if err := d.Set(consts.FieldExplicitMaxTTL, v); err != nil {
 				return diag.FromErr(err)
@@ -268,7 +264,7 @@ func terraformCloudSecretBackendUpdate(ctx context.Context, d *schema.ResourceDa
 
 	configPath := terraformCloudSecretBackendConfigPath(backend)
 
-	useRotationFields := provider.IsAPISupported(meta, tfseRotationVersion)
+	useRotationFields := provider.IsAPISupported(meta, provider.VaultVersion210)
 	isEnterprise := provider.IsEnterpriseSupported(meta)
 
 	rotationFieldsChanged := useRotationFields && isEnterprise &&

--- a/vault/resource_terraform_cloud_secret_backend_test.go
+++ b/vault/resource_terraform_cloud_secret_backend_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
 )
 
@@ -137,6 +138,81 @@ func TestTerraformCloudSecretBackend_tokenWO(t *testing.T) {
 		},
 	})
 }
+
+// TestTerraformCloudSecretBackend_automatedRotation tests that the automated
+// root token rotation parameters are accepted and round-tripped by the
+// Terraform Cloud secret backend resource. Automated rotation relies on the
+// Vault Enterprise Rotation Manager.
+func TestTerraformCloudSecretBackend_automatedRotation(t *testing.T) {
+	backend := acctest.RandomWithPrefix("tf-test-terraform-cloud")
+
+	resourceType := "vault_terraform_cloud_secret_backend"
+	resourceName := resourceType + ".test"
+	vals := testutil.SkipTestEnvUnset(t, "TEST_TF_TOKEN")
+	token := vals[0]
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		PreCheck: func() {
+			testutil.TestEntPreCheck(t)
+			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion210)
+		},
+		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeTerraform, consts.FieldBackend),
+		Steps: []resource.TestStep{
+			{
+				Config: testTerraformCloudSecretBackend_automatedRotation(backend, token, "", 10, 0, 3600, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldBackend, backend),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldExplicitMaxTTL, "3600"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldRotationPeriod, "10"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldRotationWindow, "0"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldRotationSchedule, ""),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldDisableAutomatedRotation, "false"),
+				),
+			},
+			// switch to a schedule-based rotation and zero-out rotation_period
+			{
+				Config: testTerraformCloudSecretBackend_automatedRotation(backend, token, "*/20 * * * *", 0, 120, 3600, false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldRotationPeriod, "0"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldRotationWindow, "120"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldRotationSchedule, "*/20 * * * *"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldDisableAutomatedRotation, "false"),
+				),
+			},
+			// rotation_window is not compatible with rotation_period
+			{
+				Config:      testTerraformCloudSecretBackend_automatedRotation(backend, token, "", 30, 120, 3600, true),
+				ExpectError: regexp.MustCompile("rotation_window does not apply to period"),
+			},
+			// zero-out rotation_schedule and rotation_window, disable rotation
+			{
+				Config: testTerraformCloudSecretBackend_automatedRotation(backend, token, "", 30, 0, 3600, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldRotationPeriod, "30"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldRotationWindow, "0"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldRotationSchedule, ""),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldDisableAutomatedRotation, "true"),
+				),
+			},
+			testutil.GetImportTestStep(resourceName, false, nil, consts.FieldToken, consts.FieldDisableRemount),
+		},
+	})
+}
+
+func testTerraformCloudSecretBackend_automatedRotation(backend, token, schedule string, period, window, explicitMaxTTL int, disable bool) string {
+	return fmt.Sprintf(`
+resource "vault_terraform_cloud_secret_backend" "test" {
+  backend                    = "%s"
+  token                      = "%s"
+  explicit_max_ttl           = "%d"
+  rotation_period            = "%d"
+  rotation_schedule          = "%s"
+  rotation_window            = "%d"
+  disable_automated_rotation = %t
+}`, backend, token, explicitMaxTTL, period, schedule, window, disable)
+}
+
 func testTerraformCloudSecretBackend_initialConfig(path, token string) string {
 	return fmt.Sprintf(`
 resource "vault_terraform_cloud_secret_backend" "test" {

--- a/website/docs/r/terraform_cloud_secret_backend.md
+++ b/website/docs/r/terraform_cloud_secret_backend.md
@@ -59,6 +59,27 @@ on `token`. Changing the value, however, _will_ overwrite the previously stored 
 * `disable_remount` - (Optional) If set, opts out of mount migration on path updates.
   See here for more info on [Mount Migration](https://www.vaultproject.io/docs/concepts/mount-migration)
 
+* `explicit_max_ttl` - (Optional) The maximum amount of time in seconds the root token
+  issued by rotation is valid for. A value of `0` uses the Terraform Cloud/Enterprise
+  default token lifetime. Requires Vault 2.1.0+.
+
+* `rotation_period` - (Optional) The amount of time in seconds Vault should wait before
+  rotating the root token. A zero value tells Vault not to rotate the root token. The
+  minimum rotation period is 10 seconds. Requires Vault Enterprise 2.1.0+. Mutually
+  exclusive with `rotation_schedule`.
+
+* `rotation_schedule` - (Optional) The schedule, in cron-style time format
+  defining the schedule on which Vault should rotate the root token. Requires Vault
+  Enterprise 2.1.0+. Mutually exclusive with `rotation_period`.
+
+* `rotation_window` - (Optional) The maximum amount of time in seconds allowed to complete
+  a rotation when a scheduled token rotation occurs. The default rotation window is
+  unbound and the minimum allowable window is `3600`. Only valid with `rotation_schedule`.
+  Requires Vault Enterprise 2.1.0+.
+
+* `disable_automated_rotation` - (Optional) Cancels all upcoming rotations of the root token
+  until unset. Requires Vault Enterprise 2.1.0+.
+
 ### Common Mount Arguments
 These arguments are common across all resources that mount a secret engine.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes: https://hashicorp.atlassian.net/browse/VAULT-46134
Related plugin change: https://github.com/hashicorp/vault-plugin-secrets-terraform/pull/111

This PR adds support for root token rotation to the vault_terraform_cloud_secret_backend resource, mirroring the companion changes in the Terraform Cloud/Enterprise secrets engine (vault-plugin-secrets-terraform).

Two capabilities are exposed on the backend configuration:

* Automated root token rotation via the shared automated-root-rotation fields, rotation_period, rotation_schedule, rotation_window, and disable_automated_rotation. These are backed by the Vault Enterprise Rotation Manager and are only written when the target server is Enterprise.
* explicit_max_ttl: bounds the lifetime of the root token Vault issues during rotation. Applies to both manual (rotate-root) and automated rotation, and works on Vault CE and Enterprise.

### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
export TEST_TF_TOKEN=<token>
 make testacc-ent TEST_PATH=./vault \
  TESTARGS='-run=TestTerraformCloudSecretBackend_automatedRotation -test.v'
make testacc TF_ACC_ENTERPRISE=1
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -run=TestTerraformCloudSecretBackend_automatedRotation -test.v -timeout 30m ./vault
=== RUN   TestTerraformCloudSecretBackend_automatedRotation
--- PASS: TestTerraformCloudSecretBackend_automatedRotation (2.99s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     4.140s
```

Test is skipped on vault version below 2.1.0
```
$  make testacc-ent TEST_PATH=./vault \
  TESTARGS='-run=TestTerraformCloudSecretBackend_automatedRotation -test.v'                                                                                                                                            make testacc TF_ACC_ENTERPRISE=1
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test -run=TestTerraformCloudSecretBackend_automatedRotation -test.v -timeout 30m ./vault
=== RUN   TestTerraformCloudSecretBackend_automatedRotation
    resource_terraform_cloud_secret_backend_test.go:157: Vault server version "2.0.3+ent"
    resource_terraform_cloud_secret_backend_test.go:157: Vault version < "2.1.0"
--- SKIP: TestTerraformCloudSecretBackend_automatedRotation (0.00s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     0.599s
...
```

### Testing

Create a TFE Token
<img width="1156" height="186" alt="image" src="https://github.com/user-attachments/assets/e02d8c3b-9763-4869-b243-29032fcc75c8" />

Apply the changes
```
 terraform apply -auto-approve
╷
│ Warning: Provider development overrides are in effect
│
│ The following provider development overrides are set in the CLI configuration:
│  - hashicorp/vault in /Users/abbyck/.terraform.d/plugins
│
│ The behavior may therefore not match any released version of the provider and applying changes may cause
│ the state to become incompatible with published releases.
╵
var.tfe_token
  Enter a value:


Terraform used the selected providers to generate the following execution plan. Resource actions are
indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # vault_terraform_cloud_secret_backend.this will be created
  + resource "vault_terraform_cloud_secret_backend" "this" {
      + accessor                     = (known after apply)
      + address                      = "https://app.terraform.io"
      + audit_non_hmac_request_keys  = (known after apply)
      + audit_non_hmac_response_keys = (known after apply)
      + backend                      = "terraform"
      + base_path                    = "/api/v2/"
      + default_lease_ttl_seconds    = 0
      + disable_remount              = false
      + explicit_max_ttl             = (known after apply)
      + external_entropy_access      = false
      + force_no_cache               = (known after apply)
      + id                           = (known after apply)
      + max_lease_ttl_seconds        = 0
      + rotation_period              = 60
      + seal_wrap                    = (known after apply)
      + token                        = (sensitive value)
      + token_wo                     = (write-only attribute)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
vault_terraform_cloud_secret_backend.this: Creating...
vault_terraform_cloud_secret_backend.this: Creation complete after 1s [id=terraform]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.
```

Post rotation
<img width="1139" height="140" alt="image" src="https://github.com/user-attachments/assets/4502f13f-0382-4aad-b807-946d5d450a49" />

```
vault read terraform/config
Key                           Value
---                           -----
address                       https://app.terraform.io
base_path                     /api/v2/
disable_automated_rotation    false
explicit_max_ttl              0s
next_vault_rotation           <timestamp>
owner_id                      user-<id>
rotation_period               1m
rotation_policy               n/a
rotation_schedule             n/a
rotation_window               0
token_owner_type              user
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
