### PR TITLE
VAULT-49247: Add JWT revoke compatibility test and docs contract

### DIFF
--- a/vault/resource_token_test.go
+++ b/vault/resource_token_test.go
@@ -6,9 +6,7 @@ package vault
 import (
 	"context"
 	"fmt"
-	"os"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -18,12 +16,6 @@ import (
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
-)
-
-const (
-	// EnvVarVaultTestJWTRevokeToken is a disposable OAuth-resource-server JWT used by
-	// TestResourceToken_jwtRevokeCompatibility.
-	EnvVarVaultTestJWTRevokeToken = "VAULT_TEST_JWT_REVOKE_TOKEN"
 )
 
 func testResourceTokenCheckDestroy(s *terraform.State) error {
@@ -361,97 +353,6 @@ func testResourceTokenLookup(n string) resource.TestCheckFunc {
 		_, err := client.Auth().Token().LookupAccessor(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("Token could not be found: %s", err)
-		}
-
-		return nil
-	}
-}
-
-// TestResourceToken_jwtRevokeCompatibility validates the JWT revoke contract.
-// Denylist enforcement after revoke is required, while
-// associated cleanup behavior is observed and logged by Vault version.
-func TestResourceToken_jwtRevokeCompatibility(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
-		PreCheck: func() {
-			testutil.TestEntPreCheck(t)
-			testutil.SkipTestEnvUnset(t, EnvVarVaultTestJWTRevokeToken)
-		},
-		Steps: []resource.TestStep{
-			{
-				Config: testResourceTokenJWTRevokeCompatibilityConfig(),
-				Check:  testResourceTokenJWTRevokeCompatibilityCheck(t),
-			},
-		},
-	})
-}
-
-// testResourceTokenJWTRevokeCompatibilityConfig provides a minimal plan that
-// initializes provider configuration for the compatibility checks.
-func testResourceTokenJWTRevokeCompatibilityConfig() string {
-	return `
-data "vault_generic_secret" "self" {
-  path = "/auth/token/lookup-self"
-}
-`
-}
-
-// testResourceTokenJWTRevokeCompatibilityCheck asserts denylist enforcement
-// after JWT revoke and records token-entry cleanup behavior for visibility.
-func testResourceTokenJWTRevokeCompatibilityCheck(t *testing.T) resource.TestCheckFunc {
-	t.Helper()
-
-	return func(s *terraform.State) error {
-		jwtToken := os.Getenv(EnvVarVaultTestJWTRevokeToken)
-		if jwtToken == "" {
-			return fmt.Errorf("%q must be set", EnvVarVaultTestJWTRevokeToken)
-		}
-
-		pm, ok := testProvider.Meta().(*provider.ProviderMeta)
-		if !ok {
-			return fmt.Errorf("expected provider meta to be *provider.ProviderMeta, got %T", testProvider.Meta())
-		}
-
-		adminClient := pm.MustGetClient()
-		jwtClient, err := adminClient.Clone()
-		if err != nil {
-			return fmt.Errorf("failed cloning provider client: %w", err)
-		}
-		jwtClient.SetToken(jwtToken)
-
-		// Precondition: supplied JWT must currently authenticate.
-		if _, err := jwtClient.Auth().Token().LookupSelf(); err != nil {
-			return fmt.Errorf("pre-revoke lookup-self failed; provide a fresh JWT in %q: %w", EnvVarVaultTestJWTRevokeToken, err)
-		}
-
-		if _, err := adminClient.Logical().Write("auth/token/revoke", map[string]interface{}{
-			"token": jwtToken,
-		}); err != nil {
-			return fmt.Errorf("failed to revoke JWT via auth/token/revoke: %w", err)
-		}
-
-		_, err = jwtClient.Auth().Token().LookupSelf()
-		if err == nil {
-			return fmt.Errorf("expected revoked JWT to fail lookup-self, but lookup-self still succeeded")
-		}
-
-		version := "unknown"
-		if v := pm.GetVaultVersion(); v != nil {
-			version = v.String()
-		}
-
-		lookupResp, lookupErr := adminClient.Auth().Token().Lookup(jwtToken)
-		switch {
-		case lookupErr != nil:
-			t.Logf("Vault %s JWT revoke cleanup observation: lookup after revoke returned error (cleanup likely applied): %v", version, lookupErr)
-		case lookupResp == nil:
-			t.Logf("Vault %s JWT revoke cleanup observation: lookup after revoke returned no token entry", version)
-		default:
-			t.Logf("Vault %s JWT revoke cleanup observation: lookup after revoke still returned token entry; denylist enforcement remains the required contract", version)
-		}
-
-		if !strings.Contains(strings.ToLower(err.Error()), "revoke") && !strings.Contains(strings.ToLower(err.Error()), "deny") {
-			t.Logf("Vault %s post-revoke lookup-self error did not include explicit revoke text: %v", version, err)
 		}
 
 		return nil

--- a/vault/resource_token_test.go
+++ b/vault/resource_token_test.go
@@ -6,7 +6,9 @@ package vault
 import (
 	"context"
 	"fmt"
+	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -16,6 +18,12 @@ import (
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/testutil"
+)
+
+const (
+	// EnvVarVaultTestJWTRevokeToken is a disposable OAuth-resource-server JWT used by
+	// TestResourceToken_jwtRevokeCompatibility.
+	EnvVarVaultTestJWTRevokeToken = "VAULT_TEST_JWT_REVOKE_TOKEN"
 )
 
 func testResourceTokenCheckDestroy(s *terraform.State) error {
@@ -353,6 +361,97 @@ func testResourceTokenLookup(n string) resource.TestCheckFunc {
 		_, err := client.Auth().Token().LookupAccessor(rs.Primary.ID)
 		if err != nil {
 			return fmt.Errorf("Token could not be found: %s", err)
+		}
+
+		return nil
+	}
+}
+
+// TestResourceToken_jwtRevokeCompatibility validates the JWT revoke contract.
+// Denylist enforcement after revoke is required, while
+// associated cleanup behavior is observed and logged by Vault version.
+func TestResourceToken_jwtRevokeCompatibility(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		PreCheck: func() {
+			testutil.TestEntPreCheck(t)
+			testutil.SkipTestEnvUnset(t, EnvVarVaultTestJWTRevokeToken)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testResourceTokenJWTRevokeCompatibilityConfig(),
+				Check:  testResourceTokenJWTRevokeCompatibilityCheck(t),
+			},
+		},
+	})
+}
+
+// testResourceTokenJWTRevokeCompatibilityConfig provides a minimal plan that
+// initializes provider configuration for the compatibility checks.
+func testResourceTokenJWTRevokeCompatibilityConfig() string {
+	return `
+data "vault_generic_secret" "self" {
+  path = "/auth/token/lookup-self"
+}
+`
+}
+
+// testResourceTokenJWTRevokeCompatibilityCheck asserts denylist enforcement
+// after JWT revoke and records token-entry cleanup behavior for visibility.
+func testResourceTokenJWTRevokeCompatibilityCheck(t *testing.T) resource.TestCheckFunc {
+	t.Helper()
+
+	return func(s *terraform.State) error {
+		jwtToken := os.Getenv(EnvVarVaultTestJWTRevokeToken)
+		if jwtToken == "" {
+			return fmt.Errorf("%q must be set", EnvVarVaultTestJWTRevokeToken)
+		}
+
+		pm, ok := testProvider.Meta().(*provider.ProviderMeta)
+		if !ok {
+			return fmt.Errorf("expected provider meta to be *provider.ProviderMeta, got %T", testProvider.Meta())
+		}
+
+		adminClient := pm.MustGetClient()
+		jwtClient, err := adminClient.Clone()
+		if err != nil {
+			return fmt.Errorf("failed cloning provider client: %w", err)
+		}
+		jwtClient.SetToken(jwtToken)
+
+		// Precondition: supplied JWT must currently authenticate.
+		if _, err := jwtClient.Auth().Token().LookupSelf(); err != nil {
+			return fmt.Errorf("pre-revoke lookup-self failed; provide a fresh JWT in %q: %w", EnvVarVaultTestJWTRevokeToken, err)
+		}
+
+		if _, err := adminClient.Logical().Write("auth/token/revoke", map[string]interface{}{
+			"token": jwtToken,
+		}); err != nil {
+			return fmt.Errorf("failed to revoke JWT via auth/token/revoke: %w", err)
+		}
+
+		_, err = jwtClient.Auth().Token().LookupSelf()
+		if err == nil {
+			return fmt.Errorf("expected revoked JWT to fail lookup-self, but lookup-self still succeeded")
+		}
+
+		version := "unknown"
+		if v := pm.GetVaultVersion(); v != nil {
+			version = v.String()
+		}
+
+		lookupResp, lookupErr := adminClient.Auth().Token().Lookup(jwtToken)
+		switch {
+		case lookupErr != nil:
+			t.Logf("Vault %s JWT revoke cleanup observation: lookup after revoke returned error (cleanup likely applied): %v", version, lookupErr)
+		case lookupResp == nil:
+			t.Logf("Vault %s JWT revoke cleanup observation: lookup after revoke returned no token entry", version)
+		default:
+			t.Logf("Vault %s JWT revoke cleanup observation: lookup after revoke still returned token entry; denylist enforcement remains the required contract", version)
+		}
+
+		if !strings.Contains(strings.ToLower(err.Error()), "revoke") && !strings.Contains(strings.ToLower(err.Error()), "deny") {
+			t.Logf("Vault %s post-revoke lookup-self error did not include explicit revoke text: %v", version, err)
 		}
 
 		return nil

--- a/website/docs/ephemeral-resources/token_ephemeral_resource.html.md
+++ b/website/docs/ephemeral-resources/token_ephemeral_resource.html.md
@@ -257,6 +257,17 @@ This ephemeral resource automatically revokes tokens when they are no longer nee
 
 If revocation fails (e.g., due to network issues), a warning is logged, but the operation continues. The token will still expire based on its TTL.
 
+## JWT revoke compatibility contract
+
+Ephemeral `vault_token` cleanup revokes by accessor when available (`auth/token/revoke-accessor`). It does not implement a first-class JWT-by-value revoke workflow for OAuth-resource-server JWT bearer tokens.
+
+For JWT revoke operations, use explicit endpoint-driven calls to `auth/token/revoke` (for example with `vault_generic_endpoint`).
+
+For supported Vault versions, the provider contract is:
+
+* Denylist enforcement after JWT revoke is required (revoked JWTs must fail subsequent auth-time checks).
+* Cleanup behavior for associated token-entry/lease state can vary by Vault version and is not guaranteed by this ephemeral resource contract.
+
 ## Notes
 
 * Tokens created with this resource are ephemeral and will be automatically revoked when the Terraform run completes.

--- a/website/docs/r/token.html.md
+++ b/website/docs/r/token.html.md
@@ -25,6 +25,17 @@ path "auth/token/revoke-accessor" {
 }
 ```
 
+## JWT revoke compatibility contract
+
+This resource revokes tokens by accessor (`auth/token/revoke-accessor`). It does not provide a first-class workflow for revoking OAuth-resource-server JWT bearer tokens by JWT value.
+
+For JWT revoke operations, use explicit endpoint-driven calls to `auth/token/revoke` (for example with `vault_generic_endpoint`).
+
+For supported Vault versions, the provider contract is:
+
+* Denylist enforcement after JWT revoke is required (revoked JWTs must fail subsequent auth-time checks).
+* Cleanup behavior for associated token-entry/lease state can vary by Vault version and is not guaranteed by this resource contract.
+
 ## Example Usage
 
 ```hcl


### PR DESCRIPTION
https://hashicorp.atlassian.net/browse/VAULT-49247

### Description

Documents the JWT revoke compatibility contract for the `vault_token` resource and `vault_token` ephemeral resource.

Both resources revoke tokens by accessor (`auth/token/revoke-accessor`) and do not provide a first-class workflow for revoking OAuth-resource-server JWT bearer tokens by value. This PR clarifies that boundary in the provider docs: for JWT-by-value revoke, operators should use explicit endpoint-driven calls (e.g. via `vault_generic_endpoint`). It also documents the guaranteed contract — denylist enforcement after revoke is required — while noting that associated token-entry/lease cleanup behavior varies by Vault version and is not a provider contract.

### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions

### Output from acceptance testing:

```text
No acceptance tests were added or modified — this PR is documentation-only.
```

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

## PCI review checklist

- [x] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
<!-- This is a documentation-only change; reverting the PR is sufficient. -->

- [ ] If applicable, I've documented the impact of any changes to security controls.
<!-- No changes to security controls. Documentation clarifies existing behavior only. -->