### PR TITLE
feat: support password_wo for elasticsearch database connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,10 @@ IMPROVEMENTS:
   * Vault Enterprise test images: `1.19.19-ent` → `1.19.20-ent`, `1.20.13-ent` → `1.20.14-ent`, `1.21.8-ent` → `1.21.9-ent`, `2.0.3-ent` → `2.0.4-ent`
 
 
+IMPROVEMENTS:
+
+* `vault_database_secret_backend_connection`: Add write-only `password_wo` and `password_wo_version` fields to the `elasticsearch` engine block, so the connection password can be configured without being persisted in Terraform state (parity with the connection-URL engines). ([#PR](https://github.com/hashicorp/terraform-provider-vault/pull/PR))
+
 BUG FIXES:
 
 * `vault_jwt_auth_backend`: Fixed a perpetual diff where Vault returned non-string values that were silently dropped by Terraform’s TypeMap(TypeString) schema. All values are now converted to strings when read, preventing keys such as `fetch_groups` and `groups_recurse_max_depth` from appearing missing on every plan.([#2993](https://github.com/hashicorp/terraform-provider-vault/pull/2993))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ IMPROVEMENTS:
 
 IMPROVEMENTS:
 
-* `vault_database_secret_backend_connection`: Add write-only `password_wo` and `password_wo_version` fields to the `elasticsearch` engine block, so the connection password can be configured without being persisted in Terraform state (parity with the connection-URL engines). ([#PR](https://github.com/hashicorp/terraform-provider-vault/pull/PR))
+* `vault_database_secret_backend_connection`: Add write-only `password_wo` and `password_wo_version` fields to the `elasticsearch` engine block, so the connection password can be configured without being persisted in Terraform state (parity with the connection-URL engines). ([#2961](https://github.com/hashicorp/terraform-provider-vault/pull/2961))
 
 BUG FIXES:
 

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -232,9 +232,20 @@ func getDatabaseSchema(typ schema.ValueType) schemaMap {
 					},
 					consts.FieldPassword: {
 						Type:        schema.TypeString,
-						Required:    true,
+						Optional:    true,
 						Description: "The password to be used in the connection URL",
 						Sensitive:   true,
+					},
+					consts.FieldPasswordWO: {
+						Type:        schema.TypeString,
+						Optional:    true,
+						Description: "Write-only field for the password to be used in the connection URL",
+						WriteOnly:   true,
+					},
+					consts.FieldPasswordWOVersion: {
+						Type:        schema.TypeInt,
+						Optional:    true,
+						Description: "Version counter for the password write-only field",
 					},
 					consts.FieldCACert: {
 						Type:        schema.TypeString,
@@ -1521,6 +1532,11 @@ func getElasticsearchConnectionDetailsFromResponse(d *schema.ResourceData, prefi
 		result["username_template"] = v.(string)
 	}
 
+	// ensure password_wo_version is updated in state
+	if v, ok := d.GetOk(prefix + consts.FieldPasswordWOVersion); ok {
+		result[consts.FieldPasswordWOVersion] = v.(int)
+	}
+
 	return result
 }
 
@@ -1854,10 +1870,34 @@ func setElasticsearchDatabaseConnectionData(d *schema.ResourceData, prefix strin
 		data["username"] = v.(string)
 	}
 
+	// Vault does not return the password in the API. If the root credentials have been rotated, sending
+	// the old password in the update request would break the connection config. Thus we only send it,
+	// if it actually changed to still support updating it for non-rotated cases.
 	passwordKey := prefix + consts.FieldPassword
-	if v, ok := d.GetOk(passwordKey); ok {
-		if d.IsNewResource() || d.HasChange(passwordKey) {
+	passwordWriteOnlyVersionKey := prefix + consts.FieldPasswordWOVersion
+	if d.IsNewResource() || d.HasChange(passwordKey) || d.HasChange(passwordWriteOnlyVersionKey) {
+		if v, ok := d.GetOk(passwordKey); ok && v != nil {
+			log.Printf("[DEBUG] using persisted password; please use new write-only attributes `password_wo` " +
+				"and `password_wo_version` for security")
 			data[consts.FieldPassword] = v.(string)
+		} else if d.HasChange(passwordWriteOnlyVersionKey) {
+			engineName, engineIdx, err := databaseEngineNameAndIndexFromPrefix(prefix)
+			if err != nil {
+				// this should not happen, since we control how the prefix is created
+				panic(fmt.Sprintf("[ERROR] invalid prefix %q for database connection: %s", prefix, err))
+			}
+
+			idx, err := strconv.Atoi(engineIdx)
+			if err != nil {
+				// this should not happen, since we control how the index has been set
+				panic(fmt.Sprintf("[ERROR] unable to convert string index to integer: %s", err))
+			}
+
+			// construct path to use GetRawConfig
+			path := cty.GetAttrPath(engineName).IndexInt(idx).GetAttr(consts.FieldPasswordWO)
+			if pwWo, _ := d.GetRawConfigAt(path); !pwWo.IsNull() {
+				data[consts.FieldPassword] = pwWo.AsString()
+			}
 		}
 	}
 

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -1400,6 +1400,50 @@ func TestAccDatabaseSecretBackendConnection_postgresql_password_wo(t *testing.T)
 	})
 }
 
+// TestAccDatabaseSecretBackendConnection_elasticsearch_password_wo asserts that the
+// write-only attribute `password_wo` works as expected for the elasticsearch engine.
+//
+// To run locally you will need to set ELASTIC_URL / ELASTIC_USERNAME / ELASTIC_PASSWORD.
+func TestAccDatabaseSecretBackendConnection_elasticsearch_password_wo(t *testing.T) {
+	MaybeSkipDBTests(t, dbEngineElasticSearch)
+
+	values := testutil.SkipTestEnvUnset(t, "ELASTIC_URL")
+	connURL := values[0]
+	username := os.Getenv("ELASTIC_USERNAME")
+	password := os.Getenv("ELASTIC_PASSWORD")
+	backend := acctest.RandomWithPrefix("tf-test-db")
+	pluginName := dbEngineElasticSearch.DefaultPluginName()
+	name := acctest.RandomWithPrefix("db")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
+		CheckDestroy:             testAccDatabaseSecretBackendConnectionCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseSecretBackendConnectionConfig_elasticsearch_writeOnly(name, backend, connURL, username, password, 1),
+				Check: testComposeCheckFuncCommonDatabaseSecretBackend(name, backend, pluginName,
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "elasticsearch.0.url", connURL),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "elasticsearch.0.username", username),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "elasticsearch.0.password_wo_version", "1"),
+				),
+			},
+			{
+				Config: testAccDatabaseSecretBackendConnectionConfig_elasticsearch_writeOnly(name, backend, connURL, username, password, 2),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(testDefaultDatabaseSecretBackendResource, plancheck.ResourceActionUpdate),
+					},
+				},
+				// a successful connection after bumping the version guarantees password_wo was re-sent
+				Check: testComposeCheckFuncCommonDatabaseSecretBackend(name, backend, pluginName,
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "elasticsearch.0.password_wo_version", "2"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDatabaseSecretBackendConnection_elasticsearch(t *testing.T) {
 	MaybeSkipDBTests(t, dbEngineElasticSearch)
 
@@ -2838,6 +2882,28 @@ resource "vault_database_secret_backend_connection" "test" {
   }
 }
 `, path, name, connUrl, username, password, version)
+}
+
+func testAccDatabaseSecretBackendConnectionConfig_elasticsearch_writeOnly(name, path, host, username, password string, version int) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "db" {
+  path = "%s"
+  type = "database"
+}
+
+resource "vault_database_secret_backend_connection" "test" {
+  backend = vault_mount.db.path
+  name = "%s"
+  allowed_roles = ["dev", "prod"]
+
+  elasticsearch {
+    url                 = "%s"
+    username            = "%s"
+    password_wo         = "%s"
+    password_wo_version = %d
+  }
+}
+`, path, name, host, username, password, version)
 }
 
 func testAccDatabaseSecretBackendConnectionConfig_snowflake_userpass(name, path, url, username, password, userTempl string) string {

--- a/website/docs/r/database_secret_backend_connection.md
+++ b/website/docs/r/database_secret_backend_connection.md
@@ -499,7 +499,10 @@ See the [Vault
 
 * `username` - (Required) The username to be used in the connection.
 
-* `password` - (Required) The password to be used in the connection.
+* `password` - (Optional) The password to be used in the connection.
+
+* `password_wo` - (Optional) Write-only password to be used in the connection.
+  **Note**: This property is write-only and will not be read from the API.
 
 * `ca_cert` - (Optional) The path to a PEM-encoded CA cert file to use to verify the Elasticsearch server's identity.
 


### PR DESCRIPTION
### Description

Adds write-only `password_wo` and `password_wo_version` fields to the **elasticsearch** engine block of `vault_database_secret_backend_connection`.

The connection-URL engines (postgres, mysql, mongodb, mssql, oracle, redshift) already support `password_wo`, but the elasticsearch engine has its own schema block and only exposed the plain `password`, which is persisted in Terraform state. This brings elasticsearch to parity so the connection password can be supplied via a write-only field (e.g. from an `ephemeral` resource) without ever landing in state.

Note: the docs already listed `password_wo_version` under the Elasticsearch section, but the schema never implemented it — this makes the code match the docs.

### Changes

- **schema**: relax `password` from `Required` to `Optional`; add `password_wo` (`WriteOnly: true`) and `password_wo_version`.
- **write path** (`setElasticsearchDatabaseConnectionData`): send the password sourced from `password_wo` when `password_wo_version` changes, mirroring `setDatabaseConnectionDataWithUserPass` (only send on create / password change / version bump so rotated root creds aren't clobbered).
- **read path** (`getElasticsearchConnectionDetailsFromResponse`): preserve `password_wo_version` in state.
- **docs**: mark `password` optional and document `password_wo`.
- **changelog** + **acceptance test** (`TestAccDatabaseSecretBackendConnection_elasticsearch_password_wo`).

### Example

```hcl
resource "vault_database_secret_backend_connection" "es" {
  backend       = vault_mount.db.path
  name          = "es"
  allowed_roles = ["*"]

  elasticsearch {
    url                 = "https://es.example.com:9200"
    username            = "vault"
    password_wo         = ephemeral.vault_kv_secret_v2.es.data["password"]
    password_wo_version = 1
  }
}
```

### Backwards compatibility

Fully backward compatible — existing configs using `password` are unchanged; the write-only fields are opt-in. Relaxing `password` to Optional is non-breaking.

### Tests

```
make testacc TESTARGS='-run=TestAccDatabaseSecretBackendConnection_elasticsearch'
```

Requires `ELASTIC_URL` / `ELASTIC_USERNAME` / `ELASTIC_PASSWORD` (same as the existing elasticsearch acceptance test). `go build ./...` and `go vet ./vault/` pass locally.