### PR TITLE
VAULT-48807: Local field for agent registration and oauth resource server config

### DIFF
--- a/internal/vault/sys/agent_registration_resource.go
+++ b/internal/vault/sys/agent_registration_resource.go
@@ -58,6 +58,7 @@ type AgentRegistrationModel struct {
 	CreationTime                 types.String `tfsdk:"creation_time"`
 	LastUpdatedTime              types.String `tfsdk:"last_updated_time"`
 	OptionalAuthorizationDetails types.Bool   `tfsdk:"optional_authorization_details"`
+	Local                        types.Bool   `tfsdk:"local"`
 }
 
 // AgentRegistrationAPIModel describes the Vault API data model.
@@ -72,6 +73,7 @@ type AgentRegistrationAPIModel struct {
 	CreationTime                 string   `json:"creation_time" mapstructure:"creation_time"`
 	LastUpdatedTime              string   `json:"last_updated_time" mapstructure:"last_updated_time"`
 	OptionalAuthorizationDetails bool     `json:"optional_authorization_details" mapstructure:"optional_authorization_details"`
+	Local                        bool     `json:"local" mapstructure:"local"`
 }
 
 // Metadata defines the resource name as it would appear in Terraform configurations
@@ -149,6 +151,12 @@ func (r *AgentRegistrationResource) Schema(ctx context.Context, req resource.Sch
 				Default:             booldefault.StaticBool(false),
 				MarkdownDescription: "When false, RAR (Rich Authorization Requests) is mandatory and authorization_details must be present in the token. When set to true, authorization_details in the JWT token are optional for this agent. This setting works in conjunction with the OAuth Resource Server profile's optional_authorization_details setting - RAR is optional if EITHER is true. Defaults to false.",
 			},
+			consts.FieldLocal: schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+				MarkdownDescription: "When set to true, the agent registration is not replicated globally and will be local to the current cluster. Defaults to false.",
+			},
 		},
 		MarkdownDescription: "Manages Agent Registry registrations in Vault Enterprise. " +
 			"The Agent Registry allows you to register agents with Vault and apply authorization ceilings to them.",
@@ -209,6 +217,9 @@ func (r *AgentRegistrationResource) Create(ctx context.Context, req resource.Cre
 	}
 	if !data.Owner.IsNull() && !data.Owner.IsUnknown() {
 		vaultRequest[consts.FieldOwner] = data.Owner.ValueString()
+	}
+	if !data.Local.IsNull() && !data.Local.IsUnknown() {
+		vaultRequest[consts.FieldLocal] = data.Local.ValueBool()
 	}
 
 	// RAR support
@@ -514,6 +525,7 @@ func (r *AgentRegistrationResource) readFromVault(ctx context.Context, client *a
 	}
 
 	data.NoDefaultCeilingPolicy = types.BoolValue(apiModel.NoDefaultCeilingPolicy)
+	data.Local = types.BoolValue(apiModel.Local)
 
 	// RAR support
 	data.OptionalAuthorizationDetails = types.BoolValue(apiModel.OptionalAuthorizationDetails)

--- a/internal/vault/sys/agent_registration_resource_test.go
+++ b/internal/vault/sys/agent_registration_resource_test.go
@@ -485,7 +485,7 @@ func TestAccAgentRegistration_local(t *testing.T) {
 		PreCheck: func() {
 			acctestutil.TestAccPreCheck(t)
 			acctestutil.TestEntPreCheck(t)
-			acctestutil.SkipIfAPIVersionLT(t, provider.VaultVersion210)
+			acctestutil.SkipIfAPIVersionLT(t, provider.VaultVersion220)
 		},
 		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
@@ -518,7 +518,7 @@ func TestAccAgentRegistration_localDefault(t *testing.T) {
 		PreCheck: func() {
 			acctestutil.TestAccPreCheck(t)
 			acctestutil.TestEntPreCheck(t)
-			acctestutil.SkipIfAPIVersionLT(t, provider.VaultVersion210)
+			acctestutil.SkipIfAPIVersionLT(t, provider.VaultVersion220)
 		},
 		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/vault/sys/agent_registration_resource_test.go
+++ b/internal/vault/sys/agent_registration_resource_test.go
@@ -474,6 +474,65 @@ func TestAccAgentRegistration_duplicateDisplayNameAcrossNamespaces(t *testing.T)
 	})
 }
 
