### PR TITLE
docs: fix open-source hyphenation, missing article, and verb form in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This provider plugin is maintained by the Vault team at [HashiCorp](https://www.
 Best Practices
 --------------
 
-We recommend that you avoid placing secrets in your Terraform config or state file wherever possible, and if placed there, you take steps to reduce and manage your risk. We have created a practical guide on how to do this with our opensource versions in Best Practices for Using HashiCorp Terraform with HashiCorp Vault:
+We recommend that you avoid placing secrets in your Terraform config or state file wherever possible, and if placed there, you take steps to reduce and manage your risk. We have created a practical guide on how to do this with our open-source versions in Best Practices for Using HashiCorp Terraform with HashiCorp Vault:
 
 [![Best Practices for Using HashiCorp Terraform with HashiCorp Vault](https://img.youtube.com/vi/fOybhcbuxJ0/0.jpg)](https://www.youtube.com/watch?v=fOybhcbuxJ0)
 
@@ -28,7 +28,7 @@ Requirements
 Building The Provider
 ---------------------
 
-Clone repository to: `$GOPATH/src/github.com/hashicorp/terraform-provider-vault`
+Clone the repository to: `$GOPATH/src/github.com/hashicorp/terraform-provider-vault`
 
 ```sh
 $ mkdir -p $GOPATH/src/github.com/hashicorp; cd $GOPATH/src/github.com/hashicorp
@@ -45,7 +45,7 @@ $ make build
 Developing the Provider
 ---------------------------
 
-If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.20+ is *required*). You'll also need to correctly setup a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.
+If you wish to work on the provider, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.20+ is *required*). You'll also need to correctly set up a [GOPATH](http://golang.org/doc/code.html#GOPATH), as well as adding `$GOPATH/bin` to your `$PATH`.
 
 To compile the provider, run `make build`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
 


### PR DESCRIPTION
## Description
This PR fixes minor grammar and spelling in `README.md`.

## Details
1. Hyphenated compound adjective (`opensource` -> `open-source`).
2. Added missing article (`Clone repository` -> `Clone the repository`).
3. Fixed verb form (`setup a GOPATH` -> `set up a GOPATH`).