### PR TITLE
[VAULT-48786] Add `metadata` field to secrets engine role resources

### DIFF
--- a/vault/resource_aws_secret_backend_role.go
+++ b/vault/resource_aws_secret_backend_role.go
@@ -126,9 +126,18 @@ func awsSecretBackendRoleResource(name string) *schema.Resource {
 				Optional:    true,
 				Description: "The ARN or hardware device number of the device configured to the IAM user for multi-factor authentication. Only required if the IAM user has an MFA device set up in AWS.",
 			},
+			consts.FieldMetadata: {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: "A map of string key-value pairs to associate with the role. Requires Vault Enterprise 2.0.0+.",
+			},
 		},
 	}
-}
+	}
 
 func awsSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) error {
 	client, e := provider.GetClient(d, meta)
@@ -229,6 +238,16 @@ func awsSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+	if provider.IsAPISupported(meta, provider.VaultVersion200) && provider.IsEnterpriseSupported(meta) {
+		if d.IsNewResource() {
+			if v, ok := d.GetOk(consts.FieldMetadata); ok && len(v.(map[string]interface{})) > 0 {
+				data[consts.FieldMetadata] = v.(map[string]interface{})
+			}
+		} else if d.HasChange(consts.FieldMetadata) {
+			data[consts.FieldMetadata] = d.Get(consts.FieldMetadata)
+		}
+	}
+
 	log.Printf("[DEBUG] Creating role %q on AWS backend %q", name, backend)
 	_, err := client.Logical().Write(backend+"/roles/"+name, data)
 	if err != nil {
@@ -304,6 +323,12 @@ func awsSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	if v, ok := secret.Data[consts.FieldMFASerialNumber]; ok {
 		d.Set(consts.FieldMFASerialNumber, v)
+	}
+
+	if provider.IsAPISupported(meta, provider.VaultVersion200) && provider.IsEnterpriseSupported(meta) {
+		if err := d.Set(consts.FieldMetadata, secret.Data[consts.FieldMetadata]); err != nil {
+			return fmt.Errorf("error setting %s: %s", consts.FieldMetadata, err)
+		}
 	}
 
 	d.Set("backend", strings.Join(pathPieces[:len(pathPieces)-2], "/"))

--- a/vault/resource_consul_secret_backend_role.go
+++ b/vault/resource_consul_secret_backend_role.go
@@ -121,6 +121,15 @@ func consulSecretBackendRoleResource() *schema.Resource {
 				Description: "Indicates that the token should not be replicated globally and instead be local to the current datacenter.",
 				Default:     false,
 			},
+			consts.FieldMetadata: {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: "A map of string key-value pairs to associate with the role. Requires Vault Enterprise 2.0.0+.",
+			},
 		},
 	}
 }
@@ -187,6 +196,16 @@ func consulSecretBackendRoleWrite(ctx context.Context, d *schema.ResourceData, m
 	for _, k := range params {
 		if v, ok := d.GetOkExists(k); ok {
 			data[k] = v
+		}
+	}
+
+	if provider.IsAPISupported(meta, provider.VaultVersion200) && provider.IsEnterpriseSupported(meta) {
+		if d.IsNewResource() {
+			if v, ok := d.GetOk(consts.FieldMetadata); ok && len(v.(map[string]interface{})) > 0 {
+				data[consts.FieldMetadata] = v.(map[string]interface{})
+			}
+		} else if d.HasChange(consts.FieldMetadata) {
+			data[consts.FieldMetadata] = d.Get(consts.FieldMetadata)
 		}
 	}
 
@@ -294,6 +313,12 @@ func consulSecretBackendRoleRead(ctx context.Context, d *schema.ResourceData, me
 			}
 		}
 		if err := d.Set(v, val); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if provider.IsAPISupported(meta, provider.VaultVersion200) && provider.IsEnterpriseSupported(meta) {
+		if err := d.Set(consts.FieldMetadata, data[consts.FieldMetadata]); err != nil {
 			return diag.FromErr(err)
 		}
 	}

--- a/vault/resource_database_secret_backend_role.go
+++ b/vault/resource_database_secret_backend_role.go
@@ -109,6 +109,15 @@ func databaseSecretBackendRoleResource() *schema.Resource {
 				Optional:    true,
 				Description: "Specifies the configuration for the given credential_type.",
 			},
+			consts.FieldMetadata: {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: "A map of string key-value pairs to associate with the role. Requires Vault Enterprise 2.0.0+.",
+			},
 		},
 	}
 }
@@ -132,6 +141,16 @@ func databaseSecretBackendRoleWrite(ctx context.Context, d *schema.ResourceData,
 	for _, k := range roleAPIFields {
 		if d.HasChange(k) {
 			data[k] = d.Get(k)
+		}
+	}
+
+	if provider.IsAPISupported(meta, provider.VaultVersion200) && provider.IsEnterpriseSupported(meta) {
+		if d.IsNewResource() {
+			if v, ok := d.GetOk(consts.FieldMetadata); ok && len(v.(map[string]interface{})) > 0 {
+				data[consts.FieldMetadata] = v.(map[string]interface{})
+			}
+		} else if d.HasChange(consts.FieldMetadata) {
+			data[consts.FieldMetadata] = d.Get(consts.FieldMetadata)
 		}
 	}
 
@@ -199,6 +218,13 @@ func databaseSecretBackendRoleRead(ctx context.Context, d *schema.ResourceData, 
 			}
 		}
 	}