+// TestAccAgentRegistration_local tests that the local flag is persisted and
+// read back correctly. A local registration is not replicated globally and
+// stays on the current cluster.
+func TestAccAgentRegistration_local(t *testing.T) {
+	displayName := acctest.RandomWithPrefix("test-agent")
+	resourceName := "vault_agent_registration.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctestutil.TestAccPreCheck(t)
+			acctestutil.TestEntPreCheck(t)
+			acctestutil.SkipIfAPIVersionLT(t, provider.VaultVersion210)
+		},
+		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAgentRegistrationConfig_local(displayName, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldDisplayName, displayName),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldLocal, "true"),
+				),
+			},
+			{
+				ResourceName:                         resourceName,
+				ImportState:                          true,
+				ImportStateIdFunc:                    testAccAgentRegistrationImportStateIdFunc(resourceName),
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: consts.FieldDisplayName,
+				ImportStateVerifyIgnore:              []string{consts.FieldLastUpdatedTime},
+			},
+		},
+	})
+}
+
+// TestAccAgentRegistration_localDefault tests that the local flag defaults to
+// false when not explicitly set.
+func TestAccAgentRegistration_localDefault(t *testing.T) {
+	displayName := acctest.RandomWithPrefix("test-agent")
+	resourceName := "vault_agent_registration.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctestutil.TestAccPreCheck(t)
+			acctestutil.TestEntPreCheck(t)
+			acctestutil.SkipIfAPIVersionLT(t, provider.VaultVersion210)
+		},
+		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAgentRegistrationConfig_basic(displayName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldDisplayName, displayName),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldLocal, "false"),
+				),
+			},
+		},
+	})
+}
+
 // Config helper functions
 
 func testAccAgentRegistrationConfig_basic(displayName string) string {
@@ -722,4 +781,19 @@ resource "vault_agent_registration" "test" {
   optional_authorization_details = %t
 }
 `, displayName, displayName, optionalRAR)
+}
+
+func testAccAgentRegistrationConfig_local(displayName string, local bool) string {
+	return fmt.Sprintf(`
+resource "vault_identity_entity" "test" {
+  name     = "%s-entity"
+  policies = ["default"]
+}
+
+resource "vault_agent_registration" "test" {
+  display_name = "%s"
+  entity_id    = vault_identity_entity.test.id
+  local        = %t
+}
+`, displayName, displayName, local)
 }

--- a/internal/vault/sys/oauth_resource_server_config_profile_resource.go
+++ b/internal/vault/sys/oauth_resource_server_config_profile_resource.go
@@ -83,6 +83,7 @@ type OAuthResourceServerConfigProfileModel struct {
 	ClockSkewLeeway              types.Int64  `tfsdk:"clock_skew_leeway"`
 	Enabled                      types.Bool   `tfsdk:"enabled"`
 	OptionalAuthorizationDetails types.Bool   `tfsdk:"optional_authorization_details"`
+	Local                        types.Bool   `tfsdk:"local"`
 }
 
 // OAuthResourceServerConfigProfileAPIModel describes the Vault API data model
@@ -102,6 +103,7 @@ type OAuthResourceServerConfigProfileAPIModel struct {
 	ClockSkewLeeway              int                 `json:"clock_skew_leeway" mapstructure:"clock_skew_leeway"`
 	Enabled                      bool                `json:"enabled" mapstructure:"enabled"`
 	OptionalAuthorizationDetails bool                `json:"optional_authorization_details" mapstructure:"optional_authorization_details"`
+	Local                        bool                `json:"local" mapstructure:"local"`
 }
 
 // PublicKeyAPIModel represents a public key in the API
@@ -219,6 +221,14 @@ func (r *OAuthResourceServerConfigProfileResource) Schema(ctx context.Context, r
 				Computed:            true,
 				Default:             booldefault.StaticBool(false),
 				MarkdownDescription: "When false, RAR (Rich Authorization Requests) is mandatory and authorization_details must be present in the token. When set to true, authorization_details in the JWT token are optional. Defaults to false.",
+			},
+			consts.FieldLocal: schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  booldefault.StaticBool(false),
+				MarkdownDescription: "If true, this profile is cluster-scoped and never replicated to performance secondaries. " +
+					"If false (default), the profile is written to replicated storage and propagated to all secondaries. " +
+					"This field is immutable after creation; delete and recreate the profile to change locality.",
 			},
 		},
 		// Note: ListNestedBlock is used instead of ListNestedAttribute because this provider
@@ -532,6 +542,8 @@ func (r *OAuthResourceServerConfigProfileResource) readFromVault(ctx context.Con
 	// RAR support
 	data.OptionalAuthorizationDetails = types.BoolValue(apiModel.OptionalAuthorizationDetails)
 
+	data.Local = types.BoolValue(apiModel.Local)
+
 	return true
 }
 
@@ -613,6 +625,9 @@ func (r *OAuthResourceServerConfigProfileResource) buildVaultRequest(ctx context
 		vaultRequest[consts.FieldOptionalAuthorizationDetails] = data.OptionalAuthorizationDetails.ValueBool()
 	}
 
+	if !data.Local.IsNull() && !data.Local.IsUnknown() {
+		vaultRequest[consts.FieldLocal] = data.Local.ValueBool()
+	}
 	return vaultRequest
 }
 

--- a/internal/vault/sys/oauth_resource_server_config_profile_resource_test.go
+++ b/internal/vault/sys/oauth_resource_server_config_profile_resource_test.go
@@ -394,7 +394,7 @@ func TestAccOAuthResourceServerConfigProfile_localDefault(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccOAuthResourceServerConfigProfilePreCheck(t, provider.VaultVersion210)
+			testAccOAuthResourceServerConfigProfilePreCheck(t, provider.VaultVersion220)
 		},
 		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/vault/sys/oauth_resource_server_config_profile_resource_test.go
+++ b/internal/vault/sys/oauth_resource_server_config_profile_resource_test.go
@@ -5,8 +5,10 @@ package sys_test
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -23,9 +25,7 @@ func TestAccOAuthResourceServerConfigProfile_jwks(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			acctestutil.TestAccPreCheck(t)
-			acctestutil.TestEntPreCheck(t)
-			acctestutil.SkipIfAPIVersionLT(t, provider.VaultVersion201)
+			testAccOAuthResourceServerConfigProfilePreCheck(t, provider.VaultVersion201)
 		},
 		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
@@ -68,9 +68,7 @@ mwIDAQAB
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			acctestutil.TestAccPreCheck(t)
-			acctestutil.TestEntPreCheck(t)
-			acctestutil.SkipIfAPIVersionLT(t, provider.VaultVersion201)
+			testAccOAuthResourceServerConfigProfilePreCheck(t, provider.VaultVersion201)
 		},
 		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
@@ -102,9 +100,7 @@ func TestAccOAuthResourceServerConfigProfile_withAudiences(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			acctestutil.TestAccPreCheck(t)
-			acctestutil.TestEntPreCheck(t)
-			acctestutil.SkipIfAPIVersionLT(t, provider.VaultVersion201)
+			testAccOAuthResourceServerConfigProfilePreCheck(t, provider.VaultVersion201)
 		},
 		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
@@ -128,9 +124,7 @@ func TestAccOAuthResourceServerConfigProfile_update(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			acctestutil.TestAccPreCheck(t)
-			acctestutil.TestEntPreCheck(t)
-			acctestutil.SkipIfAPIVersionLT(t, provider.VaultVersion201)
+			testAccOAuthResourceServerConfigProfilePreCheck(t, provider.VaultVersion201)
 		},
 		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
@@ -161,9 +155,7 @@ func TestAccOAuthResourceServerConfigProfile_requiresReplace(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			acctestutil.TestAccPreCheck(t)
-			acctestutil.TestEntPreCheck(t)
-			acctestutil.SkipIfAPIVersionLT(t, provider.VaultVersion201)
+			testAccOAuthResourceServerConfigProfilePreCheck(t, provider.VaultVersion201)
 		},
 		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
@@ -191,9 +183,7 @@ func TestAccOAuthResourceServerConfigProfile_namespace(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			acctestutil.TestAccPreCheck(t)
-			acctestutil.TestEntPreCheck(t)
-			acctestutil.SkipIfAPIVersionLT(t, provider.VaultVersion201)
+			testAccOAuthResourceServerConfigProfilePreCheck(t, provider.VaultVersion201)
 		},
 		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
@@ -224,9 +214,7 @@ func TestAccOAuthResourceServerConfigProfile_algorithms(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			acctestutil.TestAccPreCheck(t)
-			acctestutil.TestEntPreCheck(t)
-			acctestutil.SkipIfAPIVersionLT(t, provider.VaultVersion201)
+			testAccOAuthResourceServerConfigProfilePreCheck(t, provider.VaultVersion201)
 		},
 		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
@@ -253,9 +241,7 @@ func TestAccOAuthResourceServerConfigProfile_duplicateProfileNameAcrossNamespace
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			acctestutil.TestAccPreCheck(t)
-			acctestutil.TestEntPreCheck(t)
-			acctestutil.SkipIfAPIVersionLT(t, provider.VaultVersion201)
+			testAccOAuthResourceServerConfigProfilePreCheck(t, provider.VaultVersion201)
 		},
 		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
@@ -285,9 +271,7 @@ func TestAccOAuthResourceServerConfigProfile_rarOptional(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			acctestutil.TestAccPreCheck(t)
-			acctestutil.TestEntPreCheck(t)
-			acctestutil.SkipIfAPIVersionLT(t, provider.VaultVersion203)
+			testAccOAuthResourceServerConfigProfilePreCheck(t, provider.VaultVersion203)
 		},
 		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
@@ -315,9 +299,7 @@ func TestAccOAuthResourceServerConfigProfile_rarMandatory(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			acctestutil.TestAccPreCheck(t)
-			acctestutil.TestEntPreCheck(t)
-			acctestutil.SkipIfAPIVersionLT(t, provider.VaultVersion203)
+			testAccOAuthResourceServerConfigProfilePreCheck(t, provider.VaultVersion203)
 		},
 		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
@@ -345,9 +327,7 @@ func TestAccOAuthResourceServerConfigProfile_rarUpdate(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			acctestutil.TestAccPreCheck(t)
-			acctestutil.TestEntPreCheck(t)
-			acctestutil.SkipIfAPIVersionLT(t, provider.VaultVersion203)
+			testAccOAuthResourceServerConfigProfilePreCheck(t, provider.VaultVersion203)
 		},
 		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
 		Steps: []resource.TestStep{
@@ -376,13 +356,91 @@ func TestAccOAuthResourceServerConfigProfile_rarUpdate(t *testing.T) {
 	})
 }
 
+// TestAccOAuthResourceServerConfigProfile_local tests that the local flag is
+// persisted and read back correctly. A local profile is cluster-scoped and
+// never replicated to performance secondaries.
+func TestAccOAuthResourceServerConfigProfile_local(t *testing.T) {
+	profileName := acctest.RandomWithPrefix("test-profile")
+	resourceName := "vault_oauth_resource_server_config_profile.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccOAuthResourceServerConfigProfilePreCheck(t, provider.VaultVersion210)
+		},
+		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOAuthResourceServerConfigProfileConfig_local(profileName, true),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldProfileName, profileName),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldLocal, "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccOAuthResourceServerConfigProfileImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// TestAccOAuthResourceServerConfigProfile_localDefault tests that the local
+// flag defaults to false when not explicitly set.
+func TestAccOAuthResourceServerConfigProfile_localDefault(t *testing.T) {
+	profileName := acctest.RandomWithPrefix("test-profile")
+	resourceName := "vault_oauth_resource_server_config_profile.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccOAuthResourceServerConfigProfilePreCheck(t, provider.VaultVersion210)
+		},
+		ProtoV5ProviderFactories: providertest.ProtoV5ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOAuthResourceServerConfigProfileConfig_jwks(profileName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, consts.FieldProfileName, profileName),
+					resource.TestCheckResourceAttr(resourceName, consts.FieldLocal, "false"),
+				),
+			},
+		},
+	})
+}
+
 // Config helper functions
+
+func testAccOAuthResourceServerConfigProfilePreCheck(t *testing.T, minVersion *version.Version) {
+	t.Helper()
+	acctestutil.TestAccPreCheck(t)
+	acctestutil.TestEntPreCheck(t)
+	acctestutil.SkipIfAPIVersionLT(t, minVersion)
+
+	meta := acctestutil.TestProvider.Meta().(*provider.ProviderMeta)
+	t.Setenv(
+		"TF_VAR_vault_test_activate_oauth_resource_server",
+		strconv.FormatBool(!meta.IsAPISupported(provider.VaultVersion210)),
+	)
+}
+
+func testAccOAuthResourceServerConfigProfileActivationFlagsConfig() string {
+	return `
+variable "vault_test_activate_oauth_resource_server" {
+  type = bool
+}
+
+resource "vault_activation_flags" "oauth" {
+  count = var.vault_test_activate_oauth_resource_server ? 1 : 0
+
+  feature = "oauth-resource-server"
+}
+`
+}
 
 func testAccOAuthResourceServerConfigProfileConfig_jwks(profileName string) string {
 	return fmt.Sprintf(`
-resource "vault_activation_flags" "oauth" {
-  feature = "oauth-resource-server"
-}
+%s
 
 resource "vault_oauth_resource_server_config_profile" "test" {
   depends_on   = [vault_activation_flags.oauth]
@@ -391,14 +449,12 @@ resource "vault_oauth_resource_server_config_profile" "test" {
   use_jwks     = true
   jwks_uri     = "https://example.com/.well-known/jwks.json"
 }
-`, profileName)
+`, testAccOAuthResourceServerConfigProfileActivationFlagsConfig(), profileName)
 }
 
 func testAccOAuthResourceServerConfigProfileConfig_jwksUpdated(profileName string) string {
 	return fmt.Sprintf(`
-resource "vault_activation_flags" "oauth" {
-  feature = "oauth-resource-server"
-}
+%s
 
 resource "vault_oauth_resource_server_config_profile" "test" {
   depends_on        = [vault_activation_flags.oauth]
@@ -410,14 +466,12 @@ resource "vault_oauth_resource_server_config_profile" "test" {
   user_claim        = "email"
   clock_skew_leeway = 30
 }
-`, profileName)
+`, testAccOAuthResourceServerConfigProfileActivationFlagsConfig(), profileName)
 }
 
 func testAccOAuthResourceServerConfigProfileConfig_pem(profileName, publicKeyPEM string) string {
 	return fmt.Sprintf(`
-resource "vault_activation_flags" "oauth" {
-  feature = "oauth-resource-server"
-}
+%s
 
 resource "vault_oauth_resource_server_config_profile" "test" {
   depends_on   = [vault_activation_flags.oauth]
@@ -432,14 +486,12 @@ resource "vault_oauth_resource_server_config_profile" "test" {
 EOT
   }
 }
-`, profileName, publicKeyPEM)
+`, testAccOAuthResourceServerConfigProfileActivationFlagsConfig(), profileName, publicKeyPEM)
 }
 
 func testAccOAuthResourceServerConfigProfileConfig_withAudiences(profileName string) string {
 	return fmt.Sprintf(`
-resource "vault_activation_flags" "oauth" {
-  feature = "oauth-resource-server"
-}
+%s
 
 resource "vault_oauth_resource_server_config_profile" "test" {
   depends_on   = [vault_activation_flags.oauth]
@@ -449,14 +501,12 @@ resource "vault_oauth_resource_server_config_profile" "test" {
   jwks_uri     = "https://example.com/.well-known/jwks.json"
   audiences    = ["api.example.com", "vault.example.com"]
 }
-`, profileName)
+`, testAccOAuthResourceServerConfigProfileActivationFlagsConfig(), profileName)
 }
 
 func testAccOAuthResourceServerConfigProfileConfig_namespace(ns, profileName string) string {
 	return fmt.Sprintf(`
-resource "vault_activation_flags" "oauth" {
-  feature = "oauth-resource-server"
-}
+%s
 
 resource "vault_namespace" "test" {
   path = "%s"
@@ -470,14 +520,12 @@ resource "vault_oauth_resource_server_config_profile" "test" {
   use_jwks     = true
   jwks_uri     = "https://example.com/.well-known/jwks.json"
 }
-`, ns, profileName)
+`, testAccOAuthResourceServerConfigProfileActivationFlagsConfig(), ns, profileName)
 }
 
 func testAccOAuthResourceServerConfigProfileConfig_twoNamespaces(ns1, ns2, profileName string) string {
 	return fmt.Sprintf(`
-resource "vault_activation_flags" "oauth" {
-  feature = "oauth-resource-server"
-}
+%s
 
 resource "vault_namespace" "test1" {
   path = "%s"
@@ -507,14 +555,12 @@ resource "vault_oauth_resource_server_config_profile" "test2" {
   use_jwks     = true
   jwks_uri     = "https://example.com/.well-known/jwks.json"
 }
-`, ns1, ns2, profileName, profileName)
+`, testAccOAuthResourceServerConfigProfileActivationFlagsConfig(), ns1, ns2, profileName, profileName)
 }
 
 func testAccOAuthResourceServerConfigProfileConfig_algorithms(profileName string) string {
 	return fmt.Sprintf(`
-resource "vault_activation_flags" "oauth" {
-  feature = "oauth-resource-server"
-}
+%s
 
 resource "vault_oauth_resource_server_config_profile" "test" {
   depends_on            = [vault_activation_flags.oauth]
@@ -524,14 +570,12 @@ resource "vault_oauth_resource_server_config_profile" "test" {
   jwks_uri              = "https://example.com/.well-known/jwks.json"
   supported_algorithms  = ["RS256", "ES256"]
 }
-`, profileName)
+`, testAccOAuthResourceServerConfigProfileActivationFlagsConfig(), profileName)
 }
 
 func testAccOAuthResourceServerConfigProfileConfig_rarOptional(profileName string) string {
 	return fmt.Sprintf(`
-resource "vault_activation_flags" "oauth" {
-  feature = "oauth-resource-server"
-}
+%s
 
 resource "vault_oauth_resource_server_config_profile" "test" {
   depends_on                       = [vault_activation_flags.oauth]
@@ -541,14 +585,12 @@ resource "vault_oauth_resource_server_config_profile" "test" {
   jwks_uri                         = "https://example.com/.well-known/jwks.json"
   optional_authorization_details   = true
 }
-`, profileName)
+`, testAccOAuthResourceServerConfigProfileActivationFlagsConfig(), profileName)
 }
 
 func testAccOAuthResourceServerConfigProfileConfig_rarMandatory(profileName string) string {
 	return fmt.Sprintf(`
-resource "vault_activation_flags" "oauth" {
-  feature = "oauth-resource-server"
-}
+%s
 
 resource "vault_oauth_resource_server_config_profile" "test" {
   depends_on                       = [vault_activation_flags.oauth]
@@ -558,7 +600,22 @@ resource "vault_oauth_resource_server_config_profile" "test" {
   jwks_uri                         = "https://example.com/.well-known/jwks.json"
   optional_authorization_details   = false
 }
-`, profileName)
+`, testAccOAuthResourceServerConfigProfileActivationFlagsConfig(), profileName)
+}
+
+func testAccOAuthResourceServerConfigProfileConfig_local(profileName string, local bool) string {
+	return fmt.Sprintf(`
+%s
+
+resource "vault_oauth_resource_server_config_profile" "test" {
+  depends_on   = [vault_activation_flags.oauth]
+  profile_name = "%s"
+  issuer_id    = "https://example.com"
+  use_jwks     = true
+  jwks_uri     = "https://example.com/.well-known/jwks.json"
+  local        = %t
+}
+`, testAccOAuthResourceServerConfigProfileActivationFlagsConfig(), profileName, local)
 }
 
 func testAccOAuthResourceServerConfigProfileImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {

--- a/website/docs/r/agent_registration.html.md
+++ b/website/docs/r/agent_registration.html.md
@@ -145,6 +145,22 @@ resource "vault_agent_registration" "example" {
 }
 ```
 
+### Agent Registry Record with Data Locality 
+
+```hcl
+resource "vault_identity_entity" "agent" {
+  name     = "my-agent-entity"
+  policies = ["default"]
+}
+
+resource "vault_agent_registration" "example" {
+  display_name = "my-agent"
+  entity_id    = vault_identity_entity.agent.id
+  local        = true 
+  description  = "Agent with optional RAR support"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -164,7 +180,10 @@ The following arguments are supported:
 * `description` - (Optional) A human-readable description of the Agent Registry record. This field is for documentation purposes and does not affect the agent's behavior.
 
 * `owner` - (Optional) Owner of the Agent Registry record.
+
 * `optional_authorization_details` - (Optional) When `false`, RAR (Rich Authorization Requests) is mandatory and authorization_details must be present in the token. When set to `true`, authorization_details in the JWT token are optional for this agent. This setting works in conjunction with the OAuth Resource Server profile's optional_authorization_details setting - RAR is optional if EITHER is `true`. Defaults to `false`. Requires Vault 2.0.3 or later.
+
+* `local` - (Optional) When `false`, the registration is written to replicated storage and propagated to all performance secondaries. When set to `true`, the registration remains local to the current cluster and is not replicated. Requires Vault 2.2.0 or later.
 
 ## Attributes Reference
 

--- a/website/docs/r/oauth_resource_server_config_profile.html.md
+++ b/website/docs/r/oauth_resource_server_config_profile.html.md
@@ -190,6 +190,8 @@ The following arguments are supported:
 
 * `optional_authorization_details` - (Optional) When `false`, RAR (Rich Authorization Requests) is mandatory and authorization_details must be present in the token. When set to `true`, authorization_details in the JWT token are optional. Defaults to `false`. Requires Vault 2.0.3 or later.
 
+* `local` - (Optional) When `false`, the profile is written to replicated storage and propagated to all performance secondaries. When set to `true`, the profile remains local to the current cluster and is not replicated. Requires Vault 2.2.0 or later.
+
 ## Attributes Reference
 
 In addition to the arguments above, the following attributes are exported:


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-vault/blob/master/.github/CONTRIBUTING.md --->


### Description
Adds the `local` field to agent registry and oauth resource server. Updated docs. 

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000


### Checklist
- [x] Added [CHANGELOG](https://github.com/hashicorp/terraform-provider-vault/blob/master/CHANGELOG.md) entry (only for user-facing changes)
- [x] Acceptance tests where run against all supported Vault Versions


### Output from acceptance testing:

```
$ make testacc TESTARGS="github.com/hashicorp/terraform-provider-vault/internal/vault/sys -run TestAccOAuthResourceServerConfigProfile*"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test github.com/hashicorp/terraform-provider-vault/internal/vault/sys -run TestAccOAuthResourceServerConfigProfile* -timeout 30m ./...
ok      github.com/hashicorp/terraform-provider-vault/internal/vault/sys        0.714s...

$ make testacc TESTARGS="github.com/hashicorp/terraform-provider-vault/internal/vault/sys -run TestAccAgentRegistration*"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test github.com/hashicorp/terraform-provider-vault/internal/vault/sys -run TestAccAgentRegistration* -timeout 30m ./...
ok      github.com/hashicorp/terraform-provider-vault/internal/vault/sys        0.848s
```


<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->


## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
