### PR TITLE
Remove sensitive from EAB fields

### DIFF
--- a/internal/vault/secrets/pki-external-ca/acme_account_resource.go
+++ b/internal/vault/secrets/pki-external-ca/acme_account_resource.go
@@ -120,7 +120,7 @@ func (r *PKIACMEAccountResource) Schema(_ context.Context, _ resource.SchemaRequ
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"eab_kid": schema.StringAttribute{
-				MarkdownDescription: "The external binding key ID to create the initial account.",
+				MarkdownDescription: "The external account binding key ID to create the initial account. If specified, `eab_key` must also be provided.",
 				Optional:            true,
 				WriteOnly:           true,
 				Validators: []validator.String{
@@ -129,7 +129,7 @@ func (r *PKIACMEAccountResource) Schema(_ context.Context, _ resource.SchemaRequ
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"eab_key": schema.StringAttribute{
-				MarkdownDescription: "An url base64 encoded external binding token to create the initial account.",
+				MarkdownDescription: "A URL base64-encoded external account binding HMAC key to create the initial account. If specified, `eab_kid` must also be provided.",
 				Optional:            true,
 				WriteOnly:           true,
 				Validators: []validator.String{

--- a/internal/vault/secrets/pki-external-ca/acme_account_resource.go
+++ b/internal/vault/secrets/pki-external-ca/acme_account_resource.go
@@ -143,7 +143,7 @@ func (r *PKIACMEAccountResource) Schema(_ context.Context, _ resource.SchemaRequ
 			},
 			"active_key_version": schema.Int64Attribute{
 				Computed:            true,
-				MarkdownDescription: "Version of account key, starts at zero",
+				MarkdownDescription: "Current version of the account key, starting at zero.",
 			},
 		},
 		MarkdownDescription: "Manage PKI ACME accounts for external CA integration.",
@@ -233,7 +233,8 @@ func (r *PKIACMEAccountResource) Read(ctx context.Context, req resource.ReadRequ
 
 func (r *PKIACMEAccountResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var data PKIACMEAccountModel
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	// Use req.Config to read write-only fields, which are nullified in plan.
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/vault/secrets/pki-external-ca/acme_account_resource.go
+++ b/internal/vault/secrets/pki-external-ca/acme_account_resource.go
@@ -122,16 +122,20 @@ func (r *PKIACMEAccountResource) Schema(_ context.Context, _ resource.SchemaRequ
 			"eab_kid": schema.StringAttribute{
 				MarkdownDescription: "The external binding key ID to create the initial account.",
 				Optional:            true,
-				Sensitive:           true,
 				WriteOnly:           true,
-				PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
+				Validators: []validator.String{
+					stringvalidator.AlsoRequires(path.MatchRoot("eab_key")),
+				},
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"eab_key": schema.StringAttribute{
 				MarkdownDescription: "An url base64 encoded external binding token to create the initial account.",
 				Optional:            true,
-				Sensitive:           true,
 				WriteOnly:           true,
-				PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
+				Validators: []validator.String{
+					stringvalidator.AlsoRequires(path.MatchRoot("eab_kid")),
+				},
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"trusted_ca": schema.StringAttribute{
 				MarkdownDescription: "Trusted CA certificates for the ACME server.",
@@ -283,9 +287,6 @@ func handleAccountResponseData(ctx context.Context, data *PKIACMEAccountModel, r
 	if apiModel.TrustedCA != "" {
 		data.TrustedCA = types.StringValue(apiModel.TrustedCA)
 	}
-
-	// Note: EAB credentials are write-only and won't be returned by the API
-	// Keep the values from state if they were set
 
 	return rd
 }

--- a/internal/vault/secrets/pki-external-ca/acme_account_resource_test.go
+++ b/internal/vault/secrets/pki-external-ca/acme_account_resource_test.go
@@ -25,7 +25,7 @@ func TestAccPKIACMEAccount_basic(t *testing.T) {
 	acctestutil.SkipTestAccEnt(t)
 	ca, directoryUrl := setupVaultAndPebble(t)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
 		PreCheck: func() {
 			acctestutil.TestEntPreCheck(t)

--- a/website/docs/r/pki_external_ca_secret_backend_acme_account.html.md
+++ b/website/docs/r/pki_external_ca_secret_backend_acme_account.html.md
@@ -86,9 +86,9 @@ The following arguments are supported:
 
 * `key_type` - (Optional) Key type to generate for the account key. Valid values are `ec-256`, `ec-384`, `ec-521`, `rsa-2048`, `rsa-4096`, `rsa-8192`. Defaults to `ec-256`.
 
-* `eab_kid` - (Optional) The external account binding key ID to create the initial account. Required by some CAs for account registration. This is a write-only field.
+* `eab_kid` - (Optional) The external account binding key ID to create the initial account. Required by some CAs for account registration. If specified, `eab_key` is also required. This is a write-only field.
 
-* `eab_key` - (Optional) The external account binding HMAC key to create the initial account. Required by some CAs for account registration. This is a write-only field.
+* `eab_key` - (Optional) The external account binding HMAC key (URL base64-encoded) to create the initial account. Required by some CAs for account registration. If specified, `eab_kid` is also required. This is a write-only field.
 
 * `trusted_ca` - (Optional) PEM-encoded trusted CA certificates for the ACME server. Use this when connecting to an ACME server with a custom or self-signed certificate.
 


### PR DESCRIPTION
Removes `Sensitive: true` from eab_kid and eab_key

`eab_kid` and `eab_key` have `WriteOnly: true` set, which means the Terraform framework never persists their values in state and it always writes null. Setting `Sensitive: true` alongside `WriteOnly: true` is contradictory. Sensitive implies a value is stored in state (just masked in output), while WriteOnly guarantees no value is ever stored.

Because these fields have always been WriteOnly, existing state files already contain null for both fields. Removing Sensitive should not affect stored state and should not be a breaking change for existing users.

It also adds docs and validations to enforce both fields are required when set (see https://github.com/hashicorp/vault-plugin-secrets-pki-external-ca/blob/main/plugin/path_acme_account.go#L852)
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
<!--- Description of the change. For example: This PR updates ABC resource so that we can XYZ --->


<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000


### Checklist
- [ ] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [ ] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
