### PR TITLE
add rotate-on-read option on ldap secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 FEATURES:
 
 * **LDAP Role Level Password Policy Support**: Added `password_policy` parameter to `vault_ldap_secret_backend_static_role` and `vault_ldap_secret_backend_dynamic_role` resources to support role-level password policy configuration ([#2921](https://github.com/hashicorp/terraform-provider-vault/pull/2921)). Requires Vault 2.1.0+.
+* **LDAP Rotate-on-Read Support**: Added `rotate_on_read` and `rotate_on_read_cooldown` parameters to `vault_ldap_secret_backend` and `vault_ldap_secret_backend_static_role` resources, and `rotated_on_read` attribute to `vault_ldap_static_role_credentials` data source to support credential rotation on each read ([#2960](https://github.com/hashicorp/terraform-provider-vault/pull/2960). Requires Vault Enterprise 2.1.0+.
 
 ## 5.10.1 (June 26, 2026)
 

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -866,6 +866,7 @@ const (
 	FieldSelfManaged               = "self_managed"
 	FieldRotateOnRead              = "rotate_on_read"
 	FieldRotateOnReadCooldown      = "rotate_on_read_cooldown"
+	FieldRotatedOnRead             = "rotated_on_read"
 	FieldRotationPolicy            = "rotation_policy"
 	FieldAWSSecretAccessKeyWO      = "aws_secret_access_key_wo"
 	FieldSecretsWOVersion          = "secrets_wo_version"

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -864,6 +864,8 @@ const (
 	FieldAzureClientID             = "azure_client_id"
 	FieldAzureAuthMode             = "azure_auth_mode"
 	FieldSelfManaged               = "self_managed"
+	FieldRotateOnRead              = "rotate_on_read"
+	FieldRotateOnReadCooldown      = "rotate_on_read_cooldown"
 	FieldRotationPolicy            = "rotation_policy"
 	FieldAWSSecretAccessKeyWO      = "aws_secret_access_key_wo"
 	FieldSecretsWOVersion          = "secrets_wo_version"

--- a/vault/data_source_ldap_static_role_credentials.go
+++ b/vault/data_source_ldap_static_role_credentials.go
@@ -179,7 +179,10 @@ func parseLDAPStaticCredSecret(secret *api.Secret) (lDAPStaticCredResponse, erro
 		return lDAPStaticCredResponse{}, fmt.Errorf("username is not set in response")
 	}
 
-	password, _ := secret.Data[consts.FieldPassword].(string)
+	password := secret.Data[consts.FieldPassword].(string)
+	if password == "" {
+		return lDAPStaticCredResponse{}, fmt.Errorf("password is not set in response")
+	}
 
 	return lDAPStaticCredResponse{
 		dn:                dn,

--- a/vault/data_source_ldap_static_role_credentials.go
+++ b/vault/data_source_ldap_static_role_credentials.go
@@ -69,6 +69,11 @@ func ldapStaticCredDataSource() *schema.Resource {
 				Computed:    true,
 				Description: "Name of the static role.",
 			},
+			consts.FieldRotatedOnRead: {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Whether the credential was rotated during this read (rotate-on-read feature). Requires Vault Enterprise.",
+			},
 		},
 	}
 }
@@ -119,6 +124,9 @@ func readLDAPStaticCreds(ctx context.Context, d *schema.ResourceData, meta inter
 	if err := d.Set(consts.FieldUsername, response.username); err != nil {
 		return diag.FromErr(err)
 	}
+	if err := d.Set(consts.FieldRotatedOnRead, response.rotatedOnRead); err != nil {
+		return diag.FromErr(err)
+	}
 	return nil
 }
 
@@ -130,6 +138,7 @@ type lDAPStaticCredResponse struct {
 	rotationPeriod    int64
 	ttl               int64
 	username          string
+	rotatedOnRead     bool
 }
 
 func parseLDAPStaticCredSecret(secret *api.Secret) (lDAPStaticCredResponse, error) {
@@ -139,6 +148,7 @@ func parseLDAPStaticCredSecret(secret *api.Secret) (lDAPStaticCredResponse, erro
 		lastVaultRotation string
 		rotationPeriod    int64
 		ttl               int64
+		rotatedOnRead     bool
 	)
 	if dnRaw, ok := secret.Data[consts.FieldDN]; ok {
 		dn = dnRaw.(string)
@@ -160,15 +170,16 @@ func parseLDAPStaticCredSecret(secret *api.Secret) (lDAPStaticCredResponse, erro
 		ttl, _ = ttlRaw.(json.Number).Int64()
 	}
 
+	if rotatedOnReadRaw, ok := secret.Data[consts.FieldRotatedOnRead]; ok {
+		rotatedOnRead, _ = rotatedOnReadRaw.(bool)
+	}
+
 	username := secret.Data[consts.FieldUsername].(string)
 	if username == "" {
 		return lDAPStaticCredResponse{}, fmt.Errorf("username is not set in response")
 	}
 
-	password := secret.Data[consts.FieldPassword].(string)
-	if password == "" {
-		return lDAPStaticCredResponse{}, fmt.Errorf("password is not set in response")
-	}
+	password, _ := secret.Data[consts.FieldPassword].(string)
 
 	return lDAPStaticCredResponse{
 		dn:                dn,
@@ -178,5 +189,6 @@ func parseLDAPStaticCredSecret(secret *api.Secret) (lDAPStaticCredResponse, erro
 		rotationPeriod:    rotationPeriod,
 		ttl:               ttl,
 		username:          username,
+		rotatedOnRead:     rotatedOnRead,
 	}, nil
 }

--- a/vault/resource_ldap_secret_backend.go
+++ b/vault/resource_ldap_secret_backend.go
@@ -272,11 +272,11 @@ func createUpdateLDAPConfigResource(ctx context.Context, d *schema.ResourceData,
 
 	// get rotate-on-read fields
 	if provider.IsAPISupported(meta, provider.VaultVersion210) && provider.IsEnterpriseSupported(meta) {
-		if v, ok := d.GetOk(consts.FieldRotateOnRead); ok {
-			data[consts.FieldRotateOnRead] = v
+		if d.HasChange(consts.FieldRotateOnRead) {
+			data[consts.FieldRotateOnRead] = d.Get(consts.FieldRotateOnRead)
 		}
-		if v, ok := d.GetOk(consts.FieldRotateOnReadCooldown); ok {
-			data[consts.FieldRotateOnReadCooldown] = v
+		if d.HasChange(consts.FieldRotateOnReadCooldown) {
+			data[consts.FieldRotateOnReadCooldown] = d.Get(consts.FieldRotateOnReadCooldown)
 		}
 	}
 

--- a/vault/resource_ldap_secret_backend.go
+++ b/vault/resource_ldap_secret_backend.go
@@ -150,6 +150,18 @@ func ldapSecretBackendResource() *schema.Resource {
 			ConflictsWith: []string{consts.FieldBindPass, consts.FieldBindPassWO},
 			ExactlyOneOf:  []string{consts.FieldBindPass, consts.FieldBindPassWO, consts.FieldSelfManaged},
 		},
+		consts.FieldRotateOnRead: {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Computed:    true,
+			Description: "If true, static role credentials are rotated on each read. Acts as a default for all static roles. Requires Vault Enterprise ≥ 2.1.0.",
+		},
+		consts.FieldRotateOnReadCooldown: {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Computed:    true,
+			Description: "Minimum seconds between rotate-on-read rotations. Acts as a default cooldown for all static roles. Requires Vault Enterprise ≥ 2.1.0.",
+		},
 	}
 	resource := provider.MustAddMountMigrationSchema(&schema.Resource{
 		CreateContext: provider.MountCreateContextWrapper(createUpdateLDAPConfigResource, provider.VaultVersion112),
@@ -258,6 +270,16 @@ func createUpdateLDAPConfigResource(ctx context.Context, d *schema.ResourceData,
 		automatedrotationutil.ParseAutomatedRotationFields(d, data)
 	}
 
+	// get rotate-on-read fields
+	if provider.IsAPISupported(meta, provider.VaultVersion210) && provider.IsEnterpriseSupported(meta) {
+		if v, ok := d.GetOk(consts.FieldRotateOnRead); ok {
+			data[consts.FieldRotateOnRead] = v
+		}
+		if v, ok := d.GetOk(consts.FieldRotateOnReadCooldown); ok {
+			data[consts.FieldRotateOnReadCooldown] = v
+		}
+	}
+
 	// get self-managed boolean
 	if provider.IsAPISupported(meta, provider.VaultVersion200) && provider.IsEnterpriseSupported(meta) {
 		if d.HasChange(consts.FieldSelfManaged) {
@@ -345,6 +367,19 @@ func readLDAPConfigResource(ctx context.Context, d *schema.ResourceData, meta in
 	if provider.IsAPISupported(meta, provider.VaultVersion200) && provider.IsEnterpriseSupported(meta) {
 		if err := d.Set(consts.FieldSelfManaged, resp.Data[consts.FieldSelfManaged]); err != nil {
 			return diag.Errorf("error setting self-managed field: %s", err)
+		}
+	}
+
+	if provider.IsAPISupported(meta, provider.VaultVersion210) && provider.IsEnterpriseSupported(meta) {
+		if v, ok := resp.Data[consts.FieldRotateOnRead]; ok {
+			if err := d.Set(consts.FieldRotateOnRead, v); err != nil {
+				return diag.Errorf("error setting %s: %s", consts.FieldRotateOnRead, err)
+			}
+		}
+		if v, ok := resp.Data[consts.FieldRotateOnReadCooldown]; ok {
+			if err := d.Set(consts.FieldRotateOnReadCooldown, v); err != nil {
+				return diag.Errorf("error setting %s: %s", consts.FieldRotateOnReadCooldown, err)
+			}
 		}
 	}
 

--- a/vault/resource_ldap_secret_backend_static_role.go
+++ b/vault/resource_ldap_secret_backend_static_role.go
@@ -102,6 +102,8 @@ var ldapSecretBackendStaticRoleFields = []string{
 	consts.FieldRotationPeriod,
 	consts.FieldSkipImportRotation,
 	consts.FieldPasswordPolicy,
+	consts.FieldRotateOnRead,
+	consts.FieldRotateOnReadCooldown,
 }
 
 func createUpdateLDAPStaticRoleResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -205,19 +207,6 @@ func readLDAPStaticRoleResource(ctx context.Context, d *schema.ResourceData, met
 	if provider.IsAPISupported(meta, provider.VaultVersion200) && provider.IsEnterpriseSupported(meta) {
 		if err := automatedrotationutil.PopulateAutomatedRotationFieldsWithPolicy(d, resp, rolePath); err != nil {
 			return diag.Errorf("error setting automated rotation fields: %s", err)
-		}
-	}
-
-	if provider.IsAPISupported(meta, provider.VaultVersion210) && provider.IsEnterpriseSupported(meta) {
-		if v, ok := resp.Data[consts.FieldRotateOnRead]; ok {
-			if err := d.Set(consts.FieldRotateOnRead, v); err != nil {
-				return diag.Errorf("error setting %s: %s", consts.FieldRotateOnRead, err)
-			}
-		}
-		if v, ok := resp.Data[consts.FieldRotateOnReadCooldown]; ok {
-			if err := d.Set(consts.FieldRotateOnReadCooldown, v); err != nil {
-				return diag.Errorf("error setting %s: %s", consts.FieldRotateOnReadCooldown, err)
-			}
 		}
 	}
 

--- a/vault/resource_ldap_secret_backend_static_role.go
+++ b/vault/resource_ldap_secret_backend_static_role.go
@@ -6,9 +6,10 @@ package vault
 import (
 	"context"
 	"fmt"
+	"log"
+
 	"github.com/hashicorp/go-cty/cty"
 	automatedrotationutil "github.com/hashicorp/terraform-provider-vault/internal/rotation"
-	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -153,11 +154,11 @@ func createUpdateLDAPStaticRoleResource(ctx context.Context, d *schema.ResourceD
 
 	// get rotate-on-read role-level overrides
 	if provider.IsAPISupported(meta, provider.VaultVersion210) && provider.IsEnterpriseSupported(meta) {
-		if v, ok := d.GetOk(consts.FieldRotateOnRead); ok {
-			data[consts.FieldRotateOnRead] = v
+		if d.HasChange(consts.FieldRotateOnRead) {
+			data[consts.FieldRotateOnRead] = d.Get(consts.FieldRotateOnRead)
 		}
-		if v, ok := d.GetOk(consts.FieldRotateOnReadCooldown); ok {
-			data[consts.FieldRotateOnReadCooldown] = v
+		if d.HasChange(consts.FieldRotateOnReadCooldown) {
+			data[consts.FieldRotateOnReadCooldown] = d.Get(consts.FieldRotateOnReadCooldown)
 		}
 	}
 
@@ -207,7 +208,6 @@ func readLDAPStaticRoleResource(ctx context.Context, d *schema.ResourceData, met
 		}
 	}
 
-	// read rotate-on-read role-level overrides (only present when explicitly set on the role)
 	if provider.IsAPISupported(meta, provider.VaultVersion210) && provider.IsEnterpriseSupported(meta) {
 		if v, ok := resp.Data[consts.FieldRotateOnRead]; ok {
 			if err := d.Set(consts.FieldRotateOnRead, v); err != nil {

--- a/vault/resource_ldap_secret_backend_static_role.go
+++ b/vault/resource_ldap_secret_backend_static_role.go
@@ -67,6 +67,16 @@ func ldapSecretBackendStaticRoleResource() *schema.Resource {
 			Optional:    true,
 			Description: "Name of the password policy to use to generate passwords for this role.",
 		},
+		consts.FieldRotateOnRead: {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "If true, credentials are rotated on each read. Overrides the engine-level default when set. Requires Vault Enterprise ≥ 2.1.0.",
+		},
+		consts.FieldRotateOnReadCooldown: {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Description: "Minimum seconds between rotate-on-read rotations for this role. Overrides the engine-level default when set. Requires Vault Enterprise ≥ 2.1.0.",
+		},
 	}
 	resource := &schema.Resource{
 		CreateContext: createUpdateLDAPStaticRoleResource,
@@ -141,6 +151,16 @@ func createUpdateLDAPStaticRoleResource(ctx context.Context, d *schema.ResourceD
 		}
 	}
 
+	// get rotate-on-read role-level overrides
+	if provider.IsAPISupported(meta, provider.VaultVersion210) && provider.IsEnterpriseSupported(meta) {
+		if v, ok := d.GetOk(consts.FieldRotateOnRead); ok {
+			data[consts.FieldRotateOnRead] = v
+		}
+		if v, ok := d.GetOk(consts.FieldRotateOnReadCooldown); ok {
+			data[consts.FieldRotateOnReadCooldown] = v
+		}
+	}
+
 	if _, err := client.Logical().WriteWithContext(ctx, rolePath, data); err != nil {
 		return diag.FromErr(fmt.Errorf("error writing %q: %s", rolePath, err))
 	}
@@ -184,6 +204,20 @@ func readLDAPStaticRoleResource(ctx context.Context, d *schema.ResourceData, met
 	if provider.IsAPISupported(meta, provider.VaultVersion200) && provider.IsEnterpriseSupported(meta) {
 		if err := automatedrotationutil.PopulateAutomatedRotationFieldsWithPolicy(d, resp, rolePath); err != nil {
 			return diag.Errorf("error setting automated rotation fields: %s", err)
+		}
+	}
+
+	// read rotate-on-read role-level overrides (only present when explicitly set on the role)
+	if provider.IsAPISupported(meta, provider.VaultVersion210) && provider.IsEnterpriseSupported(meta) {
+		if v, ok := resp.Data[consts.FieldRotateOnRead]; ok {
+			if err := d.Set(consts.FieldRotateOnRead, v); err != nil {
+				return diag.Errorf("error setting %s: %s", consts.FieldRotateOnRead, err)
+			}
+		}
+		if v, ok := resp.Data[consts.FieldRotateOnReadCooldown]; ok {
+			if err := d.Set(consts.FieldRotateOnReadCooldown, v); err != nil {
+				return diag.Errorf("error setting %s: %s", consts.FieldRotateOnReadCooldown, err)
+			}
 		}
 	}
 

--- a/vault/resource_ldap_secret_backend_static_role.go
+++ b/vault/resource_ldap_secret_backend_static_role.go
@@ -102,8 +102,6 @@ var ldapSecretBackendStaticRoleFields = []string{
 	consts.FieldRotationPeriod,
 	consts.FieldSkipImportRotation,
 	consts.FieldPasswordPolicy,
-	consts.FieldRotateOnRead,
-	consts.FieldRotateOnReadCooldown,
 }
 
 func createUpdateLDAPStaticRoleResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -207,6 +205,19 @@ func readLDAPStaticRoleResource(ctx context.Context, d *schema.ResourceData, met
 	if provider.IsAPISupported(meta, provider.VaultVersion200) && provider.IsEnterpriseSupported(meta) {
 		if err := automatedrotationutil.PopulateAutomatedRotationFieldsWithPolicy(d, resp, rolePath); err != nil {
 			return diag.Errorf("error setting automated rotation fields: %s", err)
+		}
+	}
+
+	if provider.IsAPISupported(meta, provider.VaultVersion210) && provider.IsEnterpriseSupported(meta) {
+		if v, ok := resp.Data[consts.FieldRotateOnRead]; ok {
+			if err := d.Set(consts.FieldRotateOnRead, v); err != nil {
+				return diag.Errorf("error setting %s: %s", consts.FieldRotateOnRead, err)
+			}
+		}
+		if v, ok := resp.Data[consts.FieldRotateOnReadCooldown]; ok {
+			if err := d.Set(consts.FieldRotateOnReadCooldown, v); err != nil {
+				return diag.Errorf("error setting %s: %s", consts.FieldRotateOnReadCooldown, err)
+			}
 		}
 	}
 

--- a/vault/resource_ldap_secret_backend_static_role_test.go
+++ b/vault/resource_ldap_secret_backend_static_role_test.go
@@ -278,3 +278,64 @@ resource "vault_ldap_secret_backend_static_role" "role" {
 }
 `, passwordPolicy, mount, bindDN, bindPass, url, username, dn, role, rotationPeriod)
 }
+
+func TestAccLDAPSecretBackendStaticRole_RotateOnRead(t *testing.T) {
+	path := acctest.RandomWithPrefix("tf-test-ldap-static-role")
+	bindDN, bindPass, url := testutil.GetTestLDAPCreds(t)
+	resourceType := "vault_ldap_secret_backend_static_role"
+	resourceName := resourceType + ".role"
+	username := "alice"
+	dn := "cn=alice,ou=users,dc=example,dc=org"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		PreCheck: func() {
+			acctestutil.TestEntPreCheck(t)
+			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion210)
+		},
+		CheckDestroy: testCheckMountDestroyed(resourceType, consts.MountTypeLDAP, consts.FieldMount),
+		Steps: []resource.TestStep{
+			{
+				Config: testLDAPSecretBackendStaticRoleConfig_rotateOnRead(path, bindDN, bindPass, url, username, dn, "true", "60"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldUsername, username),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldDN, dn),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldRotateOnRead, "true"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldRotateOnReadCooldown, "60"),
+				),
+			},
+			{
+				Config: testLDAPSecretBackendStaticRoleConfig_rotateOnRead(path, bindDN, bindPass, url, username, dn, "true", "120"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldRotateOnRead, "true"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldRotateOnReadCooldown, "120"),
+				),
+			},
+			testutil.GetImportTestStep(resourceName, false, nil,
+				consts.FieldMount, consts.FieldRoleName, consts.FieldSkipImportRotation),
+		},
+	})
+}
+
+func testLDAPSecretBackendStaticRoleConfig_rotateOnRead(mount, bindDN, bindPass, url, username, dn, rotateOnRead, cooldown string) string {
+	return fmt.Sprintf(`
+resource "vault_ldap_secret_backend" "test" {
+  path     = "%s"
+  binddn   = "%s"
+  bindpass = "%s"
+  url      = "%s"
+  userdn   = "CN=Users,DC=corp,DC=example,DC=net"
+}
+
+resource "vault_ldap_secret_backend_static_role" "role" {
+  mount                    = vault_ldap_secret_backend.test.path
+  username                 = "%s"
+  dn                       = "%s"
+  role_name                = "%s"
+  rotation_period          = 60
+  rotate_on_read           = %s
+  rotate_on_read_cooldown  = %s
+  skip_import_rotation     = true
+}
+`, mount, bindDN, bindPass, url, username, dn, username, rotateOnRead, cooldown)
+}

--- a/vault/resource_ldap_secret_backend_test.go
+++ b/vault/resource_ldap_secret_backend_test.go
@@ -487,3 +487,53 @@ resource "vault_ldap_secret_backend" "test" {
   bindpass_wo_version  = 1
 }`, path)
 }
+
+func TestLDAPSecretBackend_RotateOnRead(t *testing.T) {
+	var (
+		path         = acctest.RandomWithPrefix("tf-test-ldap")
+		bindDN       = "test-bind-dn"
+		resourceType = "vault_ldap_secret_backend"
+		resourceName = resourceType + ".test"
+	)
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		PreCheck: func() {
+			acctestutil.TestEntPreCheck(t)
+			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion210)
+		},
+		PreventPostDestroyRefresh: true,
+		CheckDestroy:              testCheckMountDestroyed(resourceType, consts.MountTypeLDAP, consts.FieldPath),
+		Steps: []resource.TestStep{
+			{
+				Config: testLDAPSecretBackendConfig_rotateOnRead(path, bindDN, "true", "120"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldBindDN, bindDN),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldRotateOnRead, "true"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldRotateOnReadCooldown, "120"),
+				),
+			},
+			{
+				Config: testLDAPSecretBackendConfig_rotateOnRead(path, bindDN, "true", "240"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldRotateOnRead, "true"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldRotateOnReadCooldown, "240"),
+				),
+			},
+			testutil.GetImportTestStep(resourceName, false, nil, consts.FieldDisableRemount),
+		},
+	})
+}
+
+func testLDAPSecretBackendConfig_rotateOnRead(path, bindDN, rotateOnRead, cooldown string) string {
+	return fmt.Sprintf(`
+resource "vault_ldap_secret_backend" "test" {
+  path                      = "%s"
+  description               = "test description"
+  binddn                    = "%s"
+  userdn                    = "CN=Users,DC=corp,DC=example,DC=net"
+  self_managed              = true
+  rotate_on_read            = %s
+  rotate_on_read_cooldown   = %s
+}`, path, bindDN, rotateOnRead, cooldown)
+}

--- a/website/docs/r/ldap_secret_backend.html.md
+++ b/website/docs/r/ldap_secret_backend.html.md
@@ -106,6 +106,13 @@ The following arguments are supported:
   using its current password (no privileged bind DN). Immutable after creation. Enforces `password`
   requirement when creating static roles. Requires Vault Enterprise 2.0+.
 
+* `rotate_on_read` - (Optional) If true, static role credentials are rotated on each read. Acts as
+  the default for all static roles that do not provide their own override. Requires Vault Enterprise 2.1.0+.
+
+* `rotate_on_read_cooldown` - (Optional) Minimum number of seconds between rotate-on-read rotations.
+  Acts as the default cooldown for all static roles that do not provide their own override.
+  Requires Vault Enterprise 2.1.0+.
+
 ### Common Mount Arguments
 These arguments are common across all resources that mount a secret engine.
 

--- a/website/docs/r/ldap_secret_backend_static_role.html.md
+++ b/website/docs/r/ldap_secret_backend_static_role.html.md
@@ -77,6 +77,17 @@ The following arguments are supported:
 * `password_policy` - (Optional) Name of the password policy to use to generate passwords for this role.
   Requires Vault 2.1.0+.
 
+* `rotate_on_read` - (Optional) If true, credentials are rotated on each read. When set, this overrides
+  the engine-level `rotate_on_read` default. When unset, the role inherits the engine-level value.
+  Removing this attribute after it has been set is not supported without recreating the role.
+  Requires Vault Enterprise 2.1.0+.
+
+* `rotate_on_read_cooldown` - (Optional) Minimum number of seconds between rotate-on-read rotations
+  for this role. When set, this overrides the engine-level `rotate_on_read_cooldown` default.
+  When unset, the role inherits the engine-level value.
+  Removing this attribute after it has been set is not supported without recreating the role.
+  Requires Vault Enterprise 2.1.0+.
+
 * `disable_automated_rotation` - (Optional) Cancels all upcoming rotations of the static credential until unset. Requires Vault Enterprise 2.0+.
 
 * `password_wo_version` - (Optional) The version of the `password_wo`. For more info see [updating write-only attributes](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/guides/using_write_only_attributes.html#updating-write-only-attributes).


### PR DESCRIPTION



### Description
Support for Vault's openldap rotate-on-read feature
Adds a rotate_on_read configuration field to the LDAP secrets engine and static roles, enabling on-demand password rotation at the time of credential read. This complements (not replaces) the existing scheduled rotation mechanism.