### PR TITLE
VAULT-49089: add issuer and external_id fields to aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ FEATURES:
 
 IMPROVEMENTS:
 
+* `vault_identity_entity_alias`: Add support for `external_id` and `issuer` fields. Available only for Vault Enterprise. ([#2994](https://github.com/hashicorp/terraform-provider-vault/pull/2994))
+
 * `vault_aws_auth_backend_config_identity`: Add support for `canonical_arn` as a valid value for the `iam_alias` parameter. Requires Vault 1.16+. ([#2982](https://github.com/hashicorp/terraform-provider-vault/pull/2982))
 
 * `vault_jwt_auth_backend`: Add string-to-integer conversion for `groups_cap` field in `provider_config` to support Okta provider configuration. ([#2939](https://github.com/hashicorp/terraform-provider-vault/pull/2939))

--- a/vault/resource_identity_entity_alias.go
+++ b/vault/resource_identity_entity_alias.go
@@ -55,6 +55,18 @@ func identityEntityAliasResource() *schema.Resource {
 					Type: schema.TypeString,
 				},
 			},
+			consts.FieldExternalID: {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Unique external identifier from the external IdP.",
+			},
+			consts.FieldIssuer: {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "Issuer name associated with this alias.",
+			},
 		},
 	}
 }
@@ -76,6 +88,8 @@ func identityEntityAliasCreate(ctx context.Context, d *schema.ResourceData, meta
 		consts.FieldMountAccessor: "",
 		"canonical_id":            "",
 		"custom_metadata":         "",
+		consts.FieldExternalID:    "",
+		consts.FieldIssuer:        "",
 	})
 
 	diags := diag.Diagnostics{}
@@ -160,6 +174,8 @@ func identityEntityAliasUpdate(ctx context.Context, d *schema.ResourceData, meta
 		consts.FieldMountAccessor: "",
 		"canonical_id":            "",
 		"custom_metadata":         "",
+		consts.FieldExternalID:    "",
+		consts.FieldIssuer:        "",
 	})
 	if _, err := client.Logical().Write(path, data); err != nil {
 		diags = append(diags, diag.Diagnostic{
@@ -205,7 +221,7 @@ func identityEntityAliasRead(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	d.SetId(resp.Data["id"].(string))
-	for _, k := range []string{"name", consts.FieldMountAccessor, "canonical_id", "custom_metadata"} {
+	for _, k := range []string{"name", consts.FieldMountAccessor, "canonical_id", "custom_metadata", consts.FieldExternalID, consts.FieldIssuer} {
 		if err := d.Set(k, resp.Data[k]); err != nil {
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,

--- a/vault/resource_identity_entity_alias_test.go
+++ b/vault/resource_identity_entity_alias_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
+	"github.com/hashicorp/terraform-provider-vault/acctestutil"
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/identity/entity"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
@@ -284,6 +285,62 @@ func testAccCheckIdentityEntityAliasDestroy(s *terraform.State) error {
 		}
 	}
 	return nil
+}
+
+func TestAccIdentityEntityAlias_ExternalIDIssuer(t *testing.T) {
+	entityName := acctest.RandomWithPrefix("my-entity")
+	externalID := acctest.RandomWithPrefix("ext-id")
+	issuer := "https://issuer.example.com"
+
+	nameEntityAlias := "vault_identity_entity_alias.entity-alias"
+	nameGithubA := "vault_auth_backend.githubA"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctestutil.TestEntPreCheck(t)
+			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion200)
+		},
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		CheckDestroy:             testAccCheckIdentityEntityAliasDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityEntityAliasExternalIDConfig(entityName, externalID, issuer),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(nameEntityAlias, "canonical_id", "vault_identity_entity.entity", "id"),
+					resource.TestCheckResourceAttrPair(nameEntityAlias, consts.FieldMountAccessor, nameGithubA, "accessor"),
+					resource.TestCheckResourceAttr(nameEntityAlias, consts.FieldExternalID, externalID),
+					resource.TestCheckResourceAttr(nameEntityAlias, consts.FieldIssuer, issuer),
+				),
+			},
+			{
+				ResourceName:      nameEntityAlias,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccIdentityEntityAliasExternalIDConfig(entityName, externalID, issuer string) string {
+	return fmt.Sprintf(`
+resource "vault_identity_entity" "entity" {
+  name = %q
+  policies = ["test"]
+}
+
+resource "vault_auth_backend" "githubA" {
+  type = "github"
+  path = "github-%s"
+}
+
+resource "vault_identity_entity_alias" "entity-alias" {
+  name           = %q
+  mount_accessor = vault_auth_backend.githubA.accessor
+  canonical_id   = vault_identity_entity.entity.id
+  external_id    = %q
+  issuer         = %q
+}
+`, entityName, entityName, entityName, externalID, issuer)
 }
 
 func TestAccIdentityEntityAlias_Metadata(t *testing.T) {

--- a/website/docs/r/identity_entity_alias.html.md
+++ b/website/docs/r/identity_entity_alias.html.md
@@ -42,10 +42,21 @@ The following arguments are supported:
 
 * `canonical_id` - (Required) Entity ID to which this alias belongs to.
 
+* `custom_metadata` - (Optional) Custom metadata to be associated with this alias.
+
+* `external_id` - (Optional, Forces new resource) Unique external identifier from the external IdP.
+  *Available only for Vault Enterprise*.
+
+* `issuer` - (Optional, Forces new resource) Issuer name associated with this alias.
+  *Available only for Vault Enterprise*.
 
 ## Attributes Reference
 
 * `id` - ID of the entity alias.
+
+* `issuer` - Issuer name stored on the alias.
+
+* `external_id` - External identifier stored on the alias.
 
 ## Import
 


### PR DESCRIPTION
### Description
Adds the missing fields `issuer` and `external_id` to aliases.
Jira: https://hashicorp.atlassian.net/browse/VAULT-49089


### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ TF_ACC=1 TF_ACC_ENTERPRISE=1 TESTARGS="-v --run TestAccIdentityEntityAlias_ExternalIDIssuer" make testacc

...
```
<img width="703" height="74" alt="Screenshot 2026-08-11 at 2 04 56 PM" src="https://github.com/user-attachments/assets/f3ce0937-fcb1-47d3-b30e-25fa0623893c" />



<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