+
+	if provider.IsAPISupported(meta, provider.VaultVersion200) && provider.IsEnterpriseSupported(meta) {
+		if err := d.Set(consts.FieldMetadata, secret.Data[consts.FieldMetadata]); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	return nil
 }
 

--- a/vault/resource_database_secret_backend_static_role.go
+++ b/vault/resource_database_secret_backend_static_role.go
@@ -135,6 +135,15 @@ func databaseSecretBackendStaticRoleResource() *schema.Resource {
 				Description: "The configuration for the credential type." +
 					"Full documentation for the allowed values can be found under \"https://developer.hashicorp.com/vault/api-docs/secret/databases#credential_config\".",
 			},
+			consts.FieldMetadata: {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: "A map of string key-value pairs to associate with the role. Requires Vault Enterprise 2.0.0+.",
+			},
 		},
 	}
 }
@@ -205,6 +214,16 @@ func databaseSecretBackendStaticRoleWrite(ctx context.Context, d *schema.Resourc
 			if pwWo.IsKnown() && !pwWo.IsNull() && strings.TrimSpace(pwWo.AsString()) != "" {
 				data[consts.FieldPassword] = pwWo.AsString()
 			}
+		}
+	}
+
+	if provider.IsAPISupported(meta, provider.VaultVersion200) && provider.IsEnterpriseSupported(meta) {
+		if d.IsNewResource() {
+			if v, ok := d.GetOk(consts.FieldMetadata); ok && len(v.(map[string]interface{})) > 0 {
+				data[consts.FieldMetadata] = v.(map[string]interface{})
+			}
+		} else if d.HasChange(consts.FieldMetadata) {
+			data[consts.FieldMetadata] = d.Get(consts.FieldMetadata)
 		}
 	}
 
@@ -299,6 +318,12 @@ func databaseSecretBackendStaticRoleRead(ctx context.Context, d *schema.Resource
 			if err := d.Set(k, v); err != nil {
 				return diag.FromErr(err)
 			}
+		}
+	}
+
+	if provider.IsAPISupported(meta, provider.VaultVersion200) && provider.IsEnterpriseSupported(meta) {
+		if err := d.Set(consts.FieldMetadata, role.Data[consts.FieldMetadata]); err != nil {
+			return diag.FromErr(err)
 		}
 	}
 

--- a/vault/resource_nomad_secret_role.go
+++ b/vault/resource_nomad_secret_role.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"
 )
@@ -55,6 +56,15 @@ func nomadSecretBackendRoleResource() *schema.Resource {
 			Optional:    true,
 			Computed:    true,
 			Description: `Specifies the type of token to create when using this role. Valid values are "client" or "management".`,
+		},
+		consts.FieldMetadata: {
+			Type:     schema.TypeMap,
+			Optional: true,
+			Computed: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+			Description: "A map of string key-value pairs to associate with the role. Requires Vault Enterprise 2.0.0+.",
 		},
 	}
 	return &schema.Resource{
@@ -109,6 +119,12 @@ func createNomadRoleResource(d *schema.ResourceData, meta interface{}) error {
 	// Policies not supported when role type is 'management'
 	if roleType == "management" && data["policies"] != nil {
 		return fmt.Errorf("error creating role %s: policies should be empty when using management tokens", role)
+	}
+
+	if provider.IsAPISupported(meta, provider.VaultVersion200) && provider.IsEnterpriseSupported(meta) {
+		if v, ok := d.GetOk(consts.FieldMetadata); ok && len(v.(map[string]interface{})) > 0 {
+			data[consts.FieldMetadata] = v.(map[string]interface{})
+		}
 	}
 
 	log.Printf("[DEBUG] Writing %q", rolePath)
@@ -171,6 +187,14 @@ func readNomadRoleResource(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+
+	if provider.IsAPISupported(meta, provider.VaultVersion200) && provider.IsEnterpriseSupported(meta) {
+		if err := d.Set(consts.FieldMetadata, resp.Data[consts.FieldMetadata]); err != nil {
+			return fmt.Errorf("error setting %s: %s", consts.FieldMetadata, err)
+		}
+	}
+
+
 	return nil
 }
 
@@ -207,6 +231,12 @@ func updateNomadRoleResource(d *schema.ResourceData, meta interface{}) error {
 
 	if roleType == "client" && data["policies"] == "" {
 		return fmt.Errorf("error updating role %s: policies are required when role type is 'client'", roleName)
+	}
+
+	if provider.IsAPISupported(meta, provider.VaultVersion200) && provider.IsEnterpriseSupported(meta) {
+		if d.HasChange(consts.FieldMetadata) {
+			data[consts.FieldMetadata] = d.Get(consts.FieldMetadata)
+		}
 	}
 
 	if _, err := client.Logical().Write(rolePath, data); err != nil {

--- a/vault/resource_rabbitmq_secret_backend_role.go
+++ b/vault/resource_rabbitmq_secret_backend_role.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
@@ -111,6 +112,15 @@ func rabbitMQSecretBackendRoleResource() *schema.Resource {
 					},
 				},
 			},
+			consts.FieldMetadata: {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Description: "A map of string key-value pairs to associate with the role. Requires Vault Enterprise 2.0.0+.",
+			},
 		},
 	}
 }
