### PR TITLE
feat: add import to cert_auth_backend_role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ FEATURES:
 
 IMPROVEMENTS:
 
+* `vault_cert_auth_backend_role`: Added import support for existing certificate auth roles. ([#2970](https://github.com/hashicorp/terraform-provider-vault/pull/2970))
 * `vault_jwt_auth_backend`: Add string-to-integer conversion for `groups_cap` field in `provider_config` to support Okta provider configuration. ([#2939](https://github.com/hashicorp/terraform-provider-vault/pull/2939))
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ FEATURES:
 
 IMPROVEMENTS:
 
+* `vault_cert_auth_backend_role`: Added import support for existing certificate auth roles. ([#2970](https://github.com/hashicorp/terraform-provider-vault/pull/2970))
 * `vault_cert_auth_backend_role`: Add `certificate_wo` and `certificate_wo_version` write-only fields to allow ephemeral resource values, to supply the CA certificate. The `certificate` field is now `Computed` and `ForceNew` has been removed enabling in-place updates when the certificate changes instead of resource replacement.
 
 * `vault_ldap_auth_backend`: emit a warning when the auth mount or its config is not found during refresh, so users see an actionable message in `terraform plan` output rather than a silent state removal. ([#2997](https://github.com/hashicorp/terraform-provider-vault/pull/2997))

--- a/vault/resource_cert_auth_backend_role.go
+++ b/vault/resource_cert_auth_backend_role.go
@@ -5,7 +5,9 @@ package vault
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"regexp"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -16,6 +18,9 @@ import (
 )
 
 var (
+	certAuthBackendRoleBackendFromPathRegex = regexp.MustCompile("^auth/(.+)/certs/[^/]+$")
+	certAuthBackendRoleNameFromPathRegex    = regexp.MustCompile("^auth/.+/certs/([^/]+)$")
+
 	certAuthStringFields = []string{
 		consts.FieldCertificate,
 		consts.FieldDisplayName,
@@ -63,6 +68,9 @@ func certAuthBackendRoleResource() *schema.Resource {
 			Type:     schema.TypeString,
 			Required: true,
 			ForceNew: true,
+			StateFunc: func(v interface{}) string {
+				return strings.Trim(v.(string), "/")
+			},
 		},
 		consts.FieldCertificate: {
 			Type:     schema.TypeString,
@@ -202,12 +210,37 @@ func certAuthBackendRoleResource() *schema.Resource {
 		UpdateContext: certAuthResourceUpdate,
 		ReadContext:   provider.ReadContextWrapper(certAuthResourceRead),
 		DeleteContext: certAuthResourceDelete,
-		Schema:        fields,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: fields,
 	}
 }
 
 func certCertResourcePath(backend, name string) string {
 	return "auth/" + strings.Trim(backend, "/") + "/certs/" + strings.Trim(name, "/")
+}
+
+func certAuthBackendRoleNameFromPath(path string) (string, error) {
+	if !certAuthBackendRoleNameFromPathRegex.MatchString(path) {
+		return "", fmt.Errorf("no role found")
+	}
+	res := certAuthBackendRoleNameFromPathRegex.FindStringSubmatch(path)
+	if len(res) != 2 {
+		return "", fmt.Errorf("unexpected number of matches (%d) for role", len(res))
+	}
+	return res[1], nil
+}
+
+func certAuthBackendRoleBackendFromPath(path string) (string, error) {
+	if !certAuthBackendRoleBackendFromPathRegex.MatchString(path) {
+		return "", fmt.Errorf("no backend found")
+	}
+	res := certAuthBackendRoleBackendFromPathRegex.FindStringSubmatch(path)
+	if len(res) != 2 {
+		return "", fmt.Errorf("unexpected number of matches (%d) for backend", len(res))
+	}
+	return res[1], nil
 }
 
 func certAuthResourceWrite(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -336,6 +369,15 @@ func certAuthResourceRead(_ context.Context, d *schema.ResourceData, meta interf
 		return diag.FromErr(e)
 	}
 	path := d.Id()
+	backend, err := certAuthBackendRoleBackendFromPath(path)
+	if err != nil {
+		return diag.Errorf("invalid path %q for cert auth backend role: %s", path, err)
+	}
+
+	name, err := certAuthBackendRoleNameFromPath(path)
+	if err != nil {
+		return diag.Errorf("invalid path %q for cert auth backend role: %s", path, err)
+	}
 
 	log.Printf("[DEBUG] Reading cert %q", path)
 	resp, err := client.Logical().Read(path)
@@ -348,6 +390,13 @@ func certAuthResourceRead(_ context.Context, d *schema.ResourceData, meta interf
 		log.Printf("[WARN] cert %q not found, removing from state", path)
 		d.SetId("")
 		return nil
+	}
+
+	if err := d.Set(consts.FieldBackend, backend); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set(consts.FieldName, name); err != nil {
+		return diag.FromErr(err)
 	}
 
 	if err := readTokenFields(d, resp); err != nil {

--- a/vault/resource_cert_auth_backend_role.go
+++ b/vault/resource_cert_auth_backend_role.go
@@ -5,7 +5,9 @@ package vault
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"regexp"
 	"strings"
 
 	"github.com/hashicorp/go-cty/cty"
@@ -17,6 +19,9 @@ import (
 )
 
 var (
+	certAuthBackendRoleBackendFromPathRegex = regexp.MustCompile("^auth/(.+)/certs/[^/]+$")
+	certAuthBackendRoleNameFromPathRegex    = regexp.MustCompile("^auth/.+/certs/([^/]+)$")
+
 	certAuthStringFields = []string{
 		consts.FieldDisplayName,
 		consts.FieldOCSPCACertificates,
@@ -63,6 +68,9 @@ func certAuthBackendRoleResource() *schema.Resource {
 			Type:     schema.TypeString,
 			Required: true,
 			ForceNew: true,
+			StateFunc: func(v interface{}) string {
+				return strings.Trim(v.(string), "/")
+			},
 		},
 		consts.FieldCertificate: {
 			Type:          schema.TypeString,
@@ -217,12 +225,37 @@ func certAuthBackendRoleResource() *schema.Resource {
 		UpdateContext: certAuthResourceUpdate,
 		ReadContext:   provider.ReadContextWrapper(certAuthResourceRead),
 		DeleteContext: certAuthResourceDelete,
-		Schema:        fields,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: fields,
 	}
 }
 
 func certCertResourcePath(backend, name string) string {
 	return "auth/" + strings.Trim(backend, "/") + "/certs/" + strings.Trim(name, "/")
+}
+
+func certAuthBackendRoleNameFromPath(path string) (string, error) {
+	if !certAuthBackendRoleNameFromPathRegex.MatchString(path) {
+		return "", fmt.Errorf("no role found")
+	}
+	res := certAuthBackendRoleNameFromPathRegex.FindStringSubmatch(path)
+	if len(res) != 2 {
+		return "", fmt.Errorf("unexpected number of matches (%d) for role", len(res))
+	}
+	return res[1], nil
+}
+
+func certAuthBackendRoleBackendFromPath(path string) (string, error) {
+	if !certAuthBackendRoleBackendFromPathRegex.MatchString(path) {
+		return "", fmt.Errorf("no backend found")
+	}
+	res := certAuthBackendRoleBackendFromPathRegex.FindStringSubmatch(path)
+	if len(res) != 2 {
+		return "", fmt.Errorf("unexpected number of matches (%d) for backend", len(res))
+	}
+	return res[1], nil
 }
 
 func certAuthResourceWrite(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -367,6 +400,15 @@ func certAuthResourceRead(_ context.Context, d *schema.ResourceData, meta interf
 		return diag.FromErr(e)
 	}
 	path := d.Id()
+	backend, err := certAuthBackendRoleBackendFromPath(path)
+	if err != nil {
+		return diag.Errorf("invalid path %q for cert auth backend role: %s", path, err)
+	}
+
+	name, err := certAuthBackendRoleNameFromPath(path)
+	if err != nil {
+		return diag.Errorf("invalid path %q for cert auth backend role: %s", path, err)
+	}
 
 	log.Printf("[DEBUG] Reading cert %q", path)
 	resp, err := client.Logical().Read(path)
@@ -379,6 +421,13 @@ func certAuthResourceRead(_ context.Context, d *schema.ResourceData, meta interf
 		log.Printf("[WARN] cert %q not found, removing from state", path)
 		d.SetId("")
 		return nil
+	}
+
+	if err := d.Set(consts.FieldBackend, backend); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set(consts.FieldName, name); err != nil {
+		return diag.FromErr(err)
 	}
 
 	if err := readTokenFields(d, resp); err != nil {
@@ -395,6 +444,17 @@ func certAuthResourceRead(_ context.Context, d *schema.ResourceData, meta interf
 				schema.HashString, resp.Data["allowed_names"].([]interface{})))
 	} else {
 		d.Set("allowed_names",
+			schema.NewSet(
+				schema.HashString, []interface{}{}))
+	}
+
+	// Vault sometimes returns these as null instead of an empty list.
+	if resp.Data["allowed_common_names"] != nil {
+		d.Set("allowed_common_names",
+			schema.NewSet(
+				schema.HashString, resp.Data["allowed_common_names"].([]interface{})))
+	} else {
+		d.Set("allowed_common_names",
 			schema.NewSet(
 				schema.HashString, []interface{}{}))
 	}

--- a/vault/resource_cert_auth_backend_role_test.go
+++ b/vault/resource_cert_auth_backend_role_test.go
@@ -75,6 +75,111 @@ bwvTJuiSbAHkhG+eM/04PpWPMo6skek10KmIBvGveHM8R89gbA1Fgw==
 
 const testBase64PEM = `MIIDIzCCAgugAwIBAgIJAIxJbvl6PnmvMA0GCSqGSIb3DQEBBQUAMBUxEzARBgNVBAMTClZhdWx0IFRlc3QwHhcNMTgwNTA5MTcyMjU0WhcNMjgwNTA2MTcyMjU0WjAVMRMwEQYDVQQDEwpWYXVsdCBUZXN0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxZj/1W69FiancHSEbMhfL0KZvftNksIN2rsMHhVkLDSn7KZyqlVhSOmygARFVmSwi5AO894FAuJU7L/RDcBD6mI3lTzDokeuRoRMpwbNg2aR+VNQaQpdHbLFm3xTO1na7wuxO4F7tDzLQRKzO0wSmqBhXXdJsoTG97mA8Gq5tAR20Uz8vWh3PI8taFG6aSuL7rfm+O3iMoCPTj3DofUENfnd0ZxlXpR/X7Z1iQej5+jXIn0ygoXxc07rfPd6J2jxz0lWL95Q65QWBSaKKNjWHaShSsqGe8KLZu9BFp20+M4Y8fd40B7+mlWk17nUdqvwZtnNL1qf+t0SFFhueQY+4wIDAQABo3YwdDAdBgNVHQ4EFgQUoTWVof3QQakI0Xfamu5nJglXUwswRQYDVR0jBD4wPIAUoTWVof3QQakI0Xfamu5nJglXUwuhGaQXMBUxEzARBgNVBAMTClZhdWx0IFRlc3SCCQCMSW75ej55rzAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBBQUAA4IBAQDFmMBq5s5vBHMrACXfgIBpZSSaiBXz8tVDaiYO5UfZsWqEIn61+NrgJT4Xvhba3VZgGkOLX/9CfnTXx9nq4qL2ht4my2QszXXBJyi0pB+0VIQhbRzjbrYeQn8uCmN5DLph3sA+vJuUWvR7l6h1zUjzRrXWLFQ+qQxtyYT18fgO3uttnbuzptDT23RDRySaoYLpeUFY47RIzFmuIO8bNsh8h5ymHNkVXrrvvqDIxIPD/M21z4ZlZSbsokyVcsGKbF87xv8SFXj5GbtZ7UI0qVYr9zk/Y090Qv1aypM1k5jHWSBCixTrUFtWENQYLYhh2bMP1uJ4UMxSNJXCthRASqNF`
 
+func TestCertAuthBackendRolePathMatching(t *testing.T) {
+	tests := map[string]struct {
+		path        string
+		wantBackend string
+		wantName    string
+		wantErr     bool
+	}{
+		"default backend": {
+			path:        "auth/cert/certs/example",
+			wantBackend: "cert",
+			wantName:    "example",
+		},
+		"nested backend": {
+			path:        "auth/custom/cert/certs/service.example",
+			wantBackend: "custom/cert",
+			wantName:    "service.example",
+		},
+		"final delimiter": {
+			path:        "auth/custom/certs/backend/certs/example",
+			wantBackend: "custom/certs/backend",
+			wantName:    "example",
+		},
+		"missing auth prefix": {
+			path:    "cert/certs/example",
+			wantErr: true,
+		},
+		"empty backend": {
+			path:    "auth//certs/example",
+			wantErr: true,
+		},
+		"missing certs delimiter": {
+			path:    "auth/cert/example",
+			wantErr: true,
+		},
+		"empty role name": {
+			path:    "auth/cert/certs/",
+			wantErr: true,
+		},
+		"role name with path separator": {
+			path:    "auth/cert/certs/example/child",
+			wantErr: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			backend, backendErr := certAuthBackendRoleBackendFromPath(tt.path)
+			role, roleErr := certAuthBackendRoleNameFromPath(tt.path)
+			if tt.wantErr {
+				if backendErr == nil || roleErr == nil {
+					t.Fatalf("expected path %q to be rejected", tt.path)
+				}
+				return
+			}
+
+			if backendErr != nil {
+				t.Fatalf("unexpected backend error: %s", backendErr)
+			}
+			if backend != tt.wantBackend {
+				t.Fatalf("expected backend %q, got %q", tt.wantBackend, backend)
+			}
+
+			if roleErr != nil {
+				t.Fatalf("unexpected role error: %s", roleErr)
+			}
+			if role != tt.wantName {
+				t.Fatalf("expected role name %q, got %q", tt.wantName, role)
+			}
+		})
+	}
+}
+
+func TestAccCertAuthBackendRole_import(t *testing.T) {
+	backend := acctest.RandomWithPrefix("tf-test-cert-auth") + "/nested"
+	name := acctest.RandomWithPrefix("tf-test-cert-name") + ".example"
+	configuredName := "/" + name + "/"
+	allowedNames := []string{"foo.example.org", "bar.example.org"}
+	allowedOrgUnits := []string{"engineering", "security"}
+	resourceName := "vault_cert_auth_backend_role.test"
+	config := testCertAuthBackendConfig_basic(backend, configuredName, testCertificate, "", allowedNames, allowedOrgUnits)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		CheckDestroy:             testCertAuthBackendDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldBackend, backend),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldName, name),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldTokenTTL, "300"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldTokenMaxTTL, "600"),
+				),
+			},
+			testutil.GetImportTestStep(resourceName, false, nil),
+			{
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 func TestCertAuthBackend(t *testing.T) {
 	backend := acctest.RandomWithPrefix("tf-test-cert-auth")
 	name := acctest.RandomWithPrefix("tf-test-cert-name")

--- a/vault/resource_cert_auth_backend_role_test.go
+++ b/vault/resource_cert_auth_backend_role_test.go
@@ -75,6 +75,115 @@ bwvTJuiSbAHkhG+eM/04PpWPMo6skek10KmIBvGveHM8R89gbA1Fgw==
 
 const testBase64PEM = `MIIDIzCCAgugAwIBAgIJAIxJbvl6PnmvMA0GCSqGSIb3DQEBBQUAMBUxEzARBgNVBAMTClZhdWx0IFRlc3QwHhcNMTgwNTA5MTcyMjU0WhcNMjgwNTA2MTcyMjU0WjAVMRMwEQYDVQQDEwpWYXVsdCBUZXN0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxZj/1W69FiancHSEbMhfL0KZvftNksIN2rsMHhVkLDSn7KZyqlVhSOmygARFVmSwi5AO894FAuJU7L/RDcBD6mI3lTzDokeuRoRMpwbNg2aR+VNQaQpdHbLFm3xTO1na7wuxO4F7tDzLQRKzO0wSmqBhXXdJsoTG97mA8Gq5tAR20Uz8vWh3PI8taFG6aSuL7rfm+O3iMoCPTj3DofUENfnd0ZxlXpR/X7Z1iQej5+jXIn0ygoXxc07rfPd6J2jxz0lWL95Q65QWBSaKKNjWHaShSsqGe8KLZu9BFp20+M4Y8fd40B7+mlWk17nUdqvwZtnNL1qf+t0SFFhueQY+4wIDAQABo3YwdDAdBgNVHQ4EFgQUoTWVof3QQakI0Xfamu5nJglXUwswRQYDVR0jBD4wPIAUoTWVof3QQakI0Xfamu5nJglXUwuhGaQXMBUxEzARBgNVBAMTClZhdWx0IFRlc3SCCQCMSW75ej55rzAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBBQUAA4IBAQDFmMBq5s5vBHMrACXfgIBpZSSaiBXz8tVDaiYO5UfZsWqEIn61+NrgJT4Xvhba3VZgGkOLX/9CfnTXx9nq4qL2ht4my2QszXXBJyi0pB+0VIQhbRzjbrYeQn8uCmN5DLph3sA+vJuUWvR7l6h1zUjzRrXWLFQ+qQxtyYT18fgO3uttnbuzptDT23RDRySaoYLpeUFY47RIzFmuIO8bNsh8h5ymHNkVXrrvvqDIxIPD/M21z4ZlZSbsokyVcsGKbF87xv8SFXj5GbtZ7UI0qVYr9zk/Y090Qv1aypM1k5jHWSBCixTrUFtWENQYLYhh2bMP1uJ4UMxSNJXCthRASqNF`
 
+func TestCertAuthBackendRolePathMatching(t *testing.T) {
+	tests := map[string]struct {
+		path        string
+		wantBackend string
+		wantName    string
+		wantErr     bool
+	}{
+		"default backend": {
+			path:        "auth/cert/certs/example",
+			wantBackend: "cert",
+			wantName:    "example",
+		},
+		"nested backend": {
+			path:        "auth/custom/cert/certs/service.example",
+			wantBackend: "custom/cert",
+			wantName:    "service.example",
+		},
+		"final delimiter": {
+			path:        "auth/custom/certs/backend/certs/example",
+			wantBackend: "custom/certs/backend",
+			wantName:    "example",
+		},
+		"missing auth prefix": {
+			path:    "cert/certs/example",
+			wantErr: true,
+		},
+		"empty backend": {
+			path:    "auth//certs/example",
+			wantErr: true,
+		},
+		"missing certs delimiter": {
+			path:    "auth/cert/example",
+			wantErr: true,
+		},
+		"empty role name": {
+			path:    "auth/cert/certs/",
+			wantErr: true,
+		},
+		"role name with path separator": {
+			path:    "auth/cert/certs/example/child",
+			wantErr: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			backend, backendErr := certAuthBackendRoleBackendFromPath(tt.path)
+			role, roleErr := certAuthBackendRoleNameFromPath(tt.path)
+			if tt.wantErr {
+				if backendErr == nil || roleErr == nil {
+					t.Fatalf("expected path %q to be rejected", tt.path)
+				}
+				return
+			}
+
+			if backendErr != nil {
+				t.Fatalf("unexpected backend error: %s", backendErr)
+			}
+			if backend != tt.wantBackend {
+				t.Fatalf("expected backend %q, got %q", tt.wantBackend, backend)
+			}
+
+			if roleErr != nil {
+				t.Fatalf("unexpected role error: %s", roleErr)
+			}
+			if role != tt.wantName {
+				t.Fatalf("expected role name %q, got %q", tt.wantName, role)
+			}
+		})
+	}
+}
+
+func TestAccCertAuthBackendRole_import(t *testing.T) {
+	backend := acctest.RandomWithPrefix("tf-test-cert-auth") + "/nested"
+	name := acctest.RandomWithPrefix("tf-test-cert-name") + ".example"
+	configuredName := "/" + name + "/"
+	allowedNames := []string{"foo.example.org", "bar.example.org"}
+	allowedOrgUnits := []string{"engineering", "security"}
+	allowedCommonName := "foo.example.com"
+	resourceName := "vault_cert_auth_backend_role.test"
+	extraConfig := fmt.Sprintf("allowed_common_names = [%q]", allowedCommonName)
+	config := testCertAuthBackendConfig_basic(backend, configuredName, testCertificate, extraConfig, allowedNames, allowedOrgUnits)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		CheckDestroy:             testCertAuthBackendDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldBackend, backend),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldName, name),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldTokenTTL, "300"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldTokenMaxTTL, "600"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldAllowedCommonNames+".#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, consts.FieldAllowedCommonNames+".*", allowedCommonName),
+				),
+			},
+			testutil.GetImportTestStep(resourceName, false, nil),
+			{
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 func TestCertAuthBackend(t *testing.T) {
 	backend := acctest.RandomWithPrefix("tf-test-cert-auth")
 	name := acctest.RandomWithPrefix("tf-test-cert-name")
@@ -364,6 +473,7 @@ func testCertAuthBackendCheck_attrs(resourceName, backend, name string) resource
 		attrs := map[string]string{
 			consts.FieldName:                       consts.FieldDisplayName,
 			consts.FieldAllowedNames:               consts.FieldAllowedNames,
+			consts.FieldAllowedCommonNames:         consts.FieldAllowedCommonNames,
 			consts.FieldAllowedDNSSans:             consts.FieldAllowedDNSSans,
 			consts.FieldAllowedEmailSans:           consts.FieldAllowedEmailSans,
 			consts.FieldAllowedURISans:             consts.FieldAllowedURISans,
@@ -384,7 +494,7 @@ func testCertAuthBackendCheck_attrs(resourceName, backend, name string) resource
 				VaultAttr:    v,
 			}
 			switch k {
-			case TokenFieldPolicies, consts.FieldAllowedNames, consts.FieldAllowedOrganizationalUnits:
+			case TokenFieldPolicies, consts.FieldAllowedNames, consts.FieldAllowedCommonNames, consts.FieldAllowedOrganizationalUnits:
 				ta.AsSet = true
 			}
 

--- a/website/docs/r/cert_auth_backend_role.html.md
+++ b/website/docs/r/cert_auth_backend_role.html.md
@@ -139,3 +139,13 @@ For more details on the usage of each argument consult the [Vault Cert API docum
 ## Attribute Reference
 
 No additional attributes are exposed by this resource.
+
+## Import
+
+Certificate auth backend roles can be imported using the Vault API path,
+relative to the target namespace, in the format
+`auth/<backend>/certs/<name>`, e.g.
+
+```shell
+$ terraform import vault_cert_auth_backend_role.example auth/custom/cert/certs/service.example
+```

--- a/website/docs/r/cert_auth_backend_role.html.md
+++ b/website/docs/r/cert_auth_backend_role.html.md
@@ -167,3 +167,13 @@ The following write-only attributes are supported:
 ## Attribute Reference
 
 No additional attributes are exposed by this resource.
+
+## Import
+
+Certificate auth backend roles can be imported using the Vault API path,
+relative to the target namespace, in the format
+`auth/<backend>/certs/<name>`, e.g.
+
+```shell
+$ terraform import vault_cert_auth_backend_role.example auth/custom/cert/certs/service.example
+```


### PR DESCRIPTION
<!-- Suggested PR title: vault_cert_auth_backend_role: add import support -->

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->

Existing certificate auth roles cannot currently be imported because `vault_cert_auth_backend_role` does not register an importer.

This adds import support using the role's Vault API path:

```shell
terraform import vault_cert_auth_backend_role.example \
  auth/custom/cert/certs/service.example
```


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests were run against all supported Vault Versions


### Output from acceptance testing:

Tested against Vault 1.21.3, 1.19.5, 1.16.3.

```
$ make testacc TEST_PATH=./vault \
    TESTARGS='-run=TestAccCertAuthBackendRole_import -count=1 -v'

...
--- PASS: TestAccCertAuthBackendRole_import
PASS
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.
