### PR TITLE
vault: handle null auth tune blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+* Prevent auth backend resources from panicking when a `tune` block resolves to null.
 * Fixed the token namespace being set as the provider namespace, even when `set_namespace_from_token` was `false`. ([#2926](https://github.com/hashicorp/terraform-provider-vault/pull/2926/))
 * `vault_pki_secret_backend_role`: Fix crash when the Vault client was not successfully initialized ([#2801](https://github.com/hashicorp/terraform-provider-vault/pull/2801))
 

--- a/vault/structures.go
+++ b/vault/structures.go
@@ -25,6 +25,9 @@ func expandAuthMethodTune(raw interface{}) (api.MountConfigInput, error) {
 	if len(rawL) == 0 {
 		return data, nil
 	}
+	if rawL[0] == nil {
+		return data, nil
+	}
 	config := rawL[0].(map[string]interface{})
 
 	if v, ok := config[consts.FieldDefaultLeaseTTL]; ok {

--- a/vault/structures_test.go
+++ b/vault/structures_test.go
@@ -47,6 +47,16 @@ func TestExpandAuthMethodTune(t *testing.T) {
 	}
 }
 
+func TestExpandAuthMethodTuneNull(t *testing.T) {
+	actual, err := expandAuthMethodTune([]interface{}{nil})
+	if err != nil {
+		t.Fatalf("error expanding null auth method tune: %s", err)
+	}
+	if !reflect.DeepEqual(actual, api.MountConfigInput{}) {
+		t.Fatalf("got %#v, expected empty mount config", actual)
+	}
+}
+
 func TestFlattenAuthMethodTune(t *testing.T) {
 	expanded := &api.MountConfigOutput{
 		DefaultLeaseTTL:           600,


### PR DESCRIPTION
### Description

Treat null auth backend `tune` blocks as unset instead of type-asserting them to a map. This prevents dynamic blocks that resolve to null from panicking the provider process. Includes a focused regression test and changelog entry.

Closes #2973

### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions

### Output from acceptance testing:

```
$ make test
PASS

$ make vet
PASS

$ make fmtcheck
PASS
```

Acceptance testing was not run because the failure occurs during local configuration expansion before any Vault API call.

### Community Note

* Please vote on this pull request by adding a 👍 reaction to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

## PCI review checklist

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.