@@ -139,6 +149,17 @@ func rabbitMQSecretBackendRoleWrite(d *schema.ResourceData, meta interface{}) er
 		"vhosts":       vhostsJSON,
 		"vhost_topics": vhostTopicsJSON,
 	}
+
+	if provider.IsAPISupported(meta, provider.VaultVersion200) && provider.IsEnterpriseSupported(meta) {
+		if d.IsNewResource() {
+			if v, ok := d.GetOk(consts.FieldMetadata); ok && len(v.(map[string]interface{})) > 0 {
+				data[consts.FieldMetadata] = v.(map[string]interface{})
+			}
+		} else if d.HasChange(consts.FieldMetadata) {
+			data[consts.FieldMetadata] = d.Get(consts.FieldMetadata)
+		}
+	}
+
 	log.Printf("[DEBUG] Creating role %q on Rabbitmq backend %q", name, backend)
 	_, err = client.Logical().Write(backend+"/roles/"+name, data)
 	if err != nil {
@@ -187,6 +208,12 @@ func rabbitMQSecretBackendRoleRead(d *schema.ResourceData, meta interface{}) err
 	if vhostTopics, ok := secret.Data["vhost_topics"]; ok && vhostTopics != nil {
 		if err := d.Set("vhost_topic", flattenRabbitMQSecretBackendRoleVhostTopics(vhostTopics.(map[string]interface{}))); err != nil {
 			return fmt.Errorf("error setting vhosts topics in state: %w", err)
+		}
+	}
+
+	if provider.IsAPISupported(meta, provider.VaultVersion200) && provider.IsEnterpriseSupported(meta) {
+		if err := d.Set(consts.FieldMetadata, secret.Data[consts.FieldMetadata]); err != nil {
+			return fmt.Errorf("error setting %s in state: %w", consts.FieldMetadata, err)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Adds an optional `metadata` TypeMap field to six Terraform resource schemas for Vault Enterprise secrets engine roles, gated behind `IsAPISupported(meta, VaultVersion200) && IsEnterpriseSupported(meta)`.

Jira: [VAULT-48786](https://hashicorp.atlassian.net/browse/VAULT-48786)

## Resources updated

| Resource | File |
|----------|------|
| `vault_aws_secret_backend_role` | `vault/resource_aws_secret_backend_role.go` |
| `vault_database_secret_backend_role` | `vault/resource_database_secret_backend_role.go` |
| `vault_database_secret_backend_static_role` | `vault/resource_database_secret_backend_static_role.go` |
| `vault_consul_secret_backend_role` | `vault/resource_consul_secret_backend_role.go` |
| `vault_nomad_secret_role` | `vault/resource_nomad_secret_role.go` |
| `vault_rabbitmq_secret_backend_role` | `vault/resource_rabbitmq_secret_backend_role.go` |

## Schema

Each resource gains:
```hcl
metadata = {
  "env"  = "prod"
  "team" = "platform"
}
```

Field is `TypeMap`, `Optional`, `Computed`, element type `TypeString`.

## Write behaviour

```go
if provider.IsAPISupported(meta, provider.VaultVersion200) && provider.IsEnterpriseSupported(meta) {
    if d.IsNewResource() {
        if v, ok := d.GetOk(consts.FieldMetadata); ok && len(v.(map[string]interface{})) > 0 {
            data[consts.FieldMetadata] = v.(map[string]interface{})
        }
    } else if d.HasChange(consts.FieldMetadata) {
        data[consts.FieldMetadata] = d.Get(consts.FieldMetadata)
    }
}
```

- New resource: sends metadata if non-empty
- Update: sends updated map only when changed (`d.HasChange`)
- Delete metadata: set field to empty map in config — next apply sends `{}` to API
- Non-Enterprise / pre-2.0.0: field omitted from API call; no spurious diff

## Read behaviour

```go
if provider.IsAPISupported(meta, provider.VaultVersion200) && provider.IsEnterpriseSupported(meta) {
    d.Set(consts.FieldMetadata, secret.Data[consts.FieldMetadata])
}
```

## Prerequisites

- Vault Enterprise ≥ 2.0.0 with corresponding secrets engine changes (vault-enterprise PR)
- `VaultVersion200` constant — already present in provider package

## Notes

- GCP resources (`vault_gcp_secret_roleset`, `vault_gcp_secret_static_account`) are pending PM decision and not included
- Pattern is identical to `vault-plugin-secrets-azure-enterprise` integration already merged
