### PR TITLE
feat: set a standard Terraform User-Agent on all Vault requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ FEATURES:
 
 IMPROVEMENTS:
 
+* Send a standard Terraform `User-Agent` header on all Vault requests, e.g. `Terraform/1.15.8 (+https://www.terraform.io) Terraform-Plugin-SDK/2.40.1 terraform-provider-vault/5.10.1`. Previously requests were sent with the Go default of `Go-http-client/1.1`. The `TF_APPEND_USER_AGENT` environment variable is now honored and appended to this value. A `User-Agent` set explicitly via the provider `headers` block or the `VAULT_HEADERS` environment variable continues to take precedence.
+
 * `vault_aws_auth_backend_config_identity`: Add support for `canonical_arn` as a valid value for the `iam_alias` parameter. Requires Vault 1.16+. ([#2982](https://github.com/hashicorp/terraform-provider-vault/pull/2982))
 
 * `vault_jwt_auth_backend`: Add string-to-integer conversion for `groups_cap` field in `provider_config` to support Okta provider configuration. ([#2939](https://github.com/hashicorp/terraform-provider-vault/pull/2939))

--- a/internal/provider/fwprovider/provider.go
+++ b/internal/provider/fwprovider/provider.go
@@ -37,6 +37,7 @@ import (
 	"github.com/hashicorp/terraform-provider-vault/internal/vault/sys"
 	"github.com/hashicorp/terraform-provider-vault/internal/vault/sys/config"
 	sysconfig "github.com/hashicorp/terraform-provider-vault/internal/vault/sys/config"
+	providerversion "github.com/hashicorp/terraform-provider-vault/version"
 )
 
 var _ provider.ProviderWithEphemeralResources = &fwprovider{}
@@ -65,8 +66,7 @@ type fwprovider struct {
 // version data.
 func (p *fwprovider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
 	resp.TypeName = "vault"
-	// TODO: inject provider version during build time
-	// resp.Version = "0.0.0-dev"
+	resp.Version = providerversion.ProviderVersion()
 }
 
 // Schema returns the schema for this provider's configuration.

--- a/internal/provider/fwprovider/provider_test.go
+++ b/internal/provider/fwprovider/provider_test.go
@@ -1,0 +1,37 @@
+// Copyright IBM Corp. 2016, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package fwprovider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/provider"
+
+	providerversion "github.com/hashicorp/terraform-provider-vault/version"
+)
+
+// stubPrimary stands in for the SDKv2 provider; Metadata does not consult it.
+type stubPrimary struct{}
+
+func (stubPrimary) Meta() interface{} { return nil }
+
+func TestMetadata(t *testing.T) {
+	p := New(stubPrimary{})
+
+	resp := &provider.MetadataResponse{}
+	p.Metadata(context.Background(), provider.MetadataRequest{}, resp)
+
+	if resp.TypeName != "vault" {
+		t.Errorf("TypeName = %q, want %q", resp.TypeName, "vault")
+	}
+
+	if want := providerversion.ProviderVersion(); resp.Version != want {
+		t.Errorf("Version = %q, want %q", resp.Version, want)
+	}
+
+	if resp.Version == "" {
+		t.Error("Version is empty, the provider version was not reported")
+	}
+}

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/hashicorp/terraform-provider-vault/helper"
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	providerversion "github.com/hashicorp/terraform-provider-vault/version"
 )
 
 const (
@@ -69,7 +70,23 @@ type ProviderMeta struct {
 	resourceData *schema.ResourceData
 	clientCache  map[string]*api.Client
 	vaultVersion *version.Version
+	userAgent    string
 	mu           sync.RWMutex
+}
+
+// getUserAgent returns the User-Agent to send with every Vault request.
+//
+// The value is normally set during provider configuration, where the Terraform
+// version is known. ProviderMeta can also be constructed directly (notably in
+// tests), so fall back to building the string without it rather than sending no
+// User-Agent at all. Both paths go through schema.Provider.UserAgent, which
+// appends TF_APPEND_USER_AGENT when it is set.
+func (p *ProviderMeta) getUserAgent() string {
+	if p.userAgent != "" {
+		return p.userAgent
+	}
+
+	return (&schema.Provider{}).UserAgent(providerversion.ProviderName, providerversion.ProviderVersion())
 }
 
 // GetClient returns the providers default Vault client.
@@ -268,6 +285,16 @@ func (p *ProviderMeta) setClient() error {
 			parsedHeaders.Add(name.(string), header["value"].(string))
 		}
 	}
+
+	// Send a standard Terraform User-Agent, but let an explicitly configured one
+	// win. A User-Agent may already be present here from the headers block above
+	// or from VAULT_HEADERS, which api.NewClient applies. Note that net/http
+	// writes a single User-Agent line taken from the first value, so adding ours
+	// unconditionally would be silently ignored in that case anyway.
+	if parsedHeaders.Get("User-Agent") == "" {
+		parsedHeaders.Set("User-Agent", p.getUserAgent())
+	}
+
 	client.SetHeaders(parsedHeaders)
 
 	client.SetMaxRetries(GetResourceDataInt(d, "max_retries", "VAULT_MAX_RETRIES", DefaultMaxHTTPRetries))

--- a/internal/provider/meta_user_agent_test.go
+++ b/internal/provider/meta_user_agent_test.go
@@ -1,0 +1,240 @@
+// Copyright IBM Corp. 2016, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/testutil"
+	providerversion "github.com/hashicorp/terraform-provider-vault/version"
+)
+
+// userAgentRecorder captures the User-Agent of every request the provider's
+// client makes, and serves the minimum needed for setClient() to succeed.
+type userAgentRecorder struct {
+	mu   sync.Mutex
+	seen []string
+}
+
+func (u *userAgentRecorder) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u.mu.Lock()
+		u.seen = append(u.seen, r.UserAgent())
+		u.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/auth/token/lookup-self":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"data": map[string]interface{}{
+					"id":        "test-token",
+					"policies":  []string{"default"},
+					"ttl":       3600,
+					"renewable": true,
+				},
+			})
+		case "/v1/auth/token/create":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"auth": map[string]interface{}{
+					"client_token":   "test-child-token",
+					"policies":       []string{"default"},
+					"lease_duration": 3600,
+					"renewable":      true,
+				},
+			})
+		default:
+			json.NewEncoder(w).Encode(map[string]interface{}{"data": map[string]interface{}{}})
+		}
+	})
+}
+
+// observed returns the distinct User-Agent values seen, so a test can assert
+// that every request carried the same one.
+func (u *userAgentRecorder) observed() []string {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	var distinct []string
+	seen := map[string]bool{}
+	for _, ua := range u.seen {
+		if !seen[ua] {
+			seen[ua] = true
+			distinct = append(distinct, ua)
+		}
+	}
+
+	return distinct
+}
+
+func TestProviderMeta_userAgentHeader(t *testing.T) {
+	tests := []struct {
+		name         string
+		appendEnv    string
+		vaultHeaders string
+		configHeader [2]string
+		assertUA     func(t *testing.T, ua string)
+	}{
+		{
+			name: "default",
+			assertUA: func(t *testing.T, ua string) {
+				wantProduct := providerversion.ProviderName + "/" + providerversion.ProviderVersion()
+				if !strings.Contains(ua, wantProduct) {
+					t.Errorf("User-Agent %q does not contain %q", ua, wantProduct)
+				}
+				if !strings.HasPrefix(ua, "Terraform/") {
+					t.Errorf("User-Agent %q does not start with Terraform/", ua)
+				}
+				if !strings.Contains(ua, "Terraform-Plugin-SDK/") {
+					t.Errorf("User-Agent %q does not contain the SDK version", ua)
+				}
+			},
+		},
+		{
+			name:      "TF_APPEND_USER_AGENT is appended",
+			appendEnv: "my-wrapper/9.9.9",
+			assertUA: func(t *testing.T, ua string) {
+				if !strings.Contains(ua, providerversion.ProviderName+"/") {
+					t.Errorf("User-Agent %q lost the standard product token", ua)
+				}
+				if !strings.HasSuffix(ua, "my-wrapper/9.9.9") {
+					t.Errorf("User-Agent %q does not end with the appended value", ua)
+				}
+			},
+		},
+		{
+			name:         "headers block overrides the default",
+			configHeader: [2]string{"User-Agent", "from-config/1.0"},
+			assertUA: func(t *testing.T, ua string) {
+				if ua != "from-config/1.0" {
+					t.Errorf("User-Agent = %q, want %q", ua, "from-config/1.0")
+				}
+			},
+		},
+		{
+			name:         "VAULT_HEADERS overrides the default",
+			vaultHeaders: `{"User-Agent":"from-env/1.0"}`,
+			assertUA: func(t *testing.T, ua string) {
+				if ua != "from-env/1.0" {
+					t.Errorf("User-Agent = %q, want %q", ua, "from-env/1.0")
+				}
+			},
+		},
+		{
+			name:      "explicit override still wins with TF_APPEND_USER_AGENT set",
+			appendEnv: "my-wrapper/9.9.9",
+			// an operator that pins the User-Agent should get exactly that
+			configHeader: [2]string{"User-Agent", "from-config/1.0"},
+			assertUA: func(t *testing.T, ua string) {
+				if ua != "from-config/1.0" {
+					t.Errorf("User-Agent = %q, want %q", ua, "from-config/1.0")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.appendEnv != "" {
+				t.Setenv("TF_APPEND_USER_AGENT", tt.appendEnv)
+			}
+			if tt.vaultHeaders != "" {
+				t.Setenv("VAULT_HEADERS", tt.vaultHeaders)
+			}
+
+			rec := &userAgentRecorder{}
+			config, ln := testutil.TestHTTPServer(t, rec.handler())
+			defer ln.Close()
+
+			s := map[string]*schema.Schema{
+				consts.FieldAddress: {Type: schema.TypeString, Required: true},
+				consts.FieldToken:   {Type: schema.TypeString, Required: true},
+				"headers": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"name":  {Type: schema.TypeString, Required: true},
+							"value": {Type: schema.TypeString, Required: true},
+						},
+					},
+				},
+			}
+			raw := map[string]interface{}{
+				consts.FieldAddress: config.Address,
+				consts.FieldToken:   "test-token",
+			}
+			if tt.configHeader[0] != "" {
+				raw["headers"] = []interface{}{
+					map[string]interface{}{"name": tt.configHeader[0], "value": tt.configHeader[1]},
+				}
+			}
+
+			meta, err := NewProviderMeta(schema.TestResourceDataRaw(t, s, raw))
+			if err != nil {
+				t.Fatalf("NewProviderMeta() error = %v", err)
+			}
+
+			if _, err := meta.(*ProviderMeta).GetClient(); err != nil {
+				t.Fatalf("GetClient() error = %v", err)
+			}
+
+			observed := rec.observed()
+			if len(observed) == 0 {
+				t.Fatal("no requests were made, cannot assert on the User-Agent")
+			}
+			if len(observed) > 1 {
+				t.Fatalf("requests carried differing User-Agents: %q", observed)
+			}
+
+			tt.assertUA(t, observed[0])
+		})
+	}
+}
+
+func TestProviderMeta_getUserAgent(t *testing.T) {
+	t.Run("uses the value set during configuration", func(t *testing.T) {
+		p := &ProviderMeta{userAgent: "Terraform/1.2.3 terraform-provider-vault/9.9.9"}
+		if got := p.getUserAgent(); got != p.userAgent {
+			t.Errorf("getUserAgent() = %q, want %q", got, p.userAgent)
+		}
+	})
+
+	t.Run("falls back when constructed directly", func(t *testing.T) {
+		p := &ProviderMeta{}
+		got := p.getUserAgent()
+
+		wantProduct := providerversion.ProviderName + "/" + providerversion.ProviderVersion()
+		if !strings.Contains(got, wantProduct) {
+			t.Errorf("getUserAgent() = %q, does not contain %q", got, wantProduct)
+		}
+	})
+
+	t.Run("fallback still honors TF_APPEND_USER_AGENT", func(t *testing.T) {
+		t.Setenv("TF_APPEND_USER_AGENT", "my-wrapper/9.9.9")
+
+		p := &ProviderMeta{}
+		if got := p.getUserAgent(); !strings.HasSuffix(got, "my-wrapper/9.9.9") {
+			t.Errorf("getUserAgent() = %q, want suffix %q", got, "my-wrapper/9.9.9")
+		}
+	})
+}
+
+func TestProviderVersion(t *testing.T) {
+	// the embedded VERSION file must not carry surrounding whitespace, since it
+	// is emitted verbatim into a header
+	got := providerversion.ProviderVersion()
+	if got == "" {
+		t.Fatal("ProviderVersion() is empty")
+	}
+	if got != strings.TrimSpace(got) {
+		t.Errorf("ProviderVersion() = %q, has surrounding whitespace", got)
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	providerversion "github.com/hashicorp/terraform-provider-vault/version"
 )
 
 const DefaultMaxHTTPRetriesCCC = 10
@@ -199,9 +200,24 @@ func NewProvider(
 				},
 			},
 		},
