### PR TITLE
fix panic when disable_escaping from out of band

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ IMPROVEMENTS:
 BUG FIXES:
 
 * `vault_terraform_cloud_secret_backend`: Fix logic gap in `Read` where execution would fall through to a stray `GET <backend>/config` call after `readMount` detected the mount was deleted out-of-band and cleared the resource ID. Add `util.Is404` guard to `Delete` so that `terraform destroy` succeeds cleanly when the mount has already been removed from Vault. ([#3006](https://github.com/hashicorp/terraform-provider-vault/pull/3006))
+* `vault_database_secret_backend_connection`: Fix a provider panic (`interface conversion: interface {} is string, not bool`) when reading a `mssql`, `postgresql`, `hana`, or `redshift` connection whose `disable_escaping` field was stored as a string (e.g. written out-of-band via the Vault CLI). The field is now parsed tolerantly with `parseutil.ParseBool`, matching the existing handling of `contained_db`. ([#3018](https://github.com/hashicorp/terraform-provider-vault/issues/3018))
 
 
 ## 5.11.0 (August 14, 2026)

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -1267,7 +1267,10 @@ func getConnectionDetailsFromResponse(d *schema.ResourceData, prefix string, res
 }
 
 func getMSSQLConnectionDetailsFromResponse(d *schema.ResourceData, prefix string, resp *api.Secret) (map[string]interface{}, error) {
-	result := getConnectionDetailsFromResponseWithDisableEscaping(d, prefix, resp)
+	result, err := getConnectionDetailsFromResponseWithDisableEscaping(d, prefix, resp)
+	if err != nil {
+		return nil, err
+	}
 	if result == nil {
 		return nil, nil
 	}
@@ -1284,12 +1287,15 @@ func getMSSQLConnectionDetailsFromResponse(d *schema.ResourceData, prefix string
 	return result, nil
 }
 
-func getPostgresConnectionDetailsFromResponse(d *schema.ResourceData, prefix string, resp *api.Secret, meta interface{}) map[string]interface{} {
-	result := getConnectionDetailsFromResponseWithDisableEscaping(d, prefix, resp)
+func getPostgresConnectionDetailsFromResponse(d *schema.ResourceData, prefix string, resp *api.Secret, meta interface{}) (map[string]interface{}, error) {
+	result, err := getConnectionDetailsFromResponseWithDisableEscaping(d, prefix, resp)
+	if err != nil {
+		return nil, err
+	}
 	details := resp.Data["connection_details"]
 	data, ok := details.(map[string]interface{})
 	if !ok {
-		return nil
+		return nil, nil
 	}
 
 	// cloud specific
@@ -1328,21 +1334,25 @@ func getPostgresConnectionDetailsFromResponse(d *schema.ResourceData, prefix str
 			result["self_managed"] = v.(bool)
 		}
 	}
-	return result
+	return result, nil
 }
 
-func getConnectionDetailsFromResponseWithDisableEscaping(d *schema.ResourceData, prefix string, resp *api.Secret) map[string]interface{} {
+func getConnectionDetailsFromResponseWithDisableEscaping(d *schema.ResourceData, prefix string, resp *api.Secret) (map[string]interface{}, error) {
 	result := getConnectionDetailsFromResponseWithUserPass(d, prefix, resp)
 	if result == nil {
-		return nil
+		return nil, nil
 	}
 
 	details := resp.Data["connection_details"].(map[string]interface{})
 	if v, ok := details["disable_escaping"]; ok {
-		result["disable_escaping"] = v.(bool)
+		disableEscaping, err := parseutil.ParseBool(v)
+		if err != nil {
+			return nil, fmt.Errorf(`unsupported type for field "disable_escaping", err=%w`, err)
+		}
+		result["disable_escaping"] = disableEscaping
 	}
 
-	return result
+	return result, nil
 }
 
 func getMongoDBConnectionDetailsFromResponse(d *schema.ResourceData, prefix string, resp *api.Secret) map[string]interface{} {
@@ -2318,7 +2328,11 @@ func getDBConnectionConfig(d *schema.ResourceData, engine *dbEngine, idx int,
 	case dbEngineInfluxDB:
 		result = getInfluxDBConnectionDetailsFromResponse(d, prefix, resp)
 	case dbEngineHana:
-		result = getConnectionDetailsFromResponseWithDisableEscaping(d, prefix, resp)
+		values, err := getConnectionDetailsFromResponseWithDisableEscaping(d, prefix, resp)
+		if err != nil {
+			return nil, err
+		}
+		result = values
 	case dbEngineMongoDB:
 		result = getMongoDBConnectionDetailsFromResponse(d, prefix, resp)
 	case dbEngineMongoDBAtlas:
@@ -2340,7 +2354,11 @@ func getDBConnectionConfig(d *schema.ResourceData, engine *dbEngine, idx int,
 	case dbEngineOracle:
 		result = getOracleConnectionDetailsFromResponse(d, prefix, resp, meta)
 	case dbEnginePostgres:
-		result = getPostgresConnectionDetailsFromResponse(d, prefix, resp, meta)
+		values, err := getPostgresConnectionDetailsFromResponse(d, prefix, resp, meta)
+		if err != nil {
+			return nil, err
+		}
+		result = values
 	case dbEngineElasticSearch:
 		result = getElasticsearchConnectionDetailsFromResponse(d, prefix, resp)
 	case dbEngineSnowflake:
@@ -2350,7 +2368,11 @@ func getDBConnectionConfig(d *schema.ResourceData, engine *dbEngine, idx int,
 	case dbEngineRedisElastiCache:
 		result = getRedisElastiCacheConnectionDetailsFromResponse(d, prefix, resp)
 	case dbEngineRedshift:
-		result = getConnectionDetailsFromResponseWithDisableEscaping(d, prefix, resp)
+		values, err := getConnectionDetailsFromResponseWithDisableEscaping(d, prefix, resp)
+		if err != nil {
+			return nil, err
+		}
+		result = values
 	default:
 		return nil, fmt.Errorf("no response handler for dbEngine: %s", engine)
 	}

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -624,6 +624,36 @@ func TestAccDatabaseSecretBackendConnection_mssql(t *testing.T) {
 				),
 			},
 			{
+				// Regression coverage for https://github.com/hashicorp/terraform-provider-vault/issues/3018.
+				// Simulate an out-of-band write (e.g. via the Vault CLI), which stores
+				// disable_escaping as the string "true" rather than a JSON boolean. The
+				// refresh that runs before this step's apply must parse it tolerantly
+				// instead of panicking on an unchecked type assertion.
+				PreConfig: func() {
+					password, _ := parsedURL.User.Password()
+					path := fmt.Sprintf("%s/config/%s", backend, name)
+					client := testProvider.Meta().(*provider.ProviderMeta).MustGetClient()
+
+					_, err := client.Logical().Write(path, map[string]interface{}{
+						"plugin_name":              pluginName,
+						"connection_url":           parsedURL.String(),
+						"allowed_roles":            "dev,prod",
+						"root_rotation_statements": "FOOBAR",
+						"password_policy":          "mssql-policy",
+						"username":                 username,
+						"password":                 password,
+						"disable_escaping":         "true", // stored as a string, reproduces the panic
+						"verify_connection":        false,
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+				},
+				Config: testAccDatabaseSecretBackendConnectionConfig_mssql(name, backend, pluginName, parsedURL, false, false),
+				Check: resource.TestCheckResourceAttr(
+					testDefaultDatabaseSecretBackendResource, "mssql.0.disable_escaping", "true"),
+			},
+			{
 				ResourceName:            testDefaultDatabaseSecretBackendResource,
 				ImportState:             true,
 				ImportStateVerify:       true,

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -624,36 +624,6 @@ func TestAccDatabaseSecretBackendConnection_mssql(t *testing.T) {
 				),
 			},
 			{
-				// Regression coverage for https://github.com/hashicorp/terraform-provider-vault/issues/3018.
-				// Simulate an out-of-band write (e.g. via the Vault CLI), which stores
-				// disable_escaping as the string "true" rather than a JSON boolean. The
-				// refresh that runs before this step's apply must parse it tolerantly
-				// instead of panicking on an unchecked type assertion.
-				PreConfig: func() {
-					password, _ := parsedURL.User.Password()
-					path := fmt.Sprintf("%s/config/%s", backend, name)
-					client := testProvider.Meta().(*provider.ProviderMeta).MustGetClient()
-
-					_, err := client.Logical().Write(path, map[string]interface{}{
-						"plugin_name":              pluginName,
-						"connection_url":           parsedURL.String(),
-						"allowed_roles":            "dev,prod",
-						"root_rotation_statements": "FOOBAR",
-						"password_policy":          "mssql-policy",
-						"username":                 username,
-						"password":                 password,
-						"disable_escaping":         "true", // stored as a string, reproduces the panic
-						"verify_connection":        false,
-					})
-					if err != nil {
-						t.Fatal(err)
-					}
-				},
-				Config: testAccDatabaseSecretBackendConnectionConfig_mssql(name, backend, pluginName, parsedURL, false, false),
-				Check: resource.TestCheckResourceAttr(
-					testDefaultDatabaseSecretBackendResource, "mssql.0.disable_escaping", "true"),
-			},
-			{
 				ResourceName:            testDefaultDatabaseSecretBackendResource,
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -3935,4 +3905,67 @@ resource "vault_database_secret_backend_connection" "test" {
   }
 }
 `, path, name, connURL)
+}
+
+// Test_getConnectionDetailsFromResponseWithDisableEscaping verifies that the
+// disable_escaping field is parsed tolerantly regardless of whether Vault
+// returns it as a JSON boolean or as a string. The string form occurs when the
+// connection config is written out-of-band (e.g. via the Vault CLI, which sends
+// every argument as a string). Previously an unchecked type assertion panicked
+// when the field was a string. See issue #3018.
+func Test_getConnectionDetailsFromResponseWithDisableEscaping(t *testing.T) {
+	const prefix = "mssql.0."
+
+	tests := []struct {
+		name    string
+		value   interface{}
+		want    bool
+		present bool
+		wantErr bool
+	}{
+		{name: "bool-true", value: true, want: true, present: true},
+		{name: "bool-false", value: false, want: false, present: true},
+		{name: "string-true", value: "true", want: true, present: true},
+		{name: "string-false", value: "false", want: false, present: true},
+		{name: "invalid-string", value: "notabool", wantErr: true},
+		{name: "absent"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := schema.TestResourceDataRaw(t,
+				databaseSecretBackendConnectionResource().Schema,
+				map[string]interface{}{})
+
+			connectionDetails := map[string]interface{}{}
+			if tt.name != "absent" {
+				connectionDetails["disable_escaping"] = tt.value
+			}
+
+			resp := &api.Secret{
+				Data: map[string]interface{}{
+					"connection_details": connectionDetails,
+				},
+			}
+
+			result, err := getConnectionDetailsFromResponseWithDisableEscaping(d, prefix, resp)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for value %#v, got none", tt.value)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+
+			got, ok := result["disable_escaping"]
+			if tt.present != ok {
+				t.Fatalf("disable_escaping present=%t, want %t", ok, tt.present)
+			}
+			if tt.present && got.(bool) != tt.want {
+				t.Fatalf("disable_escaping = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/website/docs/r/database_secret_backend_connection.md
+++ b/website/docs/r/database_secret_backend_connection.md
@@ -333,7 +333,7 @@ See the [Vault
 
 * `password` - (Optional) The root credential password used in the connection URL.
 
-* `disable_escaping` - (Optional) Disable special character escaping in username and password.
+* `disable_escaping` - (Optional) Disable special character escaping in username and password. Advised `true` or `false`, default is `false`.
 
 * `username_template` - (Optional) Template describing how dynamic usernames are generated.
 
@@ -363,7 +363,7 @@ See the [Vault
 
 * `password` - (Optional) The root credential password used in the connection URL.
 
-* `disable_escaping` - (Optional) Disable special character escaping in username and password.
+* `disable_escaping` - (Optional) Disable special character escaping in username and password. Advised `true` or `false`, default is `false`.
 
 * `contained_db` - (Optional bool: false) For Vault v1.9+. Set to true when the target is a
   Contained Database, e.g. AzureSQL.
@@ -447,7 +447,7 @@ See the [Vault
 
 * `service_account_json` - (Optional) JSON encoding of an IAM access key. Requires `auth_type` to be `gcp_iam`.
 
-* `disable_escaping` - (Optional) Disable special character escaping in username and password.
+* `disable_escaping` - (Optional) Disable special character escaping in username and password. Advised `true` or `false`, default is `false`.
 
 * `username_template` - (Optional) For Vault v1.7+. The template to use for username generation.
 See the [Vault
@@ -562,7 +562,7 @@ See the [Vault
 
 * `password` - (Optional) The root credential password used in the connection URL.
 
-* `disable_escaping` - (Optional) Disable special character escaping in username and password.
+* `disable_escaping` - (Optional) Disable special character escaping in username and password. Advised `true` or `false`, default is `false`.
 
 * `username_template` - (Optional) - [Template](https://www.vaultproject.io/docs/concepts/username-templating) describing how dynamic usernames are generated.
 


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #3018


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ go test ./vault/ -run Test_getConnectionDetailsFromResponseWithDisableEscaping -v
=== RUN   Test_getConnectionDetailsFromResponseWithDisableEscaping
=== RUN   Test_getConnectionDetailsFromResponseWithDisableEscaping/bool-true
=== RUN   Test_getConnectionDetailsFromResponseWithDisableEscaping/bool-false
=== RUN   Test_getConnectionDetailsFromResponseWithDisableEscaping/string-true
=== RUN   Test_getConnectionDetailsFromResponseWithDisableEscaping/string-false
=== RUN   Test_getConnectionDetailsFromResponseWithDisableEscaping/invalid-string
=== RUN   Test_getConnectionDetailsFromResponseWithDisableEscaping/absent
--- PASS: Test_getConnectionDetailsFromResponseWithDisableEscaping (0.00s)
    --- PASS: Test_getConnectionDetailsFromResponseWithDisableEscaping/bool-true (0.00s)
    --- PASS: Test_getConnectionDetailsFromResponseWithDisableEscaping/bool-false (0.00s)
    --- PASS: Test_getConnectionDetailsFromResponseWithDisableEscaping/string-true (0.00s)
    --- PASS: Test_getConnectionDetailsFromResponseWithDisableEscaping/string-false (0.00s)
    --- PASS: Test_getConnectionDetailsFromResponseWithDisableEscaping/invalid-string (0.00s)
    --- PASS: Test_getConnectionDetailsFromResponseWithDisableEscaping/absent (0.00s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/vault	(cached)
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
