### PR TITLE
vault_ldap_auth_backend: surface diagnostic warning when mount not found during refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 5.12.0 (Unreleased)
 
+IMPROVEMENTS:
+
+* `vault_ldap_auth_backend`: emit a `diag.Warning` diagnostic when the auth mount or its config is not found during refresh, so users see an actionable message in `terraform plan` output rather than a silent state removal. ([#2997](https://github.com/hashicorp/terraform-provider-vault/pull/2997))
+
 BUG FIXES:
 
 * `vault_terraform_cloud_secret_backend`: Fix logic gap in `Read` where execution would fall through to a stray `GET <backend>/config` call after `readMount` detected the mount was deleted out-of-band and cleared the resource ID. Add `util.Is404` guard to `Delete` so that `terraform destroy` succeeds cleanly when the mount has already been removed from Vault. ([#3006](https://github.com/hashicorp/terraform-provider-vault/pull/3006))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 IMPROVEMENTS:
 
-* `vault_ldap_auth_backend`: emit a `diag.Warning` diagnostic when the auth mount or its config is not found during refresh, so users see an actionable message in `terraform plan` output rather than a silent state removal. ([#2997](https://github.com/hashicorp/terraform-provider-vault/pull/2997))
+* `vault_ldap_auth_backend`: emit a warning when the auth mount or its config is not found during refresh, so users see an actionable message in `terraform plan` output rather than a silent state removal. ([#2997](https://github.com/hashicorp/terraform-provider-vault/pull/2997))
 
 BUG FIXES:
 

--- a/vault/resource_ldap_auth_backend.go
+++ b/vault/resource_ldap_auth_backend.go
@@ -430,18 +430,16 @@ func ldapAuthBackendRead(ctx context.Context, d *schema.ResourceData, meta inter
 	mount, err := mountutil.GetAuthMount(ctx, client, path)
 	if err != nil {
 		if mountutil.IsMountNotFoundError(err) {
+			log.Printf("[WARN] Mount %q not found, removing from state.", path)
 			d.SetId("")
 			return diag.Diagnostics{
 				{
 					Severity: diag.Warning,
-					Summary:  "Mount not found in current namespace",
+					Summary:  "Mount not found",
 					Detail: fmt.Sprintf(
-						"Mount %q was not found in the current namespace and has been removed "+
-							"from state. If you recently migrated the namespace from a provider "+
-							"block to the resource's namespace attribute, the resource still "+
-							"exists in Vault but Terraform is searching in the wrong namespace "+
-							"during refresh. To recover, manually update the state to add the "+
-							"namespace attribute. See https://hashicorp.atlassian.net/browse/VAULT-15732 for details.", path),
+						"Mount %q was not found and has been removed from state. "+
+							"If this is unexpected, verify the mount exists in the current "+
+							"namespace and that your provider configuration is correct.", path),
 				},
 			}
 		}
@@ -463,18 +461,16 @@ func ldapAuthBackendRead(ctx context.Context, d *schema.ResourceData, meta inter
 	log.Printf("[DEBUG] Read LDAP auth backend config %q", path)
 
 	if resp == nil {
+		log.Printf("[WARN] LDAP auth backend config %q not found, removing from state", path)
 		d.SetId("")
 		return diag.Diagnostics{
 			{
 				Severity: diag.Warning,
-				Summary:  "LDAP auth backend config not found in current namespace",
+				Summary:  "LDAP auth backend config not found",
 				Detail: fmt.Sprintf(
-					"LDAP auth backend config %q was not found in the current namespace and "+
-						"has been removed from state. If you recently migrated the namespace "+
-						"from a provider block to the resource's namespace attribute, the "+
-						"resource still exists in Vault but Terraform is searching in the "+
-						"wrong namespace during refresh. To recover, manually update the "+
-						"state to add the namespace attribute. See https://hashicorp.atlassian.net/browse/VAULT-15732 for details.", path),
+					"LDAP auth backend config %q was not found and has been removed from state. "+
+						"If this is unexpected, verify the mount exists in the current "+
+						"namespace and that your provider configuration is correct.", path),
 			},
 		}
 	}

--- a/vault/resource_ldap_auth_backend.go
+++ b/vault/resource_ldap_auth_backend.go
@@ -5,6 +5,7 @@ package vault
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strings"
 
@@ -429,9 +430,20 @@ func ldapAuthBackendRead(ctx context.Context, d *schema.ResourceData, meta inter
 	mount, err := mountutil.GetAuthMount(ctx, client, path)
 	if err != nil {
 		if mountutil.IsMountNotFoundError(err) {
-			log.Printf("[WARN] Mount %q not found, removing from state.", path)
 			d.SetId("")
-			return nil
+			return diag.Diagnostics{
+				{
+					Severity: diag.Warning,
+					Summary:  "Mount not found in current namespace",
+					Detail: fmt.Sprintf(
+						"Mount %q was not found in the current namespace and has been removed "+
+							"from state. If you recently migrated the namespace from a provider "+
+							"block to the resource's namespace attribute, the resource still "+
+							"exists in Vault but Terraform is searching in the wrong namespace "+
+							"during refresh. To recover, manually update the state to add the "+
+							"namespace attribute. See https://hashicorp.atlassian.net/browse/VAULT-15732 for details.", path),
+				},
+			}
 		}
 		return diag.FromErr(err)
 	}
@@ -451,9 +463,20 @@ func ldapAuthBackendRead(ctx context.Context, d *schema.ResourceData, meta inter
 	log.Printf("[DEBUG] Read LDAP auth backend config %q", path)
 
 	if resp == nil {
-		log.Printf("[WARN] LDAP auth backend config %q not found, removing from state", path)
 		d.SetId("")
-		return nil
+		return diag.Diagnostics{
+			{
+				Severity: diag.Warning,
+				Summary:  "LDAP auth backend config not found in current namespace",
+				Detail: fmt.Sprintf(
+					"LDAP auth backend config %q was not found in the current namespace and "+
+						"has been removed from state. If you recently migrated the namespace "+
+						"from a provider block to the resource's namespace attribute, the "+
+						"resource still exists in Vault but Terraform is searching in the "+
+						"wrong namespace during refresh. To recover, manually update the "+
+						"state to add the namespace attribute. See https://hashicorp.atlassian.net/browse/VAULT-15732 for details.", path),
+			},
+		}
 	}
 
 	if err := readTokenFields(d, resp); err != nil {


### PR DESCRIPTION
Summary
When vault_ldap_auth_backend cannot find its mount during refresh, it previously removed the resource from state with only a log.Printf [WARN] message — invisible to customers unless TF_LOG=WARN was set. This caused silent state corruption that was especially confusing during provider namespace migrations (VAULT-15732). Without the warning, customers only discover the issue when terraform apply fails with path is already in use at ldap/.

Changes
vault/resource_ldap_auth_backend.go: replaced log.Printf [WARN] + d.SetId("") return nil patterns in ldapAuthBackendRead with diag.Warning diagnostics that surface as yellow warning boxes in normal terraform plan output — no special flags required.

Why not a full fix?
The correct long-term fix requires CustomizeDiff logic in the provider schema to detect when namespace transitions from "" (inherited from provider) to an explicit value representing the same namespace, and suppress the ForceNew replacement in that case. This is a larger change tracked as a follow-up. This PR makes the failure visible and actionable in the meantime.

Testing
Reproduced with Vault Enterprise 2.1.0-beta1+ent, Terraform 1.15.8. The warning logic is not version-specific and applies to all Vault versions.

Apply with a module using an aliased namespaced provider → 4 resources created
Switch module source to a version without the aliased provider
Run terraform plan → warning box now appears in normal output without any TF_LOG:
╷
│ Warning: Mount not found
│
│   with module.m1.vault_ldap_auth_backend.parent_ldap_auth_backend["foo"],
│   on m_remove_provider/m.tf line 27, in resource "vault_ldap_auth_backend":
│
│ Mount "ldap" was not found and has been removed from state. If this is
│ unexpected, verify the mount exists in the current namespace and that
│ your provider configuration is correct.