-		ConfigureFunc:  NewProviderMeta,
 		DataSourcesMap: dataSourcesMap,
 		ResourcesMap:   coreResourcesMap,
+	}
+
+	// Configured here rather than in the literal above so that the closure can
+	// capture r, whose TerraformVersion is populated by the SDK before this is
+	// called. That version is part of the standard Terraform User-Agent.
+	r.ConfigureContextFunc = func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
+		meta, err := NewProviderMeta(d)
+		if err != nil {
+			return nil, diag.FromErr(err)
+		}
+
+		if p, ok := meta.(*ProviderMeta); ok {
+			p.userAgent = r.UserAgent(providerversion.ProviderName, providerversion.ProviderVersion())
+		}
+
+		return meta, nil
 	}
 
 	MustAddAuthLoginSchema(r.Schema)

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,27 @@
+// Copyright IBM Corp. 2016, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+// Package version exposes the provider version to the rest of the provider.
+package version
+
+import (
+	_ "embed"
+	"strings"
+)
+
+// rawVersion is the contents of the VERSION file, which is the canonical
+// source of the provider version. It is read by release.sh at tag time, so
+// embedding it here keeps the reported version in sync with releases without
+// requiring any build-time linker flags.
+//
+//go:embed VERSION
+var rawVersion string
+
+// ProviderName is the product name the provider identifies itself as to Vault.
+// It matches the repository and released binary name.
+const ProviderName = "terraform-provider-vault"
+
+// ProviderVersion returns the current provider version, e.g. "5.10.1".
+func ProviderVersion() string {
+	return strings.TrimSpace(rawVersion)
+}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -228,6 +228,25 @@ The `headers` configuration block accepts the following arguments:
 
 * `value` - (Required) The value of the header.
 
+### User-Agent
+
+All requests to Vault are sent with a standard Terraform `User-Agent` header, for example:
+
+```
+Terraform/1.15.8 (+https://www.terraform.io) Terraform-Plugin-SDK/2.40.1 terraform-provider-vault/5.10.1
+```
+
+Setting the `TF_APPEND_USER_AGENT` environment variable appends its value to that string, which is
+useful for identifying traffic from wrapper tooling in Vault audit logs:
+
+```shell
+export TF_APPEND_USER_AGENT="my-tooling/1.2.3"
+```
+
+To replace the `User-Agent` entirely rather than append to it, set it explicitly through the
+`headers` block above or the `VAULT_HEADERS` environment variable; an explicitly configured value
+takes precedence over the default.
+
 
 ## Vault Authentication Configuration Options
 


### PR DESCRIPTION
### Description
Closes #2987 by setting a default Terraform `User-Agent` header on each Vault request, ex:
```
Terraform/1.15.8 (+https://www.terraform.io) Terraform-Plugin-SDK/2.40.1 terraform-provider-vault/5.10.1
```

### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
