### PR TITLE
docs: remove preview status and activation flag requirement from agentic features

### DIFF
--- a/website/docs/r/agent_registration.html.md
+++ b/website/docs/r/agent_registration.html.md
@@ -8,8 +8,6 @@ description: |-
 
 # vault\_agent\_registration
 
-~> **Preview feature:** This feature is currently available as a preview and is possibly incomplete and subject to change. **We strongly discourage using preview or beta features with production workflows.**
-
 Manages Agent Registry records in Vault Enterprise. An Agent Registry record allows you to register Vault agents with specific identity entities and configure ceiling policies that limit the maximum permissions an agent can obtain.
 
 ~> **Important** This resource is available only in Vault Enterprise and requires Vault 2.0.1 or later.

--- a/website/docs/r/oauth_resource_server_config_profile.html.md
+++ b/website/docs/r/oauth_resource_server_config_profile.html.md
@@ -8,34 +8,15 @@ description: |-
 
 # vault\_oauth\_resource\_server\_config\_profile
 
-~>  **Preview feature:** This feature is currently available as a preview and is possibly incomplete and subject to change. **We strongly discourage using preview or beta features with production workflows.**
-
-
 Manages OAuth Resource Server Configuration profiles in Vault Enterprise. These profiles define how Vault validates JWT tokens from OAuth 2.0 resource servers, enabling JWT-based authentication for API requests.
 
-~> **Important** This resource is only available in Vault Enterprise and requires Vault 2.0.1 or later.
+~> **Important** This resource is available only in Vault Enterprise and requires Vault 2.0.1 or later.
 
 ### Relationship to Agent Registry 
 
 These two features work together. You may want to refer to [Agent Registry Terraform Resource](agent_registration.html.md).
 
 ## Example Usage
-
-### Enable the Feature
-
-```hcl
-resource "vault_activation_flags" "oauth" {
-  feature = "oauth-resource-server"
-}
-
-resource "vault_oauth_resource_server_config_profile" "example" {
-  depends_on   = [vault_activation_flags.oauth]
-  profile_name = "example-profile"
-  issuer_id    = "https://example.com"
-  use_jwks     = true
-  jwks_uri     = "https://example.com/.well-known/jwks.json"
-}
-```
 
 ### JWKS-Based Profile
 
@@ -252,7 +233,7 @@ $ TERRAFORM_VAULT_NAMESPACE_IMPORT=application terraform import vault_oauth_reso
 
 * **Clock Skew**: Use `clock_skew_leeway` to handle clock differences between systems. A value of 30-60 seconds is typically sufficient for most environments.
 
-* **Enterprise Feature**: OAuth Resource Server Configuration is only available in Vault Enterprise. Attempting to use this resource with Vault Community Edition will result in an error.
+* **Enterprise Feature**: OAuth Resource Server Configuration is available only in Vault Enterprise. Attempting to use this resource with Vault Community Edition will result in an error.
 
 * **Version Requirement**: This resource requires Vault 2.0.1 or later.
 


### PR DESCRIPTION
### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->

The agent registry and OAuth resource server configuration profile features are no longer in preview. Remove the preview callout banners from both documentation pages.

Also remove the "Enable the Feature" example section from the OAuth resource server config profile docs. That example used vault_activation_flags to activate "oauth-resource-server" and wired a depends_on into the profile resource. The activation flag is no longer required before using the feature.

<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes [VAULT-49240
](https://hashicorp.atlassian.net/browse/VAULT-49240)
### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
