### PR TITLE
Add terraform resource for tokenization transformation for transform …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 FEATURES:
 
 * **New Ephemeral Resource**: `vault_azure_access_token` for fetching Azure OAuth2 access tokens from Vault's Azure secrets engine static role credentials. Requires Vault 2.2.0 or later. ([#2974](https://github.com/hashicorp/terraform-provider-vault/pull/2974))
+* **New Resource for tokenization transforms**: Add new resources `vault_transform_transformation_tokenization` and `vault_transform_transformation_tokenization_store` for tokenization transformations in transform secrets engine and tokenization stores. Uses [this endpoint](https://developer.hashicorp.com/vault/api-docs/secret/transform#create-update-tokenization-transformation) to support creating and updating of tokenization transformations and [this endpoint](https://developer.hashicorp.com/vault/api-docs/secret/transform#create-update-tokenization-store) for tokenization stores. Supported parameters include `name`, `mapping_mode`, `max_ttl`, `allowed_roles`, `stores`, `convergent`, `deletion_allowed` for `vault_transform_transformation_tokenization` and `name`, `type`, `driver`, `connection_string`, `username`, `password`, `supported_transformations`, `schema`, `max_open_connections`, `max_idle_connections`, `max_connection_lifetime` for `vault_transform_transformation_tokenization_store`.
 
 IMPROVEMENTS:
 
@@ -16,10 +17,6 @@ BUG FIXES:
 
 * `vault_mount`: Fix spurious `ForceNew` destroy when importing a `kv-v2` mount. Vault returns `type=kv`+`options.version=2` on import; a `DiffSuppressFunc` now suppresses the `kv`/`kv-v2` alias diff so the next plan is clean. ([#3007](https://github.com/hashicorp/terraform-provider-vault/pull/3007))
 * `vault_terraform_cloud_secret_backend`: Fix logic gap in `Read` where execution would fall through to a stray `GET <backend>/config` call after `readMount` detected the mount was deleted out-of-band and cleared the resource ID. Add `util.Is404` guard to `Delete` so that `terraform destroy` succeeds cleanly when the mount has already been removed from Vault. ([#3006](https://github.com/hashicorp/terraform-provider-vault/pull/3006))
-
-FEATURES:
-
-* **New Resource for tokenization transforms**: Add new resource `vault_transform_transformation_tokenization` for tokenization transformations in transform secrets engine. Uses [this endpoint](https://developer.hashicorp.com/vault/api-docs/secret/transform#create-update-tokenization-transformation) to support creating and updating of tokenization transformations. Supported parameters include `name`, `mapping_mode`, `max_ttl`, `allowed_roles`, `stores`, `convergent`, `deletion_allowed`.
 
 
 ## 5.11.0 (August 14, 2026)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ BUG FIXES:
 * `vault_mount`: Fix spurious `ForceNew` destroy when importing a `kv-v2` mount. Vault returns `type=kv`+`options.version=2` on import; a `DiffSuppressFunc` now suppresses the `kv`/`kv-v2` alias diff so the next plan is clean. ([#3007](https://github.com/hashicorp/terraform-provider-vault/pull/3007))
 * `vault_terraform_cloud_secret_backend`: Fix logic gap in `Read` where execution would fall through to a stray `GET <backend>/config` call after `readMount` detected the mount was deleted out-of-band and cleared the resource ID. Add `util.Is404` guard to `Delete` so that `terraform destroy` succeeds cleanly when the mount has already been removed from Vault. ([#3006](https://github.com/hashicorp/terraform-provider-vault/pull/3006))
 
+FEATURES:
+
+* **New Resource for tokenization transforms**: Add new resource `vault_transform_transformation_tokenization` for tokenization transformations in transform secrets engine. Uses [this endpoint](https://developer.hashicorp.com/vault/api-docs/secret/transform#create-update-tokenization-transformation) to support creating and updating of tokenization transformations. Supported parameters include `name`, `mapping_mode`, `max_ttl`, `allowed_roles`, `stores`, `convergent`, `deletion_allowed`.
+
 
 ## 5.11.0 (August 14, 2026)
 

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -713,6 +713,12 @@ const (
 	FieldTokenBoundCIDRs             = "token_bound_cidrs"
 	FieldLocalSecretIDs              = "local_secret_ids"
 	FieldTokenNumUses                = "token_num_uses"
+	FieldDriver                      = "driver"
+	FieldConnectionString            = "connection_string"
+	FieldSupportedTransformations    = "supported_transformations"
+	FieldMaxOpenConnections          = "max_open_connections"
+	FieldMaxIdleConnections          = "max_idle_connections"
+	FieldMaxConnectionLifetime       = "max_connection_lifetime"
 	// OS Secrets Engine fields
 	FieldSSHHostKey                = "ssh_host_key"
 	FieldSSHHostKeyTrustOnFirstUse = "ssh_host_key_trust_on_first_use"

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -783,6 +783,10 @@ var (
 			Resource:      UpdateSchemaResource(transformTransformationResource()),
 			PathInventory: []string{"/transform/transformation/{name}"},
 		},
+		"vault_transform_transformation_tokenization": {
+			Resource:      UpdateSchemaResource(transformTransformationTokenizationResource()),
+			PathInventory: []string{"/transform/transformations/tokenization/{name}"},
+		},
 		"vault_transform_template": {
 			Resource:      UpdateSchemaResource(transformTemplateResource()),
 			PathInventory: []string{"/transform/template/{name}"},

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -787,6 +787,10 @@ var (
 			Resource:      UpdateSchemaResource(transformTransformationTokenizationResource()),
 			PathInventory: []string{"/transform/transformations/tokenization/{name}"},
 		},
+		"vault_transform_transformation_tokenization_store": {
+			Resource:      UpdateSchemaResource(transformTransformationTokenizationStoreResource()),
+			PathInventory: []string{"/transform/stores/{name}"},
+		},
 		"vault_transform_template": {
 			Resource:      UpdateSchemaResource(transformTemplateResource()),
 			PathInventory: []string{"/transform/template/{name}"},

--- a/vault/resource_transform_transformation_tokenization.go
+++ b/vault/resource_transform_transformation_tokenization.go
@@ -1,0 +1,215 @@
+package vault
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+	"github.com/hashicorp/terraform-provider-vault/util"
+)
+
+const transformTransformationTokenizationEndpoint = "/transform/transformations/tokenization/{name}"
+
+func transformTransformationTokenizationResource() *schema.Resource {
+	fields := map[string]*schema.Schema{
+		consts.FieldPath: {
+			Type:        schema.TypeString,
+			Required:    true,
+			ForceNew:    true,
+			Description: `The mount path for a back-end, for example, the path given in "$ vault auth enable -path=my-aws aws".`,
+			StateFunc: func(v interface{}) string {
+				return strings.Trim(v.(string), "/")
+			},
+		},
+		consts.FieldName: {
+			Type:        schema.TypeString,
+			Description: "The name of the transformation.",
+			ForceNew:    true,
+			Required:    true,
+		},
+		consts.FieldMappingMode: {
+			Type: schema.TypeString,
+			Description: "Specifies the mapping mode for stored tokenization values. " +
+				"default is strongly recommended for highest security. " +
+				"exportable allows for all plaintexts to be decoded via the export-decoded endpoint in an emergency.",
+			Optional: true,
+			Computed: true,
+			ForceNew: true,
+		},
+		consts.FieldConvergent: {
+			Type:     schema.TypeBool,
+			Optional: true,
+			ForceNew: true,
+			Description: "Specifies whether to use convergent tokenization, where tokenization of the same plaintext more than once results in the same token. " +
+				"Defaults to false as unique tokens are more desirable from a security standpoint if there isn't a use-case need for convergence. " +
+				"This property cannot be changed after the transform is created.",
+		},
+		consts.FieldMaxTTL: {
+			Type:        schema.TypeString,
+			Description: "The maximum TTL of a token. If 0 or unspecified, tokens may have no expiration.",
+			Optional:    true,
+			Computed:    true,
+		},
+		consts.FieldAllowedRoles: {
+			Type: schema.TypeList,
+			Description: "Specifies a list of allowed roles that this transformation can be assigned to. " +
+				"A role using this transformation must exist in this list in order for encode and decode operations to properly function.",
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+			Optional: true,
+		},
+		consts.FieldStores: {
+			Type: schema.TypeList,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+			Description: "The list of tokenization stores to use for tokenization state. " +
+				"Vault's internal storage is used by default.",
+			Optional: true,
+			Computed: true,
+			ForceNew: true,
+		},
+		consts.FieldDeletionAllowed: {
+			Type: schema.TypeBool,
+			Description: " If true, this transform can be deleted. " + "Otherwise deletion is blocked while this value remains false. " +
+				"Note that deleting the transform deletes the underlying key making decoding of tokenized values impossible without restoring from a backup.",
+			Optional: true,
+		},
+	}
+	return &schema.Resource{
+		CreateContext: createTransformTransformationTokenizationResource,
+		ReadContext:   readTransformTransformationTokenizationResource,
+		DeleteContext: deleteTransformTransformationTokenizationResource,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		UpdateContext: updateTransformTransformationTokenizationResource,
+		Schema:        fields,
+	}
+}
+
+func createTransformTransformationTokenizationResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
+	path := d.Get(consts.FieldPath).(string)
+	vaultPath := util.ParsePath(path, transformTransformationTokenizationEndpoint, d)
+	log.Printf("[DEBUG] Creating %q", vaultPath)
+	data := map[string]interface{}{}
+	for _, v := range []string{consts.FieldMappingMode, consts.FieldMaxTTL, consts.FieldAllowedRoles, consts.FieldStores} {
+		if val, ok := d.GetOk(v); ok {
+			data[v] = val
+		}
+	}
+	for _, v := range []string{consts.FieldConvergent, consts.FieldDeletionAllowed} {
+		if raw, _ := d.GetRawConfigAt(cty.GetAttrPath(v)); !raw.IsNull() {
+			data[v] = d.Get(v)
+		}
+	}
+	log.Printf("[DEBUG] Writing %q", vaultPath)
+	if _, err := client.Logical().Write(vaultPath, data); err != nil {
+		return diag.Errorf("error writing %q: %s", vaultPath, err)
+	}
+	log.Printf("[DEBUG] Wrote %q", vaultPath)
+
+	d.SetId(vaultPath)
+	return readTransformTransformationTokenizationResource(ctx, d, meta)
+}
+
+func updateTransformTransformationTokenizationResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
+	vaultPath := d.Id()
+	log.Printf("[DEBUG] Updating %q", vaultPath)
+	data := map[string]interface{}{}
+	for _, v := range []string{consts.FieldMaxTTL, consts.FieldAllowedRoles} {
+		if val, ok := d.GetOk(v); ok {
+			data[v] = val
+		}
+	}
+	if raw, _ := d.GetRawConfigAt(cty.GetAttrPath(consts.FieldDeletionAllowed)); !raw.IsNull() {
+		data[consts.FieldDeletionAllowed] = d.Get(consts.FieldDeletionAllowed)
+	}
+	log.Printf("[DEBUG] Writing %q", vaultPath)
+	if _, err := client.Logical().Write(vaultPath, data); err != nil {
+		return diag.Errorf("error writing %q: %s", vaultPath, err)
+	}
+	log.Printf("[DEBUG] Wrote %q", vaultPath)
+
+	d.SetId(vaultPath)
+	return readTransformTransformationTokenizationResource(ctx, d, meta)
+}
+
+func readTransformTransformationTokenizationResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
+
+	vaultPath := d.Id()
+	log.Printf("[DEBUG] Reading from %q", vaultPath)
+	resp, err := client.Logical().Read(vaultPath)
+	if err != nil {
+		return diag.Errorf("error reading %q: %s", vaultPath, err)
+	}
+	if resp == nil {
+		log.Printf("[WARN] %q not found, removing from state", vaultPath)
+		d.SetId("")
+		return nil
+	}
+
+	pathParams, err := util.PathParameters(transformTransformationTokenizationEndpoint, vaultPath)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	for paramName, paramVal := range pathParams {
+		if err := d.Set(paramName, paramVal); err != nil {
+			return diag.Errorf("error setting state %q, %q: %s", paramName, paramVal, err)
+		}
+	}
+	fields := []string{
+		consts.FieldMappingMode,
+		consts.FieldConvergent,
+		consts.FieldMaxTTL,
+		consts.FieldAllowedRoles,
+		consts.FieldStores,
+		consts.FieldDeletionAllowed,
+	}
+	for _, field := range fields {
+		if val, ok := resp.Data[field]; ok {
+			if err := d.Set(field, val); err != nil {
+				return diag.Errorf("error setting state key %q: %s", field, err)
+			}
+		}
+	}
+	return nil
+}
+
+func deleteTransformTransformationTokenizationResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
+	vaultPath := d.Id()
+	log.Printf("[DEBUG] Deleting %q", vaultPath)
+
+	if _, err := client.Logical().Delete(vaultPath); err != nil && !util.Is404(err) {
+		return diag.Errorf("Error deleting %q: %s", vaultPath, err)
+	} else if err != nil {
+		log.Printf("[DEBUG] %q not found, removing from state", vaultPath)
+		d.SetId("")
+		return nil
+	}
+
+	log.Printf("[DEBUG] Deleted tokenization transformation at: %q", vaultPath)
+	return nil
+}

--- a/vault/resource_transform_transformation_tokenization.go
+++ b/vault/resource_transform_transformation_tokenization.go
@@ -176,21 +176,20 @@ func readTransformTransformationTokenizationResource(ctx context.Context, d *sch
 			return diag.Errorf("error setting state %q, %q: %s", paramName, paramVal, err)
 		}
 	}
-	fields := []string{
-		consts.FieldMappingMode,
-		consts.FieldConvergent,
-		consts.FieldMaxTTL,
-		consts.FieldAllowedRoles,
-		consts.FieldStores,
-		consts.FieldDeletionAllowed,
-	}
-	for _, field := range fields {
+	// These fields are returned by Vault, read them normally.
+	for _, field := range []string{consts.FieldMappingMode, consts.FieldMaxTTL, consts.FieldAllowedRoles, consts.FieldStores, consts.FieldDeletionAllowed} {
 		if val, ok := resp.Data[field]; ok {
 			if err := d.Set(field, val); err != nil {
 				return diag.Errorf("error setting state key %q: %s", field, err)
 			}
 		}
 	}
+
+	// convergent is not returned by Vault, preserve existing state value.
+	if err := d.Set(consts.FieldConvergent, d.Get(consts.FieldConvergent)); err != nil {
+		return diag.Errorf("error setting state key %q: %s", consts.FieldConvergent, err)
+	}
+
 	return nil
 }
 

--- a/vault/resource_transform_transformation_tokenization.go
+++ b/vault/resource_transform_transformation_tokenization.go
@@ -50,7 +50,7 @@ func transformTransformationTokenizationResource() *schema.Resource {
 				"This property cannot be changed after the transform is created.",
 		},
 		consts.FieldMaxTTL: {
-			Type:        schema.TypeString,
+			Type:        schema.TypeInt,
 			Description: "The maximum TTL of a token. If 0 or unspecified, tokens may have no expiration.",
 			Optional:    true,
 			Computed:    true,
@@ -77,7 +77,7 @@ func transformTransformationTokenizationResource() *schema.Resource {
 		},
 		consts.FieldDeletionAllowed: {
 			Type: schema.TypeBool,
-			Description: " If true, this transform can be deleted. " + "Otherwise deletion is blocked while this value remains false. " +
+			Description: "If true, this transform can be deleted. " + "Otherwise deletion is blocked while this value remains false. " +
 				"Note that deleting the transform deletes the underlying key making decoding of tokenized values impossible without restoring from a backup.",
 			Optional: true,
 		},

--- a/vault/resource_transform_transformation_tokenization.go
+++ b/vault/resource_transform_transformation_tokenization.go
@@ -84,7 +84,7 @@ func transformTransformationTokenizationResource() *schema.Resource {
 	}
 	return &schema.Resource{
 		CreateContext: createTransformTransformationTokenizationResource,
-		ReadContext:   readTransformTransformationTokenizationResource,
+		ReadContext:   provider.ReadContextWrapper(readTransformTransformationTokenizationResource),
 		DeleteContext: deleteTransformTransformationTokenizationResource,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -103,12 +103,12 @@ func createTransformTransformationTokenizationResource(ctx context.Context, d *s
 	vaultPath := util.ParsePath(path, transformTransformationTokenizationEndpoint, d)
 	log.Printf("[DEBUG] Creating %q", vaultPath)
 	data := map[string]interface{}{}
-	for _, v := range []string{consts.FieldMappingMode, consts.FieldMaxTTL, consts.FieldAllowedRoles, consts.FieldStores} {
+	for _, v := range []string{consts.FieldMappingMode, consts.FieldStores} {
 		if val, ok := d.GetOk(v); ok {
 			data[v] = val
 		}
 	}
-	for _, v := range []string{consts.FieldConvergent, consts.FieldDeletionAllowed} {
+	for _, v := range []string{consts.FieldAllowedRoles, consts.FieldMaxTTL, consts.FieldConvergent, consts.FieldDeletionAllowed} {
 		if raw, _ := d.GetRawConfigAt(cty.GetAttrPath(v)); !raw.IsNull() {
 			data[v] = d.Get(v)
 		}
@@ -132,8 +132,8 @@ func updateTransformTransformationTokenizationResource(ctx context.Context, d *s
 	log.Printf("[DEBUG] Updating %q", vaultPath)
 	data := map[string]interface{}{}
 	for _, v := range []string{consts.FieldMaxTTL, consts.FieldAllowedRoles} {
-		if val, ok := d.GetOk(v); ok {
-			data[v] = val
+		if raw, _ := d.GetRawConfigAt(cty.GetAttrPath(v)); !raw.IsNull() {
+			data[v] = d.Get(v)
 		}
 	}
 	if raw, _ := d.GetRawConfigAt(cty.GetAttrPath(consts.FieldDeletionAllowed)); !raw.IsNull() {

--- a/vault/resource_transform_transformation_tokenization_test.go
+++ b/vault/resource_transform_transformation_tokenization_test.go
@@ -50,7 +50,7 @@ func TestAccTransformTransformationTokenization_WithFields(t *testing.T) {
 		CheckDestroy:             transformTransformationTokenizationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: transformTokenizationWithFieldsConfig(path, "tkn_transform", "default", "payments", 86400),
+				Config: transformTokenizationWithFieldsConfig(path, "tkn_transform", "default", "payments", 86400, "builtin/internal"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldName, "tkn_transform"),
@@ -59,17 +59,18 @@ func TestAccTransformTransformationTokenization_WithFields(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, consts.FieldAllowedRoles+".0", "payments"),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldMaxTTL, "86400"),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldDeletionAllowed, "true"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldStores+".0", "builtin/internal"),
 				),
 			},
 			{
-				Config: transformTokenizationWithFieldsConfig(path, "tkn_transform", "default", "payments-updated", 172800),
+				Config: transformTokenizationWithFieldsConfig(path, "tkn_transform", "default", "payments-updated", 172800, "builtin/internal"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, consts.FieldAllowedRoles+".0", "payments-updated"),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldMaxTTL, "172800"),
 				),
 			},
 			{
-				Config: transformTokenizationWithFieldsConfig(path, "tkn_transform", "default", "payments-updated", 172800),
+				Config: transformTokenizationWithFieldsConfig(path, "tkn_transform", "default", "payments-updated", 172800, "builtin/internal"),
 				ConfigPlanChecks: resource.ConfigPlanChecks{
 					PreApply: []plancheck.PlanCheck{
 						plancheck.ExpectEmptyPlan(),
@@ -149,7 +150,7 @@ resource "vault_transform_transformation_tokenization" "default_transform" {
 }`, path, name)
 }
 
-func transformTokenizationWithFieldsConfig(path, name, mappingMode, allowedRole string, maxTTL int) string {
+func transformTokenizationWithFieldsConfig(path, name, mappingMode, allowedRole string, maxTTL int, store string) string {
 	return fmt.Sprintf(`
 resource "vault_mount" "mount_transform" {
   path = "%s"
@@ -162,8 +163,9 @@ resource "vault_transform_transformation_tokenization" "test" {
   mapping_mode     = "%s"
   allowed_roles    = ["%s"]
   max_ttl          = %d
+  stores = ["%s"]
   deletion_allowed = true
-}`, path, name, mappingMode, allowedRole, maxTTL)
+}`, path, name, mappingMode, allowedRole, maxTTL, store)
 }
 
 func transformTokenizationConvergentConfig(path, name string, convergent bool) string {

--- a/vault/resource_transform_transformation_tokenization_test.go
+++ b/vault/resource_transform_transformation_tokenization_test.go
@@ -127,10 +127,10 @@ func transformTransformationTokenizationDestroy(s *terraform.State) error {
 		}
 		secret, err := client.Logical().Read(rs.Primary.ID)
 		if err != nil {
-			return fmt.Errorf("error checking for role %q: %s", rs.Primary.ID, err)
+			return fmt.Errorf("error checking for transformation %q: %s", rs.Primary.ID, err)
 		}
 		if secret != nil {
-			return fmt.Errorf("role %q still exists", rs.Primary.ID)
+			return fmt.Errorf("transformation %q still exists", rs.Primary.ID)
 		}
 	}
 	return nil

--- a/vault/resource_transform_transformation_tokenization_test.go
+++ b/vault/resource_transform_transformation_tokenization_test.go
@@ -1,0 +1,178 @@
+package vault
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-vault/acctestutil"
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+)
+
+func TestAccTransformTransformationTokenization(t *testing.T) {
+	t.Parallel()
+
+	path := acctest.RandomWithPrefix("transform")
+	resourceName := "vault_transform_transformation_tokenization.default_transform"
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctestutil.PreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		CheckDestroy:             transformTransformationTokenizationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: defaultTransformTokenizationConfig(path, "tkn_transform"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldName, "tkn_transform"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccTransformTransformationTokenization_WithFields(t *testing.T) {
+	t.Parallel()
+
+	path := acctest.RandomWithPrefix("transform")
+	resourceName := "vault_transform_transformation_tokenization.test"
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctestutil.PreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		CheckDestroy:             transformTransformationTokenizationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: transformTokenizationWithFieldsConfig(path, "tkn_transform", "default", "payments", "86400"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldName, "tkn_transform"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldMappingMode, "default"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldAllowedRoles+".#", "1"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldAllowedRoles+".0", "payments"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldMaxTTL, "86400"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldDeletionAllowed, "true"),
+				),
+			},
+			{
+				Config: transformTokenizationWithFieldsConfig(path, "tkn_transform", "default", "payments-updated", "172800"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldAllowedRoles+".0", "payments-updated"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldMaxTTL, "172800"),
+				),
+			},
+			{
+				Config:   transformTokenizationWithFieldsConfig(path, "tkn_transform", "default", "payments-updated", "172800"),
+				PlanOnly: true,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccTransformTransformationTokenization_Convergent(t *testing.T) {
+	t.Parallel()
+
+	path := acctest.RandomWithPrefix("transform")
+	resourceName := "vault_transform_transformation_tokenization.test"
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctestutil.PreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		CheckDestroy:             transformTransformationTokenizationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: transformTokenizationConvergentConfig(path, "tkn_convergent", true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldName, "tkn_convergent"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldConvergent, "true"),
+				),
+			},
+			{
+				Config: transformTokenizationConvergentConfig(path, "tkn_convergent", false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldName, "tkn_convergent"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldConvergent, "false"),
+				),
+			},
+		},
+	})
+}
+
+func transformTransformationTokenizationDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "vault_transform_transformation_tokenization" {
+			continue
+		}
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+		secret, err := client.Logical().Read(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error checking for role %q: %s", rs.Primary.ID, err)
+		}
+		if secret != nil {
+			return fmt.Errorf("role %q still exists", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func defaultTransformTokenizationConfig(path, name string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "mount_transform" {
+  path = "%s"
+  type = "transform"
+}
+
+resource "vault_transform_transformation_tokenization" "default_transform" {
+  path             = vault_mount.mount_transform.path
+  name             = "%s"
+  deletion_allowed = true
+}`, path, name)
+}
+
+func transformTokenizationWithFieldsConfig(path, name, mappingMode, allowedRole, maxTTL string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "mount_transform" {
+  path = "%s"
+  type = "transform"
+}
+
+resource "vault_transform_transformation_tokenization" "test" {
+  path             = vault_mount.mount_transform.path
+  name             = "%s"
+  mapping_mode     = "%s"
+  allowed_roles    = ["%s"]
+  max_ttl          = "%s"
+  deletion_allowed = true
+}`, path, name, mappingMode, allowedRole, maxTTL)
+}
+
+func transformTokenizationConvergentConfig(path, name string, convergent bool) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "mount_transform" {
+  path = "%s"
+  type = "transform"
+}
+
+resource "vault_transform_transformation_tokenization" "test" {
+  path             = vault_mount.mount_transform.path
+  name             = "%s"
+  convergent       = %t
+  deletion_allowed = true
+}`, path, name, convergent)
+}

--- a/vault/resource_transform_transformation_tokenization_test.go
+++ b/vault/resource_transform_transformation_tokenization_test.go
@@ -20,7 +20,7 @@ func TestAccTransformTransformationTokenization(t *testing.T) {
 	path := acctest.RandomWithPrefix("transform")
 	resourceName := "vault_transform_transformation_tokenization.default_transform"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctestutil.PreCheck(t) },
+		PreCheck:                 func() { acctestutil.TestEntPreCheck(t) },
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		CheckDestroy:             transformTransformationTokenizationDestroy,
 		Steps: []resource.TestStep{
@@ -44,7 +44,7 @@ func TestAccTransformTransformationTokenization_WithFields(t *testing.T) {
 	path := acctest.RandomWithPrefix("transform")
 	resourceName := "vault_transform_transformation_tokenization.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctestutil.PreCheck(t) },
+		PreCheck:                 func() { acctestutil.TestEntPreCheck(t) },
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		CheckDestroy:             transformTransformationTokenizationDestroy,
 		Steps: []resource.TestStep{
@@ -88,7 +88,7 @@ func TestAccTransformTransformationTokenization_Convergent(t *testing.T) {
 	path := acctest.RandomWithPrefix("transform")
 	resourceName := "vault_transform_transformation_tokenization.test"
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:                 func() { acctestutil.PreCheck(t) },
+		PreCheck:                 func() { acctestutil.TestEntPreCheck(t) },
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		CheckDestroy:             transformTransformationTokenizationDestroy,
 		Steps: []resource.TestStep{

--- a/vault/resource_transform_transformation_tokenization_test.go
+++ b/vault/resource_transform_transformation_tokenization_test.go
@@ -32,9 +32,10 @@ func TestAccTransformTransformationTokenization(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{consts.FieldConvergent},
 			},
 		},
 	})
@@ -76,9 +77,10 @@ func TestAccTransformTransformationTokenization_WithFields(t *testing.T) {
 				},
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{consts.FieldConvergent},
 			},
 		},
 	})

--- a/vault/resource_transform_transformation_tokenization_test.go
+++ b/vault/resource_transform_transformation_tokenization_test.go
@@ -7,18 +7,19 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/hashicorp/terraform-provider-vault/acctestutil"
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 )
 
 func TestAccTransformTransformationTokenization(t *testing.T) {
-	t.Parallel()
-
 	path := acctest.RandomWithPrefix("transform")
 	resourceName := "vault_transform_transformation_tokenization.default_transform"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctestutil.PreCheck(t) },
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		CheckDestroy:             transformTransformationTokenizationDestroy,
@@ -40,17 +41,15 @@ func TestAccTransformTransformationTokenization(t *testing.T) {
 }
 
 func TestAccTransformTransformationTokenization_WithFields(t *testing.T) {
-	t.Parallel()
-
 	path := acctest.RandomWithPrefix("transform")
 	resourceName := "vault_transform_transformation_tokenization.test"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctestutil.PreCheck(t) },
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		CheckDestroy:             transformTransformationTokenizationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: transformTokenizationWithFieldsConfig(path, "tkn_transform", "default", "payments", "86400"),
+				Config: transformTokenizationWithFieldsConfig(path, "tkn_transform", "default", "payments", 86400),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldName, "tkn_transform"),
@@ -62,15 +61,19 @@ func TestAccTransformTransformationTokenization_WithFields(t *testing.T) {
 				),
 			},
 			{
-				Config: transformTokenizationWithFieldsConfig(path, "tkn_transform", "default", "payments-updated", "172800"),
+				Config: transformTokenizationWithFieldsConfig(path, "tkn_transform", "default", "payments-updated", 172800),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, consts.FieldAllowedRoles+".0", "payments-updated"),
 					resource.TestCheckResourceAttr(resourceName, consts.FieldMaxTTL, "172800"),
 				),
 			},
 			{
-				Config:   transformTokenizationWithFieldsConfig(path, "tkn_transform", "default", "payments-updated", "172800"),
-				PlanOnly: true,
+				Config: transformTokenizationWithFieldsConfig(path, "tkn_transform", "default", "payments-updated", 172800),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
 			},
 			{
 				ResourceName:      resourceName,
@@ -82,11 +85,9 @@ func TestAccTransformTransformationTokenization_WithFields(t *testing.T) {
 }
 
 func TestAccTransformTransformationTokenization_Convergent(t *testing.T) {
-	t.Parallel()
-
 	path := acctest.RandomWithPrefix("transform")
 	resourceName := "vault_transform_transformation_tokenization.test"
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 func() { acctestutil.PreCheck(t) },
 		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
 		CheckDestroy:             transformTransformationTokenizationDestroy,
@@ -101,11 +102,12 @@ func TestAccTransformTransformationTokenization_Convergent(t *testing.T) {
 			},
 			{
 				Config: transformTokenizationConvergentConfig(path, "tkn_convergent", false),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
-					resource.TestCheckResourceAttr(resourceName, consts.FieldName, "tkn_convergent"),
-					resource.TestCheckResourceAttr(resourceName, consts.FieldConvergent, "false"),
-				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionDestroyBeforeCreate),
+						plancheck.ExpectKnownValue(resourceName, tfjsonpath.New(consts.FieldConvergent), knownvalue.Bool(false)),
+					},
+				},
 			},
 		},
 	})
@@ -145,7 +147,7 @@ resource "vault_transform_transformation_tokenization" "default_transform" {
 }`, path, name)
 }
 
-func transformTokenizationWithFieldsConfig(path, name, mappingMode, allowedRole, maxTTL string) string {
+func transformTokenizationWithFieldsConfig(path, name, mappingMode, allowedRole string, maxTTL int) string {
 	return fmt.Sprintf(`
 resource "vault_mount" "mount_transform" {
   path = "%s"
@@ -157,7 +159,7 @@ resource "vault_transform_transformation_tokenization" "test" {
   name             = "%s"
   mapping_mode     = "%s"
   allowed_roles    = ["%s"]
-  max_ttl          = "%s"
+  max_ttl          = %d
   deletion_allowed = true
 }`, path, name, mappingMode, allowedRole, maxTTL)
 }

--- a/vault/resource_transformation_tokenization_store.go
+++ b/vault/resource_transformation_tokenization_store.go
@@ -1,0 +1,194 @@
+package vault
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+	"github.com/hashicorp/terraform-provider-vault/util"
+)
+
+const transformTransformationTokenizationStoreEndpoint = "/transform/stores/{name}"
+
+func transformTransformationTokenizationStoreResource() *schema.Resource {
+	fields := map[string]*schema.Schema{
+		consts.FieldPath: {
+			Type:        schema.TypeString,
+			Required:    true,
+			ForceNew:    true,
+			Description: `The mount path for a back-end, for example, the path given in "$ vault auth enable -path=my-aws aws".`,
+			StateFunc: func(v interface{}) string {
+				return strings.Trim(v.(string), "/")
+			},
+		},
+		consts.FieldName: {
+			Type:        schema.TypeString,
+			Description: "The name of the store.",
+			ForceNew:    true,
+			Required:    true,
+		},
+		consts.FieldType: {
+			Type:        schema.TypeString,
+			Description: `Specifies the type of store, currently only "sql" is supported,`,
+			Required:    true,
+		},
+		consts.FieldDriver: {
+			Type: schema.TypeString,
+			Description: "Specifies the database driver to use, and thus which SQL database type. " +
+				"Currently the supported options are postgres, mysql, and mssql.",
+			Required: true,
+		},
+		consts.FieldConnectionString: {
+			Type: schema.TypeString,
+			Description: "A database connection string with template slots for username and password that Vault will use for locating and connecting to a database. " +
+				"Each database driver type has a different syntax for its connection strings.",
+			Required: true,
+		},
+		consts.FieldUsername: {
+			Type:        schema.TypeString,
+			Description: "Username value to use to connect to database.",
+			Required:    true,
+		},
+		consts.FieldPassword: {
+			Type:        schema.TypeString,
+			Description: "Password value to use to connect to database.",
+			Required:    true,
+			Sensitive:   true,
+		},
+		consts.FieldSupportedTransformations: {
+			Type:        schema.TypeList,
+			Description: `The types of transformations this store can support, currently only "tokenization" is supported.`,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+			Optional: true,
+			Computed: true,
+		},
+		consts.FieldSchema: {
+			Type:        schema.TypeString,
+			Description: `The schema within the database to expect tokenization state tables. Default is "public".`,
+			Optional:    true,
+		},
+		consts.FieldMaxOpenConnections: {
+			Type:        schema.TypeInt,
+			Description: "The maximum number of connections to the database at any given time. Default is 4.",
+			Optional:    true,
+		},
+		consts.FieldMaxIdleConnections: {
+			Type:        schema.TypeInt,
+			Description: "The maximum number of idle connections to the database at any given time. Default is 4.",
+			Optional:    true,
+		},
+		consts.FieldMaxConnectionLifetime: {
+			Type: schema.TypeInt,
+			Description: "The maximum amount of time a connection can be open before closing it. " +
+				"0 means no limit. Default is 0.",
+			Optional: true,
+		},
+	}
+	return &schema.Resource{
+		Schema:        fields,
+		ReadContext:   provider.ReadContextWrapper(readTransformTransformationTokenizationStoreResource),
+		CreateContext: createUpdateTransformTransformationTokenizationStoreResource,
+		UpdateContext: createUpdateTransformTransformationTokenizationStoreResource,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		DeleteContext: deleteTransformTransformationTokenizationStoreResource,
+	}
+}
+
+func createUpdateTransformTransformationTokenizationStoreResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
+	path := d.Get(consts.FieldPath).(string)
+	vaultPath := util.ParsePath(path, transformTransformationTokenizationStoreEndpoint, d)
+	log.Printf("[DEBUG] Creating/Updating %q", vaultPath)
+	data := map[string]interface{}{}
+	for _, v := range []string{consts.FieldType, consts.FieldDriver, consts.FieldConnectionString, consts.FieldUsername, consts.FieldPassword, consts.FieldSupportedTransformations, consts.FieldSchema, consts.FieldMaxOpenConnections, consts.FieldMaxIdleConnections, consts.FieldMaxConnectionLifetime} {
+		if val, ok := d.GetOk(v); ok {
+			data[v] = val
+		}
+	}
+	log.Printf("[DEBUG] Writing %q", vaultPath)
+	if _, err := client.Logical().Write(vaultPath, data); err != nil {
+		return diag.Errorf("error writing %q: %s", vaultPath, err)
+	}
+	log.Printf("[DEBUG] Wrote %q", vaultPath)
+
+	d.SetId(vaultPath)
+	return readTransformTransformationTokenizationStoreResource(ctx, d, meta)
+}
+
+func readTransformTransformationTokenizationStoreResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
+
+	vaultPath := d.Id()
+	log.Printf("[DEBUG] Reading %q", vaultPath)
+	resp, err := client.Logical().Read(vaultPath)
+	if err != nil {
+		return diag.Errorf("error reading %q: %s", vaultPath, err)
+	}
+	if resp == nil {
+		log.Printf("[WARN] %q not found, removing from state", vaultPath)
+		d.SetId("")
+		return nil
+	}
+
+	pathParams, err := util.PathParameters(transformTransformationTokenizationStoreEndpoint, vaultPath)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	for paramName, paramVal := range pathParams {
+		if err := d.Set(paramName, paramVal); err != nil {
+			return diag.Errorf("error setting state %q, %q: %s", paramName, paramVal, err)
+		}
+	}
+
+	// fields returned by vault
+	for _, field := range []string{consts.FieldConnectionString, consts.FieldDriver, consts.FieldSupportedTransformations} {
+		if val, ok := resp.Data[field]; ok {
+			if err := d.Set(field, val); err != nil {
+				return diag.Errorf("error setting state key %q: %s", field, err)
+			}
+		}
+	}
+
+	// fields that aren't returned by vault,
+	for _, field := range []string{consts.FieldType, consts.FieldUsername, consts.FieldPassword, consts.FieldSchema, consts.FieldMaxOpenConnections, consts.FieldMaxIdleConnections, consts.FieldMaxConnectionLifetime} {
+		if err := d.Set(field, d.Get(field)); err != nil {
+			return diag.Errorf("error setting state key %q: %s", field, err)
+		}
+	}
+
+	return nil
+}
+
+func deleteTransformTransformationTokenizationStoreResource(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client, e := provider.GetClient(d, meta)
+	if e != nil {
+		return diag.FromErr(e)
+	}
+	vaultPath := d.Id()
+	log.Printf("[DEBUG] Deleting %q", vaultPath)
+
+	if _, err := client.Logical().Delete(vaultPath); err != nil && !util.Is404(err) {
+		return diag.Errorf("Error deleting %q: %s", vaultPath, err)
+	} else if err != nil {
+		log.Printf("[DEBUG] %q not found, removing from state", vaultPath)
+		d.SetId("")
+		return nil
+	}
+
+	log.Printf("[DEBUG] Deleted tokenization transformation store at: %q", vaultPath)
+	return nil
+}

--- a/vault/resource_transformation_tokenization_store_test.go
+++ b/vault/resource_transformation_tokenization_store_test.go
@@ -1,0 +1,178 @@
+package vault
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-provider-vault/acctestutil"
+	"github.com/hashicorp/terraform-provider-vault/internal/consts"
+	"github.com/hashicorp/terraform-provider-vault/internal/provider"
+)
+
+const (
+	testTokenizationStorePostgresConnURL = "postgresql://vaultuser:vaultpass@127.0.0.1:5432/vault?sslmode=disable"
+	testTokenizationStoreMysqlConnURL    = "vaultuser:vaultpass@tcp(127.0.0.1:3306)/vault"
+)
+
+func TestAccTransformTokenizationStore_postgres(t *testing.T) {
+	path := acctest.RandomWithPrefix("transform")
+	resourceName := "vault_transform_transformation_tokenization_store.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctestutil.TestEntPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		CheckDestroy:             transformTokenizationStoreDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: transformTokenizationStorePostgresConfig(path, "test-store"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldName, "test-store"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldType, "sql"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldDriver, "postgres"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldConnectionString, testTokenizationStorePostgresConnURL),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldSupportedTransformations+".#", "1"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldSupportedTransformations+".0", "tokenization"),
+				),
+			},
+			// Update mutable fields
+			{
+				Config: transformTokenizationStorePostgresConfigWithOptions(path, "test-store", 10, 5),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldMaxOpenConnections, "10"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldMaxIdleConnections, "5"),
+				),
+			},
+			// Idempotency check
+			{
+				Config: transformTokenizationStorePostgresConfigWithOptions(path, "test-store", 10, 5),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{consts.FieldType, consts.FieldUsername, consts.FieldPassword, consts.FieldSchema, consts.FieldMaxOpenConnections, consts.FieldMaxIdleConnections, consts.FieldMaxConnectionLifetime},
+			},
+		},
+	})
+}
+
+func TestAccTransformTokenizationStore_mysql(t *testing.T) {
+	path := acctest.RandomWithPrefix("transform")
+	resourceName := "vault_transform_transformation_tokenization_store.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 func() { acctestutil.TestEntPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories(context.Background(), t),
+		CheckDestroy:             transformTokenizationStoreDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: transformTokenizationStoreMysqlConfig(path, "test-store"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldPath, path),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldName, "test-store"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldType, "sql"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldDriver, "mysql"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldConnectionString, testTokenizationStoreMysqlConnURL),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldSupportedTransformations+".#", "1"),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldSupportedTransformations+".0", "tokenization"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{consts.FieldType, consts.FieldUsername, consts.FieldPassword, consts.FieldSchema, consts.FieldMaxOpenConnections, consts.FieldMaxIdleConnections, consts.FieldMaxConnectionLifetime},
+			},
+		},
+	})
+}
+
+func transformTokenizationStoreDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "vault_transform_transformation_tokenization_store" {
+			continue
+		}
+		client, e := provider.GetClient(rs.Primary, testProvider.Meta())
+		if e != nil {
+			return e
+		}
+		secret, err := client.Logical().Read(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error checking for store %q: %s", rs.Primary.ID, err)
+		}
+		if secret != nil {
+			return fmt.Errorf("store %q still exists", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func transformTokenizationStorePostgresConfig(path, name string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "mount_transform" {
+  path = "%s"
+  type = "transform"
+}
+
+resource "vault_transform_transformation_tokenization_store" "test" {
+  path                      = vault_mount.mount_transform.path
+  name                      = "%s"
+  type                      = "sql"
+  driver                    = "postgres"
+  connection_string         = "%s"
+  username                  = "vaultuser"
+  password                  = "vaultpass"
+  supported_transformations = ["tokenization"]
+}`, path, name, testTokenizationStorePostgresConnURL)
+}
+
+func transformTokenizationStorePostgresConfigWithOptions(path, name string, maxOpen, maxIdle int) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "mount_transform" {
+  path = "%s"
+  type = "transform"
+}
+
+resource "vault_transform_transformation_tokenization_store" "test" {
+  path                      = vault_mount.mount_transform.path
+  name                      = "%s"
+  type                      = "sql"
+  driver                    = "postgres"
+  connection_string         = "%s"
+  username                  = "vaultuser"
+  password                  = "vaultpass"
+  supported_transformations = ["tokenization"]
+  max_open_connections      = %d
+  max_idle_connections      = %d
+}`, path, name, testTokenizationStorePostgresConnURL, maxOpen, maxIdle)
+}
+
+func transformTokenizationStoreMysqlConfig(path, name string) string {
+	return fmt.Sprintf(`
+resource "vault_mount" "mount_transform" {
+  path = "%s"
+  type = "transform"
+}
+
+resource "vault_transform_transformation_tokenization_store" "test" {
+  path                      = vault_mount.mount_transform.path
+  name                      = "%s"
+  type                      = "sql"
+  driver                    = "mysql"
+  connection_string         = "%s"
+  username                  = "vaultuser"
+  password                  = "vaultpass"
+  supported_transformations = ["tokenization"]
+}`, path, name, testTokenizationStoreMysqlConnURL)
+}

--- a/website/docs/r/transform_transformation_tokenization.html.md
+++ b/website/docs/r/transform_transformation_tokenization.html.md
@@ -54,3 +54,13 @@ The following arguments are supported:
 * `stores` - (Optional) The list of tokenization stores to use for tokenization state. Default is `["builtin/internal"]`.
   **Note:** This field is immutable and cannot be changed after creation. Changing this value will force recreation of the resource.
 * `deletion_allowed` - (Optional) If true, this transform can be deleted. Otherwise deletion is blocked while this value remains false. Note that deleting the transform deletes the underlying key, making decoding of tokenized values impossible without restoring from a backup. Default is `false`.
+
+## Import
+
+Transform tokenization transformations can be imported using `path/name`, e.g.
+
+```
+$ terraform import vault_transform_transformation_tokenization.example transform/transformations/tokenization/tkn-example
+```
+
+Note that the `convergent` field cannot be recovered from Vault on import and will be empty after import.

--- a/website/docs/r/transform_transformation_tokenization.html.md
+++ b/website/docs/r/transform_transformation_tokenization.html.md
@@ -23,7 +23,7 @@ resource "vault_mount" "example" {
 resource "vault_transform_transformation_tokenization" "example" {
   path             = vault_mount.example.path
   name             = "tkn-example"
-  max_ttl          = "86400"
+  max_ttl          = 86400
   deletion_allowed = true
   mapping_mode     = "default"
   allowed_roles    = ["payments"]
@@ -48,7 +48,7 @@ The following arguments are supported:
 * `convergent` - (Optional) Specifies whether to use convergent tokenization, where tokenization of
   the same plaintext more than once results in the same token. Default is `false`.
   **Note:** This field is immutable and cannot be changed after creation. Changing this value will force recreation of the resource.
-* `max_ttl` - (Optional) The maximum TTL of a token. If `"0"` or unspecified, tokens may have no expiration. Default is `"0"`.
+* `max_ttl` - (Optional) The maximum TTL of a token. If `0` or unspecified, tokens may have no expiration. Default is `0`.
 * `allowed_roles` - (Optional) Specifies a list of allowed roles that this transformation can be assigned to.
   A role using this transformation must exist in this list in order for encode and decode operations to properly function. Default is `[]`.
 * `stores` - (Optional) The list of tokenization stores to use for tokenization state. Default is `["builtin/internal"]`.

--- a/website/docs/r/transform_transformation_tokenization.html.md
+++ b/website/docs/r/transform_transformation_tokenization.html.md
@@ -1,0 +1,56 @@
+---
+layout: "vault"
+page_title: "Vault: vault_transform_transformation_tokenization resource"
+sidebar_current: "docs-vault-resource-transform-transformation-tokenization"
+description: |-
+  "/transform/transformations/tokenization/{name}"
+---
+
+# vault\_transform\_transformation\_tokenization
+
+This resource supports the "/transform/transformations/tokenization/{name}" Vault endpoint.
+
+If a tokenization transformation with the given name doesn't exist, it will be created. If a tokenization transformation with the given name exists, it will be updated with the new attributes.
+
+## Example Usage
+
+```hcl
+resource "vault_mount" "example" {
+  path = "transform"
+  type = "transform"
+}
+
+resource "vault_transform_transformation_tokenization" "example" {
+  path             = vault_mount.example.path
+  name             = "tkn-example"
+  max_ttl          = "86400"
+  deletion_allowed = true
+  mapping_mode     = "default"
+  allowed_roles    = ["payments"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
+  *Available only for Vault Enterprise*.
+
+* `path` - (Required) Path to where the back-end is mounted within Vault.
+* `name` - (Required) Name of the transformation to create/update.
+* `mapping_mode` - (Optional) Specifies the mapping mode for stored tokenization values.
+  Can be `"default"` or `"exportable"`. `"default"` is strongly recommended for highest security.
+  `"exportable"` allows for all plaintexts to be decoded via the export-decoded endpoint in an emergency.
+  **Note:** This field is immutable and cannot be changed after creation. Changing this value will force recreation of the resource.
+* `convergent` - (Optional) Specifies whether to use convergent tokenization, where tokenization of
+  the same plaintext more than once results in the same token. Default is `false`.
+  **Note:** This field is immutable and cannot be changed after creation. Changing this value will force recreation of the resource.
+* `max_ttl` - (Optional) The maximum TTL of a token. If `"0"` or unspecified, tokens may have no expiration. Default is `"0"`.
+* `allowed_roles` - (Optional) Specifies a list of allowed roles that this transformation can be assigned to.
+  A role using this transformation must exist in this list in order for encode and decode operations to properly function. Default is `[]`.
+* `stores` - (Optional) The list of tokenization stores to use for tokenization state. Default is `["builtin/internal"]`.
+  **Note:** This field is immutable and cannot be changed after creation. Changing this value will force recreation of the resource.
+* `deletion_allowed` - (Optional) If true, this transform can be deleted. Otherwise deletion is blocked while this value remains false. Note that deleting the transform deletes the underlying key, making decoding of tokenized values impossible without restoring from a backup. Default is `false`.

--- a/website/docs/r/transform_transformation_tokenization_store.html.md
+++ b/website/docs/r/transform_transformation_tokenization_store.html.md
@@ -63,3 +63,13 @@ The following arguments are supported:
 * `max_idle_connections` - (Optional) The maximum number of idle connections to the database at any given time. Default is `4`.
 * `max_connection_lifetime` - (Optional) The maximum amount of time a connection can be open before closing it. 0 means no limit. Default is `0`.
 
+## Import
+
+Transform tokenization stores can be imported using `path/name`, e.g.
+
+```
+$ terraform import vault_transform_transformation_tokenization_store.example transform/stores/my-store
+```
+
+Note that the following fields cannot be recovered from Vault on import and will be empty after import:
+`type`, `username`, `password`, `schema`, `max_open_connections`, `max_idle_connections`, `max_connection_lifetime`.

--- a/website/docs/r/transform_transformation_tokenization_store.html.md
+++ b/website/docs/r/transform_transformation_tokenization_store.html.md
@@ -1,0 +1,65 @@
+---
+layout: "vault"
+page_title: "Vault: vault_transform_transformation_tokenization_store resource"
+sidebar_current: "docs-vault-resource-transform-transformation-tokenization-store"
+description: |-
+  "/transform/stores/{name}"
+---
+
+# vault\_transform\_transformation\_tokenization\_store
+
+This resource supports the "/transform/stores/{name}" Vault endpoint.
+
+If a tokenization store with the given name doesn't exist, it will be created. If a tokenization store with the given name exists, it will be updated with the new attributes.
+
+## Example Usage
+
+```hcl
+resource "vault_mount" "example" {
+  path = "transform"
+  type = "transform"
+}
+
+resource "vault_transform_transformation_tokenization_store" "example" {
+  path                      = vault_mount.example.path
+  name                      = "my-store"
+  type                      = "sql"
+  driver                    = "postgres"
+  connection_string         = "postgresql://{{username}}:{{password}}@127.0.0.1:5432/vault?sslmode=disable"
+  username                  = "vaultuser"
+  password                  = "vaultpass"
+  supported_transformations = ["tokenization"]
+}
+
+resource "vault_transform_transformation_tokenization" "example" {
+  path             = vault_mount.example.path
+  name             = "tkn-example"
+  stores           = [vault_transform_transformation_tokenization_store.example.name]
+  deletion_allowed = true
+  allowed_roles    = ["payments"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `namespace` - (Optional) The namespace to provision the resource in.
+  The value should not contain leading or trailing forward slashes.
+  The `namespace` is always relative to the provider's configured [namespace](/docs/providers/vault/index.html#namespace).
+  *Available only for Vault Enterprise*.
+
+* `path` - (Required) Path to where the back-end is mounted within Vault.
+* `name` - (Required) Name of the store to create or update.
+* `type` - (Required) Specifies the type of store, currently only `sql` is supported.
+* `driver` - (Required) Specifies the database driver to use, and thus which SQL database type. Currently the supported options are `postgres`, `mysql`, and `mssql`.
+* `connection_string` - (Required) A database connection string with template slots for username and password that Vault will use for locating and connecting to a database. Each database driver type has a different syntax for its connection strings.
+**Note:** When using MySQL, make sure to append ?parseTime=true to enable timestamp parsing.
+* `username` - (Required) The username value to use when connecting to the database.
+* `password` - (Required) The password value to use when connecting to the database.
+* `supported_transformations` - (Optional) The list of transformations that this store can support. Currently, only `tokenization` is supported. Default is `[tokenization]`
+* `schema` - (Optional) The schema within the database to expect tokenization state tables. Default is `public`.
+* `max_open_connections` - (Optional) The maximum number of connections to the database at any given time. Default is `4`.
+* `max_idle_connections` - (Optional) The maximum number of idle connections to the database at any given time. Default is `4`.
+* `max_connection_lifetime` - (Optional) The maximum amount of time a connection can be open before closing it. 0 means no limit. Default is `0`.
+

--- a/website/vault.erb
+++ b/website/vault.erb
@@ -744,6 +744,14 @@
                           <a href="/docs/providers/vault/r/transform_transformation.html">vault_transform_transformation</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-vault-resource-transform-transformation-tokenization") %>>
+                            <a href="/docs/providers/vault/r/transform_transformation_tokenization.html">vault_transform_transformation_tokenization</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-vault-resource-transform-transformation-tokenization-store") %>>
+                            <a href="/docs/providers/vault/r/transform_transformation_tokenization_store.html">vault_transform_transformation_tokenization_store</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-vault-resource-transit-secret-backend-key") %>>
                             <a href="/docs/providers/vault/r/transit_secret_backend_key.html">vault_transit_secret_backend_key</a>
                         </li>


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->
This PR adds a new resource `vault_transform_transformation_tokenization` which corresponds to this Vault endpoint: `/transform/transformations/tokenization/:name`

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
TF_ACC=1 go test -v -test.run TestAccTransform* -timeout 30m ./...=== RUN   TestAccTransformAlphabet
=== RUN   TestAccTransformAlphabet
--- PASS: TestAccTransformAlphabet (1.33s)
=== RUN   TestAccTransformKeyConfig
--- PASS: TestAccTransformKeyConfig (1.16s)
=== RUN   TestAccTransformRole
--- PASS: TestAccTransformRole (1.12s)
=== RUN   TestAccTransformTemplate
--- PASS: TestAccTransformTemplate (1.16s)
=== RUN   TestAccTransformTransformation
=== PAUSE TestAccTransformTransformation
=== RUN   TestAccTransformTransformation_TokenizationWithStores
=== PAUSE TestAccTransformTransformation_TokenizationWithStores
=== RUN   TestAccTransformTransformation_TokenizationWithConvergent
=== PAUSE TestAccTransformTransformation_TokenizationWithConvergent
=== RUN   TestAccTransformTransformationTokenization
=== PAUSE TestAccTransformTransformationTokenization
=== RUN   TestAccTransformTransformationTokenization_WithFields
=== PAUSE TestAccTransformTransformationTokenization_WithFields
=== RUN   TestAccTransformTransformationTokenization_Convergent
=== PAUSE TestAccTransformTransformationTokenization_Convergent
=== CONT  TestAccTransformTransformation
=== CONT  TestAccTransformTransformationTokenization
=== CONT  TestAccTransformTransformation_TokenizationWithConvergent
=== CONT  TestAccTransformTransformationTokenization_Convergent
=== CONT  TestAccTransformTransformation_TokenizationWithStores
=== CONT  TestAccTransformTransformationTokenization_WithFields
--- PASS: TestAccTransformTransformationTokenization (0.91s)
--- PASS: TestAccTransformTransformation_TokenizationWithStores (0.93s)
--- PASS: TestAccTransformTransformation_TokenizationWithConvergent (1.13s)
--- PASS: TestAccTransformTransformationTokenization_Convergent (1.16s)
--- PASS: TestAccTransformTransformation (1.51s)
--- PASS: TestAccTransformTransformationTokenization_WithFields (1.62s)
PASS
ok  	github.com/hashicorp/terraform-provider-vault/vault	(cached)


...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
