### PR TITLE
vault_cert_auth_backend_role: add write-only certificate support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 5.12.0 (Unreleased)
 
+IMPROVEMENTS:
+
+* `vault_cert_auth_backend_role`: Add `certificate_wo` and `certificate_wo_version` write-only fields to allow ephemeral resource values, to supply the CA certificate. The `certificate` field is now `Computed` and `ForceNew` has been removed enabling in-place updates when the certificate changes instead of resource replacement.
+
+
 BUG FIXES:
 
 * `vault_terraform_cloud_secret_backend`: Fix logic gap in `Read` where execution would fall through to a stray `GET <backend>/config` call after `readMount` detected the mount was deleted out-of-band and cleared the resource ID. Add `util.Is404` guard to `Delete` so that `terraform destroy` succeeds cleanly when the mount has already been removed from Vault. ([#3006](https://github.com/hashicorp/terraform-provider-vault/pull/3006))
@@ -23,7 +28,6 @@ FEATURES:
 
 IMPROVEMENTS:
 
-* `vault_cert_auth_backend_role`: Add `certificate_wo` and `certificate_wo_version` write-only fields to support ephemeral resource values, preventing CA certificate data from being stored in Terraform state.
 * Migrated AWS provider dependency from `aws-sdk-go` (v1) to `aws-sdk-go-v2` for improved performance and maintainability. ([#2882](https://github.com/hashicorp/terraform-provider-vault/pull/2882))
 * `vault_identity_entity_alias`: Add support for `external_id` and `issuer` fields. Available only for Vault Enterprise. ([#2994](https://github.com/hashicorp/terraform-provider-vault/pull/2994))
 * `vault_aws_auth_backend_config_identity`: Add support for `canonical_arn` as a valid value for the `iam_alias` parameter. Requires Vault 1.16+. ([#2982](https://github.com/hashicorp/terraform-provider-vault/pull/2982))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ FEATURES:
 
 IMPROVEMENTS:
 
+* `vault_cert_auth_backend_role`: Add `certificate_wo` and `certificate_wo_version` write-only fields to support ephemeral resource values, preventing CA certificate data from being stored in Terraform state.
 * Migrated AWS provider dependency from `aws-sdk-go` (v1) to `aws-sdk-go-v2` for improved performance and maintainability. ([#2882](https://github.com/hashicorp/terraform-provider-vault/pull/2882))
 * `vault_identity_entity_alias`: Add support for `external_id` and `issuer` fields. Available only for Vault Enterprise. ([#2994](https://github.com/hashicorp/terraform-provider-vault/pull/2994))
 * `vault_aws_auth_backend_config_identity`: Add support for `canonical_arn` as a valid value for the `iam_alias` parameter. Requires Vault 1.16+. ([#2982](https://github.com/hashicorp/terraform-provider-vault/pull/2982))

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -925,6 +925,8 @@ const (
 	FieldAddGroupAliases            = "add_group_aliases"
 	FieldTokenExplicitMaxTTL        = "token_explicit_max_ttl"
 	FieldTokenNoDefaultPolicy       = "token_no_default_policy"
+	FieldCertificateWO              = "certificate_wo"
+	FieldCertificateWOVersion       = "certificate_wo_version"
 
 	/*
 		common environment variables

--- a/vault/resource_cert_auth_backend_role.go
+++ b/vault/resource_cert_auth_backend_role.go
@@ -393,65 +393,55 @@ func certAuthResourceRead(_ context.Context, d *schema.ResourceData, meta interf
 	if resp.Data["allowed_names"] != nil {
 		d.Set("allowed_names",
 			schema.NewSet(
-				schema.HashString, resp.Data["allowed_names"].([]interface{}),
-			))
+				schema.HashString, resp.Data["allowed_names"].([]interface{})))
 	} else {
 		d.Set("allowed_names",
 			schema.NewSet(
-				schema.HashString, []interface{}{},
-			))
+				schema.HashString, []interface{}{}))
 	}
 
 	// Vault sometimes returns these as null instead of an empty list.
 	if resp.Data["allowed_dns_sans"] != nil {
 		d.Set("allowed_dns_sans",
 			schema.NewSet(
-				schema.HashString, resp.Data["allowed_dns_sans"].([]interface{}),
-			))
+				schema.HashString, resp.Data["allowed_dns_sans"].([]interface{})))
 	} else {
 		d.Set("allowed_dns_sans",
 			schema.NewSet(
-				schema.HashString, []interface{}{},
-			))
+				schema.HashString, []interface{}{}))
 	}
 
 	// Vault sometimes returns these as null instead of an empty list.
 	if resp.Data["allowed_email_sans"] != nil {
 		d.Set("allowed_email_sans",
 			schema.NewSet(
-				schema.HashString, resp.Data["allowed_email_sans"].([]interface{}),
-			))
+				schema.HashString, resp.Data["allowed_email_sans"].([]interface{})))
 	} else {
 		d.Set("allowed_email_sans",
 			schema.NewSet(
-				schema.HashString, []interface{}{},
-			))
+				schema.HashString, []interface{}{}))
 	}
 
 	// Vault sometimes returns these as null instead of an empty list.
 	if resp.Data["allowed_uri_sans"] != nil {
 		d.Set("allowed_uri_sans",
 			schema.NewSet(
-				schema.HashString, resp.Data["allowed_uri_sans"].([]interface{}),
-			))
+				schema.HashString, resp.Data["allowed_uri_sans"].([]interface{})))
 	} else {
 		d.Set("allowed_uri_sans",
 			schema.NewSet(
-				schema.HashString, []interface{}{},
-			))
+				schema.HashString, []interface{}{}))
 	}
 
 	// Vault sometimes returns these as null instead of an empty list.
 	if resp.Data["required_extensions"] != nil {
 		d.Set("required_extensions",
 			schema.NewSet(
-				schema.HashString, resp.Data["required_extensions"].([]interface{}),
-			))
+				schema.HashString, resp.Data["required_extensions"].([]interface{})))
 	} else {
 		d.Set("required_extensions",
 			schema.NewSet(
-				schema.HashString, []interface{}{},
-			))
+				schema.HashString, []interface{}{}))
 	}
 
 	if err := d.Set("allowed_organizational_units", resp.Data["allowed_organizational_units"]); err != nil {

--- a/vault/resource_cert_auth_backend_role.go
+++ b/vault/resource_cert_auth_backend_role.go
@@ -77,6 +77,7 @@ func certAuthBackendRoleResource() *schema.Resource {
 			Sensitive:     true,
 			ConflictsWith: []string{consts.FieldCertificate},
 			AtLeastOneOf:  []string{consts.FieldCertificate, consts.FieldCertificateWO},
+			RequiredWith: []string{consts.FieldCertificateWOVersion},
 		},
 		consts.FieldCertificateWOVersion: {
 			Type:         schema.TypeInt,

--- a/vault/resource_cert_auth_backend_role.go
+++ b/vault/resource_cert_auth_backend_role.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -17,7 +18,6 @@ import (
 
 var (
 	certAuthStringFields = []string{
-		consts.FieldCertificate,
 		consts.FieldDisplayName,
 		consts.FieldOCSPCACertificates,
 	}
@@ -65,9 +65,23 @@ func certAuthBackendRoleResource() *schema.Resource {
 			ForceNew: true,
 		},
 		consts.FieldCertificate: {
-			Type:     schema.TypeString,
-			Required: true,
-			ForceNew: true,
+			Type:          schema.TypeString,
+			Optional:      true,
+			ConflictsWith: []string{consts.FieldCertificateWO},
+			AtLeastOneOf:  []string{consts.FieldCertificate, consts.FieldCertificateWO},
+		},
+		consts.FieldCertificateWO: {
+			Type:          schema.TypeString,
+			Optional:      true,
+			WriteOnly:     true,
+			Sensitive:     true,
+			ConflictsWith: []string{consts.FieldCertificate},
+			AtLeastOneOf:  []string{consts.FieldCertificate, consts.FieldCertificateWO},
+		},
+		consts.FieldCertificateWOVersion: {
+			Type:         schema.TypeInt,
+			Optional:     true,
+			RequiredWith: []string{consts.FieldCertificateWO},
 		},
 		consts.FieldAllowedNames: {
 			Type: schema.TypeSet,
@@ -224,6 +238,14 @@ func certAuthResourceWrite(ctx context.Context, d *schema.ResourceData, meta int
 	data := map[string]interface{}{}
 	updateTokenFields(d, data, true)
 
+	if v, ok := d.GetOk(consts.FieldCertificate); ok {
+		data[consts.FieldCertificate] = v.(string)
+	} else {
+		if tokenWo, _ := d.GetRawConfigAt(cty.GetAttrPath(consts.FieldCertificateWO)); !tokenWo.IsNull() {
+			data[consts.FieldCertificate] = tokenWo.AsString()
+		}
+	}
+
 	for _, k := range certAuthStringFields {
 		if certAuthVault113Fields[k] && !provider.IsAPISupported(meta, provider.VaultVersion113) {
 			continue
@@ -279,6 +301,14 @@ func certAuthResourceUpdate(ctx context.Context, d *schema.ResourceData, meta in
 
 	data := map[string]interface{}{}
 	updateTokenFields(d, data, false)
+
+	if v, ok := d.GetOk(consts.FieldCertificate); ok {
+		data[consts.FieldCertificate] = v.(string)
+	} else if d.HasChange(consts.FieldCertificateWOVersion) {
+		if tokenWo, _ := d.GetRawConfigAt(cty.GetAttrPath(consts.FieldCertificateWO)); !tokenWo.IsNull() {
+			data[consts.FieldCertificate] = tokenWo.AsString()
+		}
+	}
 
 	for _, k := range certAuthStringFields {
 		if certAuthVault113Fields[k] && !provider.IsAPISupported(meta, provider.VaultVersion113) {
@@ -354,62 +384,74 @@ func certAuthResourceRead(_ context.Context, d *schema.ResourceData, meta interf
 		return diag.FromErr(err)
 	}
 
-	d.Set("certificate", resp.Data["certificate"])
+	if _, usingWO := d.GetOk(consts.FieldCertificateWOVersion); !usingWO {
+		d.Set(consts.FieldCertificate, resp.Data[consts.FieldCertificate])
+	}
 	d.Set("display_name", resp.Data["display_name"])
 
 	// Vault sometimes returns these as null instead of an empty list.
 	if resp.Data["allowed_names"] != nil {
 		d.Set("allowed_names",
 			schema.NewSet(
-				schema.HashString, resp.Data["allowed_names"].([]interface{})))
+				schema.HashString, resp.Data["allowed_names"].([]interface{}),
+			))
 	} else {
 		d.Set("allowed_names",
 			schema.NewSet(
-				schema.HashString, []interface{}{}))
+				schema.HashString, []interface{}{},
+			))
 	}
 
 	// Vault sometimes returns these as null instead of an empty list.
 	if resp.Data["allowed_dns_sans"] != nil {
 		d.Set("allowed_dns_sans",
 			schema.NewSet(
-				schema.HashString, resp.Data["allowed_dns_sans"].([]interface{})))
+				schema.HashString, resp.Data["allowed_dns_sans"].([]interface{}),
+			))
 	} else {
 		d.Set("allowed_dns_sans",
 			schema.NewSet(
-				schema.HashString, []interface{}{}))
+				schema.HashString, []interface{}{},
+			))
 	}
 
 	// Vault sometimes returns these as null instead of an empty list.
 	if resp.Data["allowed_email_sans"] != nil {
 		d.Set("allowed_email_sans",
 			schema.NewSet(
-				schema.HashString, resp.Data["allowed_email_sans"].([]interface{})))
+				schema.HashString, resp.Data["allowed_email_sans"].([]interface{}),
+			))
 	} else {
 		d.Set("allowed_email_sans",
 			schema.NewSet(
-				schema.HashString, []interface{}{}))
+				schema.HashString, []interface{}{},
+			))
 	}
 
 	// Vault sometimes returns these as null instead of an empty list.
 	if resp.Data["allowed_uri_sans"] != nil {
 		d.Set("allowed_uri_sans",
 			schema.NewSet(
-				schema.HashString, resp.Data["allowed_uri_sans"].([]interface{})))
+				schema.HashString, resp.Data["allowed_uri_sans"].([]interface{}),
+			))
 	} else {
 		d.Set("allowed_uri_sans",
 			schema.NewSet(
-				schema.HashString, []interface{}{}))
+				schema.HashString, []interface{}{},
+			))
 	}
 
 	// Vault sometimes returns these as null instead of an empty list.
 	if resp.Data["required_extensions"] != nil {
 		d.Set("required_extensions",
 			schema.NewSet(
-				schema.HashString, resp.Data["required_extensions"].([]interface{})))
+				schema.HashString, resp.Data["required_extensions"].([]interface{}),
+			))
 	} else {
 		d.Set("required_extensions",
 			schema.NewSet(
-				schema.HashString, []interface{}{}))
+				schema.HashString, []interface{}{},
+			))
 	}
 
 	if err := d.Set("allowed_organizational_units", resp.Data["allowed_organizational_units"]); err != nil {

--- a/vault/resource_cert_auth_backend_role.go
+++ b/vault/resource_cert_auth_backend_role.go
@@ -67,6 +67,7 @@ func certAuthBackendRoleResource() *schema.Resource {
 		consts.FieldCertificate: {
 			Type:          schema.TypeString,
 			Optional:      true,
+			Computed:      true,
 			ConflictsWith: []string{consts.FieldCertificateWO},
 			AtLeastOneOf:  []string{consts.FieldCertificate, consts.FieldCertificateWO},
 		},
@@ -74,7 +75,6 @@ func certAuthBackendRoleResource() *schema.Resource {
 			Type:          schema.TypeString,
 			Optional:      true,
 			WriteOnly:     true,
-			Sensitive:     true,
 			ConflictsWith: []string{consts.FieldCertificate},
 			AtLeastOneOf:  []string{consts.FieldCertificate, consts.FieldCertificateWO},
 			RequiredWith:  []string{consts.FieldCertificateWOVersion},
@@ -385,9 +385,7 @@ func certAuthResourceRead(_ context.Context, d *schema.ResourceData, meta interf
 		return diag.FromErr(err)
 	}
 
-	if _, usingWO := d.GetOk(consts.FieldCertificateWOVersion); !usingWO {
-		d.Set(consts.FieldCertificate, resp.Data[consts.FieldCertificate])
-	}
+	d.Set(consts.FieldCertificate, resp.Data[consts.FieldCertificate])
 	d.Set("display_name", resp.Data["display_name"])
 
 	// Vault sometimes returns these as null instead of an empty list.

--- a/vault/resource_cert_auth_backend_role.go
+++ b/vault/resource_cert_auth_backend_role.go
@@ -77,7 +77,7 @@ func certAuthBackendRoleResource() *schema.Resource {
 			Sensitive:     true,
 			ConflictsWith: []string{consts.FieldCertificate},
 			AtLeastOneOf:  []string{consts.FieldCertificate, consts.FieldCertificateWO},
-			RequiredWith: []string{consts.FieldCertificateWOVersion},
+			RequiredWith:  []string{consts.FieldCertificateWOVersion},
 		},
 		consts.FieldCertificateWOVersion: {
 			Type:         schema.TypeInt,

--- a/vault/resource_cert_auth_backend_role_test.go
+++ b/vault/resource_cert_auth_backend_role_test.go
@@ -178,7 +178,8 @@ func TestCertAuthBackend_OCSP(t *testing.T) {
 					// These fields are only available from Vault 1.16+
 					meta := testProvider.Meta().(*provider.ProviderMeta)
 					if meta.IsAPISupported(provider.VaultVersion116) {
-						checks = append(checks,
+						checks = append(
+							checks,
 							resource.TestCheckResourceAttr(resourceName, consts.FieldOCSPMaxRetries, "4"),
 							resource.TestCheckResourceAttr(resourceName, consts.FieldOCSPThisUpdateMaxAge, "0"),
 						)
@@ -205,7 +206,8 @@ func TestCertAuthBackend_OCSP(t *testing.T) {
 					// These fields are only available from Vault 1.16+
 					meta := testProvider.Meta().(*provider.ProviderMeta)
 					if meta.IsAPISupported(provider.VaultVersion116) {
-						checks = append(checks,
+						checks = append(
+							checks,
 							resource.TestCheckResourceAttr(resourceName, consts.FieldOCSPMaxRetries, "5"),
 							resource.TestCheckResourceAttr(resourceName, consts.FieldOCSPThisUpdateMaxAge, "7200"),
 						)
@@ -226,7 +228,8 @@ func TestCertAuthBackend_OCSP(t *testing.T) {
 					// These fields are only available from Vault 1.16+
 					meta := testProvider.Meta().(*provider.ProviderMeta)
 					if meta.IsAPISupported(provider.VaultVersion116) {
-						checks = append(checks,
+						checks = append(
+							checks,
 							resource.TestCheckResourceAttr(resourceName, consts.FieldOCSPMaxRetries, "10"),
 							resource.TestCheckResourceAttr(resourceName, consts.FieldOCSPThisUpdateMaxAge, "3600"),
 						)
@@ -260,6 +263,44 @@ func TestCertAuthBackend_OCSP_Negative(t *testing.T) {
 				// Negative ocsp_this_update_max_age should also be rejected by Vault API
 				Config:      testCertAuthBackendConfig_OCSP_negative_fields(backend, name, 5, -100),
 				ExpectError: regexp.MustCompile("cannot provide negative value"),
+			},
+		},
+	})
+}
+
+func TestAccCertAuthBackend_WriteOnly(t *testing.T) {
+	backend := acctest.RandomWithPrefix("tf-test-cert-auth")
+	name := acctest.RandomWithPrefix("tf-test-cert-name")
+	resourceName := "vault_cert_auth_backend_role.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctestutil.TestAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		CheckDestroy:             testCertAuthBackendDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testCertAuthBackendConfig_writeOnly(backend, name, testCertificate, 1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldBackend, backend),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldName, name),
+					resource.TestCheckNoResourceAttr(resourceName, consts.FieldCertificate),
+
+					// write-only field not be stored in state
+					resource.TestCheckNoResourceAttr(resourceName, consts.FieldCertificateWO),
+
+					// version counter is stored in state
+					resource.TestCheckResourceAttr(resourceName, consts.FieldCertificateWOVersion, "1"),
+				),
+			},
+			{
+				Config: testCertAuthBackendConfig_writeOnly(backend, name, testCertificate, 2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldBackend, backend),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldName, name),
+					resource.TestCheckNoResourceAttr(resourceName, consts.FieldCertificateWO),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldCertificateWOVersion, "2"),
+					resource.TestCheckNoResourceAttr(resourceName, consts.FieldCertificate),
+				),
 			},
 		},
 	})
@@ -381,7 +422,8 @@ EOF
 }
 
 func testCertAuthBackendConfig_unset(backend, name, certificate string, allowedNames []string) string {
-	config := fmt.Sprintf(`
+	config := fmt.Sprintf(
+		`
 
 resource "vault_auth_backend" "cert" {
     path = "%s"
@@ -400,6 +442,22 @@ __CERTIFICATE__
 	)
 
 	return config
+}
+
+func testCertAuthBackendConfig_writeOnly(backend, name, certificate string, version int) string {
+	return fmt.Sprintf(`
+resource "vault_auth_backend" "cert" {
+    path = "%s"
+    type = "cert"
+}
+
+resource "vault_cert_auth_backend_role" "test" {
+    name                   = "%s"
+	certificate_wo		   = %q
+	certificate_wo_version = %d
+    backend                = vault_auth_backend.cert.path
+}
+`, backend, name, certificate, version)
 }
 
 func testCertAuthBackendConfig_OCSP_default(backend, name string) string {

--- a/vault/resource_cert_auth_backend_role_test.go
+++ b/vault/resource_cert_auth_backend_role_test.go
@@ -283,7 +283,7 @@ func TestAccCertAuthBackend_WriteOnly(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, consts.FieldBackend, backend),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldName, name),
-					resource.TestCheckNoResourceAttr(resourceName, consts.FieldCertificate),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldCertificate, testCertificate),
 
 					// write-only field not be stored in state
 					resource.TestCheckNoResourceAttr(resourceName, consts.FieldCertificateWO),
@@ -299,7 +299,7 @@ func TestAccCertAuthBackend_WriteOnly(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, consts.FieldName, name),
 					resource.TestCheckNoResourceAttr(resourceName, consts.FieldCertificateWO),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldCertificateWOVersion, "2"),
-					resource.TestCheckNoResourceAttr(resourceName, consts.FieldCertificate),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldCertificate, testCertificate),
 				),
 			},
 		},

--- a/website/docs/r/cert_auth_backend_role.html.md
+++ b/website/docs/r/cert_auth_backend_role.html.md
@@ -29,6 +29,26 @@ resource "vault_cert_auth_backend_role" "cert" {
 }
 ```
 
+## Example Usage with Write-Only Certificate
+
+```hcl
+resource "vault_auth_backend" "cert" {
+    path = "cert"
+    type = "cert"
+}
+
+resource "vault_cert_auth_backend_role" "cert" {
+    name                    = "foo"
+    certificate_wo          = var.ca_certificate
+    certificate_wo_version  = 1
+    backend                 = vault_auth_backend.cert.path
+    allowed_names           = ["foo.example.org", "baz.example.org"]
+    token_ttl               = 300
+    token_max_ttl           = 600
+    token_policies          = ["foo"]
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -42,7 +62,9 @@ The following arguments are supported:
 
 * `name` - (Required string) Name of the role
 
-* `certificate` - (Required string) CA certificate used to validate client certificates
+* `certificate` - (Optional string) CA certificate used to validate client certificates. Conflicts with `certificate_wo`
+
+* `certificate_wo_version` - (Optional int) The version of `certificate_wo` to use during write operations. Required with `certificate_wo`. For more info see [updating write-only attributes](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/guides/using_write_only_attributes.html#updating-write-only-attributes).
 
 * `allowed_names` - (Optional string) DEPRECATED: Please use the individual `allowed_X_sans` parameters instead. Allowed subject names for authenticated client certificates
 
@@ -135,6 +157,12 @@ These arguments are common across several Authentication Token resources since V
   This should be a list or map containing the metadata in key value pairs.
 
 For more details on the usage of each argument consult the [Vault Cert API documentation](https://www.vaultproject.io/api-docs/auth/cert).
+
+## Ephemeral Attributes Reference
+
+The following write-only attributes are supported:
+
+* `certificate_wo` - (Optional string) Write-only CA certificate used to validate client certificates. Use this instead of `certificate` to prevent the certificate from being stored in Terraform state. Conflicts with `certificate`. **Note**: This property is write-only and will not be read from the API.
 
 ## Attribute Reference
 

--- a/website/docs/r/cert_auth_backend_role.html.md
+++ b/website/docs/r/cert_auth_backend_role.html.md
@@ -62,7 +62,7 @@ The following arguments are supported:
 
 * `name` - (Required string) Name of the role
 
-* `certificate` - (Optional string) CA certificate used to validate client certificates. Conflicts with `certificate_wo`
+* `certificate` - (Optional string) CA certificate used to validate client certificates. Exactly one of `certificate` or `certificate_wo` must be specified. Conflicts with `certificate_wo`
 
 * `certificate_wo_version` - (Optional int) The version of `certificate_wo` to use during write operations. Required with `certificate_wo`. For more info see [updating write-only attributes](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/guides/using_write_only_attributes.html#updating-write-only-attributes).
 
@@ -162,7 +162,7 @@ For more details on the usage of each argument consult the [Vault Cert API docum
 
 The following write-only attributes are supported:
 
-* `certificate_wo` - (Optional string) Write-only CA certificate used to validate client certificates. Use this instead of `certificate` to prevent the certificate from being stored in Terraform state. Conflicts with `certificate`. **Note**: This property is write-only and will not be read from the API.
+* `certificate_wo` - (Optional string) Write-only CA certificate used to validate client certificates. Use `certificate_wo` to prevent the certificate from being stored in Terraform state. Exactly one of `certificate_wo` or  `certificate` must be specified. This attribute conflicts with `certificate`. **Note**: This property is write-only and will not be read from the API.
 
 ## Attribute Reference
 

--- a/website/docs/r/cert_auth_backend_role.html.md
+++ b/website/docs/r/cert_auth_backend_role.html.md
@@ -62,7 +62,7 @@ The following arguments are supported:
 
 * `name` - (Required string) Name of the role
 
-* `certificate` - (Optional string) CA certificate used to validate client certificates. Exactly one of `certificate` or `certificate_wo` must be specified. Conflicts with `certificate_wo`
+* `certificate` - (Optional string) CA certificate used to validate client certificates. Exactly one of `certificate` or `certificate_wo` must be specified. Conflicts with `certificate_wo`. Changing this value updates the certificate in-place rather than recreating the resource. When `certificate_wo` is used, this field is populated from the vault API response after apply.
 
 * `certificate_wo_version` - (Optional int) The version of `certificate_wo` to use during write operations. Required with `certificate_wo`. For more info see [updating write-only attributes](https://registry.terraform.io/providers/hashicorp/vault/latest/docs/guides/using_write_only_attributes.html#updating-write-only-attributes).
 
@@ -162,7 +162,7 @@ For more details on the usage of each argument consult the [Vault Cert API docum
 
 The following write-only attributes are supported:
 
-* `certificate_wo` - (Optional string) Write-only CA certificate used to validate client certificates. Use `certificate_wo` to prevent the certificate from being stored in Terraform state. Exactly one of `certificate_wo` or  `certificate` must be specified. This attribute conflicts with `certificate`. **Note**: This property is write-only and will not be read from the API.
+* `certificate_wo` - (Optional string) Write-only CA certificate used to validate client certificates. Use `certificate_wo` to supply the certificate from an ephemeral resource. Exactly one of `certificate_wo` or  `certificate` must be specified. This attribute conflicts with `certificate`. **Note**: This property is write-only and will not be read from the API.
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->

### Description
This PR adds `certificate_wo` and `certificate_wo_version` write-only fields to the `vault_cert_auth_backend_role` resource, allowing users to supply a CA certificate via an ephemeral resource without it being stored in Terraform state. 


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates [VAULT-44145](https://hashicorp.atlassian.net/browse/VAULT-44145)


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ TF_ACC=1 go test ./vault/... -run TestAccCertAuthBackend_WriteOnly -v -timeout 30m -tags testonly
=== RUN   TestAccCertAuthBackend_WriteOnly
--- PASS: TestAccCertAuthBackend_WriteOnly (1.19s)
PASS
ok      github.com/hashicorp/terraform-provider-vault/vault     1.952s
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.


[VAULT-44145]: https://hashicorp.atlassian.net/browse/VAULT-44145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