### PR TITLE
Updating azure access token path

### DIFF
--- a/internal/vault/secrets/ephemeral/azure_access_token.go
+++ b/internal/vault/secrets/ephemeral/azure_access_token.go
@@ -218,10 +218,10 @@ const credPropagationRetries = 4
 // credPropagationDelay is the wait between retries.
 const credPropagationDelay = 4 * time.Second
 
-// requestAzureAccessToken fetches an Azure OAuth2 access token from Vault's token/ endpoint,
+// requestAzureAccessToken fetches an Azure OAuth2 access token from Vault's static-creds/<role>/token endpoint,
 // initializing the static credential on first use and retrying on Azure AD propagation errors.
 func requestAzureAccessToken(ctx context.Context, cli *api.Client, mount, role, scope string, maxRetries int, retryDelay time.Duration) (*AzureAccessTokenAPIModel, error) {
-	path := fmt.Sprintf("%s/token/%s", mount, role)
+	path := fmt.Sprintf("%s/static-creds/%s/token", mount, role)
 	initialized := false
 
 	for attempt := 0; attempt <= maxRetries; attempt++ {
@@ -247,10 +247,10 @@ func requestAzureAccessToken(ctx context.Context, cli *api.Client, mount, role, 
 				))
 				continue
 			}
-			// token/ returns a 400 when the static credential has not yet been
+			// static-creds/<role>/token returns a 400 when the static credential has not yet been
 			// provisioned. Reading static-creds/ initializes it on first access.
 			// This only happens once — on every subsequent Open() the credential
-			// already exists and token/ succeeds on the first attempt.
+			// already exists and static-creds/<role>/token succeeds on the first attempt.
 			if !initialized && isAzureCredNotInitializedError(err) {
 				tflog.Info(ctx, fmt.Sprintf(
 					"Static credential for role %q not yet provisioned; initializing via static-creds/",

--- a/website/docs/ephemeral-resources/azure_access_token.html.md
+++ b/website/docs/ephemeral-resources/azure_access_token.html.md
@@ -91,5 +91,5 @@ In addition to the arguments above, the following attributes are exported:
 
 Use of this resource requires the following capabilities:
 
-* `<mount>/token/<role>` - `update` (required on every call)
+* `<mount>/static-creds/<role>/token` - `update` (required on every call)
 * `<mount>/static-creds/<role>` - `read` (required only on first use, to initialize the static credential)


### PR DESCRIPTION
We are changing the path for azure access tokens from `{mount}/token/{role}` to `{mount}/static-creds/{role}/token`.


<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000


### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
