### PR TITLE
fix: correctly clear list fields in cert_auth_backend_role when removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+* `vault_cert_auth_backend_role`: Clear list fields in Vault when they are set to empty values or removed from configuration. ([#2972](https://github.com/hashicorp/terraform-provider-vault/pull/2972/))
 * Fixed the token namespace being set as the provider namespace, even when `set_namespace_from_token` was `false`. ([#2926](https://github.com/hashicorp/terraform-provider-vault/pull/2926/))
 * `vault_pki_secret_backend_role`: Fix crash when the Vault client was not successfully initialized ([#2801](https://github.com/hashicorp/terraform-provider-vault/pull/2801))
 

--- a/vault/resource_cert_auth_backend_role.go
+++ b/vault/resource_cert_auth_backend_role.go
@@ -75,7 +75,6 @@ func certAuthBackendRoleResource() *schema.Resource {
 				Type: schema.TypeString,
 			},
 			Optional: true,
-			Computed: true,
 		},
 		consts.FieldAllowedCommonNames: {
 			Type: schema.TypeSet,
@@ -83,7 +82,6 @@ func certAuthBackendRoleResource() *schema.Resource {
 				Type: schema.TypeString,
 			},
 			Optional: true,
-			Computed: true,
 		},
 		consts.FieldAllowedDNSSans: {
 			Type: schema.TypeSet,
@@ -91,7 +89,6 @@ func certAuthBackendRoleResource() *schema.Resource {
 				Type: schema.TypeString,
 			},
 			Optional: true,
-			Computed: true,
 		},
 		consts.FieldAllowedEmailSans: {
 			Type: schema.TypeSet,
@@ -99,7 +96,6 @@ func certAuthBackendRoleResource() *schema.Resource {
 				Type: schema.TypeString,
 			},
 			Optional: true,
-			Computed: true,
 		},
 		consts.FieldAllowedURISans: {
 			Type: schema.TypeSet,
@@ -107,7 +103,6 @@ func certAuthBackendRoleResource() *schema.Resource {
 				Type: schema.TypeString,
 			},
 			Optional: true,
-			Computed: true,
 		},
 		consts.FieldAllowedOrganizationalUnits: {
 			Type: schema.TypeSet,
@@ -122,7 +117,6 @@ func certAuthBackendRoleResource() *schema.Resource {
 				Type: schema.TypeString,
 			},
 			Optional: true,
-			Computed: true,
 		},
 		consts.FieldDisplayName: {
 			Type:     schema.TypeString,
@@ -293,14 +287,10 @@ func certAuthResourceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 		if certAuthVault113Fields[k] && !provider.IsAPISupported(meta, provider.VaultVersion113) {
 			continue
 		}
-		// special handling for allowed_organizational_units since unsetting
-		// this in Vault has special meaning (allow all OUs)
-		if k == consts.FieldAllowedOrganizationalUnits {
-			if d.HasChange(k) {
-				data[k] = d.Get(k).(*schema.Set).List()
-			}
-		} else if v, ok := d.GetOk(k); ok {
+		if v, ok := d.GetOk(k); ok {
 			data[k] = v.(*schema.Set).List()
+		} else if d.HasChange(k) {
+			data[k] = d.Get(k).(*schema.Set).List()
 		}
 	}
 

--- a/vault/resource_cert_auth_backend_role_test.go
+++ b/vault/resource_cert_auth_backend_role_test.go
@@ -6,7 +6,9 @@ package vault
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"regexp"
+	"sort"
 	"strings"
 	"testing"
 
@@ -144,6 +146,137 @@ func TestCertAuthBackend(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, FieldAliasMetadata+".%", "1"),
 					resource.TestCheckResourceAttr(resourceName, FieldAliasMetadata+".foo", "bar"),
 				),
+			},
+		},
+	})
+}
+
+func TestCertAuthBackend_ClearListFields(t *testing.T) {
+	backend := acctest.RandomWithPrefix("tf-test-cert-auth")
+	name := acctest.RandomWithPrefix("tf-test-cert-name")
+	resourceName := "vault_cert_auth_backend_role.test"
+
+	initialFields := certAuthBackendListFields{
+		allowedNames:               []string{"service.example.com"},
+		allowedCommonNames:         []string{"common.example.com"},
+		allowedDNSSans:             []string{"dns.example.com"},
+		allowedEmailSans:           []string{"service@example.com"},
+		allowedOrganizationalUnits: []string{"engineering"},
+		allowedURISans:             []string{"spiffe://old/*"},
+		ocspServersOverride:        []string{"server.example.com"},
+		requiredExtensions:         []string{"1.3.6.1.4.1.311.20.2.2:smartcardlogin"},
+	}
+	emptyFields := certAuthBackendListFields{}
+	preservedFields := certAuthBackendListFields{
+		allowedNames:               []string{"preserved.example.com"},
+		allowedOrganizationalUnits: []string{"preserved-ou"},
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctestutil.TestAccPreCheck(t)
+			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion113)
+		},
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		CheckDestroy:             testCertAuthBackendDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testCertAuthBackendConfig_listFields(backend, name, "initial", initialFields),
+				Check:  testCertAuthBackendCheckListFields(resourceName, initialFields),
+			},
+			{
+				Config: testCertAuthBackendConfig_listFields(backend, name, "initial", emptyFields),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldAllowedNames+".#", "0"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldAllowedCommonNames+".#", "0"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldAllowedDNSSans+".#", "0"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldAllowedEmailSans+".#", "0"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldAllowedOrganizationalUnits+".#", "0"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldAllowedURISans+".#", "0"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldOCSPServersOverride+".#", "0"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldRequiredExtensions+".#", "0"),
+					testCertAuthBackendCheckListFields(resourceName, emptyFields),
+				),
+			},
+			{
+				Config:             testCertAuthBackendConfig_listFields(backend, name, "initial", emptyFields),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				Config: testCertAuthBackendConfig_listFields(backend, name, "before unrelated update", preservedFields),
+				Check:  testCertAuthBackendCheckListFields(resourceName, preservedFields),
+			},
+			{
+				Config: testCertAuthBackendConfig_listFields(backend, name, "after unrelated update", preservedFields),
+				Check:  testCertAuthBackendCheckListFields(resourceName, preservedFields),
+			},
+		},
+	})
+}
+
+func TestCertAuthBackend_ClearListFieldsWhenOmitted(t *testing.T) {
+	backend := acctest.RandomWithPrefix("tf-test-cert-auth")
+	name := acctest.RandomWithPrefix("tf-test-cert-name")
+	resourceName := "vault_cert_auth_backend_role.test"
+
+	initialFields := certAuthBackendListFields{
+		allowedNames:       []string{"service.example.com"},
+		allowedCommonNames: []string{"common.example.com"},
+		allowedDNSSans:     []string{"dns.example.com"},
+		allowedEmailSans:   []string{"service@example.com"},
+		requiredExtensions: []string{"1.3.6.1.4.1.311.20.2.2:smartcardlogin"},
+	}
+	uriOnlyFields := certAuthBackendListFields{
+		allowedURISans: []string{"spiffe://new/service"},
+	}
+	nameOnlyFields := certAuthBackendListFields{
+		allowedNames: []string{"replacement.example.com"},
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		CheckDestroy:             testCertAuthBackendDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testCertAuthBackendConfig_optionalListFields(backend, name, initialFields),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldAllowedNames+".#", "1"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldAllowedCommonNames+".#", "1"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldAllowedDNSSans+".#", "1"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldAllowedEmailSans+".#", "1"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldAllowedURISans+".#", "0"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldRequiredExtensions+".#", "1"),
+					testCertAuthBackendCheckListFields(resourceName, initialFields),
+				),
+			},
+			{
+				Config: testCertAuthBackendConfig_optionalListFields(backend, name, uriOnlyFields),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldAllowedNames+".#", "0"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldAllowedCommonNames+".#", "0"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldAllowedDNSSans+".#", "0"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldAllowedEmailSans+".#", "0"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldAllowedURISans+".#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, consts.FieldAllowedURISans+".*", "spiffe://new/service"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldRequiredExtensions+".#", "0"),
+					testCertAuthBackendCheckListFields(resourceName, uriOnlyFields),
+				),
+			},
+			{
+				Config: testCertAuthBackendConfig_optionalListFields(backend, name, nameOnlyFields),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldAllowedNames+".#", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, consts.FieldAllowedNames+".*", "replacement.example.com"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldAllowedURISans+".#", "0"),
+					testCertAuthBackendCheckListFields(resourceName, nameOnlyFields),
+				),
+			},
+			{
+				Config:             testCertAuthBackendConfig_optionalListFields(backend, name, nameOnlyFields),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
 			},
 		},
 	})
