### PR TITLE
feat(provider): add env var support for auth_login fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ FEATURES:
 IMPROVEMENTS:
 
 * `vault_jwt_auth_backend`: Add string-to-integer conversion for `groups_cap` field in `provider_config` to support Okta provider configuration. ([#2939](https://github.com/hashicorp/terraform-provider-vault/pull/2939))
+* Provider `auth_login_*` blocks: Add support for configuring most auth login fields (including the common `mount`, `namespace`, and `use_root_namespace` fields, and method-specific fields such as `role`) via conventionally-named `TERRAFORM_VAULT_AUTH_<METHOD>_<FIELD>` environment variables. Explicit configuration values and existing dedicated environment variables continue to take precedence.
 
 BUG FIXES:
 

--- a/internal/provider/auth.go
+++ b/internal/provider/auth.go
@@ -7,8 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
+	"strings"
 	"sync"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"
 
@@ -22,6 +25,29 @@ type (
 	validateFunc      func(data *schema.ResourceData, params map[string]interface{}) error
 	authLoginFunc     func(*schema.ResourceData) (AuthLogin, error)
 )
+
+// authLoginEnvVarPrefix is the common prefix for all generated auth login
+// environment variables.
+const authLoginEnvVarPrefix = "TERRAFORM_VAULT_AUTH_"
+
+// authLoginEnvVar returns the conventional environment variable name for a
+// given auth login field. The name has the form
+// TERRAFORM_VAULT_AUTH_<METHOD>_<FIELD>, where METHOD is derived from the auth
+// login's top level schema field (e.g. auth_login_jwt -> JWT,
+// auth_login_token_file -> TOKEN_FILE, auth_login -> GENERIC) and FIELD is the
+// upper-cased field name (e.g. role -> ROLE, subscription_id -> SUBSCRIPTION_ID).
+//
+// This provides a consistent, collision-free scheme for configuring auth login
+// fields that do not already have a well-known environment variable.
+func authLoginEnvVar(authField, field string) string {
+	method := strings.TrimPrefix(authField, "auth_login_")
+	if method == "auth_login" {
+		// the generic auth_login method has no trailing method segment
+		method = "generic"
+	}
+	return authLoginEnvVarPrefix +
+		strings.ToUpper(method) + "_" + strings.ToUpper(field)
+}
 
 // authLoginEntry is the tuple of authLoginFunc, schemaFunc.
 type authLoginEntry struct {
@@ -244,6 +270,16 @@ func (l *AuthLoginCommon) init(d *schema.ResourceData) (string, map[string]inter
 		path = v.(string)
 	} else if v, ok := l.getOk(d, consts.FieldMount); ok {
 		path = v.(string)
+		// mount has a schema Default, so getOk cannot distinguish an
+		// explicitly configured value from the applied default. When mount is
+		// not explicitly set in the configuration, fall back to the
+		// TERRAFORM_VAULT_AUTH_<METHOD>_MOUNT environment variable before
+		// using the default.
+		if !l.isFieldSetInConfig(d, consts.FieldMount) {
+			if env := os.Getenv(authLoginEnvVar(l.authField, consts.FieldMount)); env != "" {
+				path = env
+			}
+		}
 	} else if l.mount != consts.MountTypeNone {
 		return "", nil, fmt.Errorf("no valid path configured for %q", l.authField)
 	}
@@ -266,9 +302,64 @@ func (l *AuthLoginCommon) init(d *schema.ResourceData) (string, map[string]inter
 		}
 	}
 
+	// keep the mount param in sync with the resolved path (which may have come
+	// from an environment variable) for methods that expose a mount field.
+	if _, ok := params[consts.FieldMount]; ok {
+		params[consts.FieldMount] = path
+	}
+
+	// resolve the common namespace fields from environment variables when they
+	// are not explicitly configured.
+	if err := l.applyCommonEnvDefaults(d, params); err != nil {
+		return "", nil, err
+	}
+
 	l.initialized = true
 
 	return path, params, nil
+}
+
+// isFieldSetInConfig reports whether the given field within this auth login's
+// nested block was explicitly set in the raw Terraform configuration (as
+// opposed to being absent or resolved from a schema default). It is used to
+// decide when an environment variable fallback should apply.
+func (l *AuthLoginCommon) isFieldSetInConfig(d *schema.ResourceData, field string) bool {
+	v, diags := d.GetRawConfigAt(cty.Path{
+		cty.GetAttrStep{Name: l.authField},
+		cty.IndexStep{Key: cty.NumberIntVal(0)},
+		cty.GetAttrStep{Name: field},
+	})
+	if diags.HasError() || v.IsNull() || !v.IsKnown() {
+		return false
+	}
+
+	return true
+}
+
+// applyCommonEnvDefaults resolves the namespace and use_root_namespace fields
+// (common to every auth login method) from their
+// TERRAFORM_VAULT_AUTH_<METHOD>_<FIELD> environment variables when they are not
+// explicitly set in the configuration.
+func (l *AuthLoginCommon) applyCommonEnvDefaults(d *schema.ResourceData, params map[string]interface{}) error {
+	if _, ok := params[consts.FieldNamespace]; ok && !l.isFieldSetInConfig(d, consts.FieldNamespace) {
+		if env := os.Getenv(authLoginEnvVar(l.authField, consts.FieldNamespace)); env != "" {
+			params[consts.FieldNamespace] = env
+		}
+	}
+
+	if _, ok := params[consts.FieldUseRootNamespace]; ok && !l.isFieldSetInConfig(d, consts.FieldUseRootNamespace) {
+		if env := os.Getenv(authLoginEnvVar(l.authField, consts.FieldUseRootNamespace)); env != "" {
+			b, err := strconv.ParseBool(env)
+			if err != nil {
+				return fmt.Errorf(
+					"invalid boolean value %q for field %q: %w",
+					env, consts.FieldUseRootNamespace, err)
+			}
+			params[consts.FieldUseRootNamespace] = b
+		}
+	}
+
+	return nil
 }
 
 type authDefault struct {
@@ -278,8 +369,11 @@ type authDefault struct {
 	// If there are multiple entries in the slice, we use the first value we
 	// find that is set in the environment.
 	envVars []string
-	// defaultVal is the fallback if an env var is not set
-	defaultVal string
+	// defaultVal is the fallback if an env var is not set. Its concrete type
+	// determines how environment variable values are coerced: a bool
+	// defaultVal causes env var values to be parsed with strconv.ParseBool,
+	// while any other type is treated as a string.
+	defaultVal interface{}
 }
 
 type authDefaults []authDefault
@@ -292,7 +386,11 @@ func (l *AuthLoginCommon) setDefaultFields(d *schema.ResourceData, defaults auth
 			for _, envVar := range f.envVars {
 				val := os.Getenv(envVar)
 				if val != "" {
-					params[f.field] = val
+					v, err := coerceAuthDefaultValue(f.field, val, f.defaultVal)
+					if err != nil {
+						return err
+					}
+					params[f.field] = v
 					// found a value, no need to check other options
 					break
 				}
@@ -301,6 +399,23 @@ func (l *AuthLoginCommon) setDefaultFields(d *schema.ResourceData, defaults auth
 	}
 
 	return nil
+}
+
+// coerceAuthDefaultValue converts an environment variable's string value to the
+// type indicated by defaultVal. Bool defaults are parsed with
+// strconv.ParseBool; all other types are returned as the raw string. This
+// mirrors how the Terraform SDK coerces schema.EnvDefaultFunc values for
+// bool schema fields.
+func coerceAuthDefaultValue(field, val string, defaultVal interface{}) (interface{}, error) {
+	if _, ok := defaultVal.(bool); ok {
+		b, err := strconv.ParseBool(val)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"invalid boolean value %q for field %q: %w", val, field, err)
+		}
+		return b, nil
+	}
+	return val, nil
 }
 
 func (l *AuthLoginCommon) checkRequiredFields(d *schema.ResourceData, params map[string]interface{}, required ...string) error {

--- a/internal/provider/auth_aws.go
+++ b/internal/provider/auth_aws.go
@@ -71,8 +71,9 @@ func GetAWSLoginSchemaResource(authField string) *schema.Resource {
 	return mustAddLoginSchema(&schema.Resource{
 		Schema: map[string]*schema.Schema{
 			consts.FieldRole: {
-				Type:        schema.TypeString,
-				Required:    true,
+				Type: schema.TypeString,
+				// can be set via an env var
+				Optional:    true,
 				Description: `The Vault role to use when logging into Vault.`,
 			},
 			// static credential fields
@@ -162,10 +163,11 @@ type AuthLoginAWS struct {
 }
 
 func (l *AuthLoginAWS) Init(d *schema.ResourceData, authField string) (AuthLogin, error) {
-	defaults := l.getDefaults()
 	if err := l.AuthLoginCommon.Init(d, authField,
 		func(data *schema.ResourceData, params map[string]interface{}) error {
-			return l.setDefaultFields(d, defaults, params)
+			// getDefaults is called here (rather than before Init) so that
+			// l.authField is populated for authLoginEnvVar-generated env vars.
+			return l.setDefaultFields(d, l.getDefaults(), params)
 		},
 		func(data *schema.ResourceData, params map[string]interface{}) error {
 			return l.checkRequiredFields(d, params, consts.FieldRole)
@@ -347,6 +349,26 @@ func (l *AuthLoginAWS) getDefaults() authDefaults {
 		{
 			field:      consts.FieldAWSRegion,
 			envVars:    []string{envVarAWSRegion, envVarAWSDefaultRegion},
+			defaultVal: "",
+		},
+		{
+			field:      consts.FieldRole,
+			envVars:    []string{authLoginEnvVar(l.authField, consts.FieldRole)},
+			defaultVal: "",
+		},
+		{
+			field:      consts.FieldAWSSTSEndpoint,
+			envVars:    []string{authLoginEnvVar(l.authField, consts.FieldAWSSTSEndpoint)},
+			defaultVal: "",
+		},
+		{
+			field:      consts.FieldAWSIAMEndpoint,
+			envVars:    []string{authLoginEnvVar(l.authField, consts.FieldAWSIAMEndpoint)},
+			defaultVal: "",
+		},
+		{
+			field:      consts.FieldHeaderValue,
+			envVars:    []string{authLoginEnvVar(l.authField, consts.FieldHeaderValue)},
 			defaultVal: "",
 		},
 	}

--- a/internal/provider/auth_azure.go
+++ b/internal/provider/auth_azure.go
@@ -48,19 +48,22 @@ func GetAzureLoginSchemaResource(authField string) *schema.Resource {
 					"created automatically",
 			},
 			consts.FieldRole: {
-				Type:        schema.TypeString,
-				Required:    true,
+				Type: schema.TypeString,
+				// can be set via an env var
+				Optional:    true,
 				Description: "Name of the login role.",
 			},
 			consts.FieldSubscriptionID: {
-				Type:     schema.TypeString,
-				Required: true,
+				Type: schema.TypeString,
+				// can be set via an env var
+				Optional: true,
 				Description: "The subscription ID for the machine that generated the MSI token. " +
 					"This information can be obtained through instance metadata.",
 			},
 			consts.FieldResourceGroupName: {
-				Type:     schema.TypeString,
-				Required: true,
+				Type: schema.TypeString,
+				// can be set via an env var
+				Optional: true,
 				Description: "The resource group for the machine that generated the MSI token. " +
 					"This information can be obtained through instance metadata.",
 			},
@@ -128,8 +131,33 @@ func (l *AuthLoginAzure) Init(d *schema.ResourceData, authField string) (AuthLog
 		},
 		{
 			field:      consts.FieldScope,
-			envVars:    []string{""},
+			envVars:    []string{authLoginEnvVar(authField, consts.FieldScope)},
 			defaultVal: defaultAzureScope,
+		},
+		{
+			field:      consts.FieldRole,
+			envVars:    []string{authLoginEnvVar(authField, consts.FieldRole)},
+			defaultVal: "",
+		},
+		{
+			field:      consts.FieldSubscriptionID,
+			envVars:    []string{authLoginEnvVar(authField, consts.FieldSubscriptionID)},
+			defaultVal: "",
+		},
+		{
+			field:      consts.FieldResourceGroupName,
+			envVars:    []string{authLoginEnvVar(authField, consts.FieldResourceGroupName)},
+			defaultVal: "",
+		},
+		{
+			field:      consts.FieldTenantID,
+			envVars:    []string{authLoginEnvVar(authField, consts.FieldTenantID)},
+			defaultVal: "",
+		},
+		{
+			field:      consts.FieldClientID,
+			envVars:    []string{authLoginEnvVar(authField, consts.FieldClientID)},
+			defaultVal: "",
 		},
 	}
 	if err := l.AuthLoginCommon.Init(d, authField,
@@ -196,7 +224,7 @@ func (l *AuthLoginAzure) getJWT(ctx context.Context) (string, error) {
 
 	// attempt to get the token from Azure
 	credOpts := &azidentity.ManagedIdentityCredentialOptions{}
-	if v, ok := l.params[consts.FieldClientID]; ok {
+	if v, ok := l.params[consts.FieldClientID]; ok && v.(string) != "" {
 		credOpts.ID = azidentity.ClientID(v.(string))
 	}
 
@@ -213,7 +241,7 @@ func (l *AuthLoginAzure) getJWT(ctx context.Context) (string, error) {
 	tOpts := policy.TokenRequestOptions{
 		Scopes: scopes,
 	}
-	if v, ok := l.params[consts.FieldTenantID]; ok {
+	if v, ok := l.params[consts.FieldTenantID]; ok && v.(string) != "" {
 		tOpts.TenantID = v.(string)
 	}
 

--- a/internal/provider/auth_azure_test.go
+++ b/internal/provider/auth_azure_test.go
@@ -53,6 +53,39 @@ func TestAuthLoginAzure_Init(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:      "required-fields-from-env",
+			authField: consts.FieldAuthLoginAzure,
+			raw: map[string]interface{}{
+				consts.FieldAuthLoginAzure: []interface{}{
+					map[string]interface{}{
+						consts.FieldNamespace: "ns1",
+						consts.FieldJWT:       "jwt1",
+						consts.FieldVMName:    "vm1",
+					},
+				},
+			},
+			envVars: map[string]string{
+				authLoginEnvVar(consts.FieldAuthLoginAzure, consts.FieldRole):              "alice",
+				authLoginEnvVar(consts.FieldAuthLoginAzure, consts.FieldSubscriptionID):    "sub1",
+				authLoginEnvVar(consts.FieldAuthLoginAzure, consts.FieldResourceGroupName): "res1",
+			},
+			expectParams: map[string]interface{}{
+				consts.FieldNamespace:         "ns1",
+				consts.FieldUseRootNamespace:  false,
+				consts.FieldMount:             consts.MountTypeAzure,
+				consts.FieldRole:              "alice",
+				consts.FieldJWT:               "jwt1",
+				consts.FieldSubscriptionID:    "sub1",
+				consts.FieldResourceGroupName: "res1",
+				consts.FieldVMName:            "vm1",
+				consts.FieldVMSSName:          "",
+				consts.FieldTenantID:          "",
+				consts.FieldClientID:          "",
+				consts.FieldScope:             defaultAzureScope,
+			},
+			wantErr: false,
+		},
+		{
 			name:         "error-missing-resource",
 			authField:    consts.FieldAuthLoginAzure,
 			expectParams: nil,

--- a/internal/provider/auth_cert.go
+++ b/internal/provider/auth_cert.go
@@ -40,18 +40,21 @@ func GetCertLoginSchemaResource(authField string) *schema.Resource {
 	return mustAddLoginSchema(&schema.Resource{
 		Schema: map[string]*schema.Schema{
 			consts.FieldName: {
-				Type:        schema.TypeString,
+				Type: schema.TypeString,
+				// can be set via an env var
 				Optional:    true,
 				Description: "Name of the certificate's role",
 			},
 			consts.FieldCertFile: {
-				Type:        schema.TypeString,
-				Required:    true,
+				Type: schema.TypeString,
+				// can be set via an env var
+				Optional:    true,
 				Description: "Path to a file containing the client certificate.",
 			},
 			consts.FieldKeyFile: {
-				Type:        schema.TypeString,
-				Required:    true,
+				Type: schema.TypeString,
+				// can be set via an env var
+				Optional:    true,
 				Description: "Path to a file containing the private key that the certificate was issued for.",
 			},
 		},
@@ -78,7 +81,27 @@ func (l *AuthLoginCert) LoginPath() string {
 }
 
 func (l *AuthLoginCert) Init(d *schema.ResourceData, authField string) (AuthLogin, error) {
+	defaults := authDefaults{
+		{
+			field:      consts.FieldName,
+			envVars:    []string{authLoginEnvVar(authField, consts.FieldName)},
+			defaultVal: "",
+		},
+		{
+			field:      consts.FieldCertFile,
+			envVars:    []string{authLoginEnvVar(authField, consts.FieldCertFile)},
+			defaultVal: "",
+		},
+		{
+			field:      consts.FieldKeyFile,
+			envVars:    []string{authLoginEnvVar(authField, consts.FieldKeyFile)},
+			defaultVal: "",
+		},
+	}
 	if err := l.AuthLoginCommon.Init(d, authField,
+		func(data *schema.ResourceData, params map[string]interface{}) error {
+			return l.setDefaultFields(d, defaults, params)
+		},
 		func(data *schema.ResourceData, params map[string]interface{}) error {
 			return l.checkRequiredFields(d, params, consts.FieldCertFile, consts.FieldKeyFile)
 		},
@@ -159,7 +182,7 @@ func (l *AuthLoginCert) Login(client *api.Client) (*api.Secret, error) {
 	}
 
 	params := make(map[string]interface{})
-	if v, ok := l.params[consts.FieldName]; ok {
+	if v, ok := l.params[consts.FieldName]; ok && v.(string) != "" {
 		// the cert auth API only supports the role name parameter
 		params[consts.FieldName] = v
 	}

--- a/internal/provider/auth_cert_test.go
+++ b/internal/provider/auth_cert_test.go
@@ -142,6 +142,30 @@ func TestAuthLoginCert_Init(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "cert-and-key-from-env",
+			raw: map[string]interface{}{
+				consts.FieldAuthLoginCert: []interface{}{
+					map[string]interface{}{
+						consts.FieldName: "bob",
+					},
+				},
+			},
+			authField: consts.FieldAuthLoginCert,
+			envVars: map[string]string{
+				authLoginEnvVar(consts.FieldAuthLoginCert, consts.FieldCertFile): "cert.crt",
+				authLoginEnvVar(consts.FieldAuthLoginCert, consts.FieldKeyFile):  "cert.key",
+			},
+			expectParams: map[string]interface{}{
+				consts.FieldNamespace:        "",
+				consts.FieldUseRootNamespace: false,
+				consts.FieldMount:            consts.MountTypeCert,
+				consts.FieldName:             "bob",
+				consts.FieldCertFile:         "cert.crt",
+				consts.FieldKeyFile:          "cert.key",
+			},
+			wantErr: false,
+		},
+		{
 			name:         "error-missing-resource",
 			authField:    consts.FieldAuthLoginCert,
 			expectParams: nil,

--- a/internal/provider/auth_gcp.go
+++ b/internal/provider/auth_gcp.go
@@ -50,8 +50,9 @@ func GetGCPLoginSchemaResource(authField string) *schema.Resource {
 	return mustAddLoginSchema(&schema.Resource{
 		Schema: map[string]*schema.Schema{
 			consts.FieldRole: {
-				Type:        schema.TypeString,
-				Required:    true,
+				Type: schema.TypeString,
+				// can be set via an env var
+				Optional:    true,
 				Description: "Name of the login role.",
 			},
 			consts.FieldJWT: {
@@ -96,6 +97,16 @@ func (l *AuthLoginGCP) Init(d *schema.ResourceData, authField string) (AuthLogin
 		{
 			field:      consts.FieldCredentials,
 			envVars:    []string{consts.EnvVarGoogleApplicationCreds},
+			defaultVal: "",
+		},
+		{
+			field:      consts.FieldRole,
+			envVars:    []string{authLoginEnvVar(authField, consts.FieldRole)},
+			defaultVal: "",
+		},
+		{
+			field:      consts.FieldServiceAccount,
+			envVars:    []string{authLoginEnvVar(authField, consts.FieldServiceAccount)},
 			defaultVal: "",
 		},
 	}
@@ -190,7 +201,7 @@ func (l *AuthLoginGCP) getJWT(ctx context.Context) (string, error) {
 		}
 
 		var serviceAccount string
-		if v, ok := l.params[consts.FieldServiceAccount]; ok {
+		if v, ok := l.params[consts.FieldServiceAccount]; ok && v.(string) != "" {
 			serviceAccount = v.(string)
 		} else if v, ok := m[consts.FieldClientEmail]; ok {
 			serviceAccount = v.(string)

--- a/internal/provider/auth_gcp_test.go
+++ b/internal/provider/auth_gcp_test.go
@@ -25,6 +25,61 @@ func TestAuthLoginGCP_Init(t *testing.T) {
 
 	tests := []authLoginInitTest{
 		{
+			name:      "basic",
+			authField: consts.FieldAuthLoginGCP,
+			raw: map[string]interface{}{
+				consts.FieldAuthLoginGCP: []interface{}{
+					map[string]interface{}{
+						consts.FieldNamespace: "ns1",
+						consts.FieldRole:      "alice",
+						consts.FieldJWT:       "jwt1",
+					},
+				},
+			},
+			envVars: map[string]string{
+				// neutralize any ambient GOOGLE_APPLICATION_CREDENTIALS
+				consts.EnvVarGoogleApplicationCreds: "",
+			},
+			expectParams: map[string]interface{}{
+				consts.FieldNamespace:        "ns1",
+				consts.FieldUseRootNamespace: false,
+				consts.FieldMount:            consts.MountTypeGCP,
+				consts.FieldRole:             "alice",
+				consts.FieldJWT:              "jwt1",
+				consts.FieldCredentials:      "",
+				consts.FieldServiceAccount:   "",
+			},
+			wantErr: false,
+		},
+		{
+			name:      "role-and-service-account-from-env",
+			authField: consts.FieldAuthLoginGCP,
+			raw: map[string]interface{}{
+				consts.FieldAuthLoginGCP: []interface{}{
+					map[string]interface{}{
+						consts.FieldNamespace: "ns1",
+						consts.FieldJWT:       "jwt1",
+					},
+				},
+			},
+			envVars: map[string]string{
+				// neutralize any ambient GOOGLE_APPLICATION_CREDENTIALS
+				consts.EnvVarGoogleApplicationCreds:                                   "",
+				authLoginEnvVar(consts.FieldAuthLoginGCP, consts.FieldRole):           "alice",
+				authLoginEnvVar(consts.FieldAuthLoginGCP, consts.FieldServiceAccount): "sa@example.com",
+			},
+			expectParams: map[string]interface{}{
+				consts.FieldNamespace:        "ns1",
+				consts.FieldUseRootNamespace: false,
+				consts.FieldMount:            consts.MountTypeGCP,
+				consts.FieldRole:             "alice",
+				consts.FieldJWT:              "jwt1",
+				consts.FieldCredentials:      "",
+				consts.FieldServiceAccount:   "sa@example.com",
+			},
+			wantErr: false,
+		},
+		{
 			name:         "error-missing-resource",
 			authField:    consts.FieldAuthLoginGCP,
 			expectParams: nil,

--- a/internal/provider/auth_jwt.go
+++ b/internal/provider/auth_jwt.go
@@ -37,8 +37,9 @@ func GetJWTLoginSchemaResource(authField string) *schema.Resource {
 	return mustAddLoginSchema(&schema.Resource{
 		Schema: map[string]*schema.Schema{
 			consts.FieldRole: {
-				Type:        schema.TypeString,
-				Required:    true,
+				Type: schema.TypeString,
+				// can be set via an env var
+				Optional:    true,
 				Description: "Name of the login role.",
 			},
 			consts.FieldJWT: {
@@ -78,6 +79,11 @@ func (l *AuthLoginJWT) LoginPath() string {
 
 func (l *AuthLoginJWT) Init(d *schema.ResourceData, authField string) (AuthLogin, error) {
 	defaults := authDefaults{
+		{
+			field:      consts.FieldRole,
+			envVars:    []string{authLoginEnvVar(authField, consts.FieldRole)},
+			defaultVal: "",
+		},
 		{
 			field:      consts.FieldJWT,
 			envVars:    []string{consts.EnvVarVaultAuthJWT},

--- a/internal/provider/auth_jwt_test.go
+++ b/internal/provider/auth_jwt_test.go
@@ -90,6 +90,79 @@ func TestAuthLoginJWT_Init(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:      "role-with-env",
+			authField: consts.FieldAuthLoginJWT,
+			raw: map[string]interface{}{
+				consts.FieldAuthLoginJWT: []interface{}{
+					map[string]interface{}{
+						consts.FieldNamespace: "ns1",
+						consts.FieldJWT:       "jwt1",
+					},
+				},
+			},
+			envVars: map[string]string{
+				authLoginEnvVar(consts.FieldAuthLoginJWT, consts.FieldRole): "alice",
+			},
+			expectParams: map[string]interface{}{
+				consts.FieldNamespace:                   "ns1",
+				consts.FieldUseRootNamespace:            false,
+				consts.FieldMount:                       consts.MountTypeJWT,
+				consts.FieldRole:                        "alice",
+				consts.FieldJWT:                         "jwt1",
+				consts.FieldDistributedClaimAccessToken: "",
+			},
+			wantErr: false,
+		},
+		{
+			name:      "mount-with-env",
+			authField: consts.FieldAuthLoginJWT,
+			raw: map[string]interface{}{
+				consts.FieldAuthLoginJWT: []interface{}{
+					map[string]interface{}{
+						consts.FieldNamespace: "ns1",
+						consts.FieldRole:      "alice",
+						consts.FieldJWT:       "jwt1",
+					},
+				},
+			},
+			envVars: map[string]string{
+				authLoginEnvVar(consts.FieldAuthLoginJWT, consts.FieldMount): "custom-jwt",
+			},
+			expectParams: map[string]interface{}{
+				consts.FieldNamespace:                   "ns1",
+				consts.FieldUseRootNamespace:            false,
+				consts.FieldMount:                       "custom-jwt",
+				consts.FieldRole:                        "alice",
+				consts.FieldJWT:                         "jwt1",
+				consts.FieldDistributedClaimAccessToken: "",
+			},
+			wantErr: false,
+		},
+		{
+			name:      "namespace-with-env",
+			authField: consts.FieldAuthLoginJWT,
+			raw: map[string]interface{}{
+				consts.FieldAuthLoginJWT: []interface{}{
+					map[string]interface{}{
+						consts.FieldRole: "alice",
+						consts.FieldJWT:  "jwt1",
+					},
+				},
+			},
+			envVars: map[string]string{
+				authLoginEnvVar(consts.FieldAuthLoginJWT, consts.FieldNamespace): "ns-from-env",
+			},
+			expectParams: map[string]interface{}{
+				consts.FieldNamespace:                   "ns-from-env",
+				consts.FieldUseRootNamespace:            false,
+				consts.FieldMount:                       consts.MountTypeJWT,
+				consts.FieldRole:                        "alice",
+				consts.FieldJWT:                         "jwt1",
+				consts.FieldDistributedClaimAccessToken: "",
+			},
+			wantErr: false,
+		},
+		{
 			name:         "error-missing-resource",
 			authField:    consts.FieldAuthLoginJWT,
 			expectParams: nil,

--- a/internal/provider/auth_kerberos.go
+++ b/internal/provider/auth_kerberos.go
@@ -136,6 +136,31 @@ func (l *AuthLoginKerberos) Init(d *schema.ResourceData, authField string) (Auth
 			envVars:    []string{consts.EnvVarKRBKeytab},
 			defaultVal: "",
 		},
+		{
+			field:      consts.FieldUsername,
+			envVars:    []string{authLoginEnvVar(authField, consts.FieldUsername)},
+			defaultVal: "",
+		},
+		{
+			field:      consts.FieldService,
+			envVars:    []string{authLoginEnvVar(authField, consts.FieldService)},
+			defaultVal: "",
+		},
+		{
+			field:      consts.FieldRealm,
+			envVars:    []string{authLoginEnvVar(authField, consts.FieldRealm)},
+			defaultVal: "",
+		},
+		{
+			field:      consts.FieldDisableFastNegotiation,
+			envVars:    []string{authLoginEnvVar(authField, consts.FieldDisableFastNegotiation)},
+			defaultVal: false,
+		},
+		{
+			field:      consts.FieldRemoveInstanceName,
+			envVars:    []string{authLoginEnvVar(authField, consts.FieldRemoveInstanceName)},
+			defaultVal: false,
+		},
 	}
 
 	if err := l.AuthLoginCommon.Init(d, authField,

--- a/internal/provider/auth_kerberos_test.go
+++ b/internal/provider/auth_kerberos_test.go
@@ -54,6 +54,35 @@ func TestAuthLoginKerberos_Init(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "with-token-and-bool-env",
+			raw: map[string]interface{}{
+				consts.FieldAuthLoginKerberos: []interface{}{
+					map[string]interface{}{
+						consts.FieldToken: testNegTokenInit,
+					},
+				},
+			},
+			authField: consts.FieldAuthLoginKerberos,
+			envVars: map[string]string{
+				authLoginEnvVar(consts.FieldAuthLoginKerberos, consts.FieldDisableFastNegotiation): "true",
+				authLoginEnvVar(consts.FieldAuthLoginKerberos, consts.FieldRemoveInstanceName):     "1",
+			},
+			expectParams: map[string]interface{}{
+				consts.FieldNamespace:              "",
+				consts.FieldUseRootNamespace:       false,
+				consts.FieldToken:                  testNegTokenInit,
+				consts.FieldMount:                  consts.MountTypeKerberos,
+				consts.FieldUsername:               "",
+				consts.FieldService:                "",
+				consts.FieldRealm:                  "",
+				consts.FieldKeytabPath:             "",
+				consts.FieldKRB5ConfPath:           "",
+				consts.FieldRemoveInstanceName:     true,
+				consts.FieldDisableFastNegotiation: true,
+			},
+			wantErr: false,
+		},
+		{
 			name:         "error-missing-resource",
 			authField:    consts.FieldAuthLoginKerberos,
 			expectParams: nil,

--- a/internal/provider/auth_oci.go
+++ b/internal/provider/auth_oci.go
@@ -47,13 +47,15 @@ func GetOCILoginSchemaResource(authField string) *schema.Resource {
 	return mustAddLoginSchema(&schema.Resource{
 		Schema: map[string]*schema.Schema{
 			consts.FieldRole: {
-				Type:        schema.TypeString,
-				Required:    true,
+				Type: schema.TypeString,
+				// can be set via an env var
+				Optional:    true,
 				Description: "Name of the login role.",
 			},
 			consts.FieldAuthType: {
-				Type:        schema.TypeString,
-				Required:    true,
+				Type: schema.TypeString,
+				// can be set via an env var
+				Optional:    true,
 				Description: "Authentication type to use when getting OCI credentials.",
 				ValidateDiagFunc: GetValidateDiagChoices(
 					[]string{ociAuthTypeInstance, ociAuthTypeAPIKeys},
@@ -84,7 +86,22 @@ func (l *AuthLoginOCI) LoginPath() string {
 }
 
 func (l *AuthLoginOCI) Init(d *schema.ResourceData, authField string) (AuthLogin, error) {
+	defaults := authDefaults{
+		{
+			field:      consts.FieldRole,
+			envVars:    []string{authLoginEnvVar(authField, consts.FieldRole)},
+			defaultVal: "",
+		},
+		{
+			field:      consts.FieldAuthType,
+			envVars:    []string{authLoginEnvVar(authField, consts.FieldAuthType)},
+			defaultVal: "",
+		},
+	}
 	if err := l.AuthLoginCommon.Init(d, authField,
+		func(data *schema.ResourceData, params map[string]interface{}) error {
+			return l.setDefaultFields(d, defaults, params)
+		},
 		func(data *schema.ResourceData, params map[string]interface{}) error {
 			return l.checkRequiredFields(d, params, consts.FieldRole, consts.FieldAuthType)
 		},

--- a/internal/provider/auth_oidc.go
+++ b/internal/provider/auth_oidc.go
@@ -39,8 +39,9 @@ func GetOIDCLoginSchemaResource(authField string) *schema.Resource {
 	s := mustAddLoginSchema(&schema.Resource{
 		Schema: map[string]*schema.Schema{
 			consts.FieldRole: {
-				Type:        schema.TypeString,
-				Required:    true,
+				Type: schema.TypeString,
+				// can be set via an env var
+				Optional:    true,
 				Description: "Name of the login role.",
 			},
 			consts.FieldCallbackListenerAddress: {
@@ -85,7 +86,27 @@ func (l *AuthLoginOIDC) LoginPath() string {
 }
 
 func (l *AuthLoginOIDC) Init(d *schema.ResourceData, authField string) (AuthLogin, error) {
+	defaults := authDefaults{
+		{
+			field:      consts.FieldRole,
+			envVars:    []string{authLoginEnvVar(authField, consts.FieldRole)},
+			defaultVal: "",
+		},
+		{
+			field:      consts.FieldCallbackListenerAddress,
+			envVars:    []string{authLoginEnvVar(authField, consts.FieldCallbackListenerAddress)},
+			defaultVal: "",
+		},
+		{
+			field:      consts.FieldCallbackAddress,
+			envVars:    []string{authLoginEnvVar(authField, consts.FieldCallbackAddress)},
+			defaultVal: "",
+		},
+	}
 	if err := l.AuthLoginCommon.Init(d, authField,
+		func(data *schema.ResourceData, params map[string]interface{}) error {
+			return l.setDefaultFields(d, defaults, params)
+		},
 		func(data *schema.ResourceData, params map[string]interface{}) error {
 			return l.checkRequiredFields(d, params, consts.FieldRole)
 		},

--- a/internal/provider/auth_test.go
+++ b/internal/provider/auth_test.go
@@ -477,6 +477,60 @@ func TestAuthLoginCommon_setDefaultFields(t *testing.T) {
 				"foo": "qux",
 			},
 		},
+		{
+			name: "bool-default-and-env-unset",
+			params: map[string]interface{}{
+				"foo": false,
+			},
+			defaults: authDefaults{
+				{
+					field:      "foo",
+					envVars:    []string{"TEST_TERRAFORM_VAULT_PROVIDER_FOO"},
+					defaultVal: false,
+				},
+			},
+			expectParams: map[string]interface{}{
+				"foo": false,
+			},
+		},
+		{
+			name: "bool-env-true",
+			params: map[string]interface{}{
+				"foo": false,
+			},
+			defaults: authDefaults{
+				{
+					field:      "foo",
+					envVars:    []string{"TEST_TERRAFORM_VAULT_PROVIDER_FOO"},
+					defaultVal: false,
+				},
+			},
+			setEnv: map[string]string{
+				"TEST_TERRAFORM_VAULT_PROVIDER_FOO": "true",
+			},
+			expectParams: map[string]interface{}{
+				"foo": true,
+			},
+		},
+		{
+			name: "bool-env-numeric-true",
+			params: map[string]interface{}{
+				"foo": false,
+			},
+			defaults: authDefaults{
+				{
+					field:      "foo",
+					envVars:    []string{"TEST_TERRAFORM_VAULT_PROVIDER_FOO"},
+					defaultVal: false,
+				},
+			},
+			setEnv: map[string]string{
+				"TEST_TERRAFORM_VAULT_PROVIDER_FOO": "1",
+			},
+			expectParams: map[string]interface{}{
+				"foo": true,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -510,6 +564,52 @@ func TestAuthLoginCommon_setDefaultFields(t *testing.T) {
 
 			if !reflect.DeepEqual(tt.expectParams, l.Params()) {
 				t.Errorf("setDefaultFields() expected params %#v, actual %#v", tt.expectParams, l.Params())
+			}
+		})
+	}
+}
+
+func TestAuthLoginCommon_setDefaultFieldsBoolError(t *testing.T) {
+	t.Setenv("TEST_TERRAFORM_VAULT_PROVIDER_BOOL", "not-a-bool")
+
+	l := &AuthLoginCommon{initialized: true}
+	rootProvider := NewProvider(nil, nil)
+	pr := &schema.Resource{Schema: rootProvider.Schema}
+	d := pr.TestResourceData()
+
+	params := map[string]interface{}{"foo": false}
+	defaults := authDefaults{
+		{
+			field:      "foo",
+			envVars:    []string{"TEST_TERRAFORM_VAULT_PROVIDER_BOOL"},
+			defaultVal: false,
+		},
+	}
+
+	err := l.setDefaultFields(d, defaults, params)
+	if err == nil {
+		t.Fatal("setDefaultFields() expected an error for an invalid boolean value, got nil")
+	}
+}
+
+func TestAuthLoginEnvVar(t *testing.T) {
+	tests := []struct {
+		authField string
+		field     string
+		want      string
+	}{
+		{consts.FieldAuthLoginJWT, consts.FieldRole, "TERRAFORM_VAULT_AUTH_JWT_ROLE"},
+		{consts.FieldAuthLoginJWT, consts.FieldMount, "TERRAFORM_VAULT_AUTH_JWT_MOUNT"},
+		{consts.FieldAuthLoginAzure, consts.FieldSubscriptionID, "TERRAFORM_VAULT_AUTH_AZURE_SUBSCRIPTION_ID"},
+		{consts.FieldAuthLoginTokenFile, consts.FieldNamespace, "TERRAFORM_VAULT_AUTH_TOKEN_FILE_NAMESPACE"},
+		{consts.FieldAuthLoginKerberos, consts.FieldRemoveInstanceName, "TERRAFORM_VAULT_AUTH_KERBEROS_REMOVE_INSTANCE_NAME"},
+		{consts.FieldAuthLoginGeneric, consts.FieldMethod, "TERRAFORM_VAULT_AUTH_GENERIC_METHOD"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := authLoginEnvVar(tt.authField, tt.field); got != tt.want {
+				t.Errorf("authLoginEnvVar(%q, %q) = %q, want %q",
+					tt.authField, tt.field, got, tt.want)
 			}
 		})
 	}

--- a/internal/provider/fwprovider/auth_aws.go
+++ b/internal/provider/fwprovider/auth_aws.go
@@ -17,7 +17,8 @@ func AuthLoginAWSSchema() schema.Block {
 		NestedObject: schema.NestedBlockObject{
 			Attributes: map[string]schema.Attribute{
 				consts.FieldRole: schema.StringAttribute{
-					Required:    true,
+					// can be set via an env var
+					Optional:    true,
 					Description: `The Vault role to use when logging into Vault.`,
 				},
 				// static credential fields

--- a/internal/provider/fwprovider/auth_azure.go
+++ b/internal/provider/fwprovider/auth_azure.go
@@ -30,16 +30,19 @@ func AuthLoginAzureSchema() schema.Block {
 					},
 				},
 				consts.FieldRole: schema.StringAttribute{
-					Required:    true,
+					// can be set via an env var
+					Optional:    true,
 					Description: "Name of the login role.",
 				},
 				consts.FieldSubscriptionID: schema.StringAttribute{
-					Required: true,
+					// can be set via an env var
+					Optional: true,
 					Description: "The subscription ID for the machine that generated the MSI token. " +
 						"This information can be obtained through instance metadata.",
 				},
 				consts.FieldResourceGroupName: schema.StringAttribute{
-					Required: true,
+					// can be set via an env var
+					Optional: true,
 					Description: "The resource group for the machine that generated the MSI token. " +
 						"This information can be obtained through instance metadata.",
 				},

--- a/internal/provider/fwprovider/auth_cert.go
+++ b/internal/provider/fwprovider/auth_cert.go
@@ -19,11 +19,13 @@ func AuthLoginCertSchema() schema.Block {
 					Description: "Name of the certificate's role",
 				},
 				consts.FieldCertFile: schema.StringAttribute{
-					Required:    true,
+					// can be set via an env var
+					Optional:    true,
 					Description: "Path to a file containing the client certificate.",
 				},
 				consts.FieldKeyFile: schema.StringAttribute{
-					Required:    true,
+					// can be set via an env var
+					Optional:    true,
 					Description: "Path to a file containing the private key that the certificate was issued for.",
 				},
 			},

--- a/internal/provider/fwprovider/auth_gcp.go
+++ b/internal/provider/fwprovider/auth_gcp.go
@@ -19,7 +19,8 @@ func AuthLoginGCPSchema() schema.Block {
 		NestedObject: schema.NestedBlockObject{
 			Attributes: map[string]schema.Attribute{
 				consts.FieldRole: schema.StringAttribute{
-					Required:    true,
+					// can be set via an env var
+					Optional:    true,
 					Description: "Name of the login role.",
 				},
 				consts.FieldJWT: schema.StringAttribute{

--- a/internal/provider/fwprovider/auth_jwt.go
+++ b/internal/provider/fwprovider/auth_jwt.go
@@ -9,13 +9,22 @@ import (
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 )
 
+// NOTE: This framework schema must remain field-for-field identical to the
+// SDKv2 auth login schema (internal/provider/auth_jwt.go), because the provider
+// is served as a muxed SDKv2 + framework provider and terraform requires the
+// combined schemas to match exactly. In particular, fields that are env-var
+// settable are declared Optional here to mirror the SDKv2 side. The actual
+// env-var resolution (TERRAFORM_VAULT_AUTH_<METHOD>_<FIELD>) currently lives in
+// the SDKv2 login logic; when framework-based login logic is added, the same
+// fallbacks should be applied there for parity.
 func AuthLoginJWTSchema() schema.Block {
 	return mustAddLoginSchema(&schema.ListNestedBlock{
 		Description: "Login to vault using the jwt method",
 		NestedObject: schema.NestedBlockObject{
 			Attributes: map[string]schema.Attribute{
 				consts.FieldRole: schema.StringAttribute{
-					Required:    true,
+					// can be set via an env var
+					Optional:    true,
 					Description: "Name of the login role.",
 				},
 				consts.FieldJWT: schema.StringAttribute{

--- a/internal/provider/fwprovider/auth_oci.go
+++ b/internal/provider/fwprovider/auth_oci.go
@@ -22,11 +22,13 @@ func AuthLoginOCISchema() schema.Block {
 		NestedObject: schema.NestedBlockObject{
 			Attributes: map[string]schema.Attribute{
 				consts.FieldRole: schema.StringAttribute{
-					Required:    true,
+					// can be set via an env var
+					Optional:    true,
 					Description: "Name of the login role.",
 				},
 				consts.FieldAuthType: schema.StringAttribute{
-					Required:    true,
+					// can be set via an env var
+					Optional:    true,
 					Description: "Authentication type to use when getting OCI credentials.",
 					Validators: []validator.String{
 						stringvalidator.OneOf([]string{ociAuthTypeInstance, ociAuthTypeAPIKeys}...),

--- a/internal/provider/fwprovider/auth_oidc.go
+++ b/internal/provider/fwprovider/auth_oidc.go
@@ -17,7 +17,8 @@ func AuthLoginOIDCSchema() schema.Block {
 		NestedObject: schema.NestedBlockObject{
 			Attributes: map[string]schema.Attribute{
 				consts.FieldRole: schema.StringAttribute{
-					Required:    true,
+					// can be set via an env var
+					Optional:    true,
 					Description: "Name of the login role.",
 				},
 

--- a/vault/provider_mux_schema_test.go
+++ b/vault/provider_mux_schema_test.go
@@ -1,0 +1,37 @@
+// Copyright IBM Corp. 2016, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package vault
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov5"
+)
+
+// TestMuxSchemaConsistency verifies that the SDKv2 and plugin-framework
+// provider schemas are identical, which the tf5muxserver requires. This
+// reproduces the "differing provider schema implementations" error offline,
+// without needing terraform or a live Vault.
+func TestMuxSchemaConsistency(t *testing.T) {
+	ctx := context.Background()
+	factory, _, err := ProtoV5ProviderServerFactory(ctx)
+	if err != nil {
+		t.Fatalf("ProtoV5ProviderServerFactory() error: %v", err)
+	}
+
+	srv := factory()
+	resp, err := srv.GetProviderSchema(ctx, &tfprotov5.GetProviderSchemaRequest{})
+	if err != nil {
+		t.Fatalf("GetProviderSchema() error: %v", err)
+	}
+
+	if len(resp.Diagnostics) > 0 {
+		for _, d := range resp.Diagnostics {
+			t.Errorf("schema diagnostic: severity=%v summary=%q detail=%q",
+				d.Severity, d.Summary, d.Detail)
+		}
+		t.Fatal("muxed provider reported schema diagnostics (schemas differ across providers)")
+	}
+}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -233,6 +233,22 @@ The `headers` configuration block accepts the following arguments:
 
 The Vault provider supports the following Vault authentication engines.
 
+In addition to any method-specific environment variables noted below, most
+`auth_login_*` fields can be set via a conventionally-named environment
+variable of the form `TERRAFORM_VAULT_AUTH_<METHOD>_<FIELD>`, where `<METHOD>`
+is the upper-cased auth method (e.g. `JWT`, `AWS`, `TOKEN_FILE`) and `<FIELD>`
+is the upper-cased field name (e.g. `ROLE`, `MOUNT`, `SUBSCRIPTION_ID`). For
+example, the `role` field of `auth_login_jwt` can be set with
+`TERRAFORM_VAULT_AUTH_JWT_ROLE`, and its mount with
+`TERRAFORM_VAULT_AUTH_JWT_MOUNT`. An explicit value in the configuration always
+takes precedence over the environment variable, and a field's dedicated
+environment variable (such as `AWS_ACCESS_KEY_ID`) takes precedence over the
+generated one. Boolean fields accept any value understood by Go's
+`strconv.ParseBool` (e.g. `true`, `false`, `1`, `0`).
+
+The common `mount`, `namespace`, and `use_root_namespace` fields are supported
+for every method via this scheme.
+
 ### Userpass
 
 Provides support for authenticating to Vault using the Username & Password authentication engine.
@@ -275,10 +291,11 @@ The `auth_login_aws` configuration block accepts the following arguments:
 
 * `use_root_namespace` - (Optional) Authenticate to the root Vault namespace. Conflicts with `namespace`.
 
-* `mount` - (Optional) The name of the authentication engine mount.  
+* `mount` - (Optional) The name of the authentication engine mount.
   Default: `aws`
 
 * `role` - (Required) The name of the role against which the login is being attempted.
+  Can be specified with the `TERRAFORM_VAULT_AUTH_AWS_ROLE` environment variable.
 
 * `aws_access_key_id` - (Optional) The AWS access key ID.  
  *Can be specified with the `AWS_ACCESS_KEY_ID` environment variable.*
@@ -309,10 +326,13 @@ The `auth_login_aws` configuration block accepts the following arguments:
   *Can be specified with the `AWS_ROLE_SESSION_NAME` environment variable.*
 
 * `aws_sts_endpoint` - (Optional) The STS endpoint URL.
+  Can be specified with the `TERRAFORM_VAULT_AUTH_AWS_AWS_STS_ENDPOINT` environment variable.
 
 * `aws_iam_endpoint` - (Optional) The IAM endpoint URL.
+  Can be specified with the `TERRAFORM_VAULT_AUTH_AWS_AWS_IAM_ENDPOINT` environment variable.
 
 * `header_value` - (Optional) The Vault header value to include in the STS signing request.
+  Can be specified with the `TERRAFORM_VAULT_AUTH_AWS_HEADER_VALUE` environment variable.
 
 ### TLS Certificate
 
@@ -334,12 +354,15 @@ The `auth_login_cert` configuration block accepts the following arguments:
   Default: `cert`
 
 * `name` - (Optional) Authenticate against only the named certificate role.
+  Can be specified with the `TERRAFORM_VAULT_AUTH_CERT_NAME` environment variable.
 
 * `cert_file` - (Required) Path to a file on local disk that contains the
   PEM-encoded certificate to present to the server.
+  Can be specified with the `TERRAFORM_VAULT_AUTH_CERT_CERT_FILE` environment variable.
 
 * `key_file` - (Required) Path to a file on local disk that contains the
   PEM-encoded private key for which the authentication certificate was issued.
+  Can be specified with the `TERRAFORM_VAULT_AUTH_CERT_KEY_FILE` environment variable.
 
 *This login configuration honors the top-level TLS configuration parameters:
 [ca_cert_file](#ca_cert_file), [ca_cert_dir](#ca_cert_dir), [skip_tls_verify](#skip_tls_verify),
@@ -361,18 +384,20 @@ The `auth_login_gcp` configuration block accepts the following arguments:
 
 * `use_root_namespace` - (Optional) Authenticate to the root Vault namespace. Conflicts with `namespace`.
 
-* `mount` - (Optional) The name of the authentication engine mount.  
+* `mount` - (Optional) The name of the authentication engine mount.
   Default: `gcp`
 
 * `role` - (Required) The name of the role against which the login is being attempted.
+  Can be specified with the `TERRAFORM_VAULT_AUTH_GCP_ROLE` environment variable.
 
 * `jwt` - (Optional) The signed JSON Web Token against which the login is being attempted.
 
-* `credentials` - (Optional) Path to the Google Cloud credentials to use when getting the signed 
-  JWT token from the IAM service.  
+* `credentials` - (Optional) Path to the Google Cloud credentials to use when getting the signed
+  JWT token from the IAM service.
 *conflicts with `jwt`*
 
-* `service_account` - (Optional) Name of the service account to issue the JWT token for.  
+* `service_account` - (Optional) Name of the service account to issue the JWT token for.
+  Can be specified with the `TERRAFORM_VAULT_AUTH_GCP_SERVICE_ACCOUNT` environment variable.
 *requires `credentials`*
 
 *This login configuration will attempt to get a signed JWT token if `jwt` is not specified. 
@@ -401,20 +426,25 @@ The `auth_login_kerberos` configuration block accepts the following arguments:
   Can be specified with the `KRB_SPNEGO_TOKEN` environment variable.
 
 * `username` - (Conflicts with `token`)  The username to login into Kerberos with.
+  Can be specified with the `TERRAFORM_VAULT_AUTH_KERBEROS_USERNAME` environment variable.
 
 * `service` - (Conflicts with `token`) The service principle name.
- 
+  Can be specified with the `TERRAFORM_VAULT_AUTH_KERBEROS_SERVICE` environment variable.
+
 * `realm` - (Conflicts with `token`) The Kerberos server's authoritative authentication domain.
- 
+  Can be specified with the `TERRAFORM_VAULT_AUTH_KERBEROS_REALM` environment variable.
+
 * `krb5conf_path` - (Conflicts with `token`) A valid Kerberos configuration file e.g. /etc/krb5.conf.
   Can be specified with the `KRB5_CONFIG` environment variable.
- 
+
 * `keytab_path` - (Conflicts with `token`)  The Kerberos keytab file containing the entry of the login entity.
   Can be specified with the `KRB_KEYTAB` environment variable.
 
 * `disable_fast_negotiation` - (Conflicts with `token`) Disable the Kerberos FAST negotiation.
- 
+  Can be specified with the `TERRAFORM_VAULT_AUTH_KERBEROS_DISABLE_FAST_NEGOTIATION` environment variable.
+
 * `remove_instance_name` - (Conflicts with `token`) Strip the host from the username found in the keytab.
+  Can be specified with the `TERRAFORM_VAULT_AUTH_KERBEROS_REMOVE_INSTANCE_NAME` environment variable.
 
 *This login configuration will attempt to get a SPNEGO init token from the `service` domain if `token` is not specified.
 The following fields are required when token is not specified:
@@ -463,8 +493,10 @@ The `auth_login_oci` configuration block accepts the following arguments:
   Default: `oci`
 
 * `role` - (Required) The name of the role against which the login is being attempted.
+  Can be specified with the `TERRAFORM_VAULT_AUTH_OCI_ROLE` environment variable.
 
 * `auth_type` - (Required) The OCI authentication type to use. Valid choices are: *apikeys*, *instance*
+  Can be specified with the `TERRAFORM_VAULT_AUTH_OCI_AUTH_TYPE` environment variable.
 
 ### OIDC
 
@@ -489,10 +521,13 @@ The `auth_login_oidc` configuration block accepts the following arguments:
   Default: `oidc`
 
 * `role` - (Required) The name of the role against which the login is being attempted.
+  Can be specified with the `TERRAFORM_VAULT_AUTH_OIDC_ROLE` environment variable.
 
 * `callback_listener_address` - (Optional) The callback listener's address. *Must be a valid URI without the path.*
- 
+  Can be specified with the `TERRAFORM_VAULT_AUTH_OIDC_CALLBACK_LISTENER_ADDRESS` environment variable.
+
 * `callback_address` - (Optional)  The callback address. *Must be a valid URI without the path.*
+  Can be specified with the `TERRAFORM_VAULT_AUTH_OIDC_CALLBACK_ADDRESS` environment variable.
 
 ### JWT
 
@@ -510,12 +545,13 @@ The `auth_login_jwt` configuration block accepts the following arguments:
 
 * `use_root_namespace` - (Optional) Authenticate to the root Vault namespace. Conflicts with `namespace`.
 
-* `mount` - (Optional) The name of the authentication engine mount.  
+* `mount` - (Optional) The name of the authentication engine mount.
   Default: `jwt`
 
 * `role` - (Required) The name of the role against which the login is being attempted.
+  Can be specified with the `TERRAFORM_VAULT_AUTH_JWT_ROLE` environment variable.
 
-* `jwt` - (Required) The signed JSON Web Token against which the login is being attempted.  
+* `jwt` - (Required) The signed JSON Web Token against which the login is being attempted.
   *Can be specified with the `TERRAFORM_VAULT_AUTH_JWT` environment variable.*
 
 * `distributed_claim_access_token` - (Optional) A token used to fetch group memberships specified by the distributed claim source in the jwt. This is supported only on Azure/Entra ID. Requires Vault 1.18+.
@@ -541,17 +577,20 @@ The `auth_login_azure` configuration block accepts the following arguments:
   Default: `azure`
 
 * `role` - (Required) The name of the role against which the login is being attempted.
+  Can be specified with the `TERRAFORM_VAULT_AUTH_AZURE_ROLE` environment variable.
 
-* `jwt` - (Optional) The signed JSON Web Token against which the login is being attempted. 
+* `jwt` - (Optional) The signed JSON Web Token against which the login is being attempted.
  If not provided a token will be created from Azure's managed identities for Azure resources API.
   *Can be specified with the `TERRAFORM_VAULT_AZURE_AUTH_JWT` environment variable.*
 
 * `subscription_id` - (Required) The subscription ID for the machine that generated the MSI token.
   This information can be obtained through instance metadata.
+  Can be specified with the `TERRAFORM_VAULT_AUTH_AZURE_SUBSCRIPTION_ID` environment variable.
 
 * `resource_group_name` - (Required) The resource group for the machine that generated the MSI token.
   This information can be obtained through instance metadata.
- 
+  Can be specified with the `TERRAFORM_VAULT_AUTH_AZURE_RESOURCE_GROUP_NAME` environment variable.
+
 * `vm_name` - (Optional) The virtual machine name for the machine that generated the MSI token.
   This information can be obtained through instance metadata.
 
@@ -559,10 +598,13 @@ The `auth_login_azure` configuration block accepts the following arguments:
   the MSI token. This information can be obtained through instance metadata.
 
 * `tenant_id` - (Optional) Provides the tenant ID to use in a multi-tenant authentication scenario.
+  Can be specified with the `TERRAFORM_VAULT_AUTH_AZURE_TENANT_ID` environment variable.
 
 * `client_id` - (Optional) The identity's client ID.
+  Can be specified with the `TERRAFORM_VAULT_AUTH_AZURE_CLIENT_ID` environment variable.
 
 * `scope` - (Optional) The scopes to include in the token request. Defaults to `https://management.azure.com/`
+  Can be specified with the `TERRAFORM_VAULT_AUTH_AZURE_SCOPE` environment variable.
 
 
 ### Token File


### PR DESCRIPTION
### Description

Adds a consistent `TERRAFORM_VAULT_AUTH_<METHOD>_<FIELD>` environment-variable scheme so most `auth_login_*` fields can be configured via the environment — similar to how the AzureAD and AWS providers expose their settings.

Previously only a few secret-bearing fields (e.g. `jwt`, `distributed_claim_access_token`) supported env vars, while common config fields like `role`, `mount`, and `namespace` did not.

### What changed

**Core (`internal/provider/auth.go`)**
- `authLoginEnvVar()` generates `TERRAFORM_VAULT_AUTH_<METHOD>_<FIELD>` names (e.g. `TERRAFORM_VAULT_AUTH_JWT_ROLE`).
- `authDefault` is now type-aware: bool defaults coerce env values via `strconv.ParseBool` (matching how the SDK / AzureAD handle bool env vars).
- `mount` resolves from env using raw-config detection (`GetRawConfigAt`), so explicit config beats env beats the schema default.
- Common `namespace` / `use_root_namespace` resolve from env for every method.

**Per-method** — extends each `authDefaults` list (jwt, aws, azure, gcp, cert, oci, oidc, kerberos). Existing dedicated env vars (`AWS_ACCESS_KEY_ID`, `TERRAFORM_VAULT_AUTH_JWT`, etc.) keep precedence; only gap fields get the new scheme. Fields that were `Required` are now `Optional`, with the requirement re-enforced in `checkRequiredFields` (the established `jwt` pattern).

**Muxed-provider parity** — because the provider is served as a muxed SDKv2 + plugin-framework provider, the framework schemas in `internal/provider/fwprovider/` are updated so the `Required`/`Optional` declarations stay byte-identical with the SDKv2 side; otherwise the mux rejects the combined provider at schema-load time. Adds `TestMuxSchemaConsistency` as an offline regression guard.

### Backward compatibility

Fully backward compatible. Existing configs and existing env vars are unchanged; explicit HCL values always win over env vars, and legacy dedicated env vars take precedence over the generated ones.

### Testing

- `make build`, `make test`, `go vet`, `gofmt -s -l` — all pass
- New unit tests for env-var resolution incl. bool coercion
- `TestMuxSchemaConsistency` — new offline schema-parity guard
- `make testacc TESTARGS="-run TestAccAuthLoginProviderConfigure"` — passes end-to-end against a live dev Vault

### Docs / CHANGELOG

- `website/docs/index.html.markdown` — convention note + per-field annotations
- `CHANGELOG.md` — entry under IMPROVEMENTS
