### PR TITLE
Update version support from 2.0.5 to 2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 IMPROVEMENTS:
 
 * `vault_ldap_auth_backend`: emit a warning when the auth mount or its config is not found during refresh, so users see an actionable message in `terraform plan` output rather than a silent state removal. ([#2997](https://github.com/hashicorp/terraform-provider-vault/pull/2997))
+* Update supported Vault version for `pkcs12_bundle` and `jks_bundle` PKI formats to require Vault 2.1+ (not 2.0.5+) per latest Vault versioning strategy ([#2950](https://github.com/hashicorp/terraform-provider-vault/pull/2950))
 
 BUG FIXES:
 
@@ -23,7 +24,7 @@ FEATURES:
 * **Terraform Secret Engine Root Rotation Support**: Add support for automated root token rotation via the `rotation_period`, `rotation_schedule`, `rotation_window`, and `disable_automated_rotation` fields, and add `explicit_max_ttl` to bound the lifetime of the rotated root token. Requires Vault 2.2.0+. ([#2958](https://github.com/hashicorp/terraform-provider-vault/issues/2958))
 * Add support for Kerberos auth backend: `vault_kerberos_auth_backend_config`, `vault_kerberos_auth_backend_ldap_config`, and `vault_kerberos_auth_backend_group` resources, and `vault_kerberos_auth_backend_login` ephemeral resource for Kerberos authentication. ([#2819](https://github.com/hashicorp/terraform-provider-vault/pull/2819))
 * **Secrets Sync customer controlled encryption**: `vault_secrets_sync_aws_destination` and `vault_secrets_sync_gcp_destination` now support Vault 2.2.0+ fields `kms_key_id` and `replica_regions`; and deprecated GCP legacy fields `global_kms_key`, `locational_kms_keys`, and `replication_locations` in favor of `kms_key_id` and `replica_regions`. ([#2965](https://github.com/hashicorp/terraform-provider-vault/pull/2965))
-* Add support for `pkcs12_bundle` and `jks_bundle` formats (without setting default values) in `vault_pki_secret_backend_cert`, `vault_pki_secret_backend_root_cert`, `vault_pki_secret_backend_root_sign_intermediate`, and `vault_pki_secret_backend_sign` ([#2946](https://github.com/hashicorp/terraform-provider-vault/pull/2946)). Requires Vault 2.0.5+.
+* Add support for `pkcs12_bundle` and `jks_bundle` formats (without setting default values) in `vault_pki_secret_backend_cert`, `vault_pki_secret_backend_root_cert`, `vault_pki_secret_backend_root_sign_intermediate`, and `vault_pki_secret_backend_sign` ([#2950](https://github.com/hashicorp/terraform-provider-vault/pull/2950)). Requires Vault 2.1+.
 
 IMPROVEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 IMPROVEMENTS:
 
 * `vault_ldap_auth_backend`: emit a warning when the auth mount or its config is not found during refresh, so users see an actionable message in `terraform plan` output rather than a silent state removal. ([#2997](https://github.com/hashicorp/terraform-provider-vault/pull/2997))
-* Update supported Vault version for `pkcs12_bundle` and `jks_bundle` PKI formats to require Vault 2.1+ (not 2.0.5+) per latest Vault versioning strategy ([#2950](https://github.com/hashicorp/terraform-provider-vault/pull/2950))
+* Update supported Vault version for PKI formats `pkcs12_bundle` and `jks_bundle` to require Vault 2.1.0+ (not 2.0.5+) per latest Vault versioning strategy. ([#2950](https://github.com/hashicorp/terraform-provider-vault/pull/2950))
 
 BUG FIXES:
 
@@ -24,7 +24,7 @@ FEATURES:
 * **Terraform Secret Engine Root Rotation Support**: Add support for automated root token rotation via the `rotation_period`, `rotation_schedule`, `rotation_window`, and `disable_automated_rotation` fields, and add `explicit_max_ttl` to bound the lifetime of the rotated root token. Requires Vault 2.2.0+. ([#2958](https://github.com/hashicorp/terraform-provider-vault/issues/2958))
 * Add support for Kerberos auth backend: `vault_kerberos_auth_backend_config`, `vault_kerberos_auth_backend_ldap_config`, and `vault_kerberos_auth_backend_group` resources, and `vault_kerberos_auth_backend_login` ephemeral resource for Kerberos authentication. ([#2819](https://github.com/hashicorp/terraform-provider-vault/pull/2819))
 * **Secrets Sync customer controlled encryption**: `vault_secrets_sync_aws_destination` and `vault_secrets_sync_gcp_destination` now support Vault 2.2.0+ fields `kms_key_id` and `replica_regions`; and deprecated GCP legacy fields `global_kms_key`, `locational_kms_keys`, and `replication_locations` in favor of `kms_key_id` and `replica_regions`. ([#2965](https://github.com/hashicorp/terraform-provider-vault/pull/2965))
-* Add support for `pkcs12_bundle` and `jks_bundle` formats (without setting default values) in `vault_pki_secret_backend_cert`, `vault_pki_secret_backend_root_cert`, `vault_pki_secret_backend_root_sign_intermediate`, and `vault_pki_secret_backend_sign` ([#2950](https://github.com/hashicorp/terraform-provider-vault/pull/2950)). Requires Vault 2.1+.
+* Add support for `pkcs12_bundle` and `jks_bundle` formats (without setting default values) in `vault_pki_secret_backend_cert`, `vault_pki_secret_backend_root_cert`, `vault_pki_secret_backend_root_sign_intermediate`, and `vault_pki_secret_backend_sign` ([#2946](https://github.com/hashicorp/terraform-provider-vault/pull/2946)). Requires Vault 2.0.5+.
 
 IMPROVEMENTS:
 

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -1025,7 +1025,6 @@ const (
 	VaultVersion200  = "2.0.0"
 	VaultVersion201  = "2.0.1"
 	VaultVersion203  = "2.0.3"
-	VaultVersion205  = "2.0.5"
 	VaultVersion210  = "2.1.0"
 	VaultVersion220  = "2.2.0"
 

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -56,7 +56,6 @@ var (
 	VaultVersion200  = version.Must(version.NewSemver(consts.VaultVersion200))
 	VaultVersion201  = version.Must(version.NewSemver(consts.VaultVersion201))
 	VaultVersion203  = version.Must(version.NewSemver(consts.VaultVersion203))
-	VaultVersion205  = version.Must(version.NewSemver(consts.VaultVersion205))
 	VaultVersion210  = version.Must(version.NewSemver(consts.VaultVersion210))
 	VaultVersion220  = version.Must(version.NewSemver(consts.VaultVersion220))
 

--- a/vault/pki_customize_diff_helpers.go
+++ b/vault/pki_customize_diff_helpers.go
@@ -14,7 +14,7 @@ import (
 )
 
 func pkiValidateFormatField(d *schema.ResourceDiff, meta interface{}) error {
-	if provider.IsAPISupported(meta, provider.VaultVersion205) {
+	if provider.IsAPISupported(meta, provider.VaultVersion210) {
 		return nil
 	}
 
@@ -26,7 +26,7 @@ func pkiValidateFormatField(d *schema.ResourceDiff, meta interface{}) error {
 	formatStr := format.(string)
 	switch formatStr {
 	case "pkcs12_bundle", "jks_bundle":
-		return fmt.Errorf("%q format is only supported on Vault %s or later", formatStr, consts.VaultVersion205)
+		return fmt.Errorf("%q format is only supported on Vault %s or later", formatStr, consts.VaultVersion210)
 	default:
 		return nil
 	}

--- a/vault/resource_pki_secret_backend_cert.go
+++ b/vault/resource_pki_secret_backend_cert.go
@@ -92,7 +92,7 @@ func pkiSecretBackendCertResource() *schema.Resource {
 			consts.FieldFormat: {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Description:  fmt.Sprintf(`The format of data. Values "pkcs12_bundle" and "jks_bundle" require Vault version %s or later.`, consts.VaultVersion205),
+				Description:  fmt.Sprintf(`The format of data. Values "pkcs12_bundle" and "jks_bundle" require Vault version %s or later.`, consts.VaultVersion210),
 				ForceNew:     true,
 				Default:      "pem",
 				ValidateFunc: validation.StringInSlice([]string{"pem", "der", "pem_bundle", "pkcs12_bundle", "jks_bundle"}, false),
@@ -278,7 +278,7 @@ func pkiSecretBackendCertCreate(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	// Only add additional format parameters if supported
-	if provider.IsAPISupported(meta, provider.VaultVersion205) {
+	if provider.IsAPISupported(meta, provider.VaultVersion210) {
 		certAPIFields = append(certAPIFields,
 			consts.FieldPKCS12Password,
 			consts.FieldPKCS12Encoder,

--- a/vault/resource_pki_secret_backend_cert_test.go
+++ b/vault/resource_pki_secret_backend_cert_test.go
@@ -150,7 +150,7 @@ func TestPkiSecretBackendCert_basic(t *testing.T) {
 			{
 				SkipFunc: func() (bool, error) {
 					meta := testProvider.Meta().(*provider.ProviderMeta)
-					return !meta.IsAPISupported(provider.VaultVersion205), nil
+					return !meta.IsAPISupported(provider.VaultVersion210), nil
 				},
 				Config: testPkiSecretBackendCertConfig_basic(rootPath, intermediatePath, true,
 					certFields{format: "pkcs12_bundle", pkcs12Password: "123-secure-password", pkcs12Encoder: "modern2023"}),
@@ -163,7 +163,7 @@ func TestPkiSecretBackendCert_basic(t *testing.T) {
 			{
 				SkipFunc: func() (bool, error) {
 					meta := testProvider.Meta().(*provider.ProviderMeta)
-					return !meta.IsAPISupported(provider.VaultVersion205), nil
+					return !meta.IsAPISupported(provider.VaultVersion210), nil
 				},
 				Config: testPkiSecretBackendCertConfig_basic(rootPath, intermediatePath, true,
 					certFields{format: "jks_bundle", jksPassword: "super-secure-password", jksAlias: "myapp"}),
@@ -184,7 +184,7 @@ func TestPkiSecretBackendCert_customizeDiffFormatVersionGate(t *testing.T) {
 
 	skipVersion210OrLater := func() (bool, error) {
 		meta := testProvider.Meta().(*provider.ProviderMeta)
-		return meta.IsAPISupported(provider.VaultVersion205), nil
+		return meta.IsAPISupported(provider.VaultVersion210), nil
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -195,12 +195,12 @@ func TestPkiSecretBackendCert_customizeDiffFormatVersionGate(t *testing.T) {
 			{
 				SkipFunc:    skipVersion210OrLater,
 				Config:      testPkiSecretBackendCertConfig_basic(rootPath, intermediatePath, true, certFields{format: "pkcs12_bundle"}),
-				ExpectError: regexp.MustCompile(`"pkcs12_bundle" format is only supported on Vault 2.0.5 or later`),
+				ExpectError: regexp.MustCompile(`"pkcs12_bundle" format is only supported on Vault 2.1.0 or later`),
 			},
 			{
 				SkipFunc:    skipVersion210OrLater,
 				Config:      testPkiSecretBackendCertConfig_basic(rootPath, intermediatePath, true, certFields{format: "jks_bundle"}),
-				ExpectError: regexp.MustCompile(`"jks_bundle" format is only supported on Vault 2.0.5 or later`),
+				ExpectError: regexp.MustCompile(`"jks_bundle" format is only supported on Vault 2.1.0 or later`),
 			},
 		},
 	})

--- a/vault/resource_pki_secret_backend_root_cert.go
+++ b/vault/resource_pki_secret_backend_root_cert.go
@@ -176,7 +176,7 @@ func pkiSecretBackendRootCertResource() *schema.Resource {
 			consts.FieldFormat: {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Description:  fmt.Sprintf(`The format of data. Values "pkcs12_bundle" and "jks_bundle" require Vault version %s or later.`, consts.VaultVersion205),
+				Description:  fmt.Sprintf(`The format of data. Values "pkcs12_bundle" and "jks_bundle" require Vault version %s or later.`, consts.VaultVersion210),
 				ForceNew:     true,
 				Default:      "pem",
 				ValidateFunc: validation.StringInSlice([]string{"pem", "der", "pem_bundle", "pkcs12_bundle", "jks_bundle"}, false),
@@ -547,7 +547,7 @@ func pkiSecretBackendRootCertCreate(_ context.Context, d *schema.ResourceData, m
 	}
 
 	// Only add additional format parameters if supported
-	if provider.IsAPISupported(meta, provider.VaultVersion205) {
+	if provider.IsAPISupported(meta, provider.VaultVersion210) {
 		rootCertAPIFields = append(rootCertAPIFields,
 			consts.FieldPKCS12Password,
 			consts.FieldPKCS12Encoder,

--- a/vault/resource_pki_secret_backend_root_cert_test.go
+++ b/vault/resource_pki_secret_backend_root_cert_test.go
@@ -106,7 +106,7 @@ func TestPkiSecretBackendRootCertificate_pkcs12Bundle(t *testing.T) {
 	}
 
 	testPkiSecretBackendRootCertificate(t, path, config, resourceName, checks, func(t *testing.T) {
-		SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion205)
+		SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion210)
 	})
 }
 
@@ -130,7 +130,7 @@ func TestPkiSecretBackendRootCertificate_jksBundle(t *testing.T) {
 	}
 
 	testPkiSecretBackendRootCertificate(t, path, config, resourceName, checks, func(t *testing.T) {
-		SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion205)
+		SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion210)
 	})
 }
 

--- a/vault/resource_pki_secret_backend_root_sign_intermediate.go
+++ b/vault/resource_pki_secret_backend_root_sign_intermediate.go
@@ -106,7 +106,7 @@ func pkiSecretBackendRootSignIntermediateResource() *schema.Resource {
 			consts.FieldFormat: {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Description:  fmt.Sprintf(`The format of data. Values "pkcs12_bundle" and "jks_bundle" require Vault version %s or later.`, consts.VaultVersion205),
+				Description:  fmt.Sprintf(`The format of data. Values "pkcs12_bundle" and "jks_bundle" require Vault version %s or later.`, consts.VaultVersion210),
 				ForceNew:     true,
 				Default:      "pem",
 				ValidateFunc: validation.StringInSlice([]string{"pem", "der", "pem_bundle", "pkcs12_bundle", "jks_bundle"}, false),
@@ -390,7 +390,7 @@ func pkiSecretBackendRootSignIntermediateCreate(ctx context.Context, d *schema.R
 	}
 
 	// Only add additional format parameters if supported
-	if provider.IsAPISupported(meta, provider.VaultVersion205) {
+	if provider.IsAPISupported(meta, provider.VaultVersion210) {
 		intermediateSignAPIFields = append(intermediateSignAPIFields,
 			consts.FieldPKCS12Password,
 			consts.FieldPKCS12Encoder,

--- a/vault/resource_pki_secret_backend_root_sign_intermediate_test.go
+++ b/vault/resource_pki_secret_backend_root_sign_intermediate_test.go
@@ -292,7 +292,7 @@ func TestPkiSecretBackendRootSignIntermediate_pkcs12_bundle(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			acctestutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion205)
+			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion210)
 		},
 		CheckDestroy: testCheckMountDestroyed("vault_mount", consts.MountTypePKI, consts.FieldPath),
 		Steps: []resource.TestStep{
@@ -321,7 +321,7 @@ func TestPkiSecretBackendRootSignIntermediate_jks_bundle(t *testing.T) {
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		PreCheck: func() {
 			acctestutil.TestAccPreCheck(t)
-			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion205)
+			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion210)
 		},
 		CheckDestroy: testCheckMountDestroyed("vault_mount", consts.MountTypePKI, consts.FieldPath),
 		Steps: []resource.TestStep{

--- a/vault/resource_pki_secret_backend_sign.go
+++ b/vault/resource_pki_secret_backend_sign.go
@@ -242,7 +242,7 @@ func pkiSecretBackendSignCreate(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	// Only add additional format parameters if supported
-	if provider.IsAPISupported(meta, provider.VaultVersion205) {
+	if provider.IsAPISupported(meta, provider.VaultVersion210) {
 		signAPIFields = append(signAPIFields,
 			consts.FieldPKCS12Password,
 			consts.FieldPKCS12Encoder,

--- a/vault/resource_pki_secret_backend_sign_test.go
+++ b/vault/resource_pki_secret_backend_sign_test.go
@@ -69,7 +69,7 @@ func TestPkiSecretBackendSign_basic(t *testing.T) {
 			{
 				SkipFunc: func() (bool, error) {
 					meta := testProvider.Meta().(*provider.ProviderMeta)
-					return !meta.IsAPISupported(provider.VaultVersion205), nil
+					return !meta.IsAPISupported(provider.VaultVersion210), nil
 				},
 				Config: testPkiSecretBackendSignConfig_basic(rootPath, intermediatePath,
 					`format = "pkcs12_bundle"
@@ -84,7 +84,7 @@ func TestPkiSecretBackendSign_basic(t *testing.T) {
 			{
 				SkipFunc: func() (bool, error) {
 					meta := testProvider.Meta().(*provider.ProviderMeta)
-					return !meta.IsAPISupported(provider.VaultVersion205), nil
+					return !meta.IsAPISupported(provider.VaultVersion210), nil
 				},
 				Config: testPkiSecretBackendSignConfig_basic(rootPath, intermediatePath,
 					`format       = "jks_bundle"

--- a/website/docs/r/pki_secret_backend_cert.html.md
+++ b/website/docs/r/pki_secret_backend_cert.html.md
@@ -57,19 +57,19 @@ The following arguments are supported:
 
 * `ttl` - (Optional) Time to live
 
-* `format` - (Optional) The format of data. Valid values are "pem", "pem_bundle", "der", "pkcs12_bundle" or "jks_bundle". Values "pkcs12_bundle" and "jks_bundle" require Vault 2.0.5+. 
+* `format` - (Optional) The format of data. Valid values are "pem", "pem_bundle", "der", "pkcs12_bundle" or "jks_bundle". Values "pkcs12_bundle" and "jks_bundle" require Vault 2.1+. 
 
 * `private_key_format` - (Optional) The private key format
 
-* `pkcs12_password` - (Optional) Password for encrypting the PKCS#12 archive when format is set to "pkcs12_bundle". If not provided,defaults to "changeit". It is recommended to use the default password and protect the file using other means or use a high-entropy password. Requires Vault 2.0.5+.
+* `pkcs12_password` - (Optional) Password for encrypting the PKCS#12 archive when format is set to "pkcs12_bundle". If not provided,defaults to "changeit". It is recommended to use the default password and protect the file using other means or use a high-entropy password. Requires Vault 2.1+.
 
-* `pkcs12_encoder` - (Optional) Encoder profile to use for PKCS#12 archives when format is set to "pkcs12_bundle". Valid values are "modern2026" and "modern2023". Defaults to "modern2026", which uses the newer PKCS#12 integrity format (PBMAC1). Requires Vault 2.0.5+.
+* `pkcs12_encoder` - (Optional) Encoder profile to use for PKCS#12 archives when format is set to "pkcs12_bundle". Valid values are "modern2026" and "modern2023". Defaults to "modern2026", which uses the newer PKCS#12 integrity format (PBMAC1). Requires Vault 2.1+.
 
 **NOTE**: The `jks_bundle` format is provided only for compatibility with legacy systems and should be avoided for new usage. Prefer `pkcs12_bundle`.
 
-* `jks_password` - (Optional) Password for encrypting the Java keystore when format is set to "jks_bundle". If not provided, defaults to "changeit". It is recommended to use the default password and protect the file using other means or use a high-entropy password. Requires Vault 2.0.5+.
+* `jks_password` - (Optional) Password for encrypting the Java keystore when format is set to "jks_bundle". If not provided, defaults to "changeit". It is recommended to use the default password and protect the file using other means or use a high-entropy password. Requires Vault 2.1+.
 
-* `jks_private_key_alias` - (Optional) The entry alias in the Java keystore (JKS) when format is set to "jks_bundle" and bundle contains a single PrivateKeyEntry. This field is case-sensitive, but relying on case-only differences for unique aliases is not recommended. Defaults to "1". This parameter is ignored by endpoints that return TrustedCertificateEntry values (JKS trust stores), and entry aliases are assigned incrementing numeric strings starting at "1". Requires Vault 2.0.5+.
+* `jks_private_key_alias` - (Optional) The entry alias in the Java keystore (JKS) when format is set to "jks_bundle" and bundle contains a single PrivateKeyEntry. This field is case-sensitive, but relying on case-only differences for unique aliases is not recommended. Defaults to "1". This parameter is ignored by endpoints that return TrustedCertificateEntry values (JKS trust stores), and entry aliases are assigned incrementing numeric strings starting at "1". Requires Vault 2.1+.
 
 * `exclude_cn_from_sans` - (Optional) Flag to exclude CN from SANs
 

--- a/website/docs/r/pki_secret_backend_root_cert.html.md
+++ b/website/docs/r/pki_secret_backend_root_cert.html.md
@@ -66,19 +66,19 @@ The following arguments are supported:
 
 * `ttl` - (Optional) Time to live
 
-* `format` - (Optional) The format of data. Valid values are "pem", "pem_bundle", "der", "pkcs12_bundle" or "jks_bundle". Values "pkcs12_bundle" and "jks_bundle" require Vault 2.0.5+.
+* `format` - (Optional) The format of data. Valid values are "pem", "pem_bundle", "der", "pkcs12_bundle" or "jks_bundle". Values "pkcs12_bundle" and "jks_bundle" require Vault 2.1+.
 
 * `private_key_format` - (Optional) The private key format
 
-* `pkcs12_password` - (Optional) Password for encrypting the PKCS#12 archive when format is set to "pkcs12_bundle". If not provided, defaults to "changeit". It is recommended to use the default password and protect the file using other means or use a high-entropy password. Requires Vault 2.0.5+.
+* `pkcs12_password` - (Optional) Password for encrypting the PKCS#12 archive when format is set to "pkcs12_bundle". If not provided, defaults to "changeit". It is recommended to use the default password and protect the file using other means or use a high-entropy password. Requires Vault 2.1+.
 
-* `pkcs12_encoder` - (Optional) Encoder profile to use for PKCS#12 archives when format is set to "pkcs12_bundle". Valid values are "modern2026" and "modern2023". Defaults to "modern2026", which uses the newer PKCS#12 integrity format (PBMAC1). Requires Vault 2.0.5+.
+* `pkcs12_encoder` - (Optional) Encoder profile to use for PKCS#12 archives when format is set to "pkcs12_bundle". Valid values are "modern2026" and "modern2023". Defaults to "modern2026", which uses the newer PKCS#12 integrity format (PBMAC1). Requires Vault 2.1+.
 
 **NOTE**: The `jks_bundle` format is provided only for compatibility with legacy systems and should be avoided for new usage. Prefer `pkcs12_bundle`.
 
-* `jks_password` - (Optional) Password for encrypting the Java keystore when format is set to "jks_bundle". If not provided, defaults to "changeit". It is recommended to use the default password and protect the file using other means or use a high-entropy password. Requires Vault 2.0.5+.
+* `jks_password` - (Optional) Password for encrypting the Java keystore when format is set to "jks_bundle". If not provided, defaults to "changeit". It is recommended to use the default password and protect the file using other means or use a high-entropy password. Requires Vault 2.1+.
 
-* `jks_private_key_alias` - (Optional) The entry alias in the Java keystore (JKS) when format is set to "jks_bundle" and bundle contains a single PrivateKeyEntry. This field is case-sensitive, but relying on case-only differences for unique aliases is not recommended. Defaults to "1". This parameter is ignored by endpoints that return TrustedCertificateEntry values (JKS trust stores), and entry aliases are assigned incrementing numeric strings starting at "1". Requires Vault 2.0.5+.
+* `jks_private_key_alias` - (Optional) The entry alias in the Java keystore (JKS) when format is set to "jks_bundle" and bundle contains a single PrivateKeyEntry. This field is case-sensitive, but relying on case-only differences for unique aliases is not recommended. Defaults to "1". This parameter is ignored by endpoints that return TrustedCertificateEntry values (JKS trust stores), and entry aliases are assigned incrementing numeric strings starting at "1". Requires Vault 2.1+.
 
 * `key_type` - (Optional) The desired key type
 

--- a/website/docs/r/pki_secret_backend_root_sign_intermediate.html.md
+++ b/website/docs/r/pki_secret_backend_root_sign_intermediate.html.md
@@ -51,13 +51,13 @@ The following arguments are supported:
 
 * `format` - (Optional) The format of data
 
-* `pkcs12_password` - (Optional) Password for encrypting the PKCS#12 archive when format is set to "pkcs12_bundle". If not provided, defaults to "changeit". It is recommended to use the default password and protect the file using other means or use a high-entropy password. Requires Vault 2.0.5+.
+* `pkcs12_password` - (Optional) Password for encrypting the PKCS#12 archive when format is set to "pkcs12_bundle". If not provided, defaults to "changeit". It is recommended to use the default password and protect the file using other means or use a high-entropy password. Requires Vault 2.1+.
 
-* `pkcs12_encoder` - (Optional) Encoder profile to use for PKCS#12 archives when format is set to "pkcs12_bundle". Valid values are "modern2026" and "modern2023". Defaults to "modern2026", which uses the newer PKCS#12 integrity format (PBMAC1). Requires Vault 2.0.5+.
+* `pkcs12_encoder` - (Optional) Encoder profile to use for PKCS#12 archives when format is set to "pkcs12_bundle". Valid values are "modern2026" and "modern2023". Defaults to "modern2026", which uses the newer PKCS#12 integrity format (PBMAC1). Requires Vault 2.1+.
 
 **NOTE**: The `jks_bundle` format is provided only for compatibility with legacy systems and should be avoided for new usage. Prefer `pkcs12_bundle`.
 
-* `jks_password` - (Optional) Password for encrypting the Java keystore when format is set to "jks_bundle". If not provided, defaults to "changeit". It is recommended to use the default password and protect the file using other means or use a high-entropy password. Requires Vault 2.0.5+.
+* `jks_password` - (Optional) Password for encrypting the Java keystore when format is set to "jks_bundle". If not provided, defaults to "changeit". It is recommended to use the default password and protect the file using other means or use a high-entropy password. Requires Vault 2.1+.
 
 * `max_path_length` - (Optional) The maximum path length to encode in the generated certificate
 

--- a/website/docs/r/pki_secret_backend_sign.html.md
+++ b/website/docs/r/pki_secret_backend_sign.html.md
@@ -84,15 +84,15 @@ The following arguments are supported:
 
 * `ttl` - (Optional) Time to live
 
-* `format` - (Optional) The format of data. Valid values are "pem", "pem_bundle", "der", "pkcs12_bundle" or "jks_bundle". Values "pkcs12_bundle" and "jks_bundle" require Vault 2.0.5+. 
+* `format` - (Optional) The format of data. Valid values are "pem", "pem_bundle", "der", "pkcs12_bundle" or "jks_bundle". Values "pkcs12_bundle" and "jks_bundle" require Vault 2.1+. 
 
-* `pkcs12_password` - (Optional) Password for encrypting the PKCS#12 archive when format is set to "pkcs12_bundle". If not provided, defaults to "changeit". It is recommended to use the default password and protect the file using other means or use a high-entropy password. Requires Vault 2.0.5+.
+* `pkcs12_password` - (Optional) Password for encrypting the PKCS#12 archive when format is set to "pkcs12_bundle". If not provided, defaults to "changeit". It is recommended to use the default password and protect the file using other means or use a high-entropy password. Requires Vault 2.1+.
 
-* `pkcs12_encoder` - (Optional) Encoder profile to use for PKCS#12 archives when format is set to "pkcs12_bundle". Valid values are "modern2026" and "modern2023". Defaults to "modern2026", which uses the newer PKCS#12 integrity format (PBMAC1). Requires Vault 2.0.5+.
+* `pkcs12_encoder` - (Optional) Encoder profile to use for PKCS#12 archives when format is set to "pkcs12_bundle". Valid values are "modern2026" and "modern2023". Defaults to "modern2026", which uses the newer PKCS#12 integrity format (PBMAC1). Requires Vault 2.1+.
 
 **NOTE**: The `jks_bundle` format is provided only for compatibility with legacy systems and should be avoided for new usage. Prefer `pkcs12_bundle`.
 
-* `jks_password` - (Optional) Password for encrypting the Java keystore when format is set to "jks_bundle". If not provided, defaults to "changeit". It is recommended to use the default password and protect the file using other means or use a high-entropy password. Requires Vault 2.0.5+.
+* `jks_password` - (Optional) Password for encrypting the Java keystore when format is set to "jks_bundle". If not provided, defaults to "changeit". It is recommended to use the default password and protect the file using other means or use a high-entropy password. Requires Vault 2.1+.
 
 * `exclude_cn_from_sans` - (Optional) Flag to exclude CN from SANs
 


### PR DESCRIPTION
There will no longer be a Vault 2.0.5 version and instead 2.1 will be released in early September. Updating the supported release version accordingly for pkcs12 format supported added in https://github.com/hashicorp/terraform-provider-vault/pull/2950
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000


### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
