### PR TITLE
Parse Vault connection limits without panicking on strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+* `vault_database_secret_backend_connection`: Stop panicking on refresh when Vault returns connection limits as strings, including duration values such as `"0s"` for `max_connection_lifetime`.
 * `vault_jwt_auth_backend`: Fixed a perpetual diff where Vault returned non-string values that were silently dropped by Terraform’s TypeMap(TypeString) schema. All values are now converted to strings when read, preventing keys such as `fetch_groups` and `groups_recurse_max_depth` from appearing missing on every plan.([#2993](https://github.com/hashicorp/terraform-provider-vault/pull/2993))
 * Fixed the token namespace being set as the provider namespace, even when `set_namespace_from_token` was `false`. ([#2926](https://github.com/hashicorp/terraform-provider-vault/pull/2926/))
 * `vault_pki_secret_backend_role`: Fix crash when the Vault client was not successfully initialized ([#2964](https://github.com/hashicorp/terraform-provider-vault/pull/2964))

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -13,7 +13,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/hashicorp/go-cty/cty"
 
@@ -1230,7 +1229,7 @@ func getConnectionDetailsFromResponse(d *schema.ResourceData, prefix string, res
 		}
 	}
 	if v, ok := data["max_open_connections"]; ok {
-		n, err := v.(json.Number).Int64()
+		n, err := parseutil.ParseInt(v)
 		if err != nil {
 			log.Printf("[WARN] Non-number %s returned from Vault server: %s", v, err)
 		} else {
@@ -1238,7 +1237,7 @@ func getConnectionDetailsFromResponse(d *schema.ResourceData, prefix string, res
 		}
 	}
 	if v, ok := data["max_idle_connections"]; ok {
-		n, err := v.(json.Number).Int64()
+		n, err := parseutil.ParseInt(v)
 		if err != nil {
 			log.Printf("[WARN] Non-number %s returned from Vault server: %s", v, err)
 		} else {
@@ -1246,7 +1245,7 @@ func getConnectionDetailsFromResponse(d *schema.ResourceData, prefix string, res
 		}
 	}
 	if v, ok := data["max_connection_lifetime"]; ok {
-		n, err := time.ParseDuration(v.(string))
+		n, err := parseutil.ParseDurationSecond(v)
 		if err != nil {
 			log.Printf("[WARN] Non-number %s returned from Vault server: %s", v, err)
 		} else {

--- a/vault/resource_database_secret_backend_connection_parse_test.go
+++ b/vault/resource_database_secret_backend_connection_parse_test.go
@@ -1,0 +1,69 @@
+// Copyright IBM Corp. 2016, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package vault
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/vault/api"
+)
+
+func TestGetConnectionDetailsFromResponse_mixedValueTypes(t *testing.T) {
+	empty := schema.TestResourceDataRaw(t, map[string]*schema.Schema{}, map[string]interface{}{})
+
+	tests := []struct {
+		name    string
+		details map[string]interface{}
+		want    map[string]interface{}
+	}{
+		{
+			name: "vault 2 duration string lifetime",
+			details: map[string]interface{}{
+				"max_open_connections":    json.Number("5"),
+				"max_idle_connections":    json.Number("2"),
+				"max_connection_lifetime": "0s",
+			},
+			want: map[string]interface{}{
+				"max_open_connections":    int64(5),
+				"max_idle_connections":    int64(2),
+				"max_connection_lifetime": float64(0),
+			},
+		},
+		{
+			name: "string connection limits",
+			details: map[string]interface{}{
+				"max_open_connections":    "5",
+				"max_idle_connections":    "2",
+				"max_connection_lifetime": "30s",
+			},
+			want: map[string]interface{}{
+				"max_open_connections":    int64(5),
+				"max_idle_connections":    int64(2),
+				"max_connection_lifetime": float64(30),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &api.Secret{
+				Data: map[string]interface{}{
+					"connection_details": tt.details,
+				},
+			}
+
+			got := getConnectionDetailsFromResponse(empty, "postgresql.0.", resp)
+			if got == nil {
+				t.Fatal("expected connection details, got nil")
+			}
+			for key, want := range tt.want {
+				if got[key] != want {
+					t.Fatalf("%s: got %#v, want %#v", key, got[key], want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
* Read max_open_connections, max_idle_connections, and max_connection_lifetime with parseutil so Vault string values such as 0s do not panic on refresh
* Cover json.Number and string payloads with unit tests

Closes #2992

## Test plan
* go test ./vault covering TestGetConnectionDetailsFromResponse_mixedValueTypes