### PR TITLE
Add missing refresh of allowed_common_names for vault_cert_auth_backend_role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+* `vault_cert_auth_backend_role`: Refresh `allowed_common_names` during reads so Terraform can detect out-of-band changes. ([#2971](https://github.com/hashicorp/terraform-provider-vault/pull/2971/))
 * Fixed the token namespace being set as the provider namespace, even when `set_namespace_from_token` was `false`. ([#2926](https://github.com/hashicorp/terraform-provider-vault/pull/2926/))
 * `vault_pki_secret_backend_role`: Fix crash when the Vault client was not successfully initialized ([#2801](https://github.com/hashicorp/terraform-provider-vault/pull/2801))
 

--- a/vault/resource_cert_auth_backend_role.go
+++ b/vault/resource_cert_auth_backend_role.go
@@ -369,6 +369,17 @@ func certAuthResourceRead(_ context.Context, d *schema.ResourceData, meta interf
 	}
 
 	// Vault sometimes returns these as null instead of an empty list.
+	if resp.Data["allowed_common_names"] != nil {
+		d.Set("allowed_common_names",
+			schema.NewSet(
+				schema.HashString, resp.Data["allowed_common_names"].([]interface{})))
+	} else {
+		d.Set("allowed_common_names",
+			schema.NewSet(
+				schema.HashString, []interface{}{}))
+	}
+
+	// Vault sometimes returns these as null instead of an empty list.
 	if resp.Data["allowed_dns_sans"] != nil {
 		d.Set("allowed_dns_sans",
 			schema.NewSet(

--- a/vault/resource_cert_auth_backend_role_test.go
+++ b/vault/resource_cert_auth_backend_role_test.go
@@ -149,6 +149,49 @@ func TestCertAuthBackend(t *testing.T) {
 	})
 }
 
+func TestCertAuthBackend_AllowedCommonNamesDrift(t *testing.T) {
+	backend := acctest.RandomWithPrefix("tf-test-cert-auth")
+	name := acctest.RandomWithPrefix("tf-test-cert-name")
+	resourceName := "vault_cert_auth_backend_role.test"
+	expectedCommonName := "expected.example.com"
+	driftedCommonName := "drifted.example.com"
+	config := testCertAuthBackendConfig_allowedCommonNames(backend, name, expectedCommonName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		CheckDestroy:             testCertAuthBackendDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldAllowedCommonNames+".#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, consts.FieldAllowedCommonNames+".*", expectedCommonName),
+					testCertAuthBackendCheck_attrs(resourceName, backend, name),
+				),
+			},
+			{
+				PreConfig: func() {
+					client := testProvider.Meta().(*provider.ProviderMeta).MustGetClient()
+					path := certCertResourcePath(backend, name)
+					data := map[string]interface{}{
+						consts.FieldAllowedCommonNames: []string{driftedCommonName},
+					}
+					if _, err := client.Logical().Write(path, data); err != nil {
+						t.Fatalf("failed to update allowed common names for cert auth backend role %q: %s", path, err)
+					}
+				},
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldAllowedCommonNames+".#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, consts.FieldAllowedCommonNames+".*", expectedCommonName),
+					testCertAuthBackendCheck_attrs(resourceName, backend, name),
+				),
+			},
+		},
+	})
+}
+
 func TestCertAuthBackend_OCSP(t *testing.T) {
 	backend := acctest.RandomWithPrefix("tf-test-cert-auth")
 	name := acctest.RandomWithPrefix("tf-test-cert-name")
@@ -323,6 +366,7 @@ func testCertAuthBackendCheck_attrs(resourceName, backend, name string) resource
 		attrs := map[string]string{
 			consts.FieldName:                       consts.FieldDisplayName,
 			consts.FieldAllowedNames:               consts.FieldAllowedNames,
+			consts.FieldAllowedCommonNames:         consts.FieldAllowedCommonNames,
 			consts.FieldAllowedDNSSans:             consts.FieldAllowedDNSSans,
 			consts.FieldAllowedEmailSans:           consts.FieldAllowedEmailSans,
 			consts.FieldAllowedURISans:             consts.FieldAllowedURISans,
@@ -343,7 +387,7 @@ func testCertAuthBackendCheck_attrs(resourceName, backend, name string) resource
 				VaultAttr:    v,
 			}
 			switch k {
-			case TokenFieldPolicies, consts.FieldAllowedNames, consts.FieldAllowedOrganizationalUnits:
+			case TokenFieldPolicies, consts.FieldAllowedNames, consts.FieldAllowedCommonNames, consts.FieldAllowedOrganizationalUnits:
 				ta.AsSet = true
 			}
 
@@ -378,6 +422,25 @@ EOF
 `, backend, name, certificate, util.ArrayToTerraformList(allowedNames), util.ArrayToTerraformList(allowedOrgUnits), extraConfig)
 
 	return config
+}
+
+func testCertAuthBackendConfig_allowedCommonNames(backend, name, allowedCommonName string) string {
+	return fmt.Sprintf(`
+
+resource "vault_auth_backend" "cert" {
+    path = %q
+    type = "cert"
+}
+
+resource "vault_cert_auth_backend_role" "test" {
+    name                 = %q
+    certificate          = <<EOF
+%s
+EOF
+    allowed_common_names = [%q]
+    backend              = vault_auth_backend.cert.path
+}
+`, backend, name, testCertificate, allowedCommonName)
 }
 
 func testCertAuthBackendConfig_unset(backend, name, certificate string, allowedNames []string) string {


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->

`vault_cert_auth_backend_role` writes `allowed_common_names` but does not refresh it into Terraform state, so out-of-band changes can produce an empty plan.

This adds the missing read handling for `allowed_common_names`, resolving this issue. The acceptance test changes the field directly in Vault after an initial apply, then verifies Terraform restores the configured value on the following run.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests were run against all supported Vault Versions


### Output from acceptance testing:

Tested against Vault 1.21.3, 1.19.5, 1.16.3.

```
$ make testacc TEST_PATH=./vault \
    TESTARGS='-run=TestCertAuthBackend_AllowedCommonNamesDrift -count=1 -v'

...
--- PASS: TestCertAuthBackend_AllowedCommonNamesDrift
PASS
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Terraform will now detect and restore out-of-band changes to this certificate authentication constraint. Vault's matching and enforcement semantics are unchanged.