### PR TITLE
Support tpm and tpmgroup resources without user-supplied names.

### DIFF
--- a/internal/vault/identity/tpm_group_resource.go
+++ b/internal/vault/identity/tpm_group_resource.go
@@ -119,12 +119,15 @@ func (r *IdentityTPMGroupResource) Create(ctx context.Context, req resource.Crea
 	}
 
 	// Create uses the collection path with name in the body; read/update/delete use /name/{name}.
-	if _, err := vaultClient.Logical().WriteWithContext(ctx, "identity/tpmgroup", requestBody); err != nil {
+	secret, err := vaultClient.Logical().WriteWithContext(ctx, "identity/tpmgroup", requestBody)
+	if err != nil {
 		resp.Diagnostics.AddError(errutil.VaultCreateErr(err))
 		return
 	}
 
-	secret, err := vaultClient.Logical().ReadWithContext(ctx, r.path(&data))
+	data.TPMGroupID = types.StringValue(secret.Data["id"].(string))
+
+	secret, err = vaultClient.Logical().ReadWithContext(ctx, r.path(&data))
 	if err != nil {
 		resp.Diagnostics.AddError(errutil.VaultReadErr(err))
 		return

--- a/internal/vault/identity/tpm_resource.go
+++ b/internal/vault/identity/tpm_resource.go
@@ -127,22 +127,12 @@ func (r *IdentityTPMResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	resourcePath := r.path(&data)
-	if _, err := vaultClient.Logical().WriteWithContext(ctx, resourcePath, requestBody); err != nil {
+	resourcePath := "identity/tpm"
+	secret, err := vaultClient.Logical().WriteWithContext(ctx, resourcePath, requestBody)
+	if err != nil {
 		resp.Diagnostics.AddError(errutil.VaultCreateErr(err))
 		return
 	}
-
-	secret, err := vaultClient.Logical().ReadWithContext(ctx, resourcePath)
-	if err != nil {
-		resp.Diagnostics.AddError(errutil.VaultReadErr(err))
-		return
-	}
-	if secret == nil {
-		resp.Diagnostics.AddError(errutil.VaultReadResponseNil())
-		return
-	}
-
 	resp.Diagnostics.Append(r.populateDataModelFromAPI(ctx, &data, secret)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -166,7 +156,10 @@ func (r *IdentityTPMResource) Read(ctx context.Context, req resource.ReadRequest
 
 	secret, err := vaultClient.Logical().ReadWithContext(ctx, r.path(&data))
 	if err != nil {
-		resp.Diagnostics.AddError(errutil.VaultReadErr(err))
+		resp.Diagnostics.AddError(errutil.VaultReadErr(fmt.Errorf("bad request using data=%#v: %w", data, err)))
+		return
+	}
+	if resp.Diagnostics.HasError() {
 		return
 	}
 	if secret == nil {


### PR DESCRIPTION
When creating a tpm/tmpgroup resource where we don't know the name, we have to use the bare endpoints (identity/tpm, identity/tpmgroup) to do the creation.

When creating a tpm, the response contains the same fields as a read request of the tpm would, so we can omit the extra read.

That doesn't work for identity/tpmgroup, as the write endpoint omits metadata and tpm_member_ids in the response.  Arguably that's a bug, at least I don't remember why we did it that way, but for now let's tolerate it so we can move forward.

Tested with this config:
```
resource "vault_auth_backend" "tpm" {
  type = "tpm"
}

resource "vault_tpm_auth_backend_config" "test" {
  mount          = vault_auth_backend.tpm.path
  ca_lifetime    = "24h"
  ca_soft_expiry = "1h"
}

resource "vault_identity_tpm" "one" {
  tpm_ek_public_key = <<EOT
-----BEGIN PUBLIC KEY-----
MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAugmJ1hwxFOwrvrTlEm77
MdeHhlIg4Sqtvp+cYp4ImNwayG53rUHxXTKqt+KcRd6+PrglrPjCPFDN7TCdYPnk
6C5uN5P6rqcnKVKXIIUbfC2BdT1d4XOoUGpPWSdUyJNrbbI0qCV/Yy/iuoZ4JRYY
Fe6yCaOkwOf5/H+UQrOfcxQsXs2l5u9nhsSaQX1dihQeQpawaKCSF9Zds/Vn+Fol
5ZmQjpxwcXelKbDhME9aSkfMixZ9Ml5ZhCqt6VUFaQrty1r4oeHdxzkrmVSfQDV8
DK2JeihbPD5qRVZneIhpSlm3d9EK0ndwJPOL0Ni+1NnlU2Z+B5rd/UR4SIqLGsTy
wwIDAQAB
-----END PUBLIC KEY-----
EOT
}

resource "vault_identity_tpm_group" "test" {
  member_tpm_ids = [vault_identity_tpm.one.tpm_id]
}
```