### PR TITLE
VAULT-44216: Update documentation for tfvp for vault snapshot support for AWS IRSA.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ FEATURES:
 
 * **LDAP Role Level Password Policy Support**: Added `password_policy` parameter to `vault_ldap_secret_backend_static_role` and `vault_ldap_secret_backend_dynamic_role` resources to support role-level password policy configuration ([#2921](https://github.com/hashicorp/terraform-provider-vault/pull/2921)). Requires Vault 2.1.0+.
 
-* **Autosnapshot support for AWS IRSA**: Added documentation for IRSA usage per changes in Vault. IRSA feature requires Vault 2.1.0+
+* **Autosnapshot support for AWS IRSA**: Added documentation for IRSA usage per changes in Vault ([hashicorp/raft-snapshotagent#49](https://github.com/hashicorp/raft-snapshotagent/pull/49)). IRSA feature requires Vault 2.1.0+
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ FEATURES:
 
 * **LDAP Role Level Password Policy Support**: Added `password_policy` parameter to `vault_ldap_secret_backend_static_role` and `vault_ldap_secret_backend_dynamic_role` resources to support role-level password policy configuration ([#2921](https://github.com/hashicorp/terraform-provider-vault/pull/2921)). Requires Vault 2.1.0+.
 
+* **Autosnapshot support for AWS IRSA**: Added documentation for IRSA usage per changes in Vault. IRSA feature requires Vault 2.1.0+
+
 BUG FIXES:
 
 * Fixed the token namespace being set as the provider namespace, even when `set_namespace_from_token` was `false`. ([#2926](https://github.com/hashicorp/terraform-provider-vault/pull/2926/))

--- a/website/docs/r/raft_snapshot_agent_config.html.md
+++ b/website/docs/r/raft_snapshot_agent_config.html.md
@@ -160,8 +160,8 @@ The following arguments are supported:
   Conflicts with `aws_secret_access_key_wo`.
 
 - `aws_secret_access_key_wo` - AWS secret access key (write-only).
-  This value is sent to Vault but never stored in Terraform state. If omitted (along with
-  `aws_access_key_id`), Vault authenticates to
+  This value is sent to Vault but never stored in Terraform state. With Vault 2.1.0 
+  if omitted (along with `aws_access_key_id`), Vault authenticates to
   S3 using the AWS SDK default credential chain, which supports IAM Roles for
   Service Accounts (IRSA) on EKS. When set, an Access Key ID must also be
   provided.

--- a/website/docs/r/raft_snapshot_agent_config.html.md
+++ b/website/docs/r/raft_snapshot_agent_config.html.md
@@ -160,7 +160,11 @@ The following arguments are supported:
   Conflicts with `aws_secret_access_key_wo`.
 
 - `aws_secret_access_key_wo` - AWS secret access key (write-only).
-  This value is sent to Vault but never stored in Terraform state.
+  This value is sent to Vault but never stored in Terraform state. If omitted (along with
+  `aws_access_key_id`), Vault authenticates to
+  S3 using the AWS SDK default credential chain, which supports IAM Roles for
+  Service Accounts (IRSA) on EKS. When set, an Access Key ID must also be
+  provided.
   Conflicts with `aws_secret_access_key`.
 
 - `secrets_wo_version` - Version used with write-only secrets.


### PR DESCRIPTION

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
**Autosnapshot support for AWS IRSA**: Added documentation for IRSA usage per changes in Vault ([hashicorp/raft-snapshotagent#49](https://github.com/hashicorp/raft-snapshotagent/pull/49)). IRSA feature requires Vault 2.1.0+


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
