### PR TITLE
vault_identity_group_alias: route post-write Read through CCC retry client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ FEATURES:
 BUG FIXES:
 
 * Fixed the token namespace being set as the provider namespace, even when `set_namespace_from_token` was `false`. ([#2926](https://github.com/hashicorp/terraform-provider-vault/pull/2926/))
+* `vault_identity_group_alias`: Fix "Provider produced inconsistent result after apply" when the post-create Read hits a stale performance-replica; the Read now goes through the Client Controlled Consistency retry client (honors `max_retries_ccc`), matching `vault_identity_entity_alias`. ([#2959](https://github.com/hashicorp/terraform-provider-vault/pull/2959))
 
 ## 5.10.1 (June 26, 2026)
 

--- a/internal/identity/group/group.go
+++ b/internal/identity/group/group.go
@@ -19,8 +19,9 @@ import (
 )
 
 const (
-	LookupPath        = "identity/lookup/group"
-	IdentityGroupPath = "/identity/group"
+	LookupPath             = "identity/lookup/group"
+	IdentityGroupPath      = "/identity/group"
+	IdentityGroupAliasPath = "/identity/group-alias"
 
 	GroupResourceType = iota
 	EntityResourceType
@@ -30,10 +31,25 @@ func IdentityGroupIDPath(id string) string {
 	return fmt.Sprintf("%s/id/%s", IdentityGroupPath, id)
 }
 
+func IdentityGroupAliasIDPath(id string) string {
+	return fmt.Sprintf("%s/id/%s", IdentityGroupAliasPath, id)
+}
+
 // ReadIdentityGroup may return `nil` for the IdentityGroup if it does not exist
 func ReadIdentityGroup(client *api.Client, groupID string, retry bool) (*api.Secret, error) {
 	path := IdentityGroupIDPath(groupID)
 	log.Printf("[DEBUG] Reading IdentityGroup %s from %q", groupID, path)
+
+	return entity.ReadEntity(client, path, retry)
+}
+
+// ReadIdentityGroupAlias reads a group alias by ID. When retry is true the
+// underlying client is configured for Client Controlled Consistency so that
+// a stale performance-replica read directly after a write is retried instead
+// of returning a spurious 404.
+func ReadIdentityGroupAlias(client *api.Client, aliasID string, retry bool) (*api.Secret, error) {
+	path := IdentityGroupAliasIDPath(aliasID)
+	log.Printf("[DEBUG] Reading IdentityGroupAlias %s from %q", aliasID, path)
 
 	return entity.ReadEntity(client, path, retry)
 }

--- a/vault/resource_identity_group_alias.go
+++ b/vault/resource_identity_group_alias.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/identity/group"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
@@ -138,19 +139,16 @@ func identityGroupAliasRead(ctx context.Context, d *schema.ResourceData, meta in
 
 	id := d.Id()
 
-	path := getIdentityGroupAliasIDPath(id)
-
-	log.Printf("[DEBUG] Reading IdentityGroupAlias %s from %q", id, path)
-	resp, err := client.Logical().ReadWithContext(ctx, path)
+	resp, err := group.ReadIdentityGroupAlias(client, id, d.IsNewResource())
 	if err != nil {
+		if group.IsIdentityNotFoundError(err) {
+			log.Printf("[WARN] IdentityGroupAlias %q not found, removing from state", id)
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(fmt.Errorf("error reading IdentityGroupAlias %q: %s", id, err))
 	}
 	log.Printf("[DEBUG] Read IdentityGroupAlias %s", id)
-	if resp == nil {
-		log.Printf("[WARN] IdentityGroupAlias %q not found, removing from state", id)
-		d.SetId("")
-		return nil
-	}
 
 	d.SetId(resp.Data["id"].(string))
 	for _, k := range []string{"name", consts.FieldMountAccessor, "canonical_id"} {

--- a/vault/resource_identity_group_alias_test.go
+++ b/vault/resource_identity_group_alias_test.go
@@ -37,6 +37,11 @@ func TestAccIdentityGroupAlias(t *testing.T) {
 					resource.TestCheckResourceAttrPair(nameGroupAlias, consts.FieldMountAccessor, nameGithubA, "accessor"),
 				),
 			},
+			{
+				ResourceName:      nameGroupAlias,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION
When a group alias Create writes to the active node and the follow-up Read lands on a performance-replica that has not yet caught up, the read returns 404 and the SDK reports "Provider produced inconsistent result after apply". The alias exists in Vault but state is empty, and every subsequent apply then fails with "combination of mount and group alias name is already in use" until the orphaned alias is manually deleted.

Route identityGroupAliasRead through a new group.ReadIdentityGroupAlias helper that reuses entity.ReadEntity, so the read after Create is served by the CCC-configured client (ReadYourWrites + retry on 404 up to max_retries_ccc). This matches the fix that already exists for vault_identity_entity_alias and honors the same provider setting.

Refresh reads outside of Create still take the fast path because retry is gated on d.IsNewResource().


### Description
Fixes the "Provider produced inconsistent result after apply" race on
`vault_identity_group_alias` when a Create on the active node is followed
by a Read that lands on a performance-replica that has not caught up yet.
The read returns 404, the SDK clears the ID, and the alias is left
orphaned in Vault; subsequent applies then fail with "combination of
mount and group alias name is already in use" until the alias is manually
deleted.

The fix mirrors the existing `vault_identity_entity_alias` handling —
route the post-write Read through `entity.ReadEntity` (via a new
`group.ReadIdentityGroupAlias` helper), which enables ReadYourWrites and
retries on 404 up to `max_retries_ccc`. Retry is gated on
`d.IsNewResource()` so refresh reads outside of Create keep the fast
path


Relates #1389

### Checklist
- [x] Added CHANGELOG entry
- [ ] Acceptance tests where run against all supported Vault Versions
      (I can't run TestAccIdentityGroupAlias against a licensed
      Enterprise cluster from my dev box; existing acceptance tests
      exercise the modified read path in the non-race case and should
      continue to pass.)


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
