### PR TITLE
fix(provider): align auth login block cardinality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+* Add the missing single-block constraint to the Plugin Framework schemas for all `auth_login_*` provider configuration blocks.
 * Fixed the token namespace being set as the provider namespace, even when `set_namespace_from_token` was `false`. ([#2926](https://github.com/hashicorp/terraform-provider-vault/pull/2926/))
 * `vault_pki_secret_backend_role`: Fix crash when the Vault client was not successfully initialized ([#2801](https://github.com/hashicorp/terraform-provider-vault/pull/2801))
 

--- a/internal/provider/fwprovider/auth.go
+++ b/internal/provider/fwprovider/auth.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/boolvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
@@ -16,6 +17,8 @@ import (
 )
 
 func mustAddLoginSchema(s *schema.ListNestedBlock, defaultMount string) schema.Block {
+	s.Validators = append(s.Validators, listvalidator.SizeAtMost(1))
+
 	m := map[string]schema.Attribute{
 		consts.FieldNamespace: schema.StringAttribute{
 			Optional: true,

--- a/vault/provider_config_test.go
+++ b/vault/provider_config_test.go
@@ -1,0 +1,93 @@
+// Copyright IBM Corp. 2016, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package vault
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	frameworkprovider "github.com/hashicorp/terraform-plugin-framework/provider"
+	frameworkschema "github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	sdkv2schema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hashicorp/terraform-provider-vault/internal/provider/fwprovider"
+)
+
+func TestProviderConfigListCardinalityMatches(t *testing.T) {
+	_, primary, err := ProtoV5ProviderServerFactory(context.Background())
+	require.NoError(t, err)
+
+	framework := fwprovider.New(primary)
+	var response frameworkprovider.SchemaResponse
+	framework.Schema(context.Background(), frameworkprovider.SchemaRequest{}, &response)
+	require.False(t, response.Diagnostics.HasError())
+
+	for name, sdkv2Field := range primary.SchemaProvider().Schema {
+		if sdkv2Field.Type != sdkv2schema.TypeList {
+			continue
+		}
+
+		t.Run(name, func(t *testing.T) {
+			block, ok := response.Schema.Blocks[name]
+			require.True(t, ok, "Plugin Framework schema has no matching block")
+			listBlock := getListNestedBlock(t, block)
+
+			if sdkv2Field.MaxItems == 0 {
+				require.False(t, validateListBlockSize(t, name, listBlock, 2).Diagnostics.HasError())
+				return
+			}
+
+			require.False(t,
+				validateListBlockSize(t, name, listBlock, sdkv2Field.MaxItems).Diagnostics.HasError())
+			require.True(t,
+				validateListBlockSize(t, name, listBlock, sdkv2Field.MaxItems+1).Diagnostics.HasError())
+		})
+	}
+}
+
+func getListNestedBlock(t *testing.T, block frameworkschema.Block) *frameworkschema.ListNestedBlock {
+	t.Helper()
+
+	switch block := block.(type) {
+	case frameworkschema.ListNestedBlock:
+		return &block
+	case *frameworkschema.ListNestedBlock:
+		return block
+	default:
+		t.Fatalf("expected ListNestedBlock, got %T", block)
+		return nil
+	}
+}
+
+func validateListBlockSize(
+	t *testing.T,
+	name string,
+	block *frameworkschema.ListNestedBlock,
+	size int,
+) validator.ListResponse {
+	t.Helper()
+
+	objectType, ok := block.NestedObject.Type().(types.ObjectType)
+	require.True(t, ok)
+
+	elements := make([]attr.Value, size)
+	for i := range elements {
+		elements[i] = types.ObjectNull(objectType.AttributeTypes())
+	}
+
+	request := validator.ListRequest{
+		Path:        path.Root(name),
+		ConfigValue: types.ListValueMust(objectType, elements),
+	}
+	var response validator.ListResponse
+	for _, listValidator := range block.Validators {
+		listValidator.ValidateList(context.Background(), request, &response)
+	}
+	return response
+}


### PR DESCRIPTION
### Description

The SDKv2 provider schema limits every `auth_login_*` configuration block to one item. The duplicated Plugin Framework schemas omitted that cardinality constraint. Schema consumers can therefore derive incompatible shapes for the same provider configuration. In Pulumi, an object-shaped `authLoginAws` value fails during Plugin Framework encoding with `Expected an Array PropertyValue`.

This adds `listvalidator.SizeAtMost(1)` in the shared auth login schema helper. It also adds a parity test that compares every top-level SDKv2 list limit with the matching Plugin Framework block. The audit confirms that `headers` remains unbounded and `client_auth` was already limited to one item.

Relates to https://github.com/pulumi/pulumi-vault/issues/1087

The broader mux handling problem is tracked in https://github.com/pulumi/pulumi-terraform-bridge/issues/3566.

### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests were run against all supported Vault versions

Acceptance tests were not run because this change only aligns provider schema validation and does not call Vault.

### Output from testing

```console
$ go test ./vault -run TestProviderConfigListCardinalityMatches -count=1
ok  github.com/hashicorp/terraform-provider-vault/v5/vault

$ go test ./internal/provider/fwprovider ./vault -count=1
ok  github.com/hashicorp/terraform-provider-vault/v5/internal/provider/fwprovider
ok  github.com/hashicorp/terraform-provider-vault/v5/vault

$ go vet ./internal/provider/fwprovider ./vault
```

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

  This change can be reverted by reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  This change does not modify security controls.
