### PR TITLE
vault_plugin: add `download` field for automatic enterprise plugin downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 IMPROVEMENTS:
 
-* `vault_plugin`: Add `download` field to let Vault Enterprise (1.20+) automatically download official enterprise plugin artifacts from releases.hashicorp.com during registration, instead of requiring the artifact to be pre-staged in the server's `plugin_directory`.
+* `vault_plugin`: Add `download` field to let Vault Enterprise (1.20+) automatically download official enterprise plugin artifacts from releases.hashicorp.com during registration, instead of requiring the artifact to be pre-staged in the server's `plugin_directory`. ([#3022](https://github.com/hashicorp/terraform-provider-vault/pull/3022))
 * `vault_ldap_auth_backend`: emit a warning when the auth mount or its config is not found during refresh, so users see an actionable message in `terraform plan` output rather than a silent state removal. ([#2997](https://github.com/hashicorp/terraform-provider-vault/pull/2997))
 * Update supported Vault version for PKI formats `pkcs12_bundle` and `jks_bundle` to require Vault 2.1.0+ (not 2.0.5+) per latest Vault versioning strategy. ([#2950](https://github.com/hashicorp/terraform-provider-vault/pull/2950))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 IMPROVEMENTS:
 
+* `vault_plugin`: Add `download` field to let Vault Enterprise (1.20+) automatically download official enterprise plugin artifacts from releases.hashicorp.com during registration, instead of requiring the artifact to be pre-staged in the server's `plugin_directory`.
 * `vault_ldap_auth_backend`: emit a warning when the auth mount or its config is not found during refresh, so users see an actionable message in `terraform plan` output rather than a silent state removal. ([#2997](https://github.com/hashicorp/terraform-provider-vault/pull/2997))
 * Update supported Vault version for PKI formats `pkcs12_bundle` and `jks_bundle` to require Vault 2.1.0+ (not 2.0.5+) per latest Vault versioning strategy. ([#2950](https://github.com/hashicorp/terraform-provider-vault/pull/2950))
 

--- a/vault/resource_plugin.go
+++ b/vault/resource_plugin.go
@@ -27,6 +27,7 @@ const (
 	fieldEnv      = "env"
 	fieldOCIImage = "oci_image"
 	fieldRuntime  = "runtime"
+	fieldDownload = "download"
 )
 
 var (
@@ -126,6 +127,12 @@ func pluginResource() *schema.Resource {
 				Description: "Vault plugin runtime to use if oci_image is specified.",
 				Optional:    true,
 			},
+			fieldDownload: {
+				Type:        schema.TypeBool,
+				Description: "Whether Vault should download the plugin artifact from releases.hashicorp.com when registering it. Vault Enterprise 1.20+ only, and only for official enterprise plugins (version ending in +ent).",
+				Optional:    true,
+				Default:     false,
+			},
 		},
 	}
 }
@@ -154,6 +161,11 @@ func pluginWrite(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 		return diagErr
 	}
 
+	download := d.Get(fieldDownload).(bool)
+	if diagErr := pluginDownloadSupported(meta, download); diagErr != nil {
+		return diagErr
+	}
+
 	log.Printf("[DEBUG] Writing plugin %q", id)
 	err = client.Sys().RegisterPluginWithContext(ctx, &api.RegisterPluginInput{
 		Type:     pluginType,
@@ -165,6 +177,7 @@ func pluginWrite(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 		Env:      util.ToStringArray(d.Get(fieldEnv).([]interface{})),
 		OCIImage: ociImage,
 		Runtime:  runtime,
+		Download: download,
 	})
 	if err != nil {
 		return diag.Errorf("error updating plugin %q: %s", id, err)
@@ -215,6 +228,9 @@ func pluginRead(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 		resp.SHA256 = ""
 		resp.Command = ""
 	}
+
+	// download is not returned by the plugin catalog read API, so the
+	// configured value is kept in state as-is.
 
 	result := map[string]any{
 		consts.FieldType:    typ,
@@ -280,6 +296,14 @@ func containerizedPluginsSupported(meta interface{}, ociImage, runtime string) d
 	return nil
 }
 
+func pluginDownloadSupported(meta interface{}, download bool) diag.Diagnostics {
+	if download && !provider.IsAPISupported(meta, provider.VaultVersion120) {
+		return diag.Errorf("download specified but automatic plugin downloads are only supported in Vault Enterprise 1.20 and later")
+	}
+
+	return nil
+}
+
 // diffSuppressEqualSemver is an implementation of schema.SchemaDiffSuppressFunc.
 // Vault normalizes plugin versions to have a leading v, so if users specify a
 // version without a leading v we use this to suppress the diff.
@@ -300,6 +324,9 @@ func diffSuppressEqualSemver(_, oldValue, newValue string, _ *schema.ResourceDat
 
 func pluginCustomizeDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
 	curVersion := d.Get(consts.FieldVersion).(string)
+	if d.Get(fieldDownload).(bool) && !strings.HasSuffix(curVersion, "+ent") {
+		return fmt.Errorf("field %s can only be set for enterprise plugins (version ending in +ent)", fieldDownload)
+	}
 	if strings.HasSuffix(curVersion, "+ent") {
 		if d.Get(fieldSHA256).(string) != "" {
 			return fmt.Errorf("field %s needs to be empty for enterprise plugin", fieldSHA256)

--- a/vault/resource_plugin_test.go
+++ b/vault/resource_plugin_test.go
@@ -125,6 +125,40 @@ func TestPlugin_ent(t *testing.T) {
 	})
 }
 
+func TestPlugin_entDownload(t *testing.T) {
+	resourceName := "vault_plugin.test"
+
+	// VAULT_PLUGIN_ENT_TYPE, VAULT_PLUGIN_ENT_NAME, VAULT_PLUGIN_ENT_VERSION
+	// identify an official enterprise plugin published on
+	// releases.hashicorp.com. The Vault server must be able to reach
+	// releases.hashicorp.com and must not already have the artifact in its
+	// plugin_directory for this test to be meaningful.
+	typ := os.Getenv(envPluginEntType)
+	name := os.Getenv(envPluginEntName)
+	version := os.Getenv(envPluginEntVersion)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		PreCheck: func() {
+			testutil.TestAccPreCheck(t)
+			testutil.SkipTestEnvUnset(t, envPluginEntName, envPluginEntVersion, envPluginEntType)
+			// Automatic plugin downloads were added in Vault Enterprise 1.20
+			SkipIfAPIVersionLT(t, testProvider.Meta(), provider.VaultVersion120)
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testPluginConfig_entDownload(typ, name, version),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldType, typ),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldName, name),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldVersion, version),
+					resource.TestCheckResourceAttr(resourceName, fieldDownload, "true"),
+				),
+			},
+		},
+	})
+}
+
 func testPluginConfig(pluginType, name, version, sha256, command, args, env string) string {
 	return fmt.Sprintf(`
 resource "vault_plugin" "test" {
@@ -149,6 +183,17 @@ resource "vault_plugin" "test" {
   env       = %s
 }
 `, pluginType, name, version, args, env)
+}
+
+func testPluginConfig_entDownload(pluginType, name, version string) string {
+	return fmt.Sprintf(`
+resource "vault_plugin" "test" {
+  type     = "%s"
+  name     = "%s"
+  version  = "%s"
+  download = true
+}
+`, pluginType, name, version)
 }
 
 func testValidateList(resourceName, attr string, expected []string) resource.TestCheckFunc {

--- a/website/docs/r/plugin.html.md
+++ b/website/docs/r/plugin.html.md
@@ -35,6 +35,25 @@ resource "vault_plugin" "oracle" {
 }
 ```
 
+### Register an Official Enterprise plugin with automatic download
+
+On Vault Enterprise 1.20 and later, setting `download` to `true` makes Vault
+download the plugin artifact from
+[releases.hashicorp.com](https://releases.hashicorp.com) during registration,
+so the artifact does not need to be manually extracted into the server's
+`plugin_directory` beforehand. All Vault cluster nodes need outbound HTTPS
+access to `releases.hashicorp.com`. Automatic plugin downloads are currently
+a beta feature in Vault.
+
+```hcl
+resource "vault_plugin" "os" {
+  type     = "secret"
+  name     = "vault-plugin-secrets-os"
+  version  = "v0.1.0+ent"
+  download = true
+}
+```
+
 ### Register a CE plugin (version vX.Y.Z)
 
 The `sha256` and `command` are required to register a CE plugin.
@@ -65,6 +84,12 @@ The following arguments are supported:
 * `name` - (Required) Name of the plugin.
 
 * `version` - (Optional) Semantic version of the plugin. Required for official enterprise plugins.
+
+* `download` - (Optional) If `true`, Vault downloads the plugin artifact from
+  releases.hashicorp.com during registration instead of requiring it to be
+  pre-staged in the server's `plugin_directory`. Only valid for official
+  enterprise plugins (`version` ending in `+ent`). Requires Vault Enterprise
+  1.20+ (beta feature). Defaults to `false`.
 
 * `sha256` - (Optional) SHA256 sum of the plugin binary. Need to be set for non-enterprise plugin.
 


### PR DESCRIPTION
Closes #3021

### Description

Vault Enterprise 1.20+ can automatically download official enterprise plugin artifacts from releases.hashicorp.com during registration (the CLI's `-download` flag / the `download` parameter on `PUT /v1/sys/plugins/catalog/:type/:name`, currently a beta feature). The provider did not expose this, so registering an enterprise plugin failed with `extracted artifact directory not found` unless the extracted artifact was manually pre-staged in the server's `plugin_directory`.

This adds an optional `download` bool to `vault_plugin`, passed through as `api.RegisterPluginInput.Download` (already present in the vendored `vault/api` v1.23.0).

```hcl
resource "vault_plugin" "os" {
  type     = "secret"
  name     = "vault-plugin-secrets-os"
  version  = "v0.1.0+ent"
  download = true
}
```

- Validated in `CustomizeDiff`: `download` is only allowed for enterprise plugin versions (`+ent` suffix).
- Gated at write time on Vault 1.20+.
- The plugin catalog read API does not return `download`, so the configured value is kept in state (defaults to `false` on import).

### Testing

Verified end-to-end against a live Vault Enterprise 2.0.4+ent dev server with an empty `plugin_directory`: `terraform apply` registered `vault-plugin-secrets-os v0.1.0+ent` and the server downloaded and signature-verified the artifact itself (server logs: `Downloading plugin artifact` → `Downloaded plugin artifact`), followed by a clean follow-up plan. Also verified the negative case: `download = true` with a non-`+ent` version fails at plan time.

Added `TestPlugin_entDownload` acceptance test, gated on the existing `VAULT_PLUGIN_ENT_*` env vars and Vault 1.20+.

### Checklist

- [x] Added CHANGELOG entry
- [x] Acceptance tests where run against a Vault Enterprise instance
- [x] Documentation updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)