### PR TITLE
feat(database_secret_backend_connection): add write-only password to cassandra engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ FEATURES:
 
 IMPROVEMENTS:
 
+* `vault_database_secret_backend_connection`: Add write-only `password_wo` and `password_wo_version` fields to the `cassandra` engine to set the password without storing it in state. ([#2968](https://github.com/hashicorp/terraform-provider-vault/pull/2968))
 * `vault_jwt_auth_backend`: Add string-to-integer conversion for `groups_cap` field in `provider_config` to support Okta provider configuration. ([#2939](https://github.com/hashicorp/terraform-provider-vault/pull/2939))
 
 BUG FIXES:

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -304,10 +304,25 @@ func getDatabaseSchema(typ schema.ValueType) schemaMap {
 						Description: "The username to use when authenticating with Cassandra.",
 					},
 					"password": {
-						Type:        schema.TypeString,
-						Optional:    true,
-						Description: "The password to use when authenticating with Cassandra.",
-						Sensitive:   true,
+						Type:          schema.TypeString,
+						Optional:      true,
+						Description:   "The password to use when authenticating with Cassandra.",
+						Sensitive:     true,
+						ConflictsWith: []string{fmt.Sprintf("%s.0.%s", dbEngineCassandra.name, consts.FieldPasswordWO)},
+					},
+					consts.FieldPasswordWO: {
+						Type:          schema.TypeString,
+						Optional:      true,
+						Description:   "Write-only field for the password to use when authenticating with Cassandra.",
+						Sensitive:     true,
+						WriteOnly:     true,
+						ConflictsWith: []string{fmt.Sprintf("%s.0.%s", dbEngineCassandra.name, consts.FieldPassword)},
+					},
+					consts.FieldPasswordWOVersion: {
+						Type:         schema.TypeInt,
+						Optional:     true,
+						Description:  "Version counter for the Cassandra password write-only field.",
+						RequiredWith: []string{fmt.Sprintf("%s.0.%s", dbEngineCassandra.name, consts.FieldPasswordWO)},
 					},
 					"tls": {
 						Type:        schema.TypeBool,
@@ -1168,10 +1183,34 @@ func setCassandraDatabaseConnectionData(d *schema.ResourceData, prefix string, d
 		data["username"] = v.(string)
 	}
 
+	// Vault does not return the password in the API. If the root credentials have been rotated, sending
+	// the old password in the update request would break the connection config. Thus we only send it,
+	// if it actually changed to still support updating it for non-rotated cases.
 	passwordKey := prefix + consts.FieldPassword
-	if v, ok := d.GetOk(passwordKey); ok {
-		if d.IsNewResource() || d.HasChange(passwordKey) {
+	passwordWriteOnlyVersionKey := prefix + consts.FieldPasswordWOVersion
+	if d.IsNewResource() || d.HasChange(passwordKey) || d.HasChange(passwordWriteOnlyVersionKey) {
+		if v, ok := d.GetOk(passwordKey); ok && v != nil {
+			log.Printf("[DEBUG] using persisted password; please use new write-only attributes `password_wo` " +
+				"and `password_wo_version` for security")
 			data[consts.FieldPassword] = v.(string)
+		} else if d.HasChange(passwordWriteOnlyVersionKey) {
+			engineName, engineIdx, err := databaseEngineNameAndIndexFromPrefix(prefix)
+			if err != nil {
+				// this should not happen, since we control how the prefix is created
+				panic(fmt.Sprintf("[ERROR] invalid prefix %q for database connection: %s", prefix, err))
+			}
+
+			idx, err := strconv.Atoi(engineIdx)
+			if err != nil {
+				// this should not happen, since we control how the index has been set
+				panic(fmt.Sprintf("[ERROR] unable to convert string index to integer: %s", err))
+			}
+
+			// construct path to use GetRawConfig
+			path := cty.GetAttrPath(engineName).IndexInt(idx).GetAttr(consts.FieldPasswordWO)
+			if pwWo, _ := d.GetRawConfigAt(path); !pwWo.IsNull() {
+				data[consts.FieldPassword] = pwWo.AsString()
+			}
 		}
 	}
 
@@ -2382,6 +2421,10 @@ func getConnectionDetailsCassandra(d *schema.ResourceData, prefix string, resp *
 		} else if v, ok := d.GetOk(prefix + "password"); ok {
 			// keep the password we have in state/config if the API doesn't return one
 			result["password"] = v.(string)
+		}
+		// ensure password_wo_version is updated in state
+		if v, ok := d.GetOk(prefix + consts.FieldPasswordWOVersion); ok {
+			result[consts.FieldPasswordWOVersion] = v.(int)
 		}
 		if v, ok := data["tls"]; ok {
 			result["tls"] = v.(bool)

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -144,6 +144,67 @@ func TestAccDatabaseSecretBackendConnection_cassandra(t *testing.T) {
 	})
 }
 
+// TestAccDatabaseSecretBackendConnection_cassandra_password_wo tests that the
+// write-only attribute `password_wo` works as expected for the cassandra engine.
+//
+// To run locally you will need to set the following env vars:
+//   - CASSANDRA_HOST
+//   - CASSANDRA_USERNAME
+//   - CASSANDRA_PASSWORD
+func TestAccDatabaseSecretBackendConnection_cassandra_password_wo(t *testing.T) {
+	MaybeSkipDBTests(t, dbEngineCassandra)
+
+	// TODO: make these fatal once we auto provision the required test infrastructure.
+	values := testutil.SkipTestEnvUnset(t, "CASSANDRA_HOST")
+	host := values[0]
+
+	username := os.Getenv("CASSANDRA_USERNAME")
+	password := os.Getenv("CASSANDRA_PASSWORD")
+	backend := acctest.RandomWithPrefix("tf-test-db")
+	pluginName := dbEngineCassandra.DefaultPluginName()
+	name := acctest.RandomWithPrefix("db")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
+		CheckDestroy:             testAccDatabaseSecretBackendConnectionCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				// password and password_wo are mutually exclusive
+				Config:      testAccDatabaseSecretBackendConnectionConfig_cassandra_passwordConflict(name, backend, host, username),
+				ExpectError: regexp.MustCompile("conflicts with"),
+			},
+			{
+				// password_wo_version requires password_wo
+				Config:      testAccDatabaseSecretBackendConnectionConfig_cassandra_versionWithoutWO(name, backend, host, username, 1),
+				ExpectError: regexp.MustCompile("must be specified"),
+			},
+			{
+				Config: testAccDatabaseSecretBackendConnectionConfig_cassandra_writeOnly(name, backend, host, username, password, 1),
+				Check: testComposeCheckFuncCommonDatabaseSecretBackend(name, backend, pluginName,
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.hosts.#", "1"),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.hosts.0", host),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.username", username),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.password_wo_version", "1"),
+				),
+			},
+			{
+				Config: testAccDatabaseSecretBackendConnectionConfig_cassandra_writeOnly(name, backend, host, username, password, 2),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(testDefaultDatabaseSecretBackendResource, plancheck.ResourceActionUpdate),
+					},
+				},
+				// successful connection guarantees that password_wo was re-sent on the version bump
+				Check: testComposeCheckFuncCommonDatabaseSecretBackend(name, backend, pluginName,
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.username", username),
+					resource.TestCheckResourceAttr(testDefaultDatabaseSecretBackendResource, "cassandra.0.password_wo_version", "2"),
+				),
+			},
+		},
+	})
+}
+
 // TestAccDatabaseSecretBackendConnection_cassandraProtocol tests cassandra DB connection when optional fields are ommitted
 func TestAccDatabaseSecretBackendConnection_cassandraProtocol(t *testing.T) {
 	MaybeSkipDBTests(t, dbEngineCassandra)
@@ -1934,6 +1995,75 @@ func testAccDatabaseSecretBackendConnectionConfig_cassandra(name, path, host, us
 		}
 	}
 	`, path, name, skipStaticLine, host, username, password, timeout)
+}
+
+func testAccDatabaseSecretBackendConnectionConfig_cassandra_writeOnly(name, path, host, username, password string, version int) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "db" {
+	path = "%s"
+	type = "database"
+}
+
+resource "vault_database_secret_backend_connection" "test" {
+	backend = vault_mount.db.path
+	name = "%s"
+	allowed_roles = ["dev", "prod"]
+	verify_connection = true
+
+	cassandra {
+		hosts               = ["%s"]
+		username            = "%s"
+		password_wo         = "%s"
+		password_wo_version = %d
+		tls                 = false
+		protocol_version    = 4
+	}
+}
+`, path, name, host, username, password, version)
+}
+
+func testAccDatabaseSecretBackendConnectionConfig_cassandra_passwordConflict(name, path, host, username string) string {
+	// values are dummies: this config fails validation before any connection
+	return fmt.Sprintf(`
+resource "vault_mount" "db" {
+	path = "%s"
+	type = "database"
+}
+
+resource "vault_database_secret_backend_connection" "test" {
+	backend = vault_mount.db.path
+	name = "%s"
+	allowed_roles = ["dev", "prod"]
+
+	cassandra {
+		hosts       = ["%s"]
+		username    = "%s"
+		password    = "test-password"
+		password_wo = "test-password"
+	}
+}
+`, path, name, host, username)
+}
+
+func testAccDatabaseSecretBackendConnectionConfig_cassandra_versionWithoutWO(name, path, host, username string, version int) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "db" {
+	path = "%s"
+	type = "database"
+}
+
+resource "vault_database_secret_backend_connection" "test" {
+	backend = vault_mount.db.path
+	name = "%s"
+	allowed_roles = ["dev", "prod"]
+
+	cassandra {
+		hosts               = ["%s"]
+		username            = "%s"
+		password_wo_version = %d
+	}
+}
+`, path, name, host, username, version)
 }
 
 func testAccDatabaseSecretBackendConnectionConfig_cassandraProtocol(name, path, host, username, password string) string {

--- a/vault/resource_database_secrets_mount.go
+++ b/vault/resource_database_secrets_mount.go
@@ -128,6 +128,13 @@ func getDatabaseSecretsMountSchema() schemaMap {
 	for k, v := range getDatabaseSchema(schema.TypeList) {
 		v.ConflictsWith = nil
 		v.MaxItems = 0
+		// variable-length blocks here: ".0." child validators are invalid, strip them
+		if res, ok := v.Elem.(*schema.Resource); ok {
+			for _, cs := range res.Schema {
+				cs.ConflictsWith = nil
+				cs.RequiredWith = nil
+			}
+		}
 		addCommonDatabaseSchema(v)
 		s[k] = v
 	}

--- a/website/docs/r/database_secret_backend_connection.md
+++ b/website/docs/r/database_secret_backend_connection.md
@@ -165,7 +165,7 @@ Exactly one of the nested blocks of configuration options must be supplied.
 
 * `username` - (Required) The username to authenticate with.
 
-* `password` - (Required) The password to authenticate with.
+* `password` - (Optional) The password to authenticate with. Prefer `password_wo` to avoid storing the password in state.
 
 * `port` - (Optional) The default port to connect to if no port is specified as
   part of the host.


### PR DESCRIPTION
### Description

Adds write-only password support to the `cassandra` engine of `vault_database_secret_backend_connection`.

Two new fields on the `cassandra` block let you set and rotate the root password without persisting it in Terraform state:
- `password_wo` — write-only password, never stored in state
- `password_wo_version` — integer counter; bump it to re-send the write-only value (Terraform can't diff a value it doesn't store, so the version is the trigger)

Validation:
- `password_wo` and `password` are mutually exclusive (`ConflictsWith`)
- `password_wo_version` requires `password_wo` (`RequiredWith`)

Because the same engine schema is reused by `vault_database_secrets_mount` with variable-length blocks (where `.0.` child-validator paths are invalid), those child validators are stripped there. Docs also correct `cassandra`'s `password` from Required to Optional to match the existing

This mirrors the existing write-only pattern al-based engines in the same resource.

### Checklist

* [x] Added [CHANGELOG](https://github.com/hashault/blob/master/CHANGELOG.md) entry (only foruser-facing changes)
* [] Acceptance tests where run against all supported Vault Versions

### Output from acceptance testing:

```sh
$ TF_ACC=1 VAULT_ADDR=http://localhost:8200 VAULT_TOKEN=... \
  CASSANDRA_HOST=... CASSANDRA_USERNAME=cassandra CASSANDRA_PASSWORD=cassandra \
  make testacc TESTARGS='-run=TestAccDatabaseSecretBackendConnection_cassandra'

--- PASS: TestAccDatabaseSecretBackendConnection_cassandra (2.90s)
--- PASS: TestAccDatabaseSecretBackendConnection_cassandra_password_wo (3.44s)
--- PASS: TestAccDatabaseSecretBackendConnection_cassandraProtocol (1.84s)
--- PASS: TestAccDatabaseSecretBackendConnection_cassandra_invalidFields (2.55s)
--- SKIP: TestAccDatabaseSecretBackendConnection_cassandra_customFields (TLS-only)
--- PASS: TestAccDatabaseSecretBackendConnection_cassandra_customFieldsNoTLS (1.81s)
PASS
ok  github.com/hashicorp/terraform-provider-vault/vault  14.012s
```

Community Note

- Please vote on this pull request by adding a 👍 reaction to the original pull request comment to help the community and
maintainers prioritize this request
- Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the
request

PCI review checklist

- [x] I have documented a clear reason for, ande I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

-   Revert plan: revert the PR. No data migration or state changes required.
- [x] If applicable, I've documented the impacty controls.

-   This is a security improvement: password_wo keeps the Cassandra root password out of Terraform state. No existing controls are removed; the plaintext password field remains supported for backward compatibility.