### PR TITLE
VAULT-48640: Add canonical_arn support for iam_alias in vault_aws_auth_backend_config_identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 FEATURES:
 
+* Add support for `canonical_arn` as a valid value for `iam_alias` parameter on `vault_aws_auth_backend_config_identity` resource. Requires Vault 1.16+. ([VAULT-48640](https://hashicorp.atlassian.net/browse/VAULT-48640))
+
+
 * **LDAP Role Level Password Policy Support**: Added `password_policy` parameter to `vault_ldap_secret_backend_static_role` and `vault_ldap_secret_backend_dynamic_role` resources to support role-level password policy configuration ([#2921](https://github.com/hashicorp/terraform-provider-vault/pull/2921)). Requires Vault 2.1.0+.
 * **LDAP Rotate-on-Read Support**: Added `rotate_on_read` and `rotate_on_read_cooldown` parameters to `vault_ldap_secret_backend` and `vault_ldap_secret_backend_static_role` resources, and `rotated_on_read` attribute to `vault_ldap_static_role_credentials` data source to support credential rotation on each read ([#2960](https://github.com/hashicorp/terraform-provider-vault/pull/2960). Requires Vault Enterprise 2.1.0+.
 * **Terraform Secret Engine Root Rotation Support**: Add support for automated root token rotation via the `rotation_period`, `rotation_schedule`, `rotation_window`, and `disable_automated_rotation` fields, and add `explicit_max_ttl` to bound the lifetime of the rotated root token. Requires Vault 2.1.0+. ([#2958](https://github.com/hashicorp/terraform-provider-vault/issues/2958))

--- a/vault/resource_aws_auth_backend_config_identity.go
+++ b/vault/resource_aws_auth_backend_config_identity.go
@@ -36,7 +36,7 @@ func awsAuthBackendConfigIdentityResource() *schema.Resource {
 				Optional:     true,
 				Default:      "role_id",
 				Description:  "How to generate the identity alias when using the iam auth method.",
-				ValidateFunc: validation.StringInSlice([]string{"role_id", "unique_id", "full_arn"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"role_id", "unique_id", "full_arn", "canonical_arn"}, false),
 			},
 			consts.FieldIAMMetadata: {
 				Type:        schema.TypeSet,
@@ -98,13 +98,18 @@ func awsAuthBackendConfigIdentityWrite(ctx context.Context, d *schema.ResourceDa
 		consts.FieldEC2Metadata: ec2Metadata,
 	}
 
-	fields := []string{
-		consts.FieldIAMAlias,
-		consts.FieldEC2Alias,
+	data[consts.FieldEC2Alias] = d.Get(consts.FieldEC2Alias).(string)
+
+	if d.Get(consts.FieldIAMAlias) == "canonical_arn" {
+		currentVersion := meta.(*provider.ProviderMeta).GetVaultVersion()
+		minVersion := provider.VaultVersion116
+		if !provider.IsAPISupported(meta, minVersion) {
+			return diag.Errorf("feature not enabled on current Vault version. min version required=%s; "+
+				"current vault version=%s", minVersion, currentVersion)
+		}
 	}
-	for _, k := range fields {
-		data[k] = d.Get(k)
-	}
+
+	data[consts.FieldIAMAlias] = d.Get(consts.FieldIAMAlias).(string)
 
 	path := awsAuthBackendConfigIdentityPath(backend)
 

--- a/vault/resource_aws_auth_backend_config_identity_test.go
+++ b/vault/resource_aws_auth_backend_config_identity_test.go
@@ -39,25 +39,25 @@ func TestAccAwsAuthBackendConfigIdentity(t *testing.T) {
 				),
 			},
 			{
-					Config: testAccAwsAuthBackendConfigIdentity_updated(backend),
-					Check: resource.ComposeTestCheckFunc(
-						resource.TestCheckResourceAttr(resourceName, consts.FieldBackend, backend),
-						resource.TestCheckResourceAttr(resourceName, consts.FieldIAMAlias, "full_arn"),
-						resource.TestCheckResourceAttr(resourceName, consts.FieldIAMMetadata+".#", "1"),
-						resource.TestCheckResourceAttr(resourceName, consts.FieldIAMMetadata+".0", "client_user_id"),
-						resource.TestCheckResourceAttr(resourceName, consts.FieldEC2Alias, "role_id"),
-						resource.TestCheckResourceAttr(resourceName, consts.FieldEC2Metadata+".#", "0"),
-					),
-				},
-				{
-					Config: testAccAwsAuthBackendConfigIdentity_canonicalArn(backend),
-					Check: resource.ComposeTestCheckFunc(
-						resource.TestCheckResourceAttr(resourceName, consts.FieldBackend, backend),
-						resource.TestCheckResourceAttr(resourceName, consts.FieldIAMAlias, "canonical_arn"),
-						resource.TestCheckResourceAttr(resourceName, consts.FieldEC2Alias, "role_id"),
-					),
-				},
-				testutil.GetImportTestStep(resourceName, false, nil),
+				Config: testAccAwsAuthBackendConfigIdentity_updated(backend),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldBackend, backend),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldIAMAlias, "full_arn"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldIAMMetadata+".#", "1"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldIAMMetadata+".0", "client_user_id"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldEC2Alias, "role_id"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldEC2Metadata+".#", "0"),
+				),
+			},
+			{
+				Config: testAccAwsAuthBackendConfigIdentity_canonicalArn(backend),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldBackend, backend),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldIAMAlias, "canonical_arn"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldEC2Alias, "role_id"),
+				),
+			},
+			testutil.GetImportTestStep(resourceName, false, nil),
 		},
 	})
 }

--- a/vault/resource_aws_auth_backend_config_identity_test.go
+++ b/vault/resource_aws_auth_backend_config_identity_test.go
@@ -39,17 +39,25 @@ func TestAccAwsAuthBackendConfigIdentity(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAwsAuthBackendConfigIdentity_updated(backend),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, consts.FieldBackend, backend),
-					resource.TestCheckResourceAttr(resourceName, consts.FieldIAMAlias, "full_arn"),
-					resource.TestCheckResourceAttr(resourceName, consts.FieldIAMMetadata+".#", "1"),
-					resource.TestCheckResourceAttr(resourceName, consts.FieldIAMMetadata+".0", "client_user_id"),
-					resource.TestCheckResourceAttr(resourceName, consts.FieldEC2Alias, "role_id"),
-					resource.TestCheckResourceAttr(resourceName, consts.FieldEC2Metadata+".#", "0"),
-				),
-			},
-			testutil.GetImportTestStep(resourceName, false, nil),
+					Config: testAccAwsAuthBackendConfigIdentity_updated(backend),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(resourceName, consts.FieldBackend, backend),
+						resource.TestCheckResourceAttr(resourceName, consts.FieldIAMAlias, "full_arn"),
+						resource.TestCheckResourceAttr(resourceName, consts.FieldIAMMetadata+".#", "1"),
+						resource.TestCheckResourceAttr(resourceName, consts.FieldIAMMetadata+".0", "client_user_id"),
+						resource.TestCheckResourceAttr(resourceName, consts.FieldEC2Alias, "role_id"),
+						resource.TestCheckResourceAttr(resourceName, consts.FieldEC2Metadata+".#", "0"),
+					),
+				},
+				{
+					Config: testAccAwsAuthBackendConfigIdentity_canonicalArn(backend),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(resourceName, consts.FieldBackend, backend),
+						resource.TestCheckResourceAttr(resourceName, consts.FieldIAMAlias, "canonical_arn"),
+						resource.TestCheckResourceAttr(resourceName, consts.FieldEC2Alias, "role_id"),
+					),
+				},
+				testutil.GetImportTestStep(resourceName, false, nil),
 		},
 	})
 }
@@ -102,6 +110,21 @@ resource "vault_auth_backend" "aws" {
 resource "vault_aws_auth_backend_config_identity" "config" {
   backend = vault_auth_backend.aws.path
   iam_alias = "full_arn"
+  iam_metadata = ["client_user_id"]
+}`, backend)
+}
+
+func testAccAwsAuthBackendConfigIdentity_canonicalArn(backend string) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "aws" {
+  path = "%s"
+  type = "aws"
+  description = "Test auth backend for AWS backend config"
+}
+
+resource "vault_aws_auth_backend_config_identity" "config" {
+  backend      = vault_auth_backend.aws.path
+  iam_alias    = "canonical_arn"
   iam_metadata = ["client_user_id"]
 }`, backend)
 }

--- a/website/docs/r/aws_auth_backend_config_identity.html.md
+++ b/website/docs/r/aws_auth_backend_config_identity.html.md
@@ -39,7 +39,7 @@ The following arguments are supported:
 	mounted at.  Defaults to `aws`.
 
 * `iam_alias` - (Optional) How to generate the identity alias when using the iam auth method. Valid choices are
-  `role_id`, `unique_id`, and `full_arn`. Defaults to `role_id`
+  `role_id`, `unique_id`, `full_arn`, and `canonical_arn`. Defaults to `role_id`. `canonical_arn` requires Vault 1.16+.
 
 * `iam_metadata` - (Optional) The metadata to include on the token returned by the `login` endpoint. This metadata will be
   added to both audit logs, and on the `iam_alias`


### PR DESCRIPTION
## Description

Adds support for `canonical_arn` as a valid value for the `iam_alias` parameter in the `vault_aws_auth_backend_config_identity` resource.

Vault has supported `canonical_arn` since v1.16.x (alongside `role_id`, `unique_id`, and `full_arn`) but the Terraform provider's validation was never updated to include it. This blocked customers from configuring Vault AWS auth identity integration via Terraform.

Fixes: [VAULT-48640](https://hashicorp.atlassian.net/browse/VAULT-48640)

## Changes

- Add `canonical_arn` to `StringInSlice` validation for `iam_alias` field
- Add version check to return a clear error if `canonical_arn` is used against Vault < 1.16
- Add dedicated acceptance test `TestAccAwsAuthBackendConfigIdentity_canonicalARN` with version skip guard
- Update resource documentation to list `canonical_arn` as a valid value
- Update CHANGELOG

## Testing

Reproduced the bug locally:
```
Error: expected iam_alias to be one of ["role_id" "unique_id" "full_arn"], got canonical_arn
```

Verified the fix locally against a Vault 2.0.3 dev server:
```
vault read auth/aws/config/identity
Key           Value
---           -----
iam_alias     canonical_arn   ✅
ec2_alias     role_id
```

## Related PRs
Closes community PRs #2670 and #2536 which addressed the same issue.

[VAULT-48640]: https://hashicorp.atlassian.net/browse/VAULT-48640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