### PR TITLE
secrets/azure: add seamless rotation fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 FEATURES:
 
 * **New Ephemeral Resource**: `vault_azure_access_token` for fetching Azure OAuth2 access tokens from Vault's Azure secrets engine static role credentials. Requires Vault 2.2.0 or later. ([#2974](https://github.com/hashicorp/terraform-provider-vault/pull/2974))
+* **Azure Automated Rotation for Static Roles**: added support for automated rotation of credentials for static roles. Requires Vault 2.2.0 or later. ([#3035](https://github.com/hashicorp/terraform-provider-vault/pull/3035))
+
 IMPROVEMENTS:
 
 * `vault_ldap_auth_backend`: emit a warning when the auth mount or its config is not found during refresh, so users see an actionable message in `terraform plan` output rather than a silent state removal. ([#2997](https://github.com/hashicorp/terraform-provider-vault/pull/2997))
@@ -77,7 +79,7 @@ BUG FIXES:
 
 ## 5.10.1 (June 26, 2026)
 
-BREAKING CHANGES: 
+BREAKING CHANGES:
 
 Reverted the 5.10.0 support for `pkcs12_bundle` and `jks_bundle` formats in formats in `vault_pki_secret_backend_cert`, `vault_pki_secret_backend_root_cert`, `vault_pki_secret_backend_root_sign_intermediate`, and `vault_pki_secret_backend_sign` that forced resource recreation. Configurations using these formats or their related arguments are no longer supported. ([#2945](https://github.com/hashicorp/terraform-provider-vault/pull/2945))
 
@@ -320,7 +322,7 @@ IMPROVEMENTS:
 * `vault_secrets_sync_gcp_destination`: Add support for replication field (`replication_locations`; Vault 1.18+), networking allowlist fields (`allowed_ipv4_addresses`, `allowed_ipv6_addresses`, `allowed_ports`, `disable_strict_networking`; Vault 1.19+), and encryption fields (`global_kms_key`, `locational_kms_keys`; Vault 1.19+) in `vault_secrets_sync_gcp_destination` resource. ([#2699](https://github.com/hashicorp/terraform-provider-vault/pull/2699))
 * Add support for networking allowlist fields (`allowed_ipv4_addresses`, `allowed_ipv6_addresses`, `allowed_ports`, `disable_strict_networking`) in `vault_secrets_sync_azure_destination` resource. Requires Vault 1.19+. ([#2702](https://github.com/hashicorp/terraform-provider-vault/pull/2702))
 * `vault_database_secret_backend_connection`: Add support for MongoDB `write_concern` parameter and TLS parameters (`tls_ca`, `tls_certificate_key`) ([#2678](https://github.com/hashicorp/terraform-provider-vault/pull/2678))
-* Add support for `username_template` parameter in `vault_database_secret_backend_connection` and `vault_database_secrets_mount` resource for MongoDB Atlas([#2674](https://github.com/hashicorp/terraform-provider-vault/pull/2674)) 
+* Add support for `username_template` parameter in `vault_database_secret_backend_connection` and `vault_database_secrets_mount` resource for MongoDB Atlas([#2674](https://github.com/hashicorp/terraform-provider-vault/pull/2674))
 * Add support for `username_template` parameter in `vault_database_secret_backend_connection` and `vault_database_secrets_mount` resources for HANADB connections: ([#2671](https://github.com/hashicorp/terraform-provider-vault/pull/2671))
 * Add support for networking allowlist fields (`allowed_ipv4_addresses`, `allowed_ipv6_addresses`, `allowed_ports`, `disable_strict_networking`) in `vault_secrets_sync_vercel_destination` resource. Requires Vault 1.19+. ([#2681](https://github.com/hashicorp/terraform-provider-vault/pull/2681))
 * Add support for configuration parameters (`allowed_ipv4_addresses`,`allowed_ipv6_addresses`,`allowed_ports`,`disable_strict_networking`,`secrets_location`,`environment_name`) in `vault_secrets_sync_gh_destination` resource. Requires Vault 1.18+ for `secrets_location`,`environment_name`.Requires Vault 1.19+ for `allowed_ipv4_addresses`,`allowed_ipv6_addresses`,`allowed_ports`,`disable_strict_networking`.([#2697](https://github.com/hashicorp/terraform-provider-vault/pull/2697)).
@@ -363,10 +365,10 @@ BUGS:
 
 ## 5.5.0 (Nov 19, 2025)
 
-BEHAVIOR CHANGES: With v5.5.0, the default value for `deny_null_bind` in the `vault_ldap_auth_backend` resource has changed from `false` to `true` 
-to match with the Vault API defaults. Configurations that do not explicitly set `deny_null_bind` will now have it set to `true` upon upgrade, and 
-customers should verify that this change aligns with their intended LDAP authentication behavior. Furthermore, Customers should also consider 
-upgrading to Vault Community Edition 1.21.1 and Vault Enterprise 1.21.1, 1.20.6, 1.19.12, and 1.16.28, which no longer allows Vault to perform 
+BEHAVIOR CHANGES: With v5.5.0, the default value for `deny_null_bind` in the `vault_ldap_auth_backend` resource has changed from `false` to `true`
+to match with the Vault API defaults. Configurations that do not explicitly set `deny_null_bind` will now have it set to `true` upon upgrade, and
+customers should verify that this change aligns with their intended LDAP authentication behavior. Furthermore, Customers should also consider
+upgrading to Vault Community Edition 1.21.1 and Vault Enterprise 1.21.1, 1.20.6, 1.19.12, and 1.16.28, which no longer allows Vault to perform
 unauthenticated or null binds against the LDAP server.
 
 SECURITY:
@@ -545,7 +547,7 @@ FEATURES:
 * Add support for signature_bits field to `vault_pki_secret_backend_role`, `vault_pki_secret_backend_root_cert`, `vault_pki_secret_backend_root_sign_intermediate` and `vault_pki_secret_backend_intermediate_cert_request` ([#2401])(https://github.com/hashicorp/terraform-provider-vault/pull/2401)
 * Add support for key_usage and serial_number to `vault_pki_secret_backend_intermediate_cert_request` ([#2404])(https://github.com/hashicorp/terraform-provider-vault/pull/2404)
 * Add support for `skip_import_rotation` in `vault_database_secret_backend_static_role`. Requires Vault Enterprise 1.18.5+ ([#2386](https://github.com/hashicorp/terraform-provider-vault/pull/2386)).
-* Add support for `not_after` in `vault_pki_secret_backend_cert`, `vault_pki_secret_backend_role`, `vault_pki_secret_backend_root_cert`, `vault_pki_secret_backend_root_sign_intermediate`, and `vault_pki_secret_backend_sign` ([#2385](https://github.com/hashicorp/terraform-provider-vault/pull/2385)). 
+* Add support for `not_after` in `vault_pki_secret_backend_cert`, `vault_pki_secret_backend_role`, `vault_pki_secret_backend_root_cert`, `vault_pki_secret_backend_root_sign_intermediate`, and `vault_pki_secret_backend_sign` ([#2385](https://github.com/hashicorp/terraform-provider-vault/pull/2385)).
 * Update `vault_pki_secret_backend_config_acme` to support the `max_ttl` field. [#2411](https://github.com/hashicorp/terraform-provider-vault/pull/2411)
 * Add new data source `vault_ssh_secret_backend_sign`. ([#2409](https://github.com/hashicorp/terraform-provider-vault/pull/2409))
 * Add support for `disabled_validations` in `vault_pki_secret_backend_config_cmpv2` [#2412](https://github.com/hashicorp/terraform-provider-vault/pull/2412)

--- a/internal/consts/consts.go
+++ b/internal/consts/consts.go
@@ -926,6 +926,10 @@ const (
 	FieldTokenExplicitMaxTTL        = "token_explicit_max_ttl"
 	FieldTokenNoDefaultPolicy       = "token_no_default_policy"
 
+	// Azure seamless rotation
+	FieldSeamlessRotation    = "seamless_rotation"
+	FieldRotationGracePeriod = "rotation_grace_period"
+
 	/*
 		common environment variables
 	*/

--- a/internal/vault/secrets/azure/azure_static_role_resource.go
+++ b/internal/vault/secrets/azure/azure_static_role_resource.go
@@ -58,12 +58,18 @@ type AzureStaticRoleModel struct {
 	Expiration          types.String `tfsdk:"expiration"`
 	SkipImportRotation  types.Bool   `tfsdk:"skip_import_rotation"`
 	DeferInitialCreds   types.Bool   `tfsdk:"defer_initial_creds"`
+	RotationGracePeriod types.Int64  `tfsdk:"rotation_grace_period"`
+	RotationPeriod      types.Int64  `tfsdk:"rotation_period"`
+	SeamlessRotation    types.Bool   `tfsdk:"seamless_rotation"`
 }
 
 // AzureStaticRoleAPIModel describes the Vault API data model.
 type AzureStaticRoleAPIModel struct {
 	ApplicationObjectID string            `json:"application_object_id" mapstructure:"application_object_id"`
 	TTL                 any               `json:"ttl" mapstructure:"ttl"`
+	RotationPeriod      any               `json:"rotation_period,omitempty" mapstructure:"rotation_period,omitempty"`
+	RotationGracePeriod any               `json:"rotation_grace_period,omitempty" mapstructure:"rotation_grace_period,omitempty"`
+	SeamlessRotation    bool              `json:"seamless_rotation" mapstructure:"seamless_rotation"`
 	Metadata            map[string]string `json:"metadata" mapstructure:"metadata"`
 }
 
@@ -93,6 +99,8 @@ func (r *AzureSecretsStaticRoleResource) Schema(_ context.Context, _ resource.Sc
 				MarkdownDescription: "Timespan of 1 month or more during which the role credentials are valid.",
 				Optional:            true,
 				Computed:            true,
+				DeprecationMessage: "This field is deprecated and will be removed in a future version. " +
+					"The " + consts.FieldRotationPeriod + " field should be used, instead.",
 			},
 			consts.FieldMetadata: schema.MapAttribute{
 				MarkdownDescription: "A map of string key/value pairs that will be stored as metadata on the secret.",
@@ -124,6 +132,25 @@ func (r *AzureSecretsStaticRoleResource) Schema(_ context.Context, _ resource.Sc
 			consts.FieldDeferInitialCreds: schema.BoolAttribute{
 				MarkdownDescription: "If true, the initial creation of credentials will be deferred until first static-creds read.",
 				Optional:            true,
+			},
+			consts.FieldRotationPeriod: schema.Int64Attribute{
+				MarkdownDescription: "Timespan of 1 month or more during which the role credentials are valid.",
+				Optional:            true,
+				Computed:            true,
+			},
+			consts.FieldRotationGracePeriod: schema.Int64Attribute{
+				MarkdownDescription: "Amount of time (in seconds) that active and staged credentials " +
+					"are permitted to overlap when seamless rotation is enabled. Must not exceed " +
+					"(rotation_period - 1h) / 2. Set to -1 to disable overlap or 0 to use the " +
+					"default value of 5 minutes.",
+				Optional: true,
+			},
+			consts.FieldSeamlessRotation: schema.BoolAttribute{
+				MarkdownDescription: "Enable or disable seamless rotation for the role. When enabled, " +
+					"allows the plugin to pre-provision the next credential to avoid propagation " +
+					"delays.",
+				Optional: true,
+				Computed: true,
 			},
 		},
 		MarkdownDescription: "Manage Azure static roles.",
@@ -234,6 +261,28 @@ func (r *AzureSecretsStaticRoleResource) Read(ctx context.Context, req resource.
 	}
 	data.TTL = types.Int64Value(ttlSeconds)
 
+	data.SeamlessRotation = types.BoolValue(apiModel.SeamlessRotation)
+
+	if apiModel.RotationPeriod != nil {
+		gpSeconds, err := normalizeTTL(apiModel.RotationPeriod)
+		if err != nil {
+			resp.Diagnostics.AddError("Invalid RotationPeriod format from Vault", err.Error())
+			return
+		}
+
+		data.RotationPeriod = types.Int64Value(gpSeconds)
+	}
+
+	if apiModel.RotationGracePeriod != nil {
+		rgpSeconds, err := normalizeTTL(apiModel.RotationGracePeriod)
+		if err != nil {
+			resp.Diagnostics.AddError("Invalid RotationGracePeriod format from Vault", err.Error())
+			return
+		}
+
+		data.RotationGracePeriod = types.Int64Value(rgpSeconds)
+	}
+
 	resp.Diagnostics.Append(diags...)
 	data.Metadata = val
 	data.ID = types.StringValue(makeID(backend, role))
@@ -274,13 +323,41 @@ func (r *AzureSecretsStaticRoleResource) Update(ctx context.Context, req resourc
 
 func buildVaultRequestFromModel(ctx context.Context, data *AzureStaticRoleModel) (map[string]any, diag.Diagnostics) {
 	var diags diag.Diagnostics
+	var ttl int64
 
 	vaultRequest := map[string]any{
 		consts.FieldApplicationObjectID: data.ApplicationObjectID.ValueString(),
 	}
 
 	if !data.TTL.IsNull() {
-		vaultRequest[consts.FieldTTL] = data.TTL.ValueInt64()
+		ttl = data.TTL.ValueInt64()
+		vaultRequest[consts.FieldTTL] = ttl
+	}
+
+	if !data.RotationPeriod.IsNull() {
+		rp := data.RotationPeriod.ValueInt64()
+		vaultRequest[consts.FieldRotationPeriod] = rp
+
+		// If TTL was also set to a non-zero value, make sure that it matches
+		// rotation period (if it is also non-zero).
+		if ttl != 0 && rp != 0 && rp != ttl {
+			diags.AddError(
+				"Conflicting lifetime intervals",
+				fmt.Sprintf(
+					"Expected %[1]s and %[2]s to match when both are specified "+
+						"(got %[1]s=%[3]d, %[2]s=%[4]d)",
+					consts.FieldTTL, consts.FieldRotationPeriod, ttl, rp,
+				),
+			)
+		}
+	}
+
+	if !data.RotationGracePeriod.IsNull() {
+		vaultRequest[consts.FieldRotationPeriod] = data.RotationGracePeriod.ValueInt64()
+	}
+
+	if !data.SeamlessRotation.IsNull() {
+		vaultRequest[consts.FieldSeamlessRotation] = data.SeamlessRotation.ValueBool()
 	}
 
 	if !data.Metadata.IsNull() && !data.Metadata.IsUnknown() {
@@ -306,6 +383,7 @@ func buildVaultRequestFromModel(ctx context.Context, data *AzureStaticRoleModel)
 
 func buildVaultRequestForImportCreate(ctx context.Context, data *AzureStaticRoleModel) (map[string]any, diag.Diagnostics) {
 	var diags diag.Diagnostics
+	var ttl int64
 
 	req := map[string]any{
 		consts.FieldApplicationObjectID: data.ApplicationObjectID.ValueString(),
@@ -317,7 +395,34 @@ func buildVaultRequestForImportCreate(ctx context.Context, data *AzureStaticRole
 	}
 
 	if !data.TTL.IsNull() {
-		req[consts.FieldTTL] = data.TTL.ValueInt64()
+		ttl = data.TTL.ValueInt64()
+		req[consts.FieldTTL] = ttl
+	}
+
+	if !data.RotationPeriod.IsNull() {
+		rp := data.RotationPeriod.ValueInt64()
+		req[consts.FieldRotationPeriod] = rp
+
+		// If TTL was also set to a non-zero value, make sure that it matches
+		// rotation period (if it is also non-zero).
+		if ttl != 0 && rp != 0 && rp != ttl {
+			diags.AddError(
+				"Conflicting lifetime intervals",
+				fmt.Sprintf(
+					"Expected %[1]s and %[2]s to match when both are specified "+
+						"(got %[1]s=%[3]d, %[2]s=%[4]d)",
+					consts.FieldTTL, consts.FieldRotationPeriod, ttl, rp,
+				),
+			)
+		}
+	}
+
+	if !data.RotationGracePeriod.IsNull() {
+		req[consts.FieldRotationPeriod] = data.RotationGracePeriod.ValueInt64()
+	}
+
+	if !data.SeamlessRotation.IsNull() {
+		req[consts.FieldSeamlessRotation] = data.SeamlessRotation.ValueBool()
 	}
 
 	if !data.Metadata.IsNull() && !data.Metadata.IsUnknown() {

--- a/vault/resource_azure_secret_backend.go
+++ b/vault/resource_azure_secret_backend.go
@@ -118,6 +118,12 @@ func azureSecretBackendResource() *schema.Resource {
 				Computed:    true,
 				Description: "The TTL in seconds of the root password in Azure when rotate-root generates a new client secret",
 			},
+			consts.FieldSeamlessRotation: {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "Enable or disable seamless rotation for static roles. Does not affect existing static roles.",
+			},
 		},
 	}, false)
 
@@ -222,6 +228,13 @@ func azureSecretBackendRead(ctx context.Context, d *schema.ResourceData, meta in
 		}
 	}
 
+	useAPIVer220Ent := provider.IsAPISupported(meta, provider.VaultVersion220) && provider.IsEnterpriseSupported(meta)
+	if useAPIVer220Ent {
+		if err := d.Set(consts.FieldSeamlessRotation, resp.Data[consts.FieldSeamlessRotation]); err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	if err := readMount(ctx, d, meta, true, false); err != nil {
 		return diag.FromErr(err)
 	}
@@ -280,6 +293,11 @@ func azureSecretBackendRequestData(d *schema.ResourceData, meta interface{}) map
 		consts.FieldEnvironment,
 		consts.FieldTenantID,
 		consts.FieldSubscriptionID,
+	}
+
+	useAPIVer220Ent := provider.IsAPISupported(meta, provider.VaultVersion220) && provider.IsEnterpriseSupported(meta)
+	if useAPIVer220Ent {
+		fields = append(fields, consts.FieldSeamlessRotation)
 	}
 
 	data := make(map[string]interface{})

--- a/vault/resource_azure_secret_backend_test.go
+++ b/vault/resource_azure_secret_backend_test.go
@@ -75,6 +75,18 @@ func getAzureBackendChecks(resourceName, path string, isUpdate bool) resource.Te
 		resource.TestCheckResourceAttr(resourceName, consts.FieldRootPasswordTTL, "2000000"),
 	}
 
+	if provider.IsAPISupported(testProvider.Meta(), provider.VaultVersion220) && provider.IsEnterpriseSupported(testProvider.Meta()) {
+		commonInitialChecks = append(
+			commonInitialChecks,
+			resource.TestCheckResourceAttr(resourceName, consts.FieldSeamlessRotation, "true"),
+		)
+
+		commonUpdateChecks = append(
+			commonUpdateChecks,
+			resource.TestCheckResourceAttr(resourceName, consts.FieldSeamlessRotation, "false"),
+		)
+	}
+
 	if !isUpdate {
 		baseChecks = append(baseChecks, commonInitialChecks...)
 	} else {
@@ -307,13 +319,14 @@ func TestAccAzureSecretBackendConfig_automatedRotation(t *testing.T) {
 func testAzureSecretBackend_initialConfig(path string) string {
 	return fmt.Sprintf(`
 resource "vault_azure_secret_backend" "test" {
-  path            = "%s"
-  subscription_id = "11111111-2222-3333-4444-111111111111"
-  tenant_id       = "11111111-2222-3333-4444-222222222222"
-  client_id       = "11111111-2222-3333-4444-333333333333"
-  client_secret   = "12345678901234567890"
-  environment     = "AzurePublicCloud"
-  disable_remount = true
+  path              = "%s"
+  subscription_id   = "11111111-2222-3333-4444-111111111111"
+  tenant_id         = "11111111-2222-3333-4444-222222222222"
+  client_id         = "11111111-2222-3333-4444-333333333333"
+  client_secret     = "12345678901234567890"
+  environment       = "AzurePublicCloud"
+  disable_remount   = true
+  seamless_rotation = true
 }`, path)
 }
 
@@ -327,53 +340,56 @@ resource "vault_azure_secret_backend" "test" {
   client_secret           = "098765432109876543214"
   environment             = "AzurePublicCloud"
   disable_remount         = true
-  root_password_ttl 	  = 2000000
+  root_password_ttl       = 2000000
+  seamless_rotation       = false
 }`, path)
 }
 
 func testAzureSecretBackend_remount(path string) string {
 	return fmt.Sprintf(`
 resource "vault_azure_secret_backend" "test" {
-  path            = "%s"
-  subscription_id = "11111111-2222-3333-4444-111111111111"
-  tenant_id       = "11111111-2222-3333-4444-222222222222"
-  client_id       = "11111111-2222-3333-4444-333333333333"
-  client_secret   = "12345678901234567890"
-  environment     = "AzurePublicCloud"
+  path              = "%s"
+  subscription_id   = "11111111-2222-3333-4444-111111111111"
+  tenant_id         = "11111111-2222-3333-4444-222222222222"
+  client_id         = "11111111-2222-3333-4444-333333333333"
+  client_secret     = "12345678901234567890"
+  environment       = "AzurePublicCloud"
+  seamless_rotation = false
 }`, path)
 }
 
 func testAccAzureSecretBackendConfig_wifBasic(path string) string {
 	return fmt.Sprintf(`
 resource "vault_azure_secret_backend" "test" {
-  path 					  = "%s"
-  subscription_id 		  = "11111111-2222-3333-4444-111111111111"
-  tenant_id       		  = "11111111-2222-3333-4444-222222222222"
-  client_id       		  = "11111111-2222-3333-4444-333333333333"
+  path                    = "%s"
+  subscription_id         = "11111111-2222-3333-4444-111111111111"
+  tenant_id               = "11111111-2222-3333-4444-222222222222"
+  client_id               = "11111111-2222-3333-4444-333333333333"
   identity_token_audience = "wif-audience"
-  identity_token_ttl 	  = 600
+  identity_token_ttl      = 600
+  seamless_rotation       = false
 }`, path)
 }
 
 func testAccAzureSecretBackendConfig_wifUpdated(path string) string {
 	return fmt.Sprintf(`
 resource "vault_azure_secret_backend" "test" {
-  path 					  = "%s"
+  path                    = "%s"
   subscription_id         = "11111111-2222-3333-4444-111111111111"
   tenant_id               = "22222222-3333-4444-5555-333333333333"
   client_id               = "22222222-3333-4444-5555-444444444444"
   identity_token_audience = "wif-audience-updated"
-  identity_token_ttl 	  = 1800
+  identity_token_ttl      = 1800
+  seamless_rotation       = false
 }`, path)
 }
 
 func testAccAzureSecretBackendConfig_MountConfig(path string, isUpdate bool) string {
-
 	if !isUpdate {
 		return fmt.Sprintf(`
 resource "vault_azure_secret_backend" "test" {
-  path 					      = "%s"
-  description 			      = "test desc"
+  path                        = "%s"
+  description                 = "test desc"
   subscription_id             = "11111111-2222-3333-4444-111111111111"
   tenant_id                   = "22222222-3333-4444-5555-333333333333"
   client_id                   = "22222222-3333-4444-5555-444444444444"
@@ -385,12 +401,13 @@ resource "vault_azure_secret_backend" "test" {
   delegated_auth_accessors    = ["header1", "header2"]
   listing_visibility          = "hidden"
   force_no_cache              = true
+  seamless_rotation           = false
 }`, path)
 	} else {
 		return fmt.Sprintf(`
 resource "vault_azure_secret_backend" "test" {
-  path 					      = "%s"
-  description 			      = "test desc updated"
+  path                        = "%s"
+  description                 = "test desc updated"
   subscription_id             = "11111111-2222-3333-4444-111111111111"
   tenant_id                   = "22222222-3333-4444-5555-333333333333"
   client_id                   = "22222222-3333-4444-5555-444444444444"
@@ -402,6 +419,7 @@ resource "vault_azure_secret_backend" "test" {
   delegated_auth_accessors    = ["header1", "header2"]
   listing_visibility          = "unauth"
   force_no_cache              = true
+  seamless_rotation           = false
 }`, path)
 	}
 }
@@ -409,14 +427,15 @@ resource "vault_azure_secret_backend" "test" {
 func testAccAzureSecretBackendConfig_automatedRotation(path string, rotationSchedule string, rotationWindow, rotationPeriod int, disableRotation bool) string {
 	return fmt.Sprintf(`
 resource "vault_azure_secret_backend" "test" {
-  path 					  = "%s"
-  subscription_id         = "11111111-2222-3333-4444-111111111111"
-  tenant_id               = "22222222-3333-4444-5555-333333333333"
-  client_id               = "22222222-3333-4444-5555-444444444444"
-  rotation_schedule       = "%s"
-  rotation_window         = "%d"
-  rotation_period         = "%d"
+  path                       = "%s"
+  subscription_id            = "11111111-2222-3333-4444-111111111111"
+  tenant_id                  = "22222222-3333-4444-5555-333333333333"
+  client_id                  = "22222222-3333-4444-5555-444444444444"
+  rotation_schedule          = "%s"
+  rotation_window            = "%d"
+  rotation_period            = "%d"
   disable_automated_rotation = %t
+  seamless_rotation          = false
 }
 `, path, rotationSchedule, rotationWindow, rotationPeriod, disableRotation)
 }
@@ -470,6 +489,7 @@ resource "vault_azure_secret_backend" "test" {
   client_secret_wo_version = %d
   environment              = "AzurePublicCloud"
   disable_remount          = true
+  seamless_rotation        = false
 }`, path, clientSecret, version)
 }
 
@@ -489,6 +509,7 @@ resource "vault_azure_secret_backend" "test" {
   client_secret            = "test-client-secret"
   client_secret_wo         = "test-client-secret-wo"
   client_secret_wo_version = 1
+  seamless_rotation        = false
 }`, path),
 				ExpectError: regexp.MustCompile(`Conflicting configuration arguments`),
 			},


### PR DESCRIPTION

### Description
This PR adds support for the seamless rotation feature within the Azure Secrets engine. Seamless rotation allows the Azure Secrets engine to pre-provision credentials used for Vault static roles, avoiding credential propagation issues that may arise when manually rotating credentials.

### Checklist
- [X] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests were run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