@@ -354,6 +487,79 @@ func testCertAuthBackendCheck_attrs(resourceName, backend, name string) resource
 	}
 }
 
+type certAuthBackendListFields struct {
+	allowedNames               []string
+	allowedCommonNames         []string
+	allowedDNSSans             []string
+	allowedEmailSans           []string
+	allowedOrganizationalUnits []string
+	allowedURISans             []string
+	ocspServersOverride        []string
+	requiredExtensions         []string
+}
+
+func (f certAuthBackendListFields) values() map[string][]string {
+	return map[string][]string{
+		consts.FieldAllowedNames:               f.allowedNames,
+		consts.FieldAllowedCommonNames:         f.allowedCommonNames,
+		consts.FieldAllowedDNSSans:             f.allowedDNSSans,
+		consts.FieldAllowedEmailSans:           f.allowedEmailSans,
+		consts.FieldAllowedOrganizationalUnits: f.allowedOrganizationalUnits,
+		consts.FieldAllowedURISans:             f.allowedURISans,
+		consts.FieldOCSPServersOverride:        f.ocspServersOverride,
+		consts.FieldRequiredExtensions:         f.requiredExtensions,
+	}
+}
+
+func testCertAuthBackendCheckListFields(resourceName string, expected certAuthBackendListFields) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, err := testutil.GetResourceFromRootModule(s, resourceName)
+		if err != nil {
+			return err
+		}
+
+		client, err := provider.GetClient(rs.Primary, testProvider.Meta())
+		if err != nil {
+			return err
+		}
+
+		secret, err := client.Logical().Read(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error reading certificate auth role %q: %w", rs.Primary.ID, err)
+		}
+		if secret == nil {
+			return fmt.Errorf("certificate auth role %q does not exist", rs.Primary.ID)
+		}
+
+		fields := expected.values()
+		fieldNames := make([]string, 0, len(fields))
+		for field := range fields {
+			fieldNames = append(fieldNames, field)
+		}
+		sort.Strings(fieldNames)
+
+		for _, field := range fieldNames {
+			actual, ok := util.GetStringSliceFromSecret(secret, field)
+			if !ok {
+				value, exists := secret.Data[field]
+				if exists && value != nil {
+					return fmt.Errorf("expected Vault field %q to be a string list, got %T", field, value)
+				}
+				actual = []string{}
+			}
+
+			want := append([]string{}, fields[field]...)
+			sort.Strings(actual)
+			sort.Strings(want)
+			if !reflect.DeepEqual(actual, want) {
+				return fmt.Errorf("expected Vault field %q to be %#v, got %#v", field, want, actual)
+			}
+		}
+
+		return nil
+	}
+}
+
 func testCertAuthBackendConfig_basic(backend, name, certificate, extraConfig string, allowedNames, allowedOrgUnits []string) string {
 	config := fmt.Sprintf(`
 
@@ -400,6 +606,80 @@ __CERTIFICATE__
 	)
 
 	return config
+}
+
+func testCertAuthBackendConfig_listFields(backend, name, displayName string, fields certAuthBackendListFields) string {
+	return fmt.Sprintf(`
+
+resource "vault_auth_backend" "cert" {
+    path = "%s"
+    type = "cert"
+}
+
+resource "vault_cert_auth_backend_role" "test" {
+    name                         = "%s"
+    display_name                 = "%s"
+    backend                      = vault_auth_backend.cert.path
+    allowed_names                = %s
+    allowed_common_names         = %s
+    allowed_dns_sans             = %s
+    allowed_email_sans           = %s
+    allowed_organizational_units = %s
+    allowed_uri_sans             = %s
+    ocsp_servers_override        = %s
+    required_extensions          = %s
+
+    certificate = <<EOF
+%s
+EOF
+}
+`, backend, name, displayName,
+		util.ArrayToTerraformList(fields.allowedNames),
+		util.ArrayToTerraformList(fields.allowedCommonNames),
+		util.ArrayToTerraformList(fields.allowedDNSSans),
+		util.ArrayToTerraformList(fields.allowedEmailSans),
+		util.ArrayToTerraformList(fields.allowedOrganizationalUnits),
+		util.ArrayToTerraformList(fields.allowedURISans),
+		util.ArrayToTerraformList(fields.ocspServersOverride),
+		util.ArrayToTerraformList(fields.requiredExtensions),
+		testCertificate,
+	)
+}
+
+func testCertAuthBackendConfig_optionalListFields(backend, name string, fields certAuthBackendListFields) string {
+	fieldValues := fields.values()
+	fieldNames := make([]string, 0, len(fieldValues))
+	for field := range fieldValues {
+		fieldNames = append(fieldNames, field)
+	}
+	sort.Strings(fieldNames)
+
+	configFields := make([]string, 0, len(fieldNames))
+	for _, field := range fieldNames {
+		values := fieldValues[field]
+		if values == nil {
+			continue
+		}
+		configFields = append(configFields,
+			fmt.Sprintf("    %s = %s", field, util.ArrayToTerraformList(values)))
+	}
+
+	return fmt.Sprintf(`
+
+resource "vault_auth_backend" "cert" {
+    path = "%s"
+    type = "cert"
+}
+
+resource "vault_cert_auth_backend_role" "test" {
+    name        = "%s"
+    backend     = vault_auth_backend.cert.path
+    certificate = <<EOF
+%s
+EOF
+%s
+}
+`, backend, name, testCertificate, strings.Join(configFields, "\n"))
 }
 
 func testCertAuthBackendConfig_OCSP_default(backend, name string) string {


### PR DESCRIPTION
<!-- Suggested PR title: vault_cert_auth_backend_role: clear list fields when empty or omitted -->

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->

`vault_cert_auth_backend_role` uses `GetOk` for most set-valued fields, so an empty set is omitted from updates. Six of those fields are also `Optional: true, Computed: true`, which preserves their prior state when they are removed from configuration. In either case, Vault retains stale values.

With this PR, Terraform now sends changed fields even when empty and removes `Computed` from `allowed_names`, `allowed_common_names`, `allowed_dns_sans`, `allowed_email_sans`, `allowed_uri_sans`, and `required_extensions`, allowing omitted fields to be cleared from Vault.

There are also other attributes on this resource that look incorrect to me with regard to having `Computed` set when I don't think they should.  Still looking into that and would likely be a much larger change, so keeping out of this PR for now.

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Closes #1370


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests were run against all supported Vault Versions


### Output from acceptance testing:

Tested against Vault 1.21.3, 1.19.5, 1.16.3.

```
$ make testacc TEST_PATH=./vault \
    TESTARGS='-run=TestCertAuthBackend_ClearListFields -count=1 -v'

...
=== RUN   TestCertAuthBackend_ClearListFields
--- PASS: TestCertAuthBackend_ClearListFields
=== RUN   TestCertAuthBackend_ClearListFieldsWhenOmitted
--- PASS: TestCertAuthBackend_ClearListFieldsWhenOmitted
PASS
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  For users who have active certificate constraints but do not have the attribute present in Terraform, they would start to see drift from Terraform wanting to remove these constraints, rather than ignoring them.
